### PR TITLE
fix(repo-settings,stores,mcp,forge): report outcomes and lock shared stores

### DIFF
--- a/changelog.d/fixed-mcp-repo-spelling.md
+++ b/changelog.d/fixed-mcp-repo-spelling.md
@@ -1,0 +1,3 @@
+- GitDesktop's MCP server resolves its `--repo` path to the canonical spelling,
+  so operation history and records saved under older path spellings stay in
+  sync with the app, whichever way the client config writes the path.

--- a/changelog.d/fixed-ported-host-credentials.md
+++ b/changelog.d/fixed-ported-host-credentials.md
@@ -1,3 +1,3 @@
 - Self-managed GitLab and GitHub Enterprise instances on a non-default HTTPS
-  port authenticate with your `glab`/`gh` session and report their real state in
-  Accounts.
+  port authenticate with your `glab`/`gh` session, and the repository view's
+  sign-in status reflects them.

--- a/changelog.d/fixed-ported-host-credentials.md
+++ b/changelog.d/fixed-ported-host-credentials.md
@@ -1,0 +1,3 @@
+- Self-managed GitLab and GitHub Enterprise instances on a non-default HTTPS
+  port authenticate with your `glab`/`gh` session and report their real state in
+  Accounts.

--- a/changelog.d/fixed-repo-settings-dismissed-outcomes.md
+++ b/changelog.d/fixed-repo-settings-dismissed-outcomes.md
@@ -1,0 +1,5 @@
+- Repository-settings saves, deletes and toggles report their result even
+  when the settings dialog closes or you switch to another settings section
+  while the change is still in flight — General, collaborators and webhooks, rulesets,
+  secrets and variables, Pages, security, the Sponsor button, GitLab and
+  Bitbucket project settings, and every danger-zone action.

--- a/changelog.d/fixed-store-lock-hardening.md
+++ b/changelog.d/fixed-store-lock-hardening.md
@@ -1,0 +1,2 @@
+- Local pull requests and issues survive concurrent writes from multiple
+  GitDesktop MCP servers working in the same repository.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -184,6 +184,16 @@ const HOVER_REVEAL_PAIRS = [
 const SET_QUERY_DATA_RE =
   /setQueryData\s*(?:<[^(]*?>)?\s*\([^;]{0,200},\s*undefined\s*[),]/g;
 
+// A `.mutate(` call in any spelling — the token, not the callbacks object it
+// may carry. Matching the object instead would have to recognize every way one
+// reaches the call: inline literal, hoisted variable (`.mutate(v, opts)` — the
+// shape 5 of the settings sections used, and still live elsewhere under src/),
+// spread, shorthand keys. The token has no such surface, and it costs nothing
+// here because the directory this check applies to has no `.mutate(` calls left
+// at all — every mutation there is awaited. `.mutateAsync(` does not match: the
+// `(` must follow `mutate` directly.
+const MUTATE_CALL_RE = /\.mutate\s*\(/;
+
 // Vendored shadcn/Base UI primitives are off-limits to edit (CLAUDE.md), so a
 // hit inside them could only ever be silenced by an allowlist entry, never
 // fixed. Their CALL SITES — the app code that composes them — stay scanned.
@@ -246,6 +256,17 @@ export const CHECKS = [
     allowlist: [],
     message:
       "setQueryData(key, undefined) is a silent no-op in TanStack v5 — snapshot and restore the previous value instead",
+  },
+  {
+    name: "mutate-in-repo-settings",
+    // Scoped to the settings dialog's own tree, whose sections unmount on BOTH
+    // dialog close and every rail section switch (the keyed crossfade). The
+    // wider app's call sites are a separate tier and are not scanned here.
+    appliesTo: (file) => file.startsWith("src/features/repo-settings/"),
+    scan: perLine(MUTATE_CALL_RE),
+    allowlist: [],
+    message:
+      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close or rail section switch mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -139,17 +139,14 @@ const nearPair = (a, b) => {
   return perFile(re);
 };
 
-/** Scanner: the union of several `nearPair`s — one check, one allowlist, every
- *  Tailwind spelling of the same idiom. */
-const anyPair = (pairs) => {
-  const scans = pairs.map(([a, b]) => nearPair(a, b));
-  return (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
-};
-
 /** Scanner: the union of several scanners — one check, one allowlist, every
  *  route to the same banned thing (including routes that want different
  *  views: `perLine` for a token, `perFile` for one that can wrap). */
 const anyOf = (scans) => (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
+
+/** Scanner: the union of several `nearPair`s — one check, one allowlist, every
+ *  Tailwind spelling of the same idiom. */
+const anyPair = (pairs) => anyOf(pairs.map(([a, b]) => nearPair(a, b)));
 
 // The same hover-reveal in each of its Tailwind spellings: the hiding utility
 // paired with the `group-hover:` class that undoes it. `inline` and

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -146,6 +146,11 @@ const anyPair = (pairs) => {
   return (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
 };
 
+/** Scanner: the union of several scanners — one check, one allowlist, every
+ *  route to the same banned thing (including routes that want different
+ *  views: `perLine` for a token, `perFile` for one that can wrap). */
+const anyOf = (scans) => (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
+
 // The same hover-reveal in each of its Tailwind spellings: the hiding utility
 // paired with the `group-hover:` class that undoes it. `inline` and
 // `inline-flex` are separate entries because the token boundary guard stops
@@ -193,6 +198,16 @@ const SET_QUERY_DATA_RE =
 // at all — every mutation there is awaited. `.mutateAsync(` does not match: the
 // `(` must follow `mutate` directly.
 const MUTATE_CALL_RE = /\.mutate\s*\(/;
+
+// The dot-less route to the same call: `const { mutate } = useX()` (a live idiom
+// elsewhere in src/) reaches `.mutate` off a destructured binding, so the token
+// above never sees it. The `\b` after `mutate` is what keeps `{ mutateAsync }`
+// clean, while a renamed `{ mutate: save }` still hits. Run over the whole-file
+// view, not per line: a destructure long enough to wrap is a shape this codebase
+// already produces (15 wrapped hook destructures under src/, none binding
+// `mutate` today), and `[^}]*` can't cross the destructure's own closing brace,
+// so the joined view adds no reach.
+const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 
 // Vendored shadcn/Base UI primitives are off-limits to edit (CLAUDE.md), so a
 // hit inside them could only ever be silenced by an allowlist entry, never
@@ -263,10 +278,10 @@ export const CHECKS = [
     // dialog close and every rail section switch (the keyed crossfade). The
     // wider app's call sites are a separate tier and are not scanned here.
     appliesTo: (file) => file.startsWith("src/features/repo-settings/"),
-    scan: perLine(MUTATE_CALL_RE),
+    scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],
     message:
-      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close or rail section switch mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( needs an allowlist entry with rationale",
+      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close or rail section switch mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -194,12 +194,48 @@ test("mutate-in-repo-settings flags a bare call carrying no callbacks", () => {
   assert.deepEqual(repoSettingsMutate("refresh.mutate ();"), [1]);
 });
 
+test("mutate-in-repo-settings catches the dot-less destructured route", () => {
+  // `const { mutate } = useX()` reaches the same call with no `.mutate` token
+  // for the first pattern to see — a live idiom elsewhere under src/.
+  assert.deepEqual(
+    repoSettingsMutate("const { mutate } = useUpdateLocalPr(repo);"),
+    [1],
+  );
+  assert.deepEqual(
+    repoSettingsMutate("const { mutate: save } = useUpdateThing(repo);"),
+    [1],
+  );
+  assert.deepEqual(
+    repoSettingsMutate("const { isPending, mutate } = useX(repo);"),
+    [1],
+  );
+  // Wrapped by the formatter: caught because this pattern reads the whole-file
+  // view, where `[^}]*` still can't cross the destructure's own closing brace.
+  const wrapped = [
+    "const {",
+    "  mutate,",
+    "  isPending,",
+    "} = useUpdateSomethingWithALongName(repoPath);",
+  ].join("\n");
+  assert.deepEqual(repoSettingsMutate(wrapped), [1]);
+});
+
 test("mutate-in-repo-settings leaves the awaited idiom and comments alone", () => {
   const awaited = [
     "await update.mutateAsync(form);",
     'toast.success("Repository settings saved");',
   ].join("\n");
   assert.deepEqual(repoSettingsMutate(awaited), []);
+  // The `\b` after `mutate` is the whole reason the destructure pattern can
+  // coexist with the idiom it is enforcing.
+  assert.deepEqual(
+    repoSettingsMutate("const { mutateAsync } = useUpdateRepoSettings(repo);"),
+    [],
+  );
+  assert.deepEqual(
+    repoSettingsMutate("const { mutateAsync, isPending } = useX(repo);"),
+    [],
+  );
   const documented = [
     "// never `.mutate(vars, { onSuccess, onError })` — the callbacks are",
     "// dropped when the observer unmounts.",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -43,6 +43,7 @@ function scanner(name) {
 const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
 const setQueryData = scanner("setQueryData-noop");
+const repoSettingsMutate = scanner("mutate-in-repo-settings");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -162,6 +163,49 @@ test("setQueryData-noop does not reach across a `;` statement boundary", () => {
     "logger.debug(label, undefined);",
   ].join("\n");
   assert.deepEqual(setQueryData(source), []);
+});
+
+test("mutate-in-repo-settings flags every way a call reaches its callbacks", () => {
+  // The reason this check matches the CALL and not the callbacks object: the
+  // hoisted-options pair is the shape most of these sections used, and no
+  // regex anchored on `onSuccess`/`onError` sees it.
+  assert.deepEqual(
+    repoSettingsMutate(
+      'del.mutate(hook.id, { onSuccess: () => toast.success("x"), onError: e });',
+    ),
+    [1],
+  );
+  const hoisted = [
+    "const opts = { onSuccess: done, onError: toastError };",
+    "update.mutate({ id, body }, opts);",
+  ].join("\n");
+  assert.deepEqual(repoSettingsMutate(hoisted), [2]);
+  assert.deepEqual(
+    repoSettingsMutate("setEnforcement.mutate(vars, { onError: toastError });"),
+    [1],
+  );
+});
+
+test("mutate-in-repo-settings flags a bare call carrying no callbacks", () => {
+  // Deliberate: a fire-and-forget mutation here still loses nothing to the
+  // unmount, but the ratchet stays a token match — an exemption is an
+  // allowlist entry with rationale, not a hole in the pattern.
+  assert.deepEqual(repoSettingsMutate("ping.mutate(hook.id);"), [1]);
+  assert.deepEqual(repoSettingsMutate("refresh.mutate ();"), [1]);
+});
+
+test("mutate-in-repo-settings leaves the awaited idiom and comments alone", () => {
+  const awaited = [
+    "await update.mutateAsync(form);",
+    'toast.success("Repository settings saved");',
+  ].join("\n");
+  assert.deepEqual(repoSettingsMutate(awaited), []);
+  const documented = [
+    "// never `.mutate(vars, { onSuccess, onError })` — the callbacks are",
+    "// dropped when the observer unmounts.",
+    "await save.mutateAsync(vars);",
+  ].join("\n");
+  assert.deepEqual(repoSettingsMutate(documented), []);
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "dirs",
+ "dunce",
  "keyring",
  "os_info",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,10 @@ sha1 = "0.11"
 # would silently un-ignore a file. Test fixtures use it as RAII temp dirs too, so
 # a killed or panicking run leaks nothing.
 tempfile = "3"
+# Canonicalizing the MCP server's `--repo` (mcp_server::McpArgs::parse) so per-repo
+# store keys match the GUI's spelling. dunce over std: `std::fs::canonicalize` returns
+# Windows `\\?\` verbatim paths, which those keys would read as a different repo.
+dunce = "1"
 
 # Desktop-only: the updater plugin doesn't build for mobile.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -2858,14 +2858,15 @@ async fn evict_git_credential() {
 /// sentinel seed, and re-prompts — on Windows GCM as well as macOS osxkeychain.
 /// Non-`https` URLs and URLs without userinfo pass through unchanged.
 pub(crate) fn strip_https_userinfo(url: &str) -> String {
-    // Scheme matched case-insensitively, in lockstep with `forge::is_https_remote`: an
-    // `HTTPS://user@…` remote that passed that gate but skipped this rewrite would be
-    // seeded `credential.interactive=false` with no `insteadOf`, turning a prompt into a
-    // hard auth failure.
-    let Some(rest) = url
+    // Scheme matched case-insensitively AND after trimming, in lockstep with
+    // `forge::is_https_remote`: a remote that passed that gate but skipped this rewrite
+    // would be seeded `credential.interactive=false` with no `insteadOf`, turning a
+    // prompt into a hard auth failure.
+    let trimmed = url.trim_start();
+    let Some(rest) = trimmed
         .get(..8)
         .filter(|scheme| scheme.eq_ignore_ascii_case("https://"))
-        .map(|_| &url[8..])
+        .map(|_| &trimmed[8..])
     else {
         return url.to_string();
     };
@@ -2891,7 +2892,9 @@ pub(crate) fn strip_https_userinfo(url: &str) -> String {
 ///  - For a userinfo remote (`https://user@bitbucket.org/…`): a transient
 ///    `url.<stripped>.insteadOf=<url>` rewrite so git's credential lookup resolves to the
 ///    bare host and finds the sentinel seed (see [`strip_https_userinfo`]). The stored
-///    remote is never mutated. Safe as a `-c` key: Bitbucket URLs contain no `=`.
+///    remote is never mutated. Safe as a `-c` key even for a crafted remote: the
+///    immutable `url.` section prefix can never parse as `credential.*.helper`, and a
+///    smuggled `=` only truncates into an inert `url.*` key or lands in the value.
 pub(crate) fn bitbucket_credential_entries(url: &str) -> Vec<String> {
     let mut entries = vec![CREDENTIAL_NONINTERACTIVE.to_string()];
     let stripped = strip_https_userinfo(url);
@@ -5407,6 +5410,12 @@ mod tests {
         assert_eq!(
             strip_https_userinfo("http://alice@bitbucket.org/ws/repo.git"),
             "http://alice@bitbucket.org/ws/repo.git"
+        );
+        // Leading whitespace: `is_https_remote` trims before matching, so this must too —
+        // otherwise the gate admits a remote whose rewrite silently no-ops.
+        assert_eq!(
+            strip_https_userinfo("  https://alice@bitbucket.org/ws/repo.git"),
+            "https://bitbucket.org/ws/repo.git"
         );
     }
 

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -2858,7 +2858,15 @@ async fn evict_git_credential() {
 /// sentinel seed, and re-prompts — on Windows GCM as well as macOS osxkeychain.
 /// Non-`https` URLs and URLs without userinfo pass through unchanged.
 pub(crate) fn strip_https_userinfo(url: &str) -> String {
-    let Some(rest) = url.strip_prefix("https://") else {
+    // Scheme matched case-insensitively, in lockstep with `forge::is_https_remote`: an
+    // `HTTPS://user@…` remote that passed that gate but skipped this rewrite would be
+    // seeded `credential.interactive=false` with no `insteadOf`, turning a prompt into a
+    // hard auth failure.
+    let Some(rest) = url
+        .get(..8)
+        .filter(|scheme| scheme.eq_ignore_ascii_case("https://"))
+        .map(|_| &url[8..])
+    else {
         return url.to_string();
     };
     let (authority, path) = match rest.split_once('/') {
@@ -5388,6 +5396,30 @@ mod tests {
         assert_eq!(
             strip_https_userinfo("git@bitbucket.org:ws/repo.git"),
             "git@bitbucket.org:ws/repo.git"
+        );
+        // Mixed-case scheme strips too — `forge::is_https_remote` admits it, so skipping
+        // the rewrite here would seed a non-interactive op with no credential match.
+        assert_eq!(
+            strip_https_userinfo("HTTPS://alice@bitbucket.org/ws/repo.git"),
+            "https://bitbucket.org/ws/repo.git"
+        );
+        // http:// is still not https.
+        assert_eq!(
+            strip_https_userinfo("http://alice@bitbucket.org/ws/repo.git"),
+            "http://alice@bitbucket.org/ws/repo.git"
+        );
+    }
+
+    #[test]
+    fn mixed_case_https_still_gets_its_insteadof_rewrite() {
+        // The regression the case-insensitive gate would otherwise open: interactive
+        // suppressed with no rewrite = a hard auth failure instead of a prompt.
+        let entries = bitbucket_credential_entries("HTTPS://alice@bitbucket.org/ws/repo.git");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], "credential.interactive=false");
+        assert_eq!(
+            entries[1],
+            "url.https://bitbucket.org/ws/repo.git.insteadOf=HTTPS://alice@bitbucket.org/ws/repo.git"
         );
     }
 

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -765,18 +765,16 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
     let gh = crate::agent::resolve_named(&["gh"], None)
         .await
         .ok_or(AppError::GhNotFound)?;
-    // The KEY is always the authority — git won't match a portless credential key against
-    // a ported request, so a GHES host on `:8443` would silently never see gh's token.
     let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "github.com".to_string());
     let authority =
         crate::forge::remote_authority(clone_url).unwrap_or_else(|| "github.com".to_string());
-    if !gh_authenticated_for(&authority, &host).await {
+    // Key on the spelling that actually ANSWERED. Keying a ported authority that only the
+    // bare host authenticated would sever the ambient chain for `host:port` and install a
+    // gh that answers empty there — and the clone path has no ambient retry.
+    let Some(key) = gh_authenticated_for(&authority, &host).await else {
         return Ok(Vec::new());
-    }
-    Ok(github_credential_entries(
-        &authority,
-        &gh.display().to_string(),
-    ))
+    };
+    Ok(github_credential_entries(&key, &gh.display().to_string()))
 }
 
 /// The one-shot `-c` credential entries for an authenticated GitHub host — a
@@ -789,8 +787,13 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
 /// as the sole helper so an ambient one earlier in the chain (macOS `osxkeychain`)
 /// can't shadow it. Order matters: reset FIRST — consumers prefix `-c` in Vec order.
 /// `authority` is `host[:port]`, not a bare host: git matches credential keys by
-/// authority.
+/// authority. A crafted remote can drive characters git reads as config syntax through
+/// the URL parse, so an authority failing [`crate::forge::is_safe_authority`] emits
+/// NOTHING — git falls back to ambient helpers rather than to an injected one.
 fn github_credential_entries(authority: &str, gh_path: &str) -> Vec<String> {
+    if !crate::forge::is_safe_authority(authority) {
+        return Vec::new();
+    }
     vec![
         format!("credential.https://{authority}.helper="),
         github_credential_entry(authority, gh_path),
@@ -802,13 +805,17 @@ fn github_credential_entry(authority: &str, gh_path: &str) -> String {
     format!("credential.https://{authority}.helper=!\"{gh_path}\" auth git-credential")
 }
 
-/// Whether gh holds a token for a remote, probing its AUTHORITY before its bare host.
-/// gh's host registry is port-SENSITIVE (measured, gh 2.94: `--hostname github.com:443`
-/// exits 1 where the bare host exits 0), so a `gh auth login --hostname host:8443` user
-/// answers only to the authority. Either hit injects — the entries key on the authority
-/// regardless, and gh's helper re-resolves the host itself when git invokes it.
-async fn gh_authenticated_for(authority: &str, host: &str) -> bool {
-    (authority != host && gh_authenticated(authority).await) || gh_authenticated(host).await
+/// The spelling gh holds a token for — its AUTHORITY if that answers, else its bare host,
+/// else `None`. gh's host registry is port-SENSITIVE (measured, gh 2.94:
+/// `--hostname github.com:443` exits 1 where the bare host exits 0), so a
+/// `gh auth login --hostname host:8443` user answers only to the authority. Callers key
+/// their credential entries on the RETURNED string: a helper installed under a spelling
+/// gh doesn't know would answer empty on every fill.
+async fn gh_authenticated_for(authority: &str, host: &str) -> Option<String> {
+    if authority != host && gh_authenticated(authority).await {
+        return Some(authority.to_string());
+    }
+    gh_authenticated(host).await.then(|| host.to_string())
 }
 
 /// Whether gh has a STORED token for `host` — the gate deciding whether to inject the
@@ -1335,42 +1342,59 @@ mod tests {
     // The auth cache is a process-wide static and `gh_authenticated` reads it before
     // spawning, so priming it makes these hermetic (distinct host keys per test).
     #[tokio::test]
-    async fn ported_authority_passes_the_gate_the_bare_host_fails() {
+    async fn ported_authority_answers_and_is_the_spelling_keyed() {
         // The blocker case: `gh auth login --hostname ghes-p.example.com:8443` registers
         // ONLY the authority, so a bare-host-only gate would inject nothing.
         auth_cache_put("ghes-p.example.com:8443", true);
         auth_cache_put("ghes-p.example.com", false);
-        assert!(gh_authenticated_for("ghes-p.example.com:8443", "ghes-p.example.com").await);
+        assert_eq!(
+            gh_authenticated_for("ghes-p.example.com:8443", "ghes-p.example.com").await,
+            Some("ghes-p.example.com:8443".to_string()),
+        );
     }
 
     #[tokio::test]
-    async fn bare_host_still_passes_when_only_it_is_registered() {
-        // The reverse spelling: registered portless, remote written with a port.
+    async fn bare_match_is_keyed_bare_even_for_a_ported_remote() {
+        // Registered portless, remote written with a port: keying the authority here would
+        // sever ambient for `host:port` and install a gh that answers empty there.
         auth_cache_put("ghes-b.example.com:8443", false);
         auth_cache_put("ghes-b.example.com", true);
-        assert!(gh_authenticated_for("ghes-b.example.com:8443", "ghes-b.example.com").await);
+        assert_eq!(
+            gh_authenticated_for("ghes-b.example.com:8443", "ghes-b.example.com").await,
+            Some("ghes-b.example.com".to_string()),
+        );
     }
 
     #[tokio::test]
     async fn neither_spelling_registered_fails_the_gate() {
         auth_cache_put("ghes-n.example.com:8443", false);
         auth_cache_put("ghes-n.example.com", false);
-        assert!(!gh_authenticated_for("ghes-n.example.com:8443", "ghes-n.example.com").await);
+        assert_eq!(
+            gh_authenticated_for("ghes-n.example.com:8443", "ghes-n.example.com").await,
+            None,
+        );
+    }
+
+    #[tokio::test]
+    async fn ported_remote_keys_on_the_spelling_that_answered() {
+        let url = "https://ghes-k.example.com:8443/o/r.git";
+        let host = crate::forge::remote_host(url).unwrap();
+        let authority = crate::forge::remote_authority(url).unwrap();
+        assert_eq!(host, "ghes-k.example.com");
+        assert_eq!(authority, "ghes-k.example.com:8443");
+        // Authority registered → the ported key, which is the whole point of the fix.
+        auth_cache_put("ghes-k.example.com:8443", true);
+        auth_cache_put("ghes-k.example.com", false);
+        let key = gh_authenticated_for(&authority, &host).await.unwrap();
+        let entries = github_credential_entries(&key, "/abs/gh");
+        assert_eq!(entries[0], "credential.https://ghes-k.example.com:8443.helper=");
     }
 
     #[test]
-    fn ported_remote_keys_on_authority_and_keeps_the_bare_host_for_the_gate() {
-        // Both spellings are derived: the key is always the authority, while the gate
-        // needs the bare host as its fallback probe.
-        let url = "https://github.example.com:8443/o/r.git";
-        assert_eq!(crate::forge::remote_host(url).as_deref(), Some("github.example.com"));
-        assert_eq!(
-            crate::forge::remote_authority(url).as_deref(),
-            Some("github.example.com:8443"),
-        );
-        let entries =
-            github_credential_entries(&crate::forge::remote_authority(url).unwrap(), "/abs/gh");
-        assert_eq!(entries[0], "credential.https://github.example.com:8443.helper=");
+    fn a_crafted_authority_emits_no_entries_at_all() {
+        // Fail OPEN to ambient rather than installing an attacker's `!`-shell helper.
+        assert!(github_credential_entries("github.com:443.helper=!evil #", "/abs/gh").is_empty());
+        assert!(github_credential_entries("github.com;evil", "/abs/gh").is_empty());
     }
 
     // --- gh-auth TTL cache (mirrors remote.rs's cache tests). Distinct host keys

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -754,8 +754,9 @@ pub async fn create_issue(
 /// gh's token via an ABSOLUTE gh path — works even when git's ambient `!gh` helper
 /// can't find gh (macOS launchd's minimal GUI PATH) or gh never installed the HTTPS
 /// helper. Nothing is written to git config; no token enters the URL. Returns the
-/// `[reset, helper]` pair ONLY when gh has a STORED token for `host` — otherwise an
-/// empty Vec, so ambient helpers (keychain, git-credential-manager) still run. That
+/// `[reset, helper]` pair ONLY when gh has a STORED token for the remote's authority OR
+/// its bare host — otherwise an empty Vec, so ambient helpers (keychain,
+/// git-credential-manager) still run. That
 /// check proves the token EXISTS, not that it's valid; the ambient fallback in
 /// [`crate::git::remote::run_git_mutating_with_creds`] covers a revoked one. Missing
 /// gh → `Err(GhNotFound)`, so `.unwrap_or_default()` callers stay fail-open.
@@ -764,32 +765,50 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
     let gh = crate::agent::resolve_named(&["gh"], None)
         .await
         .ok_or(AppError::GhNotFound)?;
+    // The KEY is always the authority — git won't match a portless credential key against
+    // a ported request, so a GHES host on `:8443` would silently never see gh's token.
     let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "github.com".to_string());
-    if !gh_authenticated(&host).await {
+    let authority =
+        crate::forge::remote_authority(clone_url).unwrap_or_else(|| "github.com".to_string());
+    if !gh_authenticated_for(&authority, &host).await {
         return Ok(Vec::new());
     }
-    Ok(github_credential_entries(&host, &gh.display().to_string()))
+    Ok(github_credential_entries(
+        &authority,
+        &gh.display().to_string(),
+    ))
 }
 
 /// The one-shot `-c` credential entries for an authenticated GitHub host — a
 /// `[reset, helper]` pair. Pure/format-only.
 ///
 /// entry[0] SEVERS git's accumulated helper chain for this URL: `-c
-/// credential.https://<host>.helper=` sets the EMPTY string, which git treats as
+/// credential.https://<authority>.helper=` sets the EMPTY string, which git treats as
 /// "clear the helpers so far" (gitcredentials(7)). The trailing `=` is load-bearing —
 /// `-c name` without it sets boolean true and breaks the reset. entry[1] installs gh
 /// as the sole helper so an ambient one earlier in the chain (macOS `osxkeychain`)
 /// can't shadow it. Order matters: reset FIRST — consumers prefix `-c` in Vec order.
-fn github_credential_entries(host: &str, gh_path: &str) -> Vec<String> {
+/// `authority` is `host[:port]`, not a bare host: git matches credential keys by
+/// authority.
+fn github_credential_entries(authority: &str, gh_path: &str) -> Vec<String> {
     vec![
-        format!("credential.https://{host}.helper="),
-        github_credential_entry(host, gh_path),
+        format!("credential.https://{authority}.helper="),
+        github_credential_entry(authority, gh_path),
     ]
 }
 
-/// The one-shot `-c` credential-helper config value for a GitHub host. Pure/format-only.
-fn github_credential_entry(host: &str, gh_path: &str) -> String {
-    format!("credential.https://{host}.helper=!\"{gh_path}\" auth git-credential")
+/// The one-shot `-c` credential-helper config value for a GitHub authority. Pure/format-only.
+fn github_credential_entry(authority: &str, gh_path: &str) -> String {
+    format!("credential.https://{authority}.helper=!\"{gh_path}\" auth git-credential")
+}
+
+/// Whether gh holds a token for a remote, probing its AUTHORITY before its bare host.
+/// gh's host registry is port-SENSITIVE (measured, gh 2.94: `--hostname github.com:443`
+/// exits 1 where the bare host exits 0), so a `gh auth login --hostname host:8443` user
+/// answers only to the authority. Either hit injects — the entries key on the authority
+/// regardless, and gh's helper re-resolves the host itself when git invokes it.
+async fn gh_authenticated_for(authority: &str, host: &str) -> bool {
+    (authority != host && gh_authenticated(authority).await) || gh_authenticated(host).await
 }
 
 /// Whether gh has a STORED token for `host` — the gate deciding whether to inject the
@@ -800,7 +819,10 @@ fn github_credential_entry(host: &str, gh_path: &str) -> String {
 ///
 /// SECURITY: `gh auth token`'s stdout IS the user's token — only the exit code is
 /// read; the output is dropped and never logged or formatted anywhere.
-async fn gh_authenticated(host: &str) -> bool {
+///
+/// `host` must be spelled as gh has it registered: the registry is port-SENSITIVE
+/// (case-insensitive), so a ported host answers only to its full `host:port` authority.
+pub(super) async fn gh_authenticated(host: &str) -> bool {
     if let Some(hit) = auth_cache_get(host, GH_AUTH_TTL) {
         return hit;
     }
@@ -1287,6 +1309,9 @@ mod tests {
             entries[1],
             "credential.https://github.com.helper=!\"/abs/gh\" auth git-credential"
         );
+        // No host is special-cased: a port rides through on the canonical host too.
+        let ported = github_credential_entries("github.com:8443", "/abs/gh");
+        assert_eq!(ported[0], "credential.https://github.com:8443.helper=");
     }
 
     #[test]
@@ -1298,6 +1323,54 @@ mod tests {
             entries[1],
             "credential.https://github.example.com.helper=!\"/abs/gh\" auth git-credential"
         );
+        // A ported GHES keys on the authority — git won't match a portless key.
+        let ported = github_credential_entries("github.example.com:8443", "/abs/gh");
+        assert_eq!(ported[0], "credential.https://github.example.com:8443.helper=");
+        assert_eq!(
+            ported[1],
+            "credential.https://github.example.com:8443.helper=!\"/abs/gh\" auth git-credential"
+        );
+    }
+
+    // The auth cache is a process-wide static and `gh_authenticated` reads it before
+    // spawning, so priming it makes these hermetic (distinct host keys per test).
+    #[tokio::test]
+    async fn ported_authority_passes_the_gate_the_bare_host_fails() {
+        // The blocker case: `gh auth login --hostname ghes-p.example.com:8443` registers
+        // ONLY the authority, so a bare-host-only gate would inject nothing.
+        auth_cache_put("ghes-p.example.com:8443", true);
+        auth_cache_put("ghes-p.example.com", false);
+        assert!(gh_authenticated_for("ghes-p.example.com:8443", "ghes-p.example.com").await);
+    }
+
+    #[tokio::test]
+    async fn bare_host_still_passes_when_only_it_is_registered() {
+        // The reverse spelling: registered portless, remote written with a port.
+        auth_cache_put("ghes-b.example.com:8443", false);
+        auth_cache_put("ghes-b.example.com", true);
+        assert!(gh_authenticated_for("ghes-b.example.com:8443", "ghes-b.example.com").await);
+    }
+
+    #[tokio::test]
+    async fn neither_spelling_registered_fails_the_gate() {
+        auth_cache_put("ghes-n.example.com:8443", false);
+        auth_cache_put("ghes-n.example.com", false);
+        assert!(!gh_authenticated_for("ghes-n.example.com:8443", "ghes-n.example.com").await);
+    }
+
+    #[test]
+    fn ported_remote_keys_on_authority_and_keeps_the_bare_host_for_the_gate() {
+        // Both spellings are derived: the key is always the authority, while the gate
+        // needs the bare host as its fallback probe.
+        let url = "https://github.example.com:8443/o/r.git";
+        assert_eq!(crate::forge::remote_host(url).as_deref(), Some("github.example.com"));
+        assert_eq!(
+            crate::forge::remote_authority(url).as_deref(),
+            Some("github.example.com:8443"),
+        );
+        let entries =
+            github_credential_entries(&crate::forge::remote_authority(url).unwrap(), "/abs/gh");
+        assert_eq!(entries[0], "credential.https://github.example.com:8443.helper=");
     }
 
     // --- gh-auth TTL cache (mirrors remote.rs's cache tests). Distinct host keys

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -177,14 +177,22 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
     let glab = crate::agent::resolve_named(&["glab"], None)
         .await
         .ok_or(AppError::GlabNotFound)?;
+    // The gate takes the BARE host (glab's `hosts:` keys are port-stripped), the KEY the
+    // authority — git won't match a portless credential key against a ported request, so
+    // a self-managed host on `:8443` would silently never see glab's token.
     let host = crate::forge::remote_host(clone_url).unwrap_or_else(|| "gitlab.com".to_string());
+    let authority =
+        crate::forge::remote_authority(clone_url).unwrap_or_else(|| "gitlab.com".to_string());
     // glab's signed-in hosts are the `hosts:` keys of its config.yml (written by
     // `glab auth login`) — the established repo signal, not a new `glab auth
     // status` probe. No entry → inject nothing; git's ambient helpers still run.
     if !crate::forge::glab::known_hosts().await.contains(&host) {
         return Ok(Vec::new());
     }
-    Ok(gitlab_credential_entries(&host, &glab.display().to_string()))
+    Ok(gitlab_credential_entries(
+        &authority,
+        &glab.display().to_string(),
+    ))
 }
 
 /// The one-shot `-c` credential entries for a signed-in GitLab host — a
@@ -192,11 +200,12 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
 /// URL (empty value clears the helper list per gitcredentials(7); the trailing `=`
 /// is load-bearing — `-c name` without it sets boolean `true`), entry[1] installs
 /// glab as the sole helper so no ambient helper can shadow it. Reset MUST come
-/// first — consumers prefix `-c` pairs in Vec order. Pure/format-only.
-fn gitlab_credential_entries(host: &str, glab_path: &str) -> Vec<String> {
+/// first — consumers prefix `-c` pairs in Vec order. `authority` is `host[:port]`, not
+/// a bare host: git matches credential keys by authority. Pure/format-only.
+fn gitlab_credential_entries(authority: &str, glab_path: &str) -> Vec<String> {
     vec![
-        format!("credential.https://{host}.helper="),
-        format!("credential.https://{host}.helper=!\"{glab_path}\" auth git-credential"),
+        format!("credential.https://{authority}.helper="),
+        format!("credential.https://{authority}.helper=!\"{glab_path}\" auth git-credential"),
     ]
 }
 
@@ -5044,7 +5053,14 @@ pub async fn publish_repo(
 
     // A push failure after this point self-recovers: origin exists, so the repo
     // flips GitLab-ready and the normal Push button takes over.
-    let config = clone_credential_config(&project.http_url_to_repo).await?;
+    // A plain-http instance can only get inert `credential.https://…` entries, so skip
+    // the injection — and with it a hard `GlabNotFound` that would block the push for
+    // nothing. The https path keeps `?`: glab got us this far, so its absence is real.
+    let config = if crate::forge::is_https_remote(&project.http_url_to_repo) {
+        clone_credential_config(&project.http_url_to_repo).await?
+    } else {
+        Vec::new()
+    };
     let mut push_args: Vec<&str> = Vec::new();
     for entry in &config {
         push_args.push("-c");
@@ -5179,7 +5195,12 @@ pub async fn create_mr(
     // An MR needs the branch on the remote first.
     let origin =
         crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await?;
-    let config = clone_credential_config(&origin).await?;
+    // Same http gate as `publish_repo`: inert entries aren't worth a hard `GlabNotFound`.
+    let config = if crate::forge::is_https_remote(&origin) {
+        clone_credential_config(&origin).await?
+    } else {
+        Vec::new()
+    };
     let mut push_args: Vec<&str> = Vec::new();
     for entry in &config {
         push_args.push("-c");
@@ -8410,6 +8431,9 @@ mod tests {
             entries[1],
             "credential.https://gitlab.com.helper=!\"/abs/glab\" auth git-credential"
         );
+        // No host is special-cased: a port rides through on the canonical host too.
+        let ported = gitlab_credential_entries("gitlab.com:8443", "/abs/glab");
+        assert_eq!(ported[0], "credential.https://gitlab.com:8443.helper=");
     }
 
     #[test]
@@ -8421,6 +8445,28 @@ mod tests {
             entries[1],
             "credential.https://gitlab.example.com.helper=!\"/abs/glab\" auth git-credential"
         );
+        // A ported instance keys on the authority — git won't match a portless key.
+        let ported = gitlab_credential_entries("gitlab.example.com:8443", "/abs/glab");
+        assert_eq!(ported[0], "credential.https://gitlab.example.com:8443.helper=");
+        assert_eq!(
+            ported[1],
+            "credential.https://gitlab.example.com:8443.helper=!\"/abs/glab\" auth git-credential"
+        );
+    }
+
+    #[test]
+    fn ported_remote_gates_on_bare_host_but_keys_on_authority() {
+        // The trap `clone_credential_config` threads: glab's `hosts:` keys are
+        // port-stripped, so the gate needs the bare host while the key needs the port.
+        let url = "https://gitlab.example.com:8443/g/s/r.git";
+        assert_eq!(crate::forge::remote_host(url).as_deref(), Some("gitlab.example.com"));
+        assert_eq!(
+            crate::forge::remote_authority(url).as_deref(),
+            Some("gitlab.example.com:8443"),
+        );
+        let entries =
+            gitlab_credential_entries(&crate::forge::remote_authority(url).unwrap(), "/abs/glab");
+        assert_eq!(entries[0], "credential.https://gitlab.example.com:8443.helper=");
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -186,6 +186,10 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
     // glab's signed-in hosts are the `hosts:` keys of its config.yml (written by
     // `glab auth login`) — the established repo signal, not a new `glab auth
     // status` probe. No entry → inject nothing; git's ambient helpers still run.
+    // Gate is bare-only (our reader port-strips these keys), so a bare-registered glab
+    // passes it yet serves a ported remote nothing — measured on glab 1.105:
+    // `auth git-credential get` with `host=gitlab.com:8443` answers EMPTY at exit 0. Fine:
+    // a ported instance needs a ported login anyway, and the funnel keeps its ambient retry.
     if !crate::forge::glab::known_hosts().await.contains(&host) {
         return Ok(Vec::new());
     }
@@ -201,8 +205,14 @@ pub async fn clone_credential_config(clone_url: &str) -> AppResult<Vec<String>> 
 /// is load-bearing — `-c name` without it sets boolean `true`), entry[1] installs
 /// glab as the sole helper so no ambient helper can shadow it. Reset MUST come
 /// first — consumers prefix `-c` pairs in Vec order. `authority` is `host[:port]`, not
-/// a bare host: git matches credential keys by authority. Pure/format-only.
+/// a bare host: git matches credential keys by authority. A crafted remote can drive
+/// characters git reads as config syntax through the URL parse, so an authority failing
+/// [`crate::forge::is_safe_authority`] emits NOTHING — git falls back to ambient helpers
+/// rather than to an injected one. Pure/format-only.
 fn gitlab_credential_entries(authority: &str, glab_path: &str) -> Vec<String> {
+    if !crate::forge::is_safe_authority(authority) {
+        return Vec::new();
+    }
     vec![
         format!("credential.https://{authority}.helper="),
         format!("credential.https://{authority}.helper=!\"{glab_path}\" auth git-credential"),
@@ -8467,6 +8477,15 @@ mod tests {
         let entries =
             gitlab_credential_entries(&crate::forge::remote_authority(url).unwrap(), "/abs/glab");
         assert_eq!(entries[0], "credential.https://gitlab.example.com:8443.helper=");
+    }
+
+    #[test]
+    fn a_crafted_authority_emits_no_entries_at_all() {
+        // Fail OPEN to ambient rather than installing an attacker's `!`-shell helper.
+        assert!(
+            gitlab_credential_entries("gitlab.com:443.helper=!evil #", "/abs/glab").is_empty()
+        );
+        assert!(gitlab_credential_entries("gitlab.com;evil", "/abs/glab").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/forge/jira.rs
+++ b/src-tauri/src/forge/jira.rs
@@ -1572,7 +1572,7 @@ async fn discover_field_map(
         field_names: Some(names),
         resolved_at: now_iso(),
     };
-    crate::jira_field_maps::put(site, entry.clone());
+    crate::jira_field_maps::put(site, entry.clone()).await;
     Some(entry)
 }
 

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -60,9 +60,10 @@ fn is_port(s: &str) -> bool {
 
 /// Whether a string is safe to interpolate as the authority of a `credential.https://…`
 /// config key or a `--hostname` argv: host `[A-Za-z0-9.-]+` plus an optional numeric
-/// port. Backend sibling of `isReconnectHostSafe` (`src/lib/git/host.ts`) — same class of
-/// crafted-remote guard, since `remote_host`/`remote_authority` only split on `/` and `:`
-/// and a crafted remote can carry `=`, `;`, `$`, or a space through them.
+/// port. THE reconnect/credential host grammar — `valid_reconnect_host` delegates here
+/// and `isReconnectHostSafe` (`src/lib/git/host.ts`) mirrors it, so the three can't
+/// drift. Needed because `remote_host`/`remote_authority` only split on `/` and `:`, so
+/// a crafted remote can carry `=`, `;`, `$`, or a space through them.
 pub(crate) fn is_safe_authority(value: &str) -> bool {
     let (host, port) = match value.split_once(':') {
         Some((h, p)) => (h, Some(p)),

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -51,8 +51,33 @@ pub(crate) fn remote_host(url: &str) -> Option<String> {
     (!host.is_empty()).then(|| host.to_ascii_lowercase())
 }
 
+/// A TCP port as a URL spells one: 1-5 ASCII digits. Deliberately not range-checked —
+/// git and the CLIs reject an out-of-range port themselves; this only has to guarantee
+/// the segment carries no config or shell syntax.
+fn is_port(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 5 && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Whether a string is safe to interpolate as the authority of a `credential.https://…`
+/// config key or a `--hostname` argv: host `[A-Za-z0-9.-]+` plus an optional numeric
+/// port. Backend sibling of `isReconnectHostSafe` (`src/lib/git/host.ts`) — same class of
+/// crafted-remote guard, since `remote_host`/`remote_authority` only split on `/` and `:`
+/// and a crafted remote can carry `=`, `;`, `$`, or a space through them.
+pub(crate) fn is_safe_authority(value: &str) -> bool {
+    let (host, port) = match value.split_once(':') {
+        Some((h, p)) => (h, Some(p)),
+        None => (value, None),
+    };
+    if host.is_empty() || !host.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-')
+    {
+        return false;
+    }
+    port.is_none_or(is_port)
+}
+
 /// The `host[:port]` AUTHORITY of a remote URL — [`remote_host`] plus the port it
-/// drops. Host lowercased, port verbatim; `None` on no parseable host. Three
+/// drops, when that port is one (see [`is_port`]); a non-numeric segment is not a port
+/// and yields the bare host. Host lowercased; `None` on no parseable host. Three
 /// URL-decomposition idioms live here and each has one job: `remote_host` (bare host)
 /// for gates, routing and detection; `remote_authority` for credential-helper keys;
 /// [`fork_url_from_origin`]'s path-splice for preserving a whole URL.
@@ -61,10 +86,10 @@ pub(crate) fn remote_host(url: &str) -> Option<String> {
 /// scp syntax has no port slot (ported SSH uses `ssh://`), and ssh remotes never reach
 /// the https-gated credential paths anyway.
 ///
-/// Returned verbatim, no `:443` special-casing: measured against git 2.51 (`git
-/// credential fill`, isolated config), a `host:port` key matches a ported request, git
-/// normalizes the DEFAULT port both directions, and a portless key does NOT match a
-/// `:8443` request — so the authority is the only key that always matches.
+/// A real port is returned as written, no `:443` special-casing: measured against git
+/// 2.51 (`git credential fill`, isolated config), a `host:port` key matches a ported
+/// request, git normalizes the DEFAULT port both directions, and a portless key does NOT
+/// match a `:8443` request — so the authority is the only key that always matches.
 pub(crate) fn remote_authority(url: &str) -> Option<String> {
     let url = url.trim();
     let (had_scheme, rest) = match url.split_once("://") {
@@ -82,9 +107,12 @@ pub(crate) fn remote_authority(url: &str) -> Option<String> {
         authority.split(':').next().unwrap_or("")
     };
     let (host, port) = match authority.split_once(':') {
-        Some((h, p)) if !p.is_empty() => (h, Some(p)),
-        // A degenerate empty port (`https://host:/path`) drops the `:` entirely: a
-        // trailing-colon key matches no request and would diverge from the bare-host gate.
+        // Only a real 1-5 digit port is carried. Anything else — an empty port, a mangled
+        // IPv6 fragment, or a crafted `443.helper=!cmd #` — falls back to the bare host:
+        // this string is interpolated into a `-c credential.https://…` key, and git splits
+        // a `-c` at its FIRST `=`, so a non-numeric port smuggles an attacker-chosen
+        // `!`-shell helper onto a key that still matches the real host.
+        Some((h, p)) if is_port(p) => (h, Some(p)),
         Some((h, _)) => (h, None),
         None => (authority, None),
     };
@@ -3990,8 +4018,45 @@ mod tests {
             remote_authority("https://gitlab.example.com:/g/r.git").as_deref(),
             Some("gitlab.example.com"),
         );
+        // The full 5-digit range is a real port and survives.
+        assert_eq!(
+            remote_authority("https://gitlab.acme.com:65535/g/r.git").as_deref(),
+            Some("gitlab.acme.com:65535"),
+        );
+        // A non-numeric port is not a port — fall back to the bare host.
+        assert_eq!(
+            remote_authority("https://gitlab.acme.com:8443x/g/r.git").as_deref(),
+            Some("gitlab.acme.com"),
+        );
         // No host → None (local path).
         assert_eq!(remote_authority("/local/path"), None);
+    }
+
+    #[test]
+    fn a_crafted_port_segment_never_reaches_a_credential_key() {
+        // A remote URL any opened repo's .git/config can carry. git splits a `-c` at its
+        // FIRST `=`, so keeping this port verbatim would key an attacker-chosen `!`-shell
+        // helper on `credential.https://github.com:443` — which matches plain github.com.
+        let poisoned = "https://github.com:443.helper=!evil #/o/r.git";
+        assert_eq!(remote_authority(poisoned).as_deref(), Some("github.com"));
+        // The gate's own spelling is unchanged, so the two agree again.
+        assert_eq!(remote_host(poisoned).as_deref(), Some("github.com"));
+    }
+
+    #[test]
+    fn is_safe_authority_admits_hosts_and_numeric_ports_only() {
+        assert!(is_safe_authority("github.com"));
+        assert!(is_safe_authority("gitlab.acme-corp.com:8443"));
+        assert!(is_safe_authority("gitlab.acme.com:65535"));
+        // Config/shell syntax a crafted remote can carry through the URL parse.
+        assert!(!is_safe_authority("github.com:443.helper=!evil #"));
+        assert!(!is_safe_authority("github.com;rm -rf /"));
+        assert!(!is_safe_authority("github.com:8443x"));
+        assert!(!is_safe_authority("git hub.com"));
+        assert!(!is_safe_authority("host:"));
+        assert!(!is_safe_authority("host:123456"));
+        assert!(!is_safe_authority(":8443"));
+        assert!(!is_safe_authority(""));
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -941,8 +941,8 @@ pub async fn forge_clone(
     // stored token → URL and behavior untouched (ambient auth still works).
     let mut clone_url = url;
     // The helper entries key on `credential.https://…`, so a non-https URL can only get
-    // inert config — and for GitLab a hard `GlabNotFound` on top. Both arms fail open:
-    // ambient auth or a public repo must still clone when the CLI is absent.
+    // inert config — the gate skips that plus the CLI-resolve probes. Both arms fail
+    // open: ambient auth or a public repo must still clone when the CLI is absent.
     let https = is_https_remote(&clone_url);
     let extra = match provider {
         Provider::GitLab if https => {

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -51,6 +51,53 @@ pub(crate) fn remote_host(url: &str) -> Option<String> {
     (!host.is_empty()).then(|| host.to_ascii_lowercase())
 }
 
+/// The `host[:port]` AUTHORITY of a remote URL — [`remote_host`] plus the port it
+/// drops. Host lowercased, port verbatim; `None` on no parseable host. Three
+/// URL-decomposition idioms live here and each has one job: `remote_host` (bare host)
+/// for gates, routing and detection; `remote_authority` for credential-helper keys;
+/// [`fork_url_from_origin`]'s path-splice for preserving a whole URL.
+///
+/// scp form (`git@host:path`) yields the BARE host — that `:` is a path separator and
+/// scp syntax has no port slot (ported SSH uses `ssh://`), and ssh remotes never reach
+/// the https-gated credential paths anyway.
+///
+/// Returned verbatim, no `:443` special-casing: measured against git 2.51 (`git
+/// credential fill`, isolated config), a `host:port` key matches a ported request, git
+/// normalizes the DEFAULT port both directions, and a portless key does NOT match a
+/// `:8443` request — so the authority is the only key that always matches.
+pub(crate) fn remote_authority(url: &str) -> Option<String> {
+    let url = url.trim();
+    let (had_scheme, rest) = match url.split_once("://") {
+        Some((_, after)) => (true, after),
+        None => (false, url),
+    };
+    // Drop an optional `user@` (rsplit so `user@host` keeps `host`).
+    let rest = rest.rsplit_once('@').map_or(rest, |(_, host)| host);
+    // The authority ends at the first `/`; without a scheme the remaining `:` is scp's
+    // path separator, so trim there too.
+    let authority = rest.split('/').next().unwrap_or("");
+    let authority = if had_scheme {
+        authority
+    } else {
+        authority.split(':').next().unwrap_or("")
+    };
+    let (host, port) = match authority.split_once(':') {
+        Some((h, p)) if !p.is_empty() => (h, Some(p)),
+        // A degenerate empty port (`https://host:/path`) drops the `:` entirely: a
+        // trailing-colon key matches no request and would diverge from the bare-host gate.
+        Some((h, _)) => (h, None),
+        None => (authority, None),
+    };
+    if host.is_empty() {
+        return None;
+    }
+    let host = host.to_ascii_lowercase();
+    Some(match port {
+        Some(port) => format!("{host}:{port}"),
+        None => host,
+    })
+}
+
 /// The `owner/name` (or `group/subgroup/name`) path of a remote URL — the part
 /// after the host, with any `.git` suffix and surrounding slashes trimmed.
 /// Complements [`remote_host`]; `None` when there's no path. Handles both
@@ -243,7 +290,7 @@ pub(crate) async fn detect_non_github(repo_path: &str) -> Option<(Provider, Stri
     None
 }
 
-/// The one-shot `-c credential.https://<host>.helper` entries authenticating a
+/// The one-shot `-c credential.https://<authority>.helper` entries authenticating a
 /// network op on `remote`, resolved to the provider CLI's ABSOLUTE path. The
 /// provider comes from the REQUESTED remote's own host, so a cross-forge
 /// origin/upstream pair each gets the right CLI's helper.
@@ -319,9 +366,13 @@ fn provider_for_remote_host(host: &str, glab_hosts: &[String]) -> Option<Provide
 /// True when a remote URL uses HTTPS (credential helpers apply). SSH forms
 /// (`git@host:…`, `ssh://…`) and others return false — as does plain `http://`,
 /// since the helper entry we format keys on `credential.https://…` and would
-/// never match an http remote anyway.
+/// never match an http remote anyway. The scheme is matched case-insensitively —
+/// schemes are case-insensitive per RFC 3986, and a `HTTPS://` remote that read as
+/// non-https would silently skip the helper injection.
 fn is_https_remote(url: &str) -> bool {
-    url.trim().starts_with("https://")
+    url.trim()
+        .get(..8)
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("https://"))
 }
 
 /// The provider tag the frontend keys labels on (`"github"`/`"gitlab"`/
@@ -845,9 +896,9 @@ pub async fn forge_provider_features(provider: Provider) -> AppResult<ProviderFe
 
 /// Clone a repo, supplying provider auth that plain `git clone` lacks. A private
 /// GitLab repo needs glab's token, injected as a ONE-SHOT `git -c` credential helper
-/// (no persistent config, no token in the URL) — glab IS GitLab's auth path, so that
-/// arm stays strict. GitHub gets the same one-shot gh helper when gh is present but
-/// falls open to git's ambient auth when it isn't. Returns the path.
+/// (no persistent config, no token in the URL); GitHub gets the same one-shot gh
+/// helper. Both fall open to git's ambient auth when their CLI is absent. Returns the
+/// path.
 #[tauri::command]
 pub async fn forge_clone(
     provider: Provider,
@@ -860,9 +911,18 @@ pub async fn forge_clone(
     // what finds the sentinel-account seed — and interactive helpers suppressed. No
     // stored token → URL and behavior untouched (ambient auth still works).
     let mut clone_url = url;
+    // The helper entries key on `credential.https://…`, so a non-https URL can only get
+    // inert config — and for GitLab a hard `GlabNotFound` on top. Both arms fail open:
+    // ambient auth or a public repo must still clone when the CLI is absent.
+    let https = is_https_remote(&clone_url);
     let extra = match provider {
-        Provider::GitLab => gitlab::clone_credential_config(&clone_url).await?,
-        Provider::GitHub => github::clone_credential_config(&clone_url).await.unwrap_or_default(),
+        Provider::GitLab if https => {
+            gitlab::clone_credential_config(&clone_url).await.unwrap_or_default()
+        }
+        Provider::GitHub if https => {
+            github::clone_credential_config(&clone_url).await.unwrap_or_default()
+        }
+        Provider::GitLab | Provider::GitHub => Vec::new(),
         Provider::Bitbucket => {
             if bitbucket::seed_git_credential().await {
                 clone_url = bitbucket::strip_https_userinfo(&clone_url);
@@ -3894,12 +3954,57 @@ mod tests {
     }
 
     #[test]
+    fn remote_authority_keeps_the_port_remote_host_drops() {
+        // The whole point: a non-default port survives, verbatim.
+        assert_eq!(
+            remote_authority("https://gitlab.acme.com:8443/g/s/r.git").as_deref(),
+            Some("gitlab.acme.com:8443"),
+        );
+        // No port → identical to `remote_host`.
+        assert_eq!(
+            remote_authority("https://github.com/o/r").as_deref(),
+            Some("github.com"),
+        );
+        // An explicit default port is kept as written — git normalizes it either way.
+        assert_eq!(
+            remote_authority("https://gitlab.acme.com:443/g/r.git").as_deref(),
+            Some("gitlab.acme.com:443"),
+        );
+        // scp form: the `:` is a PATH separator, never a port.
+        assert_eq!(
+            remote_authority("git@github.com:o/r.git").as_deref(),
+            Some("github.com"),
+        );
+        // Userinfo is dropped, port kept.
+        assert_eq!(
+            remote_authority("https://user@gitlab.acme.com:8443/g/r.git").as_deref(),
+            Some("gitlab.acme.com:8443"),
+        );
+        // Scheme case doesn't matter; the host lowercases, the port rides along.
+        assert_eq!(
+            remote_authority("HTTPS://GitLab.Acme.com:8443/g/r").as_deref(),
+            Some("gitlab.acme.com:8443"),
+        );
+        // A degenerate empty port drops the `:`, matching the gate's bare host.
+        assert_eq!(
+            remote_authority("https://gitlab.example.com:/g/r.git").as_deref(),
+            Some("gitlab.example.com"),
+        );
+        // No host → None (local path).
+        assert_eq!(remote_authority("/local/path"), None);
+    }
+
+    #[test]
     fn is_https_remote_distinguishes_https_from_ssh() {
         assert!(is_https_remote("https://github.com/o/r.git"));
         assert!(!is_https_remote("git@github.com:o/r.git"));
         assert!(!is_https_remote("ssh://git@github.com/o/r.git"));
         // Plain http never matches the https-keyed helper entry we format.
         assert!(!is_https_remote("http://github.example.com/o/r.git"));
+        // Schemes are case-insensitive; `HTTPS://` is still https.
+        assert!(is_https_remote("HTTPS://github.com/o/r.git"));
+        assert!(is_https_remote("  HttPs://github.com/o/r.git  "));
+        assert!(!is_https_remote("HTTP://github.example.com/o/r.git"));
     }
 
     #[test]

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -131,13 +131,25 @@ pub async fn forge_session_health(repo_path: String) -> AppResult<SessionHealth>
 }
 
 /// The GitHub host for a repo, from its `origin` URL when parseable, else
-/// `github.com`. Deliberately no `gh repo view` — that's a network round-trip this
-/// cheap health check must avoid; the origin host is enough to scope `gh auth status`.
+/// `github.com` — as gh spells it, so a ported remote resolves to the `host:port`
+/// authority gh registered it under. Deliberately no `gh repo view` — that's a network
+/// round-trip this cheap health check must avoid; the extra probe on a ported remote is
+/// gh's local-only, memoized `auth token`.
 async fn github_host_for_repo(repo_path: &str) -> String {
-    match crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await {
-        Ok(url) => crate::forge::remote_host(&url).unwrap_or_else(|| "github.com".to_string()),
-        Err(_) => "github.com".to_string(),
+    let Ok(url) =
+        crate::git::remote::git_remote_url(repo_path.to_string(), "origin".to_string()).await
+    else {
+        return "github.com".to_string();
+    };
+    let host = crate::forge::remote_host(&url).unwrap_or_else(|| "github.com".to_string());
+    let authority = crate::forge::remote_authority(&url).unwrap_or_else(|| "github.com".to_string());
+    // gh registers a ported host under its full authority, so `--hostname <bare>` would
+    // report a signed-in ported GHES as signed-out. Prefer the authority when gh knows
+    // it — the same string then keys the `auth status --json hosts` map.
+    if authority != host && crate::forge::github::gh_authenticated(&authority).await {
+        return authority;
     }
+    host
 }
 
 // ── forge_accounts_health (account-scoped) ──────────────────────────────────────

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -143,13 +143,23 @@ async fn github_host_for_repo(repo_path: &str) -> String {
     };
     let host = crate::forge::remote_host(&url).unwrap_or_else(|| "github.com".to_string());
     let authority = crate::forge::remote_authority(&url).unwrap_or_else(|| "github.com".to_string());
-    // gh registers a ported host under its full authority, so `--hostname <bare>` would
-    // report a signed-in ported GHES as signed-out. Prefer the authority when gh knows
-    // it — the same string then keys the `auth status --json hosts` map.
-    if authority != host && crate::forge::github::gh_authenticated(&authority).await {
+    // Both spellings come from a crafted-able remote URL and go straight into argv, so
+    // neither ships unvalidated; an unsafe one reads as the default host, matching what an
+    // unparseable origin already does.
+    if authority != host
+        && crate::forge::is_safe_authority(&authority)
+        && crate::forge::github::gh_authenticated(&authority).await
+    {
+        // gh registers a ported host under its full authority, so `--hostname <bare>`
+        // would report a signed-in ported GHES as signed-out. The same string then keys
+        // the `auth status --json hosts` map.
         return authority;
     }
-    host
+    if crate::forge::is_safe_authority(&host) {
+        host
+    } else {
+        "github.com".to_string()
+    }
 }
 
 // ── forge_accounts_health (account-scoped) ──────────────────────────────────────

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -143,9 +143,9 @@ async fn github_host_for_repo(repo_path: &str) -> String {
     };
     let host = crate::forge::remote_host(&url).unwrap_or_else(|| "github.com".to_string());
     let authority = crate::forge::remote_authority(&url).unwrap_or_else(|| "github.com".to_string());
-    // Both spellings come from a crafted-able remote URL and go straight into argv, so
-    // neither ships unvalidated; an unsafe one reads as the default host, matching what an
-    // unparseable origin already does.
+    // Only the ported spelling is gated — it is the one this function SYNTHESIZES, and a
+    // rejected one must fall back rather than be probed. The parsed host passes through as
+    // read: substituting a default would report a different host's session as this repo's.
     if authority != host
         && crate::forge::is_safe_authority(&authority)
         && crate::forge::github::gh_authenticated(&authority).await
@@ -155,11 +155,7 @@ async fn github_host_for_repo(repo_path: &str) -> String {
         // the `auth status --json hosts` map.
         return authority;
     }
-    if crate::forge::is_safe_authority(&host) {
-        host
-    } else {
-        "github.com".to_string()
-    }
+    host
 }
 
 // ── forge_accounts_health (account-scoped) ──────────────────────────────────────
@@ -792,14 +788,13 @@ impl Drop for ReconnectGuard {
     }
 }
 
-/// A reconnect host must be a bare hostname: no port, no scheme, no path. Narrow
-/// on purpose — the value becomes a `--hostname` argument, and the CLIs key their
-/// stored credentials by exactly this spelling.
+/// A reconnect host is a hostname with an optional numeric port — no scheme, no path,
+/// no shell syntax. The port is allowed because `gh auth login --hostname host:8443` is
+/// exactly how a ported instance registers, and the value becomes a `--hostname`
+/// argument the CLIs key their stored credentials by. One grammar, shared with the
+/// credential-key guard so the two can't drift.
 fn valid_reconnect_host(host: &str) -> bool {
-    !host.is_empty()
-        && host
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+    crate::forge::is_safe_authority(host)
 }
 
 /// The most extra scopes one reconnect may request — a scope hint asks for one, and
@@ -1854,11 +1849,14 @@ mod tests {
     }
 
     #[test]
-    fn reconnect_host_grammar_stays_bare() {
+    fn reconnect_host_grammar_allows_a_numeric_port_only() {
         assert!(valid_reconnect_host("github.com"));
         assert!(valid_reconnect_host("gitlab.example-corp.com"));
+        // A ported instance registers with gh/glab under `host:port`, so the reconnect
+        // flow must accept the same spelling the health check reports.
+        assert!(valid_reconnect_host("gitlab.example.com:8443"));
         assert!(!valid_reconnect_host("")); // empty
-        assert!(!valid_reconnect_host("gitlab.example.com:8443")); // port
+        assert!(!valid_reconnect_host("gitlab.example.com:8443x")); // not a port
         assert!(!valid_reconnect_host("https://gitlab.example.com")); // scheme
         assert!(!valid_reconnect_host("gitlab.example.com/path")); // path
         assert!(!valid_reconnect_host("host --flag")); // argv injection

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -265,7 +265,7 @@ pub(crate) async fn git_rename_branch_core(
     // gap as the commit-draft migration. Cold-start test mode is out of reach too — the
     // GUI aliases its store file there (`storeName` in src/lib/test-mode.ts).
     let identity = crate::git::repo::repo_identity(&repo_path).await;
-    if let Err(e) = crate::review_notes::rename_branch(&identity, &old_name, &new_name) {
+    if let Err(e) = crate::review_notes::rename_branch(&identity, &old_name, &new_name).await {
         eprintln!("gitdesktop: reviewer-note rename failed (branch renamed anyway): {e}");
     }
     Ok(())
@@ -1729,6 +1729,7 @@ mod tests {
 
         let identity = crate::git::repo::repo_identity(&repo_s).await;
         crate::review_notes::set(&identity, "feature", "look at the migration")
+            .await
             .expect("deposit the note");
 
         let state = AppState::default();

--- a/src-tauri/src/jira_field_maps.rs
+++ b/src-tauri/src/jira_field_maps.rs
@@ -109,6 +109,14 @@ fn name_maps() -> &'static Mutex<HashMap<String, HashMap<String, String>>> {
     NAME_MAPS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Guards the whole read-modify-write of the persisted file within THIS process, outside
+/// the cross-process file lock — the [`crate::local_prs`] pairing exactly. Losing a write
+/// here only costs a rediscovery, but a torn interleave would drop another site's entry.
+fn write_lock() -> &'static Mutex<()> {
+    static WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    WRITE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Resolve the absolute path of `jira-field-maps.json` under the app-data dir. Mirrors
 /// [`crate::local_prs::store_path`] (same `dirs::data_dir()/<identifier>` root).
 fn store_path() -> Option<PathBuf> {
@@ -168,20 +176,36 @@ pub fn get(site: &str) -> Option<SiteFieldMap> {
     Some(entry)
 }
 
-/// Persist a discovered map for a site: read → modify → atomic write (the `local_prs`
-/// pattern, tolerant of concurrent GUI/MCP writers), and update the in-process cache. A
-/// write failure is swallowed (best-effort cache) after the in-process cache is set, so a
-/// warm process still answers from memory even if the disk write couldn't land. Never
-/// errors to the caller.
-pub fn put(site: &str, entry: SiteFieldMap) {
+/// Persist a discovered map for a site: read → modify → atomic write under both locks
+/// (the `local_prs` pattern — the GUI and MCP processes both write this file), and update
+/// the in-process cache. A write failure is swallowed (best-effort cache) after the
+/// in-process cache is set, so a warm process still answers from memory even if the disk
+/// write couldn't land. Never errors to the caller.
+///
+/// The cache is warmed FIRST, then the disk write runs off the async runtime: the
+/// cross-process lock blocks its calling thread for up to the retry budget, and this
+/// caller is a GUI Jira request, not a background job.
+pub async fn put(site: &str, entry: SiteFieldMap) {
     if let Ok(mut c) = cache().lock() {
         c.insert(site.to_string(), entry.clone());
     }
+    let site = site.to_string();
+    let _ = crate::store_lock::locked_store_task(move || {
+        put_sync(&site, &entry);
+        Ok(())
+    })
+    .await;
+}
+
+/// The locked read-modify-write behind [`put`], on the caller's own thread.
+fn put_sync(site: &str, entry: &SiteFieldMap) {
     let Some(path) = store_path() else {
         return;
     };
+    let _guard = write_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path);
-    let Ok(value) = serde_json::to_value(&entry) else {
+    let Ok(value) = serde_json::to_value(entry) else {
         return;
     };
     store.insert(site.to_string(), value);

--- a/src-tauri/src/local_issues.rs
+++ b/src-tauri/src/local_issues.rs
@@ -36,8 +36,15 @@
 //!
 //! The GUI holds this store in memory (`autoSave`), so every call here does a FRESH
 //! read → modify → atomic write. We never cache across calls.
+//!
+//! ## Concurrency
+//!
+//! Every read-modify-write holds the in-process [`ISSUES_LOCK`] and, inside it, the
+//! cross-process [`crate::store_lock`] — see [`crate::local_prs`]'s concurrency section
+//! for the contract and its known GUI-side limit, which applies identically here.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -64,10 +71,42 @@ struct NewLocalIssue {
     created_at: String,
 }
 
+/// Guards the whole read-modify-write of the shared store file within THIS process,
+/// outside the cross-process file lock — the [`crate::local_prs`] pairing exactly.
+fn issues_lock() -> &'static Mutex<()> {
+    static ISSUES_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ISSUES_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// In-process test override, consulted by [`store_path`] before the real app-data
+/// resolution — the ONLY seam a test may use to reach this store (mirrors
+/// [`crate::local_prs`]'s; never process env, which races parallel tests' env reads).
+#[cfg(test)]
+static TEST_STORE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Installs (or clears) the in-process override, returning the previous value so a caller
+/// can restore it. Test-only.
+#[cfg(test)]
+fn swap_test_store_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+    let mut slot = TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut *slot, dir)
+}
+
 /// Resolve the absolute path of the `local-issues.json` the frontend store writes.
 /// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
 /// (`dirs::data_dir()/<identifier>`) — see the module contract and [`crate::local_prs`].
+/// Under `cfg(test)` an installed [`TEST_STORE_DIR`] wins.
 pub(crate) fn store_path() -> AppResult<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return Ok(dir.join(STORE_FILE));
+    }
     let data = dirs::data_dir()
         .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
     Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
@@ -171,9 +210,18 @@ pub fn get(repo: &str, id: &str) -> AppResult<Value> {
 }
 
 /// Create a new local issue under `repo` and PREPEND it (matching the GUI). Returns the
-/// created record as a `Value`.
-pub fn create(repo: &str, title: &str, body: &str) -> AppResult<Value> {
+/// created record as a `Value`. The locked write runs off the async runtime — see
+/// [`crate::local_prs::create`] for why.
+pub async fn create(repo: &str, title: &str, body: &str) -> AppResult<Value> {
+    let (repo, title, body) = (repo.to_string(), title.to_string(), body.to_string());
+    crate::store_lock::locked_store_task(move || create_sync(&repo, &title, &body)).await
+}
+
+/// The locked read-modify-write behind [`create`], on the caller's own thread.
+fn create_sync(repo: &str, title: &str, body: &str) -> AppResult<Value> {
     let path = store_path()?;
+    let _guard = issues_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let record = NewLocalIssue {
         id: uuid::Uuid::new_v4().to_string(),
@@ -199,14 +247,25 @@ pub fn create(repo: &str, title: &str, body: &str) -> AppResult<Value> {
 }
 
 /// Locate the issue with `id` inside `repo`'s array and apply `mutate` to it in place,
-/// then persist. `mutate` receives the record as a mutable `Map` so it edits only the
-/// fields it means to — unknown fields on the record survive untouched. Errors if the
-/// repo has no entry or no issue with that id.
-fn mutate_issue<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
+/// then persist, off the async runtime (see [`create`]). `mutate` receives the record as
+/// a mutable `Map` so it edits only the fields it means to — unknown fields on the record
+/// survive untouched. Errors if the repo has no entry or no issue with that id.
+async fn mutate_issue<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
+where
+    F: FnOnce(&mut Map<String, Value>) -> AppResult<()> + Send + 'static,
+{
+    let (repo, id) = (repo.to_string(), id.to_string());
+    crate::store_lock::locked_store_task(move || mutate_issue_sync(&repo, &id, mutate)).await
+}
+
+/// The locked read-modify-write behind [`mutate_issue`], on the caller's own thread.
+fn mutate_issue_sync<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
 where
     F: FnOnce(&mut Map<String, Value>) -> AppResult<()>,
 {
     let path = store_path()?;
+    let _guard = issues_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let key = existing_key(&store, repo).ok_or_else(|| {
         AppError::Command(format!(
@@ -234,13 +293,13 @@ where
 
 /// Append a comment (`{ id, body, createdAt }`) to the issue with `id` under `repo`.
 /// Mirrors the frontend `LocalIssueComment` shape. Returns the updated record.
-pub fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
+pub async fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
     let comment = serde_json::json!({
         "id": uuid::Uuid::new_v4().to_string(),
         "body": body,
         "createdAt": now_iso(),
     });
-    mutate_issue(repo, id, |iss| {
+    mutate_issue(repo, id, move |iss| {
         let comments = iss
             .entry("comments")
             .or_insert_with(|| Value::Array(Vec::new()));
@@ -250,6 +309,7 @@ pub fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
             .push(comment);
         Ok(())
     })
+    .await
 }
 
 /// The status values a local issue may hold — mirrors the frontend `LocalIssueStatus`
@@ -260,7 +320,7 @@ pub const STATUSES: [&str; 2] = ["open", "closed"];
 /// `"closed"` a `closedAt` timestamp is stamped (matching the GUI's optional field);
 /// on `"open"` any prior `closedAt` is cleared. An unknown status is rejected with an
 /// actionable error listing the valid values. Returns the updated record.
-pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
+pub async fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
     if !STATUSES.contains(&status) {
         return Err(AppError::Command(format!(
             "status must be one of {:?} (got \"{status}\")",
@@ -277,6 +337,7 @@ pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
         iss.insert("status".to_string(), Value::String(status));
         Ok(())
     })
+    .await
 }
 
 /// Fold any local-issue records still stored under a legacy checkout-PATH key into the
@@ -285,8 +346,16 @@ pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
 /// keying so the GUI's and MCP's records land on the same key). `identity` is
 /// [`crate::git::repo::repo_identity`]'s output; `legacy` is the raw `--repo` path.
 /// Idempotent: a no-op once no distinct legacy key remains.
-pub fn consolidate(identity: &str, legacy: &str) -> AppResult<()> {
+pub async fn consolidate(identity: &str, legacy: &str) -> AppResult<()> {
+    let (identity, legacy) = (identity.to_string(), legacy.to_string());
+    crate::store_lock::locked_store_task(move || consolidate_sync(&identity, &legacy)).await
+}
+
+/// The locked read-modify-write behind [`consolidate`], on the caller's own thread.
+fn consolidate_sync(identity: &str, legacy: &str) -> AppResult<()> {
     let path = store_path()?;
+    let _guard = issues_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     if fold_legacy_key(&mut store, identity, legacy) {
         write_store(&path, &store)?;
@@ -348,8 +417,64 @@ mod tests {
         (dir, path)
     }
 
+    /// The store override is process-wide, so every test that installs one — or that
+    /// asserts on the un-overridden resolution — takes this lock. Poisoning is ignored:
+    /// the guarded state is one override slot, not invariant data.
+    static STORE_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+    fn store_dir_lock() -> std::sync::MutexGuard<'static, ()> {
+        STORE_DIR_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Points the store at `dir` for as long as it's held and restores the prior override
+    /// on drop — panics included, so a failing test can't leave one standing for whichever
+    /// test is next through the lock.
+    struct StoreDirOverride(Option<PathBuf>);
+
+    impl StoreDirOverride {
+        fn set(dir: &Path) -> Self {
+            Self(swap_test_store_dir(Some(dir.to_path_buf())))
+        }
+    }
+
+    impl Drop for StoreDirOverride {
+        fn drop(&mut self) {
+            swap_test_store_dir(self.0.take());
+        }
+    }
+
+    /// The public write path end to end — through `store_path`, both locks, and the
+    /// atomic write — which the pure-logic tests below deliberately bypass.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // override installed for the whole body. Sound because each `#[tokio::test]` owns a
+    // current-thread runtime with this one task on it.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn create_then_mutate_round_trips_through_the_locked_path() {
+        let _serialized = store_dir_lock();
+        let (tmp, _unused) = tmp_store();
+        let _override = StoreDirOverride::set(tmp.path());
+        let repo = "C:/local-issues/locked-round-trip/.git";
+
+        let created = create(repo, "Title", "Body").await.unwrap();
+        let id = created["id"].as_str().unwrap().to_string();
+
+        add_comment(repo, &id, "repro attached").await.unwrap();
+        let updated = set_status(repo, &id, "closed").await.unwrap();
+        assert_eq!(updated["status"], "closed");
+        assert!(updated["closedAt"].is_string());
+
+        let back = get(repo, &id).unwrap();
+        assert_eq!(back["title"], "Title");
+        assert_eq!(back["comments"][0]["body"], "repro attached");
+        assert_eq!(list(repo).unwrap().len(), 1);
+    }
+
     #[test]
     fn store_path_is_under_identifier_and_named() {
+        let _serialized = store_dir_lock();
         let path = store_path().unwrap();
         // …/com.thebguy.gitdesktop/local-issues.json
         assert!(path.ends_with(STORE_FILE), "path: {}", path.display());
@@ -552,12 +677,12 @@ mod tests {
         assert!(back[repo][0].get("closedAt").is_none());
     }
 
-    #[test]
-    fn statuses_reject_unknown_value() {
+    #[tokio::test]
+    async fn statuses_reject_unknown_value() {
         // The public set_status rejects an out-of-vocab status; the error lists the
         // valid ones. (Uses set_status directly — it fails before touching any file
         // because the vocab check is first.)
-        let err = set_status(r"C:\nope", "iss-1", "wip").unwrap_err();
+        let err = set_status(r"C:\nope", "iss-1", "wip").await.unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("open"), "msg: {msg}");
         assert!(msg.contains("closed"), "msg: {msg}");

--- a/src-tauri/src/local_prs.rs
+++ b/src-tauri/src/local_prs.rs
@@ -29,8 +29,20 @@
 //!
 //! The GUI holds this store in memory (`autoSave`), so every call here does a FRESH
 //! read → modify → atomic write. Never write from stale memory.
+//!
+//! ## Concurrency
+//!
+//! Two `gitdesktop mcp` servers can run at once (one per repo, or two on one repo), so
+//! every read-modify-write here holds the in-process [`PRS_LOCK`] and, inside it, the
+//! cross-process [`crate::store_lock`] — cheap exact serialization first, then the
+//! OS-level file lock, which fails open. `atomic_write` gives torn-file safety; the
+//! locks give lost-update safety. Known limit: the GUI writes this store through its own
+//! plugin-store cache and takes neither lock, so a GUI/MCP overlap can still lose an
+//! update — closing that needs the GUI's writes routed through Rust, as `review_notes`
+//! does.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -61,10 +73,46 @@ struct NewLocalPr {
     created_at: String,
 }
 
+/// Guards the whole read-modify-write of the shared store file within THIS process
+/// (mirroring [`crate::oplog`]'s lock). It sits OUTSIDE the cross-process file lock
+/// deliberately: same-process serialization is exact and free, where the file lock fails
+/// open after its retry budget.
+fn prs_lock() -> &'static Mutex<()> {
+    static PRS_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    PRS_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// In-process test override, consulted by [`store_path`] before the real app-data
+/// resolution — the ONLY seam a test may use to reach this store, and the reason an
+/// in-crate test can drive the public write fns without touching the developer's own
+/// records. In-process rather than an env var: mutating process env races every other
+/// test's env reads in the same binary (unsound, not merely flaky).
+#[cfg(test)]
+static TEST_STORE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Installs (or clears) the in-process override, returning the previous value so a caller
+/// can restore it. Test-only — [`TEST_STORE_DIR`] does not exist otherwise.
+#[cfg(test)]
+fn swap_test_store_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+    let mut slot = TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut *slot, dir)
+}
+
 /// Resolve the absolute path of the `local-prs.json` the frontend store writes.
 /// Mirrors `tauri-plugin-store` v2's `BaseDirectory::AppData` resolution
-/// (`dirs::data_dir()/<identifier>`) — see the module contract.
+/// (`dirs::data_dir()/<identifier>`) — see the module contract. Under `cfg(test)` an
+/// installed [`TEST_STORE_DIR`] wins.
 pub fn store_path() -> AppResult<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = TEST_STORE_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return Ok(dir.join(STORE_FILE));
+    }
     let data = dirs::data_dir()
         .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
     Ok(data.join(APP_IDENTIFIER).join(STORE_FILE))
@@ -174,8 +222,32 @@ pub fn get(repo: &str, id: &str) -> AppResult<Value> {
 /// Create a new local PR under `repo` and PREPEND it (matching the GUI). Returns the
 /// created record as a `Value`. The caller is responsible for having validated that
 /// `base`/`head` resolve as branches — this core only touches app data.
-pub fn create(repo: &str, title: &str, body: &str, base: &str, head: &str) -> AppResult<Value> {
+///
+/// The locked write runs off the async runtime: the cross-process lock blocks its calling
+/// thread for up to the retry budget, which must not park a tokio worker.
+pub async fn create(
+    repo: &str,
+    title: &str,
+    body: &str,
+    base: &str,
+    head: &str,
+) -> AppResult<Value> {
+    let (repo, title, body, base, head) = (
+        repo.to_string(),
+        title.to_string(),
+        body.to_string(),
+        base.to_string(),
+        head.to_string(),
+    );
+    crate::store_lock::locked_store_task(move || create_sync(&repo, &title, &body, &base, &head))
+        .await
+}
+
+/// The locked read-modify-write behind [`create`], on the caller's own thread.
+fn create_sync(repo: &str, title: &str, body: &str, base: &str, head: &str) -> AppResult<Value> {
     let path = store_path()?;
+    let _guard = prs_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let record = NewLocalPr {
         id: uuid::Uuid::new_v4().to_string(),
@@ -204,14 +276,25 @@ pub fn create(repo: &str, title: &str, body: &str, base: &str, head: &str) -> Ap
 }
 
 /// Locate the PR with `id` inside `repo`'s array and apply `mutate` to it in place,
-/// then persist. `mutate` receives the record as a mutable `Map` so it edits only the
-/// fields it means to — unknown fields on the record survive untouched. Errors if the
-/// repo has no entry or no PR with that id.
-fn mutate_pr<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
+/// then persist, off the async runtime (see [`create`]). `mutate` receives the record as
+/// a mutable `Map` so it edits only the fields it means to — unknown fields on the record
+/// survive untouched. Errors if the repo has no entry or no PR with that id.
+async fn mutate_pr<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
+where
+    F: FnOnce(&mut Map<String, Value>) -> AppResult<()> + Send + 'static,
+{
+    let (repo, id) = (repo.to_string(), id.to_string());
+    crate::store_lock::locked_store_task(move || mutate_pr_sync(&repo, &id, mutate)).await
+}
+
+/// The locked read-modify-write behind [`mutate_pr`], on the caller's own thread.
+fn mutate_pr_sync<F>(repo: &str, id: &str, mutate: F) -> AppResult<Value>
 where
     F: FnOnce(&mut Map<String, Value>) -> AppResult<()>,
 {
     let path = store_path()?;
+    let _guard = prs_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     let key = existing_key(&store, repo).ok_or_else(|| {
         AppError::Command(format!("no local PRs found for this repository (id {id})"))
@@ -237,13 +320,13 @@ where
 
 /// Append a comment (`{ id, body, createdAt }`) to the PR with `id` under `repo`.
 /// Returns the updated record.
-pub fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
+pub async fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
     let comment = serde_json::json!({
         "id": uuid::Uuid::new_v4().to_string(),
         "body": body,
         "createdAt": now_iso(),
     });
-    mutate_pr(repo, id, |pr| {
+    mutate_pr(repo, id, move |pr| {
         let comments = pr
             .entry("comments")
             .or_insert_with(|| Value::Array(Vec::new()));
@@ -253,12 +336,13 @@ pub fn add_comment(repo: &str, id: &str, body: &str) -> AppResult<Value> {
             .push(comment);
         Ok(())
     })
+    .await
 }
 
 /// Set the status of the PR with `id` under `repo` to `"open"` or `"closed"`.
 /// `"merged"` is rejected here — merging is a git operation the MCP server must never
 /// perform (it happens in GitDesktop). Returns the updated record.
-pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
+pub async fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
     if status != "open" && status != "closed" {
         return Err(AppError::Command(format!(
             "status must be \"open\" or \"closed\" (got \"{status}\"); merging a local PR happens in GitDesktop, not via this server"
@@ -269,14 +353,16 @@ pub fn set_status(repo: &str, id: &str, status: &str) -> AppResult<Value> {
         pr.insert("status".to_string(), Value::String(status));
         Ok(())
     })
+    .await
 }
 
 /// Set the `approved` flag on the PR with `id` under `repo`. Returns the updated record.
-pub fn set_approved(repo: &str, id: &str, approved: bool) -> AppResult<Value> {
+pub async fn set_approved(repo: &str, id: &str, approved: bool) -> AppResult<Value> {
     mutate_pr(repo, id, move |pr| {
         pr.insert("approved".to_string(), Value::Bool(approved));
         Ok(())
     })
+    .await
 }
 
 /// Fold any local-PR records still stored under a legacy checkout-PATH key into the
@@ -288,8 +374,16 @@ pub fn set_approved(repo: &str, id: &str, approved: bool) -> AppResult<Value> {
 /// records (identity's own win) and removes the legacy key. Callers pass `identity` as
 /// the `repo` arg to every other fn here. Idempotent: a no-op once no distinct legacy
 /// key remains.
-pub fn consolidate(identity: &str, legacy: &str) -> AppResult<()> {
+pub async fn consolidate(identity: &str, legacy: &str) -> AppResult<()> {
+    let (identity, legacy) = (identity.to_string(), legacy.to_string());
+    crate::store_lock::locked_store_task(move || consolidate_sync(&identity, &legacy)).await
+}
+
+/// The locked read-modify-write behind [`consolidate`], on the caller's own thread.
+fn consolidate_sync(identity: &str, legacy: &str) -> AppResult<()> {
     let path = store_path()?;
+    let _guard = prs_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let _store_lock = crate::store_lock::lock_store(&path);
     let mut store = read_store(&path)?;
     if fold_legacy_key(&mut store, identity, legacy) {
         write_store(&path, &store)?;
@@ -355,6 +449,61 @@ mod tests {
             .expect("create temp dir");
         let path = dir.path().join("store.json");
         (dir, path)
+    }
+
+    /// The store override is process-wide, so every test that installs one takes this
+    /// lock — as must any future test that drives the public read/write fns. Poisoning is
+    /// ignored: the guarded state is one override slot, not invariant data.
+    static STORE_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+    fn store_dir_lock() -> std::sync::MutexGuard<'static, ()> {
+        STORE_DIR_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Points the store at `dir` for as long as it's held and restores the prior override
+    /// on drop — panics included, so a failing test can't leave one standing for whichever
+    /// test is next through the lock.
+    struct StoreDirOverride(Option<PathBuf>);
+
+    impl StoreDirOverride {
+        fn set(dir: &Path) -> Self {
+            Self(swap_test_store_dir(Some(dir.to_path_buf())))
+        }
+    }
+
+    impl Drop for StoreDirOverride {
+        fn drop(&mut self) {
+            swap_test_store_dir(self.0.take());
+        }
+    }
+
+    /// The public write path end to end — through `store_path`, both locks, and the
+    /// atomic write — which the pure-logic tests below deliberately bypass. A regression
+    /// that deadlocks or fails open wrongly shows up here, not in them.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // override installed for the whole body. Sound because each `#[tokio::test]` owns a
+    // current-thread runtime with this one task on it.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn create_then_mutate_round_trips_through_the_locked_path() {
+        let _serialized = store_dir_lock();
+        let (tmp, _unused) = tmp_store();
+        let _override = StoreDirOverride::set(tmp.path());
+        let repo = "C:/local-prs/locked-round-trip/.git";
+
+        let created = create(repo, "Title", "Body", "main", "feature").await.unwrap();
+        let id = created["id"].as_str().unwrap().to_string();
+
+        add_comment(repo, &id, "looks good").await.unwrap();
+        let updated = set_status(repo, &id, "closed").await.unwrap();
+        assert_eq!(updated["status"], "closed");
+
+        let back = get(repo, &id).unwrap();
+        assert_eq!(back["title"], "Title");
+        assert_eq!(back["comments"][0]["body"], "looks good");
+        assert_eq!(list(repo).unwrap().len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -17,6 +17,11 @@
 //! impl, launch-arg parsing, and the shared helpers + parameter structs. The raw-diff
 //! tools issue `git` directly rather than reusing the structured UI diff commands,
 //! whose quirks an agent shouldn't inherit. Design: docs/mcp-server-tier3.md.
+//!
+//! `--repo` is canonicalized at parse, which RESOLVES junctions and symlinks — so a
+//! client configured with a link path, or a GUI keying its records by one, spells the
+//! repo differently than this server does; [`GitDesktopMcp::raw_repo`] keeps that
+//! spelling as the bridge every per-repo store lookup probes second.
 
 mod generate;
 mod read_forge;
@@ -64,6 +69,12 @@ const GD_COMMENT_FOOTER: &str =
 #[derive(Clone)]
 pub struct GitDesktopMcp {
     repo: String,
+    /// The `--repo` spelling as the client CONFIGURED it, kept only when canonicalization
+    /// changed it. Canonicalizing resolves junctions, symlinks, 8.3 names and case, so a
+    /// session that ran before it did keyed its per-repo records under this spelling
+    /// instead — and `same_repo`'s separator/drive-case tolerance does not bridge those.
+    /// Every per-repo store lookup therefore probes it as a second, legacy key.
+    raw_repo: Option<String>,
     /// Whether the app-data write tools (local PRs AND local issues) are enabled. Off
     /// unless launched with `--allow-write`; when off they stay registered and return a
     /// clear "disabled" error.
@@ -213,6 +224,7 @@ impl GitDesktopMcp {
     ) -> Self {
         Self {
             repo,
+            raw_repo: None,
             allow_write,
             allow_remote_write,
             allow_git_write,
@@ -236,14 +248,24 @@ impl GitDesktopMcp {
         }
     }
 
+    /// Carry the pre-canonicalization `--repo` spelling (see [`Self::raw_repo`]). Kept off
+    /// [`Self::with_options`] so the many test constructors stay five-argument; only the
+    /// real launch path has a raw spelling to hand over.
+    fn with_raw_repo(mut self, raw: Option<String>) -> Self {
+        self.raw_repo = raw;
+        self
+    }
+
     /// The bound repo's working-tree TOPLEVEL, resolved once per process.
     ///
-    /// `--repo` is taken verbatim and may name any directory inside the tree, but
-    /// anything that reads repo-relative names out of git — or joins a fixed
-    /// relative path onto it — has to use the root or it answers about the
-    /// subdirectory instead, quietly. Cached because `repo` never changes after
-    /// construction; only a successful resolution is stored, so a repo that
-    /// becomes readable later is still picked up.
+    /// `--repo` is canonicalized at parse (true case, separators, 8.3 expansion,
+    /// trailing slash, symlinks) so store keys and legacy-key probes see the
+    /// filesystem's own spelling.
+    /// It may still name any directory inside the tree, and anything that reads
+    /// repo-relative names out of git — or joins a fixed relative path onto it —
+    /// has to use the root or it answers about the subdirectory instead, quietly.
+    /// Cached because `repo` never changes after construction; only a successful
+    /// resolution is stored, so a repo that becomes readable later is still picked up.
     pub(super) async fn toplevel(&self) -> crate::error::AppResult<&str> {
         self.toplevel
             .get_or_try_init(|| crate::git::runner::worktree_toplevel(&self.repo))
@@ -326,9 +348,17 @@ impl GitDesktopMcp {
     async fn local_pr_key(&self) -> Result<String, McpError> {
         let identity = crate::git::repo::repo_identity(&self.repo).await;
         // Fold once per session (the server is bound to one repo). The flag is set only
-        // AFTER a successful fold, so a transient failure retries next call.
+        // AFTER a successful fold, so a transient failure retries next call. BOTH
+        // spellings are probed as legacy keys — see [`Self::raw_repo`].
         if !self.consolidated.load(Ordering::Relaxed) {
-            crate::local_prs::consolidate(&identity, &self.repo).map_err(app_err)?;
+            crate::local_prs::consolidate(&identity, &self.repo)
+                .await
+                .map_err(app_err)?;
+            if let Some(raw) = &self.raw_repo {
+                crate::local_prs::consolidate(&identity, raw)
+                    .await
+                    .map_err(app_err)?;
+            }
             self.consolidated.store(true, Ordering::Relaxed);
         }
         Ok(identity)
@@ -342,16 +372,22 @@ impl GitDesktopMcp {
     /// telling the user how to create one in GitDesktop (the same call-time pattern the
     /// Bitbucket-issue tools use — registration stays static).
     async fn jira_link(&self) -> Result<crate::jira_links::JiraLinkEntry, McpError> {
-        crate::jira_links::get_link(&self.repo)
-            .await
-            .map_err(app_err)?
-            .ok_or_else(|| {
-                McpError::invalid_request(
-                    "This repository has no linked Jira project — link one in GitDesktop \
-                     (repo menu → Link Jira project).",
-                    None,
-                )
-            })
+        let mut link = crate::jira_links::get_link(&self.repo).await.map_err(app_err)?;
+        if link.is_none() {
+            // A link stored against the pre-canonicalization spelling — see
+            // [`Self::raw_repo`]. Only consulted when the canonical probe found nothing,
+            // so the current spelling always wins.
+            if let Some(raw) = &self.raw_repo {
+                link = crate::jira_links::get_link(raw).await.map_err(app_err)?;
+            }
+        }
+        link.ok_or_else(|| {
+            McpError::invalid_request(
+                "This repository has no linked Jira project — link one in GitDesktop \
+                 (repo menu → Link Jira project).",
+                None,
+            )
+        })
     }
 }
 
@@ -623,6 +659,7 @@ async fn serve(args: McpArgs) -> Result<(), Box<dyn std::error::Error>> {
         args.allow_git_write,
         args.allow_destructive,
     )
+    .with_raw_repo(args.raw_repo)
     .serve(stdio())
     .await?;
     service.waiting().await?;
@@ -634,6 +671,9 @@ async fn serve(args: McpArgs) -> Result<(), Box<dyn std::error::Error>> {
 /// forge, `--allow-git-write` → local git, `--allow-destructive` → destructive git).
 struct McpArgs {
     repo: String,
+    /// The `--repo` spelling before canonicalization, kept ONLY when it differs — the
+    /// legacy store key a session that predates canonicalization wrote under.
+    raw_repo: Option<String>,
     allow_write: bool,
     allow_remote_write: bool,
     allow_git_write: bool,
@@ -650,7 +690,8 @@ impl McpArgs {
     /// `--allow-destructive`) from an argv iterator; the repo falls back to the
     /// current working directory, matching how reference MCP git servers are
     /// configured. Every flag is off by default, parsing is order-independent, and
-    /// unknown args are ignored.
+    /// unknown args are ignored. The repo path is canonicalized before it is
+    /// returned; parse itself stays infallible.
     fn parse(args: impl Iterator<Item = String>) -> Self {
         let mut repo: Option<String> = None;
         let mut allow_write = false;
@@ -680,8 +721,18 @@ impl McpArgs {
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_else(|_| ".".to_string())
         });
+        // Canonicalize so every per-repo store key and legacy-key probe sees the
+        // filesystem's spelling rather than the client config's. A path that can't be
+        // resolved keeps its raw form, so the server still starts and errors as usual.
+        let canonical = dunce::canonicalize(&repo)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| repo.clone());
+        // The config's own spelling is kept only when canonicalizing moved it — that is
+        // exactly when an older session's records sit under a key this one would miss.
+        let raw_repo = (canonical != repo).then_some(repo);
         Self {
-            repo,
+            repo: canonical,
+            raw_repo,
             allow_write,
             allow_remote_write,
             allow_git_write,
@@ -845,6 +896,75 @@ mod tests {
         assert!(!destructive_only.allow_remote_write);
         assert!(!destructive_only.allow_git_write);
         assert!(destructive_only.allow_destructive);
+    }
+
+    /// A trailing separator is the cheapest spelling difference to pin on every
+    /// platform; on Windows the drive letter's case is the one a client config most
+    /// often carries. Both must land on the filesystem's own spelling.
+    #[test]
+    fn repo_canonicalizes_an_existing_path() {
+        let base = tempfile::Builder::new()
+            .prefix("gd-mcp-repo-canon-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = base.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let canonical = dunce::canonicalize(&repo)
+            .expect("canonicalize fixture")
+            .to_string_lossy()
+            .into_owned();
+
+        let trailing = format!("{}{}", repo.to_string_lossy(), std::path::MAIN_SEPARATOR);
+        assert_ne!(
+            trailing, canonical,
+            "fixture must differ from the canonical form"
+        );
+        assert_eq!(parse(&["--repo", trailing.as_str()]).repo, canonical);
+        let joined = format!("--repo={trailing}");
+        assert_eq!(parse(&[joined.as_str()]).repo, canonical);
+        // The spelling canonicalization moved off is kept as the legacy store key an
+        // older session of this same repo would have written under.
+        assert_eq!(
+            parse(&["--repo", trailing.as_str()]).raw_repo.as_deref(),
+            Some(trailing.as_str())
+        );
+        // …and a config already spelling it canonically carries no second key.
+        assert_eq!(parse(&["--repo", canonical.as_str()]).raw_repo, None);
+
+        #[cfg(windows)]
+        {
+            let mut lower_drive = repo.to_string_lossy().into_owned();
+            let drive = lower_drive[..1].to_lowercase();
+            lower_drive.replace_range(..1, &drive);
+            assert_eq!(parse(&["--repo", lower_drive.as_str()]).repo, canonical);
+        }
+    }
+
+    /// A path that doesn't exist can't be canonicalized, and parse can never fail:
+    /// the raw spelling goes downstream, where the normal git errors surface.
+    #[test]
+    fn repo_falls_back_to_the_raw_path_when_unresolvable() {
+        let missing = std::env::temp_dir().join("gd-mcp-no-such-repo-8f3a1c");
+        assert!(!missing.exists(), "fixture path must not exist");
+        let raw = missing.to_string_lossy().into_owned();
+        let args = parse(&["--repo", raw.as_str()]);
+        assert_eq!(args.repo, raw);
+        // Nothing moved, so there is no second spelling to probe — a legacy key equal to
+        // the live one would fold the store onto itself on every call.
+        assert_eq!(args.raw_repo, None);
+    }
+
+    /// The no-`--repo` fallback goes through the same canonicalization. It only
+    /// discriminates when the runner's own cwd is non-canonical (a short name or a
+    /// symlinked parent), so treat it as a contract pin, not a regression net.
+    #[test]
+    fn cwd_fallback_is_canonicalized() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let canonical = dunce::canonicalize(&cwd)
+            .expect("canonicalize cwd")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(parse(&["--allow-write"]).repo, canonical);
     }
 
     /// Constructs a handler with exactly one gate-flag true and asserts ONLY that

--- a/src-tauri/src/mcp_server/mod.rs
+++ b/src-tauri/src/mcp_server/mod.rs
@@ -97,6 +97,9 @@ pub struct GitDesktopMcp {
     /// `Arc` because rmcp clones the handler per request. Mirrors `foldedGuards` in the
     /// frontend.
     consolidated: Arc<AtomicBool>,
+    /// The same latch for the SEPARATE `local-issues.json` store — one flag can't serve
+    /// both, or whichever store folded first would suppress the other's migration.
+    issues_consolidated: Arc<AtomicBool>,
     /// Per-process backend state — supplies the per-repo locks that serialize mutating git
     /// ops (`run_git_mutating` takes `&AppState`). Built with `AppState::default()` (no
     /// Tauri runtime needed); `Arc` so it survives the per-request clones.
@@ -230,6 +233,7 @@ impl GitDesktopMcp {
             allow_git_write,
             allow_destructive,
             consolidated: Arc::new(AtomicBool::new(false)),
+            issues_consolidated: Arc::new(AtomicBool::new(false)),
             state: Arc::new(crate::state::AppState::default()),
             toplevel: Arc::new(tokio::sync::OnceCell::new()),
             // `ToolRouter` implements `Add`, so the domain modules stay independent — a

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -348,6 +348,18 @@ impl GitDesktopMcp {
         Parameters(args): Parameters<CommitArgs>,
     ) -> Result<CallToolResult, McpError> {
         self.ensure_git_write()?;
+        // A session that predates canonicalization journaled its paused picks under the
+        // RAW `--repo` spelling, which `git_commit_core`'s close — keyed on the canonical
+        // path — cannot reach. Mirror that close's gate here for the second spelling,
+        // reading the marker BEFORE the commit clears it. Skipped when the two already
+        // resolve to one journal key, which is what keeps this from closing a second
+        // paused record under the same key.
+        let legacy_repo = self
+            .raw_repo
+            .clone()
+            .filter(|raw| !crate::oplog::same_repo(raw, &self.repo));
+        let was_picking =
+            legacy_repo.is_some() && crate::git::ops::cherry_pick_marker_present(&self.repo);
         let result = crate::git::commit::git_commit_core(
             &self.state,
             self.repo.clone(),
@@ -357,6 +369,11 @@ impl GitDesktopMcp {
         )
         .await
         .map_err(app_err)?;
+        if was_picking && !crate::git::ops::cherry_pick_marker_present(&self.repo) {
+            if let Some(raw) = legacy_repo {
+                crate::oplog::close_paused_pick(&raw, crate::oplog::PausedOutcome::Continued).await;
+            }
+        }
         json_result(&result)
     }
 

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -132,6 +132,7 @@ impl GitDesktopMcp {
             &args.base,
             &args.head,
         )
+        .await
         .map_err(app_err)?;
         json_result(&record)
     }
@@ -147,7 +148,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_pr_key().await?;
-        let record = crate::local_prs::add_comment(&repo, &args.id, &args.body).map_err(app_err)?;
+        let record = crate::local_prs::add_comment(&repo, &args.id, &args.body)
+            .await
+            .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -163,8 +166,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_pr_key().await?;
-        let record =
-            crate::local_prs::set_status(&repo, &args.id, &args.status).map_err(app_err)?;
+        let record = crate::local_prs::set_status(&repo, &args.id, &args.status)
+            .await
+            .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -179,8 +183,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_pr_key().await?;
-        let record =
-            crate::local_prs::set_approved(&repo, &args.id, args.approved).map_err(app_err)?;
+        let record = crate::local_prs::set_approved(&repo, &args.id, args.approved)
+            .await
+            .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -200,6 +205,7 @@ impl GitDesktopMcp {
         let repo = self.local_issue_key().await?;
         let record =
             crate::local_issues::create(&repo, &args.title, args.body.as_deref().unwrap_or(""))
+                .await
                 .map_err(app_err)?;
         json_result(&record)
     }
@@ -216,8 +222,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_issue_key().await?;
-        let record =
-            crate::local_issues::add_comment(&repo, &args.id, &args.body).map_err(app_err)?;
+        let record = crate::local_issues::add_comment(&repo, &args.id, &args.body)
+            .await
+            .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -234,8 +241,9 @@ impl GitDesktopMcp {
     ) -> Result<CallToolResult, McpError> {
         self.ensure_write()?;
         let repo = self.local_issue_key().await?;
-        let record =
-            crate::local_issues::set_status(&repo, &args.id, &args.status).map_err(app_err)?;
+        let record = crate::local_issues::set_status(&repo, &args.id, &args.status)
+            .await
+            .map_err(app_err)?;
         json_result(&record)
     }
 
@@ -260,7 +268,9 @@ impl GitDesktopMcp {
         // naming it — before any app-data write.
         verify_branch(&self.repo, &args.branch).await?;
         let repo = crate::git::repo::repo_identity(&self.repo).await;
-        let saved = crate::review_notes::set(&repo, &args.branch, &args.body).map_err(app_err)?;
+        let saved = crate::review_notes::set(&repo, &args.branch, &args.body)
+            .await
+            .map_err(app_err)?;
         json_result(&serde_json::json!({ "branch": args.branch, "saved": saved }))
     }
 
@@ -397,7 +407,16 @@ impl GitDesktopMcp {
     /// call — acceptable given how infrequent local-issue mutations are.
     async fn local_issue_key(&self) -> Result<String, McpError> {
         let identity = crate::git::repo::repo_identity(&self.repo).await;
-        crate::local_issues::consolidate(&identity, &self.repo).map_err(app_err)?;
+        crate::local_issues::consolidate(&identity, &self.repo)
+            .await
+            .map_err(app_err)?;
+        // The pre-canonicalization spelling is a second legacy key (see
+        // `GitDesktopMcp::raw_repo`); folding it is idempotent like the first.
+        if let Some(raw) = &self.raw_repo {
+            crate::local_issues::consolidate(&identity, raw)
+                .await
+                .map_err(app_err)?;
+        }
         Ok(identity)
     }
 }

--- a/src-tauri/src/mcp_server/write_local.rs
+++ b/src-tauri/src/mcp_server/write_local.rs
@@ -12,6 +12,8 @@
 //! - **Reads** (list/get) are UNGATED, like every other read tool — this is the user's
 //!   own local app-data, not the forge.
 
+use std::sync::atomic::Ordering;
+
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::CallToolResult;
 use rmcp::{schemars, tool, tool_router, ErrorData as McpError};
@@ -399,23 +401,26 @@ impl GitDesktopMcp {
     /// points at. Uses the SAME shared resolver (`git::repo::repo_identity`) the GUI's
     /// `git_repo_identity` command uses.
     ///
-    /// Unlike `local_pr_key`, this folds on EVERY call rather than once-per-session:
-    /// the session's once-flag (`consolidated`) is owned by `mod.rs` and reserved for
-    /// the local-PR store, and adding a second flag field would mean editing `mod.rs`
-    /// (out of scope for this store). `local_issues::consolidate` is idempotent and a
-    /// no-op read once folded, so the only cost is one extra small store read per
-    /// call — acceptable given how infrequent local-issue mutations are.
+    /// Folds once per session behind `issues_consolidated`, the local-issue twin of
+    /// `local_pr_key`'s latch (one flag can't serve both stores). Each fold is a locked
+    /// read-modify-write that can block for the store lock's whole retry budget, and both
+    /// spellings are folded, so per-call would pay that twice for a migration that is a
+    /// no-op after the first. The flag is set only AFTER both folds succeed, so a
+    /// transient failure retries on the next call.
     async fn local_issue_key(&self) -> Result<String, McpError> {
         let identity = crate::git::repo::repo_identity(&self.repo).await;
-        crate::local_issues::consolidate(&identity, &self.repo)
-            .await
-            .map_err(app_err)?;
-        // The pre-canonicalization spelling is a second legacy key (see
-        // `GitDesktopMcp::raw_repo`); folding it is idempotent like the first.
-        if let Some(raw) = &self.raw_repo {
-            crate::local_issues::consolidate(&identity, raw)
+        if !self.issues_consolidated.load(Ordering::Relaxed) {
+            crate::local_issues::consolidate(&identity, &self.repo)
                 .await
                 .map_err(app_err)?;
+            // The pre-canonicalization spelling is a second legacy key — see
+            // `GitDesktopMcp::raw_repo`.
+            if let Some(raw) = &self.raw_repo {
+                crate::local_issues::consolidate(&identity, raw)
+                    .await
+                    .map_err(app_err)?;
+            }
+            self.issues_consolidated.store(true, Ordering::Relaxed);
         }
         Ok(identity)
     }

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -153,8 +153,10 @@ fn write_store(path: &Path, store: &Map<String, Value>) -> AppResult<()> {
 
 /// Compare two repo-path keys for "same repo" tolerantly: normalize separators to
 /// `/` and treat a leading Windows drive letter case-insensitively (`C:` == `c:`).
-/// Mirrors `local_prs.rs`.
-fn same_repo(a: &str, b: &str) -> bool {
+/// Mirrors `local_prs.rs`. `pub(crate)` so a caller holding two spellings of one repo can
+/// tell whether they already resolve to one journal key — junctions, symlinks, 8.3 names
+/// and path-body case are outside this tolerance and need a second probe.
+pub(crate) fn same_repo(a: &str, b: &str) -> bool {
     fn norm(s: &str) -> String {
         let slashed: String = s.chars().map(|c| if c == '\\' { '/' } else { c }).collect();
         let bytes = slashed.as_bytes();
@@ -429,11 +431,34 @@ fn reconcile(
     cherry_picking: bool,
     pick_in_progress: impl Fn() -> bool,
 ) -> AppResult<Vec<OpLogEntry>> {
-    let path = store_path()?;
+    reconcile_at(
+        &store_path()?,
+        repo,
+        mid_op,
+        tree_dirty,
+        current_branch,
+        cherry_picking,
+        pick_in_progress,
+    )
+}
+
+/// The store logic behind [`reconcile`], taking an explicit path so a test can drive it
+/// against a temp file of its own (mirroring [`crate::review_notes`]'s `set_at`). The
+/// shared `cfg(test)` store can't answer whether a check WROTE, only what it left.
+#[allow(clippy::too_many_arguments)]
+fn reconcile_at(
+    path: &Path,
+    repo: &str,
+    mid_op: bool,
+    tree_dirty: bool,
+    current_branch: &str,
+    cherry_picking: bool,
+    pick_in_progress: impl Fn() -> bool,
+) -> AppResult<Vec<OpLogEntry>> {
     let now = now_iso();
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
-    let _store_lock = crate::store_lock::lock_store(&path);
-    let mut store = read_store(&path)?;
+    let _store_lock = crate::store_lock::lock_store(path);
+    let mut store = read_store(path)?;
     let Some(key) = existing_key(&store, repo) else {
         return Ok(Vec::new());
     };
@@ -499,7 +524,7 @@ fn reconcile(
     };
 
     if changed {
-        write_store(&path, &store)?;
+        write_store(path, &store)?;
     }
     Ok(results)
 }
@@ -530,7 +555,8 @@ pub async fn begin(
         pre_op_tip: pre_op_tip.map(str::to_string),
         error: None,
     };
-    match insert_pending(repo, &entry) {
+    let repo = repo.to_string();
+    match crate::store_lock::locked_store_task(move || insert_pending(&repo, &entry)).await {
         Ok(()) => Some(id),
         Err(e) => {
             eprintln!("gitdesktop: opslog begin failed (op continues): {e}");
@@ -548,18 +574,22 @@ pub async fn finish(repo: &str, id: &Option<String>, error: Option<String>) {
     };
     let now = now_iso();
     let status = if error.is_some() { "failed" } else { "done" };
-    let result = mutate_entry(repo, id, |obj| {
-        obj.insert("status".to_string(), Value::String(status.to_string()));
-        obj.insert("finishedAt".to_string(), Value::String(now));
-        match &error {
-            Some(msg) => {
-                obj.insert("error".to_string(), Value::String(msg.clone()));
+    let (repo, id) = (repo.to_string(), id.clone());
+    let result = crate::store_lock::locked_store_task(move || {
+        mutate_entry(&repo, &id, |obj| {
+            obj.insert("status".to_string(), Value::String(status.to_string()));
+            obj.insert("finishedAt".to_string(), Value::String(now));
+            match error {
+                Some(msg) => {
+                    obj.insert("error".to_string(), Value::String(msg));
+                }
+                None => {
+                    obj.insert("error".to_string(), Value::Null);
+                }
             }
-            None => {
-                obj.insert("error".to_string(), Value::Null);
-            }
-        }
-    });
+        })
+    })
+    .await;
     if let Err(e) = result {
         eprintln!("gitdesktop: opslog finish failed (op unaffected): {e}");
     }
@@ -573,7 +603,10 @@ pub(crate) async fn pause(repo: &str, id: &Option<String>) {
     let Some(id) = id else {
         return;
     };
-    if let Err(e) = mutate_entry(repo, id, apply_pause) {
+    let (repo, id) = (repo.to_string(), id.clone());
+    let result =
+        crate::store_lock::locked_store_task(move || mutate_entry(&repo, &id, apply_pause)).await;
+    if let Err(e) = result {
         eprintln!("gitdesktop: opslog pause failed (op unaffected): {e}");
     }
 }
@@ -586,7 +619,12 @@ pub(crate) async fn pause(repo: &str, id: &Option<String>) {
 /// of picks ended outside the app on the next [`git_oplog_check`] that finds no pick
 /// in progress, which is what keeps one from standing in as this op's handle.
 pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
-    if let Err(e) = close_newest_paused_pick(repo, &outcome, now_iso()) {
+    let (repo, now) = (repo.to_string(), now_iso());
+    let result = crate::store_lock::locked_store_task(move || {
+        close_newest_paused_pick(&repo, &outcome, now)
+    })
+    .await;
+    if let Err(e) = result {
         eprintln!("gitdesktop: opslog close failed (op unaffected): {e}");
     }
 }
@@ -628,13 +666,9 @@ fn close_newest_paused_pick(repo: &str, outcome: &PausedOutcome, now: String) ->
 /// (unjournaled op, pruned entry, unreadable store), so callers must treat the
 /// absence as "unknown", never as "unchanged".
 pub(crate) async fn pre_op_tip(repo: &str, id: &Option<String>) -> Option<String> {
-    let id = id.as_ref()?;
-    let path = store_path().ok()?;
-    let entries = {
-        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
-        let store = read_store(&path).ok()?;
-        repo_entries(&store, repo)
-    };
+    let id = id.as_ref()?.clone();
+    let repo = repo.to_string();
+    let entries = read_repo_entries(repo).await.ok()?;
     entries
         .iter()
         .find(|e| e.get("id").and_then(Value::as_str) == Some(id.as_str()))
@@ -643,16 +677,25 @@ pub(crate) async fn pre_op_tip(repo: &str, id: &Option<String>) -> Option<String
         .map(str::to_string)
 }
 
+/// `repo`'s entries in stored order, read off the async runtime. The read takes no FILE
+/// lock (`atomic_write` already gives it a whole file or none) but it does take
+/// [`OPLOG_LOCK`], which the writers now hold across the store lock's blocking retry — so
+/// a reader on a tokio worker could park behind one for the whole budget.
+async fn read_repo_entries(repo: String) -> AppResult<Vec<Value>> {
+    crate::store_lock::locked_store_task(move || {
+        let path = store_path()?;
+        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let store = read_store(&path)?;
+        Ok(repo_entries(&store, &repo))
+    })
+    .await
+}
+
 /// Return `repo`'s journal entries newest-first by `startedAt`. Pure store read,
 /// no git access. Missing repo key → `[]`.
 #[tauri::command]
 pub async fn git_oplog_list(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
-    let path = store_path()?;
-    let mut entries = {
-        let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
-        let store = read_store(&path)?;
-        repo_entries(&store, &repo_path)
-    };
+    let mut entries = read_repo_entries(repo_path).await?;
     sort_newest_first(&mut entries);
     Ok(entries
         .into_iter()
@@ -696,24 +739,33 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     .await
     .map(|o| o.stdout_lossy().trim().to_string())
     .unwrap_or_default();
-    reconcile(
-        &repo_path,
-        mid_op,
-        tree_dirty,
-        &current_branch,
-        cherry_picking,
-        // FS-only (no subprocess), so it is cheap to run while holding the store lock.
-        || crate::git::ops::cherry_pick_marker_present(&repo_path),
-    )
+    // The store RMW blocks on the cross-process lock's retry budget, so it runs off the
+    // async runtime; the marker re-probe is built inside the job, which keeps it on the
+    // same thread as the lock it must run under.
+    crate::store_lock::locked_store_task(move || {
+        reconcile(
+            &repo_path,
+            mid_op,
+            tree_dirty,
+            &current_branch,
+            cherry_picking,
+            // FS-only (no subprocess), so it is cheap to run while holding the store lock.
+            || crate::git::ops::cherry_pick_marker_present(&repo_path),
+        )
+    })
+    .await
 }
 
 /// Set the entry with `id` under `repo` to `status = "dismissed"` and persist.
 /// Unknown id → `Ok(())` (no-op) — never error the UI.
 #[tauri::command]
 pub async fn git_oplog_dismiss(repo_path: String, id: String) -> AppResult<()> {
-    mutate_entry(&repo_path, &id, |obj| {
-        obj.insert("status".to_string(), Value::String("dismissed".to_string()));
+    crate::store_lock::locked_store_task(move || {
+        mutate_entry(&repo_path, &id, |obj| {
+            obj.insert("status".to_string(), Value::String("dismissed".to_string()));
+        })
     })
+    .await
 }
 
 #[cfg(test)]
@@ -1144,6 +1196,70 @@ mod tests {
         let store = read_store(&path).unwrap();
         let entries = repo_entries(&store, r"C:\nope");
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn same_repo_tolerates_slashes_and_drive_case() {
+        // The key matcher the GUI and the MCP both depend on to land on ONE key per repo
+        // (mirrors `local_prs`'s): separators normalize, the drive letter is
+        // case-insensitive, the rest of the path is not.
+        assert!(same_repo(
+            r"C:\ProjectRepos\demo\harbor",
+            "C:/ProjectRepos/demo/harbor"
+        ));
+        assert!(same_repo(
+            r"C:\ProjectRepos\demo\harbor",
+            r"c:\ProjectRepos\demo\harbor"
+        ));
+        assert!(!same_repo(r"C:\a\b", r"C:\a\c"));
+    }
+
+    #[test]
+    fn existing_key_reuses_a_tolerant_match() {
+        let mut store = Map::new();
+        store.insert(r"C:\repo\one".to_string(), json!([]));
+        // A differently-spelled but same repo reuses the stored key, so a journal write
+        // can't strand a second entry the reader never looks at.
+        assert_eq!(
+            existing_key(&store, "c:/repo/one").as_deref(),
+            Some(r"C:\repo\one")
+        );
+        assert_eq!(existing_key(&store, r"C:\repo\two"), None);
+    }
+
+    /// A reconcile that changes nothing must not rewrite the file: the store is shared
+    /// with a second process, and a needless write is a needless chance to lose its
+    /// concurrent update. The seeded bytes are deliberately NOT what `write_store`
+    /// produces (compact, unsorted), so any write at all — even one that changes no
+    /// record — is visible in the comparison.
+    #[test]
+    fn a_reconcile_with_nothing_to_do_writes_nothing() {
+        let (_tmp, path) = tmp_store();
+        let repo = r"C:\oplog\no-write-pin";
+        let mut store = Map::new();
+        store.insert(
+            repo.to_string(),
+            Value::Array(vec![
+                pick_record("live-pause", "2026-01-01T00:00:00.000Z", "paused"),
+                pending_record("interrupted", "2026-01-02T00:00:00.000Z"),
+            ]),
+        );
+        // Compact, which is NOT what `write_store` emits.
+        let seeded = serde_json::to_string(&Value::Object(store)).unwrap();
+        std::fs::write(&path, seeded.as_bytes()).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        // Nothing to do on either arm: a pick is in progress (so the pause stands), and
+        // the pending op is genuinely interrupted (so it stays pending).
+        let returned = reconcile_at(&path, repo, true, true, "feature", true, || true).unwrap();
+        assert_eq!(returned.len(), 1);
+        assert_eq!(returned[0].id, "interrupted");
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a no-op check must leave the file byte-identical"
+        );
     }
 
     // ── Stale-pause reconcile ────────────────────────────────────────────────

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -445,7 +445,6 @@ fn reconcile(
 /// The store logic behind [`reconcile`], taking an explicit path so a test can drive it
 /// against a temp file of its own (mirroring [`crate::review_notes`]'s `set_at`). The
 /// shared `cfg(test)` store can't answer whether a check WROTE, only what it left.
-#[allow(clippy::too_many_arguments)]
 fn reconcile_at(
     path: &Path,
     repo: &str,

--- a/src-tauri/src/review_notes.rs
+++ b/src-tauri/src/review_notes.rs
@@ -167,15 +167,22 @@ fn now_iso() -> String {
 /// whitespace-only CLEARS the branch entry (and removes the repo key entirely once its map
 /// empties, so an emptied store stays tidy). Returns `true` when a note was saved, `false`
 /// when the empty-body rule cleared the deposit.
-pub fn set(repo: &str, branch: &str, body: &str) -> AppResult<bool> {
-    let path = store_path()?;
-    // Hold both locks across the whole read→modify→write: the GUI and the
-    // `gitdesktop mcp` server both write this file, and an unlocked RMW drops whichever
-    // note lost the race (see [`crate::store_lock`]; acquisition fails open, which is
-    // why the exact in-process mutex goes outside it).
-    let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
-    let _lock = crate::store_lock::lock_store(&path);
-    set_at(&path, repo, branch, body)
+///
+/// The locked write runs off the async runtime: the cross-process lock blocks its
+/// calling thread for up to the retry budget, which must not park a tokio worker.
+pub async fn set(repo: &str, branch: &str, body: &str) -> AppResult<bool> {
+    let (repo, branch, body) = (repo.to_string(), branch.to_string(), body.to_string());
+    crate::store_lock::locked_store_task(move || {
+        let path = store_path()?;
+        // Hold both locks across the whole read→modify→write: the GUI and the
+        // `gitdesktop mcp` server both write this file, and an unlocked RMW drops
+        // whichever note lost the race (see [`crate::store_lock`]; acquisition fails
+        // open, which is why the exact in-process mutex goes outside it).
+        let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::store_lock::lock_store(&path);
+        set_at(&path, &repo, &branch, &body)
+    })
+    .await
 }
 
 /// Save (or clear) the GUI's reviewer note for `branch`, taking the same
@@ -190,7 +197,7 @@ pub async fn review_notes_set_branch(
     body: String,
 ) -> AppResult<bool> {
     let identity = crate::git::repo::repo_identity(&repo_path).await;
-    set(&identity, &branch, &body)
+    set(&identity, &branch, &body).await
 }
 
 /// Remove the GUI's reviewer note for `branch` — the consume-on-open path behind the
@@ -199,7 +206,7 @@ pub async fn review_notes_set_branch(
 #[tauri::command]
 pub async fn review_notes_delete_branch(repo_path: String, branch: String) -> AppResult<()> {
     let identity = crate::git::repo::repo_identity(&repo_path).await;
-    set(&identity, &branch, "")?;
+    set(&identity, &branch, "").await?;
     Ok(())
 }
 
@@ -242,13 +249,18 @@ fn upsert_branch(store: &mut Map<String, Value>, repo: &str, branch: &str, body:
 ///
 /// The note record moves verbatim (unknown fields included) and its `savedAt` is left alone —
 /// a rename is not a re-save. Nothing is written when there is nothing to migrate.
-pub(crate) fn rename_branch(repo: &str, from: &str, to: &str) -> AppResult<()> {
-    let path = store_path()?;
-    // Same lock pair as [`set`]: the read→move→write must not interleave with a
-    // concurrent deposit, which would resurrect the old branch name's note.
-    let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
-    let _lock = crate::store_lock::lock_store(&path);
-    rename_at(&path, repo, from, to)
+pub(crate) async fn rename_branch(repo: &str, from: &str, to: &str) -> AppResult<()> {
+    let (repo, from, to) = (repo.to_string(), from.to_string(), to.to_string());
+    crate::store_lock::locked_store_task(move || {
+        let path = store_path()?;
+        // Same lock pair as [`set`], off the runtime for the same reason: the
+        // read→move→write must not interleave with a concurrent deposit, which would
+        // resurrect the old branch name's note.
+        let _guard = notes_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let _lock = crate::store_lock::lock_store(&path);
+        rename_at(&path, &repo, &from, &to)
+    })
+    .await
 }
 
 /// The pure store logic behind [`rename_branch`], taking an explicit path so tests can drive

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -148,7 +148,7 @@ fn read_token_twice(path: &Path) -> Option<String> {
 /// contender can observe the file without its owner. `Ok(true)` = created by us,
 /// `Ok(false)` = someone else holds it.
 fn create_with_token(path: &Path, token: &str) -> std::io::Result<bool> {
-    create_stamped(path, token, |file, token| {
+    create_stamped(path, token, |file| {
         file.write_all(token.as_bytes())?;
         file.flush()
     })
@@ -159,7 +159,7 @@ fn create_with_token(path: &Path, token: &str) -> std::io::Result<bool> {
 fn create_stamped(
     path: &Path,
     token: &str,
-    stamp: impl FnOnce(&mut std::fs::File, &str) -> std::io::Result<()>,
+    stamp: impl FnOnce(&mut std::fs::File) -> std::io::Result<()>,
 ) -> std::io::Result<bool> {
     if token.is_empty() {
         // The one content this file must never be given deliberately: an empty stamp is
@@ -181,7 +181,7 @@ fn create_stamped(
         // lock. Unstamped, it blocks this store's writers for at most 2× the stale window
         // before [`acquire`]'s escape hatch reclaims it — bounded, where a deleted live
         // lock is an unbounded double grant.
-        Ok(mut file) => stamp(&mut file, token).map(|()| true),
+        Ok(mut file) => stamp(&mut file).map(|()| true),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
         Err(e) => Err(e),
     }
@@ -578,7 +578,7 @@ mod tests {
         let (_tmp, store) = tmp_store();
         let path = lock_path(&store);
 
-        let err = create_stamped(&path, "1:doomed", |_, _| {
+        let err = create_stamped(&path, "1:doomed", |_| {
             Err(std::io::Error::other("the disk filled mid-stamp"))
         })
         .unwrap_err();

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -1,10 +1,21 @@
 //! Cross-process advisory lock for GitDesktop's shared app-data JSON stores.
 //!
-//! `opslog.json` and `review-notes.json` are whole-file read→modify→write stores with
-//! TWO writing processes: the GUI and the `gitdesktop mcp` server — the SAME binary
-//! under a different subcommand, so both link this module and share its protocol. An
-//! in-process mutex cannot serialize across that boundary, so a concurrent write
-//! silently drops the loser's records.
+//! `opslog.json`, `review-notes.json`, `local-prs.json`, `local-issues.json` and
+//! `jira-field-maps.json` are whole-file read→modify→write stores with TWO writing
+//! processes: the GUI and the `gitdesktop mcp` server — the SAME binary under a
+//! different subcommand, so both link this module and share its protocol. An in-process
+//! mutex cannot serialize across that boundary, so a concurrent write silently drops the
+//! loser's records. Carve-out: the GUI writes `local-prs.json` and `local-issues.json`
+//! through the Tauri Store plugin, which takes neither lock, so those two are protected
+//! MCP-side only until the GUI's writes route through Rust the way `review_notes` does.
+//!
+//! ## Ownership token
+//!
+//! The lock file carries `<pid>:<uuid>`, stamped and flushed before the exclusive create
+//! returns. Existence answers "is it held"; mtime answers "is it abandoned"; only the
+//! token answers "is this the SAME lock" — which is what a release and an eviction each
+//! have to prove before they delete a file, or two writers end up inside one critical
+//! section.
 //!
 //! Exclusion is taken at the OS level with `OpenOptions::create_new` on a
 //! `<store>.lock` file beside the store — the atomic exclusive-create
@@ -18,18 +29,22 @@
 //!
 //! ## Fail-open, always
 //!
-//! Both stores are best-effort by contract — a journal write must never fail or alter
+//! These stores are best-effort by contract — a journal write must never fail or alter
 //! a git op ([`crate::oplog`]'s module docs) — so every failure to acquire (a poisoned
 //! directory, a holder that outlasts the retry budget) runs the caller's mutation
 //! ANYWAY. Worst case of fail-open is the pre-existing lost update; worst case of
 //! fail-closed is a git operation reporting failure because a journal file was busy.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-/// Retry budget for a held lock: 20 × 25ms ≈ 500ms of blocking. An RMW on these
-/// stores is ms-scale, so a holder still present after half a second is either wedged
-/// or dead, and the caller is better served by proceeding than by waiting.
+use crate::error::{AppError, AppResult};
+
+/// Retry budget for a held lock: 20 attempts, sleeping between them but not after the
+/// last, so 19 × 25ms = 475ms of blocking. An RMW on these stores is ms-scale, so a
+/// holder still present after half a second is either wedged or dead, and the caller is
+/// better served by proceeding than by waiting.
 const MAX_ATTEMPTS: u32 = 20;
 const RETRY_DELAY: Duration = Duration::from_millis(25);
 
@@ -42,17 +57,37 @@ const STALE_LOCK_AGE: Duration = Duration::from_secs(10);
 /// RAII holder of a store lock: dropping it releases (best-effort `remove_file`) on
 /// every path, success or panic. A guard that FAILED to acquire owns nothing and
 /// releases nothing — deleting a live holder's file would break the exclusion it is
-/// currently providing to someone else.
+/// currently providing to someone else. What it owns is a path AND the ownership token
+/// stamped in that file, because the path alone can name a LATER generation's lock.
 pub(crate) struct StoreLock {
-    owned: Option<PathBuf>,
+    owned: Option<(PathBuf, String)>,
 }
 
 impl Drop for StoreLock {
     fn drop(&mut self) {
-        if let Some(path) = &self.owned {
-            let _ = std::fs::remove_file(path);
+        // Release through the same proof an eviction uses. A holder that outlives
+        // [`STALE_LOCK_AGE`] can be evicted mid-RMW, and both an unconditional
+        // `remove_file` and a read-then-remove (a whole eviction cycle fits between its
+        // two calls) would then delete the EVICTOR's lock, granting the store twice.
+        if let Some((path, token)) = &self.owned {
+            claim_by_rename(path, token);
         }
     }
+}
+
+/// Run a locked store read-modify-write off the async runtime. [`lock_store`] blocks the
+/// calling thread for up to the retry budget above, which must never park a tokio worker
+/// — a journal write happens twice inside a held repo lock, stalling every other op on
+/// that repo. A join failure is returned as an error the caller folds into its own
+/// fail-open arm.
+pub(crate) async fn locked_store_task<T, F>(job: F) -> AppResult<T>
+where
+    F: FnOnce() -> AppResult<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(job)
+        .await
+        .map_err(|e| AppError::Command(format!("store task did not run: {e}")))?
 }
 
 /// Take the cross-process lock for `store_file` and hold it until the returned guard
@@ -84,68 +119,140 @@ fn lock_at(lock_file: &Path, max_attempts: u32, delay: Duration, stale_age: Dura
     }
 }
 
-/// Atomically create `path`. `Ok(true)` = created by us, `Ok(false)` = someone else
-/// holds it. `create_new` is the atomic exclusive-create: exactly one of two racing
-/// callers gets `Ok(File)`, the other gets `AlreadyExists`. The file stays empty —
-/// only its existence and its mtime carry meaning.
-fn create_new_lock(path: &Path) -> std::io::Result<bool> {
+/// A holder's ownership stamp, `<pid>:<uuid>`. The pid alone cannot identify a holder —
+/// two threads of one process contend for the same store, and the MCP server can be a
+/// second run of this very binary — so the uuid is what makes it unique; the pid is
+/// there to make an abandoned file legible to a human.
+fn new_token() -> String {
+    format!("{}:{}", std::process::id(), uuid::Uuid::new_v4())
+}
+
+/// The ownership token stamped in the lock at `path`, or `None` when it can't be read
+/// (an I/O error, a handle held by something else, bytes that are not UTF-8). An EMPTY
+/// string is a file that exists without a stamp — never an ownerless one.
+fn read_token(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// [`read_token`] with one retry. The answer decides whether a file gets DELETED, so a
+/// momentary read failure — a scanner holding the handle for an instant — must not be
+/// mistaken for "nobody owns this".
+fn read_token_twice(path: &Path) -> Option<String> {
+    read_token(path).or_else(|| read_token(path))
+}
+
+/// Exclusively create `path` and stamp `token` into it, flushed before returning so no
+/// contender can observe the file without its owner. `Ok(true)` = created by us,
+/// `Ok(false)` = someone else holds it. A failed stamp removes the file rather than
+/// leaving an unidentifiable one behind: we won the exclusive create, so nobody else can
+/// be holding it, and an untokened file is spared by eviction until double the stale
+/// window ([`acquire`]).
+fn create_with_token(path: &Path, token: &str) -> std::io::Result<bool> {
+    if token.is_empty() {
+        // The one content this file must never be given deliberately: an empty stamp is
+        // indistinguishable from a create in flight, so writing one manufactures a lock
+        // that eviction spares until double the window.
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to stamp a store lock with an empty token",
+        ));
+    }
     match std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
     {
-        Ok(_) => Ok(true),
+        Ok(mut file) => match file.write_all(token.as_bytes()).and_then(|()| file.flush()) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                drop(file);
+                let _ = std::fs::remove_file(path);
+                Err(e)
+            }
+        },
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
         Err(e) => Err(e),
     }
+}
+
+/// Atomically create `path` under a FRESH ownership token, answering that token when we
+/// created it and `None` when someone else holds it. `create_new` is the atomic
+/// exclusive-create: exactly one of two racing callers gets `Ok(File)`, the other gets
+/// `AlreadyExists`.
+fn create_new_lock(path: &Path) -> std::io::Result<Option<String>> {
+    let token = new_token();
+    Ok(create_with_token(path, &token)?.then_some(token))
 }
 
 fn mtime(path: &Path) -> Option<SystemTime> {
     path.metadata().and_then(|m| m.modified()).ok()
 }
 
-/// `path`'s mtime WHEN it is at least `stale_age` old, else `None`. Unreadable
-/// metadata, or a future mtime (clock skew, which yields `Err`), both answer `None` —
-/// a lock we cannot age is never evicted. The mtime comes back because the eviction
-/// has to prove it removed the very file it aged.
-fn stale_mtime(path: &Path, stale_age: Duration) -> Option<SystemTime> {
-    let modified = mtime(path)?;
-    let age = SystemTime::now().duration_since(modified).ok()?;
-    (age >= stale_age).then_some(modified)
+/// Whether `path` is at least `stale_age` old — the only question mtime decides.
+/// Unreadable metadata, or a future mtime (clock skew, which yields `Err`), both answer
+/// `false`: a lock we cannot age is never evicted. WHICH file an eviction then took is
+/// proven by the ownership token, never by this timestamp (a re-created lock can land
+/// the same coarse mtime).
+fn is_stale(path: &Path, stale_age: Duration) -> bool {
+    mtime(path)
+        .and_then(|m| SystemTime::now().duration_since(m).ok())
+        .is_some_and(|age| age >= stale_age)
 }
 
-/// Evict the abandoned lock at `path`, whose mtime was observed as `observed`, and
-/// take it. The eviction is claimed by RENAME rather than unlink, because the aside
-/// copy proves WHICH file we removed: a plain `remove_file` + `create_new` lets a
-/// second contender — still carrying its own older staleness verdict — unlink the
-/// lock the first has already re-created and then claim it too, leaving two holders
-/// inside the critical section.
+/// Remove the file at `path` while PROVING it is the one stamped `expect`, answering
+/// whether that proof held. The claim is made by RENAME rather than unlink, because the
+/// aside copy is the proof: a `remove_file` — or a read-then-remove, whose two calls a
+/// whole eviction cycle can land between — deletes whatever is at the path NOW, which may
+/// be a later generation's live lock, leaving two holders inside the critical section.
 ///
-/// So if what we renamed away is not the file we aged, someone re-created it in that
-/// window: put it back and fail open rather than hold a lock we broke.
-fn evict_stale(path: &Path, observed: SystemTime) -> Option<PathBuf> {
-    let name = path.file_name()?.to_string_lossy().into_owned();
+/// Every other outcome ends with the slot as close to untouched as it can be. A lock we
+/// renamed away and then found to be someone else's is restored by exclusive create. One
+/// whose token we could not read AT ALL, or that carries no stamp, or whose slot has
+/// already been retaken, is left as an inert `.evict.*` file rather than unlinked: a
+/// stray beside the store costs nothing, and deleting a live holder's only lock is the
+/// one mistake here with no recovery.
+fn claim_by_rename(path: &Path, expect: &str) -> bool {
+    let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+        return false;
+    };
     let aside = path.with_file_name(format!(
         "{name}.evict.{}.{}",
         std::process::id(),
         uuid::Uuid::new_v4()
     ));
-    // A failed rename means the lock is gone or another contender is already evicting
+    // A failed rename means the lock is gone or another contender is already claiming
     // it — either way it is not ours to take.
     if std::fs::rename(path, &aside).is_err() {
-        return None;
+        return false;
     }
-    if mtime(&aside) != Some(observed) {
-        // A live lock, not the abandoned one. Restore it; if the restore loses to a
-        // third contender that has already taken the empty slot, drop the aside copy
-        // rather than leak it beside the store.
-        if std::fs::rename(&aside, path).is_err() {
-            let _ = std::fs::remove_file(&aside);
-        }
-        return None;
+    let found = read_token_twice(&aside);
+    if found.as_deref() == Some(expect) {
+        let _ = std::fs::remove_file(&aside);
+        return true;
     }
-    let _ = std::fs::remove_file(&aside);
-    won(path)
+    // Not the file we identified. Restore it by EXCLUSIVE CREATE, never a rename: rename
+    // replaces on both platforms, so restoring over a third contender that already took
+    // the emptied slot would destroy the exclusion it is providing. An unreadable or
+    // unstamped token has nothing safe to restore, so the aside stays put (see above).
+    let restored = found
+        .as_deref()
+        .filter(|live| !live.is_empty())
+        .is_some_and(|live| create_with_token(path, live).unwrap_or(false));
+    if restored {
+        let _ = std::fs::remove_file(&aside);
+    }
+    false
+}
+
+/// Evict the abandoned lock at `path`, whose ownership token was read as `observed`, and
+/// take it. Anything short of proving we removed that very file leaves the slot alone and
+/// fails open, rather than holding a lock we broke.
+fn evict_stale(path: &Path, observed: &str) -> Option<(PathBuf, String)> {
+    if claim_by_rename(path, observed) {
+        won(path)
+    } else {
+        None
+    }
 }
 
 /// Acquire the lock at `path`, answering the owned path or `None` to fail open.
@@ -154,11 +261,11 @@ fn acquire(
     max_attempts: u32,
     delay: Duration,
     stale_age: Duration,
-) -> Option<PathBuf> {
+) -> Option<(PathBuf, String)> {
     for attempt in 0..max_attempts {
         match create_new_lock(path) {
-            Ok(true) => return Some(path.to_path_buf()),
-            Ok(false) => {}
+            Ok(Some(token)) => return Some((path.to_path_buf(), token)),
+            Ok(None) => {}
             // The store's directory doesn't exist yet — nothing has been written
             // there. `atomic_write` creates it at write time, so create it here too
             // rather than leaving the first-ever write of a fresh install unlocked.
@@ -174,8 +281,19 @@ fn acquire(
         // Held by someone. Only an ABANDONED lock is evictable, and the eviction is
         // itself claimed atomically ([`evict_stale`]); anything short of winning it
         // outright yields rather than looping (mirrors `automation_claims`).
-        if let Some(observed) = stale_mtime(path, stale_age) {
-            return evict_stale(path, observed);
+        if is_stale(path, stale_age) {
+            // No identity, no eviction: a lock whose token we cannot read is one we could
+            // never prove we removed.
+            let observed = read_token_twice(path)?;
+            // An unstamped file is normally a create still in flight, so it is spared.
+            // Past DOUBLE the window that reading no longer holds — stamping takes
+            // microseconds — and what is left is a process that died between the create
+            // and the stamp. Sparing that one forever would wedge every writer of this
+            // store into running unlocked.
+            if observed.is_empty() && !is_stale(path, stale_age.saturating_mul(2)) {
+                return None;
+            }
+            return evict_stale(path, &observed);
         }
         if attempt + 1 < max_attempts {
             std::thread::sleep(delay);
@@ -184,11 +302,11 @@ fn acquire(
     None
 }
 
-/// One exclusive-create attempt as an ownership answer: `Some(path)` only when this
-/// caller created the file.
-fn won(path: &Path) -> Option<PathBuf> {
+/// One exclusive-create attempt as an ownership answer: the path plus our token, only
+/// when this caller created the file.
+fn won(path: &Path) -> Option<(PathBuf, String)> {
     match create_new_lock(path) {
-        Ok(true) => Some(path.to_path_buf()),
+        Ok(Some(token)) => Some((path.to_path_buf(), token)),
         _ => None,
     }
 }
@@ -207,15 +325,20 @@ mod tests {
         (dir, store)
     }
 
-    /// Age `path`'s mtime by `age`. The write handle is required: on Windows
+    /// Stamp `path`'s mtime to exactly `when`. The write handle is required: on Windows
     /// `set_modified` fails with PermissionDenied on a read-only one.
-    fn backdate(path: &Path, age: Duration) {
+    fn set_mtime(path: &Path, when: SystemTime) {
         std::fs::OpenOptions::new()
             .write(true)
             .open(path)
             .unwrap()
-            .set_modified(SystemTime::now() - age)
+            .set_modified(when)
             .unwrap();
+    }
+
+    /// Age `path`'s mtime by `age`.
+    fn backdate(path: &Path, age: Duration) {
+        set_mtime(path, SystemTime::now() - age);
     }
 
     #[test]
@@ -260,7 +383,7 @@ mod tests {
         let path = lock_path(&store);
 
         // A process took the lock and died without releasing it.
-        assert!(create_new_lock(&path).unwrap());
+        assert!(create_new_lock(&path).unwrap().is_some());
         backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
 
         let taken = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
@@ -277,17 +400,16 @@ mod tests {
     fn eviction_takes_the_lock_it_aged_and_leaves_no_scratch() {
         let (_tmp, store) = tmp_store();
         let path = lock_path(&store);
-        assert!(create_new_lock(&path).unwrap());
+        let observed = create_new_lock(&path).unwrap().expect("the first caller wins");
         backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
-        let observed = mtime(&path).unwrap();
 
-        let owned = evict_stale(&path, observed).expect("an abandoned lock is evictable");
+        let (owned, token) = evict_stale(&path, &observed).expect("an abandoned lock is evictable");
         assert_eq!(owned, path);
         assert_ne!(
-            mtime(&path),
-            Some(observed),
+            token, observed,
             "the evictor holds its own fresh file, not the corpse"
         );
+        assert_eq!(read_token(&path).as_deref(), Some(token.as_str()));
         let strays: Vec<_> = std::fs::read_dir(path.parent().unwrap())
             .unwrap()
             .flatten()
@@ -300,26 +422,24 @@ mod tests {
     fn eviction_that_finds_a_re_created_lock_restores_it_and_stands_down() {
         let (_tmp, store) = tmp_store();
         let path = lock_path(&store);
-        assert!(create_new_lock(&path).unwrap());
+        let observed = create_new_lock(&path).unwrap().unwrap();
         backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
-        let observed = mtime(&path).unwrap();
 
         // Another contender got there first: it evicted the abandoned lock and took
-        // its own, so the file on disk is no longer the one we aged. Under a plain
+        // its own, so the file on disk is no longer the one we identified. Under a plain
         // remove + create_new this caller would unlink that live lock and claim the
         // slot too — two holders inside the critical section.
         std::fs::remove_file(&path).unwrap();
-        assert!(create_new_lock(&path).unwrap());
-        let theirs = mtime(&path).unwrap();
+        let theirs = create_new_lock(&path).unwrap().unwrap();
         assert_ne!(theirs, observed);
 
         assert!(
-            evict_stale(&path, observed).is_none(),
-            "a lock we did not age is not ours to evict"
+            evict_stale(&path, &observed).is_none(),
+            "a lock we did not identify is not ours to evict"
         );
         assert_eq!(
-            mtime(&path),
-            Some(theirs),
+            read_token(&path).as_deref(),
+            Some(theirs.as_str()),
             "the live lock must be put back, not consumed"
         );
     }
@@ -328,7 +448,7 @@ mod tests {
     fn a_lock_younger_than_the_window_is_never_evicted() {
         let (_tmp, store) = tmp_store();
         let path = lock_path(&store);
-        assert!(create_new_lock(&path).unwrap());
+        assert!(create_new_lock(&path).unwrap().is_some());
         // Just inside the window: a live holder mid-RMW must keep excluding, or the
         // eviction path reintroduces the lost update it exists to prevent.
         backdate(&path, STALE_LOCK_AGE - Duration::from_secs(2));
@@ -378,5 +498,188 @@ mod tests {
             second.owned.is_some(),
             "a released lock must be immediately re-acquirable"
         );
+    }
+
+    // ── Ownership token ──────────────────────────────────────────────────────
+
+    #[test]
+    fn a_new_lock_carries_its_owners_token() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+
+        let token = create_new_lock(&path).unwrap().expect("the create wins");
+        assert_eq!(
+            read_token(&path).as_deref(),
+            Some(token.as_str()),
+            "the stamp must be flushed before the create returns, or a contender reads \
+             an ownerless file"
+        );
+        assert!(
+            token.starts_with(&format!("{}:", std::process::id())),
+            "the pid prefix makes an abandoned lock legible: {token}"
+        );
+        // Two locks on the same store never share a token: same-process test threads
+        // contend here, so the pid alone could not tell them apart.
+        std::fs::remove_file(&path).unwrap();
+        assert_ne!(create_new_lock(&path).unwrap().unwrap(), token);
+    }
+
+    #[test]
+    fn an_unstamped_lock_inside_double_the_window_is_never_evicted() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        // An empty file is a create whose stamp has not landed — the one state that must
+        // NOT read as ownerless, or the evictor takes a lock someone is about to hold.
+        std::fs::write(&path, b"").unwrap();
+        backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
+
+        let denied = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
+        assert!(denied.owned.is_none(), "an unidentifiable lock is not ours");
+        assert!(path.exists(), "and it must not be consumed either");
+    }
+
+    #[test]
+    fn an_unstamped_lock_past_double_the_window_is_evictable() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        // The escape hatch: a stamp takes microseconds, so an unstamped file this old is
+        // a process that died between the create and the stamp — not one in flight.
+        // Without the hatch it would spare itself forever and every writer of this store
+        // would run unlocked from here on.
+        std::fs::write(&path, b"").unwrap();
+        backdate(&path, STALE_LOCK_AGE * 2 + Duration::from_secs(1));
+
+        let taken = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
+        let (_, token) = taken.owned.clone().expect("a dead create must not wedge the store");
+        assert_eq!(read_token(&path).as_deref(), Some(token.as_str()));
+    }
+
+    #[test]
+    fn an_empty_token_is_never_stamped() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        let err = create_with_token(&path, "").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            !path.exists(),
+            "the refusal must not leave the poisoned file it declined to stamp"
+        );
+    }
+
+    #[test]
+    fn a_claim_whose_aside_cannot_be_read_never_unlinks_it() {
+        let (tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        // Bytes `read_to_string` rejects: the file may be a live holder's only lock (the
+        // same answer a transient read error gives), so the claim must fail WITHOUT
+        // destroying it.
+        std::fs::write(&path, [0xFFu8, 0xFE, 0xFD]).unwrap();
+
+        assert!(
+            !claim_by_rename(&path, "1:someone"),
+            "a file we cannot identify is not ours to take"
+        );
+        let survivors: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| std::fs::read(e.path()).unwrap_or_default() == [0xFF, 0xFE, 0xFD])
+            .collect();
+        assert_eq!(
+            survivors.len(),
+            1,
+            "the lock's content must survive — restored or left aside, never unlinked"
+        );
+    }
+
+    #[test]
+    fn a_claim_whose_aside_is_unstamped_never_unlinks_it() {
+        let (tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        // The interleaving that used to manufacture permanent poison: the claim finds an
+        // in-flight create's empty file. Restoring it would write an empty token back;
+        // unlinking it would destroy a lock that is about to be stamped. Neither.
+        std::fs::write(&path, b"").unwrap();
+
+        assert!(!claim_by_rename(&path, "1:someone"));
+        let asides: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
+            .collect();
+        assert_eq!(asides.len(), 1, "the in-flight file is kept, not deleted");
+        assert!(
+            read_token(&path).is_none_or(|t| !t.is_empty()),
+            "and no empty token is ever written back into the slot"
+        );
+    }
+
+    #[test]
+    fn a_guard_whose_lock_was_replaced_releases_nothing() {
+        let (tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        let held = lock_store(&store);
+        assert!(held.owned.is_some());
+
+        // The holder outlived the stale window and was evicted; the evictor's own lock
+        // now sits at that path. Releasing by PATH alone would delete it and put two
+        // writers inside the critical section — and so would a read-then-remove that
+        // this same replacement lands between.
+        std::fs::remove_file(&path).unwrap();
+        let theirs = create_new_lock(&path).unwrap().unwrap();
+
+        drop(held);
+        assert_eq!(
+            read_token(&path).as_deref(),
+            Some(theirs.as_str()),
+            "a stale guard must not release a later generation's lock"
+        );
+        // The release yanks before it proves, so the put-back has to be complete: the
+        // live lock is back in the slot AND its aside copy is gone.
+        let strays: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
+            .collect();
+        assert!(strays.is_empty(), "a restored lock leaves no scratch behind");
+    }
+
+    #[test]
+    fn a_re_created_lock_sharing_the_evicted_ones_mtime_is_not_taken() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        let observed = create_new_lock(&path).unwrap().unwrap();
+        // One timestamp for both generations: filesystem mtime is coarse (tens of ms on
+        // Windows), so "same mtime" is not "same file" — only the token can say.
+        let aged = SystemTime::now() - (STALE_LOCK_AGE + Duration::from_secs(5));
+        set_mtime(&path, aged);
+
+        std::fs::remove_file(&path).unwrap();
+        let theirs = create_new_lock(&path).unwrap().unwrap();
+        set_mtime(&path, aged);
+
+        assert!(
+            evict_stale(&path, &observed).is_none(),
+            "an mtime match is not an identity match"
+        );
+        assert_eq!(
+            read_token(&path).as_deref(),
+            Some(theirs.as_str()),
+            "the live lock must be put back intact"
+        );
+    }
+
+    #[test]
+    fn a_restore_never_replaces_a_lock_that_took_the_slot() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        // The restore arm's mechanism: an exclusive create, so a third contender that
+        // already claimed the emptied slot keeps its lock. A replacing `rename` here
+        // would hand two callers the store at once.
+        let theirs = create_new_lock(&path).unwrap().unwrap();
+        assert!(
+            !create_with_token(&path, "1:restored").unwrap(),
+            "an occupied slot must refuse the restore"
+        );
+        assert_eq!(read_token(&path).as_deref(), Some(theirs.as_str()));
     }
 }

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -146,11 +146,21 @@ fn read_token_twice(path: &Path) -> Option<String> {
 
 /// Exclusively create `path` and stamp `token` into it, flushed before returning so no
 /// contender can observe the file without its owner. `Ok(true)` = created by us,
-/// `Ok(false)` = someone else holds it. A failed stamp removes the file rather than
-/// leaving an unidentifiable one behind: we won the exclusive create, so nobody else can
-/// be holding it, and an untokened file is spared by eviction until double the stale
-/// window ([`acquire`]).
+/// `Ok(false)` = someone else holds it.
 fn create_with_token(path: &Path, token: &str) -> std::io::Result<bool> {
+    create_stamped(path, token, |file, token| {
+        file.write_all(token.as_bytes())?;
+        file.flush()
+    })
+}
+
+/// [`create_with_token`] with the stamp step injected, so a test can drive the arm where
+/// the file is created but never receives its token.
+fn create_stamped(
+    path: &Path,
+    token: &str,
+    stamp: impl FnOnce(&mut std::fs::File, &str) -> std::io::Result<()>,
+) -> std::io::Result<bool> {
     if token.is_empty() {
         // The one content this file must never be given deliberately: an empty stamp is
         // indistinguishable from a create in flight, so writing one manufactures a lock
@@ -165,14 +175,13 @@ fn create_with_token(path: &Path, token: &str) -> std::io::Result<bool> {
         .create_new(true)
         .open(path)
     {
-        Ok(mut file) => match file.write_all(token.as_bytes()).and_then(|()| file.flush()) {
-            Ok(()) => Ok(true),
-            Err(e) => {
-                drop(file);
-                let _ = std::fs::remove_file(path);
-                Err(e)
-            }
-        },
+        // A failed stamp LEAVES the file. Unlinking by path is the class this module
+        // refuses everywhere else: a stamp that stalled past the eviction window can find
+        // the path already re-created by someone else, and the cleanup would delete THEIR
+        // lock. Unstamped, it blocks this store's writers for at most 2× the stale window
+        // before [`acquire`]'s escape hatch reclaims it — bounded, where a deleted live
+        // lock is an unbounded double grant.
+        Ok(mut file) => stamp(&mut file, token).map(|()| true),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
         Err(e) => Err(e),
     }
@@ -290,9 +299,10 @@ fn acquire(
             let observed = read_token_twice(path)?;
             // An unstamped file is normally a create still in flight, so it is spared.
             // Past DOUBLE the window that reading no longer holds — stamping takes
-            // microseconds — and what is left is a process that died between the create
-            // and the stamp. Sparing that one forever would wedge every writer of this
-            // store into running unlocked.
+            // microseconds — and what is left is a create whose stamp never landed,
+            // because the process died or the write failed ([`create_stamped`] leaves
+            // those). Sparing them forever would wedge every writer of this store into
+            // running unlocked.
             if observed.is_empty() && !is_stale(path, stale_age.saturating_mul(2)) {
                 return None;
             }
@@ -545,8 +555,9 @@ mod tests {
     fn an_unstamped_lock_past_double_the_window_is_evictable() {
         let (_tmp, store) = tmp_store();
         let path = lock_path(&store);
-        // The escape hatch: a stamp takes microseconds, so an unstamped file this old is
-        // a process that died between the create and the stamp — not one in flight.
+        // The escape hatch, and the reclamation half of what
+        // `a_failed_stamp_leaves_its_file_for_the_hatch` leaves behind: a stamp takes
+        // microseconds, so an unstamped file this old never got one — not one in flight.
         // Without the hatch it would spare itself forever and every writer of this store
         // would run unlocked from here on.
         std::fs::write(&path, b"").unwrap();
@@ -555,6 +566,30 @@ mod tests {
         let taken = lock_at(&path, 1, Duration::from_millis(1), STALE_LOCK_AGE);
         let (_, token) = taken.owned.clone().expect("a dead create must not wedge the store");
         assert_eq!(read_token(&path).as_deref(), Some(token.as_str()));
+    }
+
+    /// A stamp that fails must LEAVE the file it created. Removing it is an unlink by
+    /// path, and a stamp slow enough to fail can be slow enough to have been evicted —
+    /// the cleanup would then delete whichever lock took the slot. The reclamation half
+    /// of this trade (an unstamped file self-heals after 2× the window) is owned by
+    /// `an_unstamped_lock_past_double_the_window_is_evictable`.
+    #[test]
+    fn a_failed_stamp_leaves_its_file_for_the_hatch() {
+        let (_tmp, store) = tmp_store();
+        let path = lock_path(&store);
+
+        let err = create_stamped(&path, "1:doomed", |_, _| {
+            Err(std::io::Error::other("the disk filled mid-stamp"))
+        })
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "the disk filled mid-stamp");
+        assert!(path.exists(), "the created file must not be unlinked");
+        assert_eq!(
+            read_token(&path).as_deref(),
+            Some(""),
+            "and it is unstamped, which is what the escape hatch keys on"
+        );
     }
 
     #[test]
@@ -643,7 +678,10 @@ mod tests {
             .flatten()
             .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
             .collect();
-        assert!(strays.is_empty(), "a restored lock leaves no scratch behind");
+        assert!(
+            strays.is_empty(),
+            "the live lock is never moved, so no aside is ever created"
+        );
     }
 
     #[test]

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -54,8 +54,9 @@ const RETRY_DELAY: Duration = Duration::from_millis(25);
 /// heartbeat would need a write handle on Windows for no gain.
 const STALE_LOCK_AGE: Duration = Duration::from_secs(10);
 
-/// RAII holder of a store lock: dropping it releases (best-effort `remove_file`) on
-/// every path, success or panic. A guard that FAILED to acquire owns nothing and
+/// RAII holder of a store lock: dropping it releases by proving the on-disk token is
+/// still ours and claiming the file by rename ([`claim_by_rename`]); a mismatch
+/// releases nothing. A guard that FAILED to acquire owns nothing and
 /// releases nothing — deleting a live holder's file would break the exclusion it is
 /// currently providing to someone else. What it owns is a path AND the ownership token
 /// stamped in that file, because the path alone can name a LATER generation's lock.
@@ -635,8 +636,8 @@ mod tests {
             Some(theirs.as_str()),
             "a stale guard must not release a later generation's lock"
         );
-        // The release yanks before it proves, so the put-back has to be complete: the
-        // live lock is back in the slot AND its aside copy is gone.
+        // The pre-read short-circuits the release, so the live lock is never touched:
+        // still in the slot, and no aside scratch was ever created.
         let strays: Vec<_> = std::fs::read_dir(tmp.path())
             .unwrap()
             .flatten()

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -65,12 +65,14 @@ pub(crate) struct StoreLock {
 
 impl Drop for StoreLock {
     fn drop(&mut self) {
-        // Release through the same proof an eviction uses. A holder that outlives
-        // [`STALE_LOCK_AGE`] can be evicted mid-RMW, and both an unconditional
-        // `remove_file` and a read-then-remove (a whole eviction cycle fits between its
-        // two calls) would then delete the EVICTOR's lock, granting the store twice.
+        // Two gates, both needed. PRE-READ: a guard evicted past [`STALE_LOCK_AGE`] finds
+        // the evictor's LIVE lock here, and even renaming that aside to inspect it empties
+        // the slot long enough to be stolen — so on a mismatch, touch nothing. Then
+        // [`claim_by_rename`] guards the microseconds after it (an unlink alone would not).
         if let Some((path, token)) = &self.owned {
-            claim_by_rename(path, token);
+            if read_token_twice(path).as_deref() == Some(token.as_str()) {
+                claim_by_rename(path, token);
+            }
         }
     }
 }
@@ -641,6 +643,37 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
             .collect();
         assert!(strays.is_empty(), "a restored lock leaves no scratch behind");
+    }
+
+    #[test]
+    fn a_guard_whose_lock_was_replaced_never_touches_the_file() {
+        let (tmp, store) = tmp_store();
+        let path = lock_path(&store);
+        let held = lock_store(&store);
+        assert!(held.owned.is_some());
+
+        // Same setup as the test above, but pinning the stronger property: not merely
+        // that the evictor's lock survives, that it is never MOVED. A yank-then-restore
+        // empties the slot for the read, which is all a third contender needs to take it
+        // and leave the rightful holder running unprotected beside it.
+        std::fs::remove_file(&path).unwrap();
+        create_new_lock(&path).unwrap().unwrap();
+        // Backdated so a restore would be visible: an exclusive re-create stamps `now`.
+        backdate(&path, STALE_LOCK_AGE + Duration::from_secs(5));
+        let untouched = mtime(&path).expect("the live lock must be readable");
+
+        drop(held);
+        assert_eq!(
+            mtime(&path),
+            Some(untouched),
+            "a stale guard must not even move a later generation's lock"
+        );
+        let strays: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".evict."))
+            .collect();
+        assert!(strays.is_empty(), "and must leave no scratch of its own");
     }
 
     #[test]

--- a/src/features/repo-settings/BitbucketBranchRestrictionsSection.tsx
+++ b/src/features/repo-settings/BitbucketBranchRestrictionsSection.tsx
@@ -76,6 +76,19 @@ export function BitbucketBranchRestrictionsSection({
   >(null);
   const [confirming, setConfirming] = useState<string | null>(null);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleRemove(id: string) {
+    try {
+      await remove.mutateAsync(id);
+      toast.success("Restriction deleted");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (editing) {
     return (
       <RestrictionForm
@@ -126,15 +139,7 @@ export function BitbucketBranchRestrictionsSection({
                   actLabel="Delete"
                   pending={remove.isPending}
                   onCancel={() => setConfirming(null)}
-                  onAct={() =>
-                    remove.mutate(r.id, {
-                      onSuccess: () => {
-                        toast.success("Restriction deleted");
-                        setConfirming(null);
-                      },
-                      onError: toastError,
-                    })
-                  }
+                  onAct={() => handleRemove(r.id)}
                 />
               ) : (
                 <>
@@ -196,27 +201,27 @@ function RestrictionForm({
       ? "Enter a whole number between 1 and 10."
       : null;
 
-  function submit() {
+  async function submit() {
     const payloadValue = needsValue ? numValue : null;
-    const done = {
-      onSuccess: () => {
-        toast.success(editing ? "Restriction updated" : "Restriction added");
-        onDone();
-      },
-      onError: toastError,
-    };
-    if (restriction) {
-      update.mutate(
-        {
+    try {
+      if (restriction) {
+        await update.mutateAsync({
           id: restriction.id,
           kind: restriction.kind,
           pattern: trimmed,
           value: payloadValue,
-        },
-        done,
-      );
-    } else {
-      create.mutate({ kind, pattern: trimmed, value: payloadValue }, done);
+        });
+      } else {
+        await create.mutateAsync({
+          kind,
+          pattern: trimmed,
+          value: payloadValue,
+        });
+      }
+      toast.success(editing ? "Restriction updated" : "Restriction added");
+      onDone();
+    } catch (e) {
+      toastError(e);
     }
   }
 

--- a/src/features/repo-settings/BitbucketDefaultReviewersSection.tsx
+++ b/src/features/repo-settings/BitbucketDefaultReviewersSection.tsx
@@ -37,6 +37,28 @@ export function BitbucketDefaultReviewersSection({
 
   const rows = reviewers.data ?? [];
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleAdd(user: ForgeUserRef) {
+    try {
+      await add.mutateAsync(user.id);
+      toast.success(`Added ${user.label}`);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRemove(reviewer: ForgeUserRef) {
+    try {
+      await remove.mutateAsync(reviewer.id);
+      toast.success(`Removed ${reviewer.label}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="min-w-0 space-y-4">
       <div className="flex items-center justify-between gap-2">
@@ -48,12 +70,7 @@ export function BitbucketDefaultReviewersSection({
           open={open}
           added={rows}
           pending={add.isPending}
-          onAdd={(user) =>
-            add.mutate(user.id, {
-              onSuccess: () => toast.success(`Added ${user.label}`),
-              onError: toastError,
-            })
-          }
+          onAdd={handleAdd}
         />
       </div>
 
@@ -90,15 +107,7 @@ export function BitbucketDefaultReviewersSection({
               pending={remove.isPending}
               onConfirm={() => setConfirming(r.id)}
               onCancel={() => setConfirming(null)}
-              onRemove={() =>
-                remove.mutate(r.id, {
-                  onSuccess: () => {
-                    toast.success(`Removed ${r.label}`);
-                    setConfirming(null);
-                  },
-                  onError: toastError,
-                })
-              }
+              onRemove={() => handleRemove(r)}
             />
           ))}
         </div>

--- a/src/features/repo-settings/BitbucketEnvironmentsSection.tsx
+++ b/src/features/repo-settings/BitbucketEnvironmentsSection.tsx
@@ -31,16 +31,23 @@ export function BitbucketEnvironmentsSection({
   const settings = useBbRepoSettings(repoPath, open);
   const webUrl = settings.data?.webUrl;
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleEnablePipelines() {
+    try {
+      await setEnabled.mutateAsync(true);
+      toast.success("Pipelines enabled");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (config.data && !enabled) {
     return (
       <PipelinesDisabledBanner
         pending={setEnabled.isPending}
-        onEnable={() =>
-          setEnabled.mutate(true, {
-            onSuccess: () => toast.success("Pipelines enabled"),
-            onError: toastError,
-          })
-        }
+        onEnable={handleEnablePipelines}
       />
     );
   }

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -142,6 +142,18 @@ function BitbucketGeneralForm({
 
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleSave() {
+    try {
+      await update.mutateAsync(form);
+      toast.success("Settings saved");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   // Keep the current default selectable even if that branch isn't local; drop
   // agent-session branches (`gd/session/*`) — they're app-internal.
   const branchNames = branches
@@ -292,12 +304,7 @@ function BitbucketGeneralForm({
       <div className="flex items-center justify-end gap-2 border-t pt-3">
         <Button
           disabled={!dirty || update.isPending || descGen.generating}
-          onClick={() =>
-            update.mutate(form, {
-              onSuccess: () => toast.success("Settings saved"),
-              onError: toastError,
-            })
-          }
+          onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}
           Save changes

--- a/src/features/repo-settings/BitbucketSchedulesSection.tsx
+++ b/src/features/repo-settings/BitbucketSchedulesSection.tsx
@@ -36,7 +36,8 @@ const bbSchedulesKey = (repo: string) => ["repo", repo, "bb-schedules"];
  *  in place (a single discrete control, so apply-on-change) and deletes with a
  *  confirm. Cron patterns are QUARTZ format (e.g. "0 0 12 * * ?"). The list can lag
  *  a create by ~1s (server replication), so the created row is patched into the
- *  cache in the create's onSuccess and reconciled by a single delayed refetch. */
+ *  cache by the awaited create's continuation and reconciled by a single
+ *  delayed refetch. */
 export function BitbucketSchedulesSection({
   repoPath,
   open,
@@ -82,16 +83,41 @@ export function BitbucketSchedulesSection({
     }, 2500);
   }
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleEnablePipelines() {
+    try {
+      await setEnabled.mutateAsync(true);
+      toast.success("Pipelines enabled");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleToggle(uuid: string, next: boolean) {
+    try {
+      await setScheduleEnabled.mutateAsync({ uuid, enabled: next });
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRemove(uuid: string) {
+    try {
+      await remove.mutateAsync(uuid);
+      toast.success("Schedule deleted");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (config.data && !enabled) {
     return (
       <PipelinesDisabledBanner
         pending={setEnabled.isPending}
-        onEnable={() =>
-          setEnabled.mutate(true, {
-            onSuccess: () => toast.success("Pipelines enabled"),
-            onError: toastError,
-          })
-        }
+        onEnable={handleEnablePipelines}
       />
     );
   }
@@ -139,25 +165,12 @@ export function BitbucketSchedulesSection({
               setScheduleEnabled.isPending &&
               setScheduleEnabled.variables?.uuid === s.uuid
             }
-            onToggle={(next) =>
-              setScheduleEnabled.mutate(
-                { uuid: s.uuid, enabled: next },
-                { onError: toastError },
-              )
-            }
+            onToggle={(next) => handleToggle(s.uuid, next)}
             confirming={confirming === s.uuid}
             pending={remove.isPending}
             onConfirm={() => setConfirming(s.uuid)}
             onCancel={() => setConfirming(null)}
-            onRemove={() =>
-              remove.mutate(s.uuid, {
-                onSuccess: () => {
-                  toast.success("Schedule deleted");
-                  setConfirming(null);
-                },
-                onError: toastError,
-              })
-            }
+            onRemove={() => handleRemove(s.uuid)}
           />
         ))}
       </AsyncListBody>
@@ -272,7 +285,7 @@ function ScheduleForm({
       ? "Enter a Quartz cron pattern."
       : null;
 
-  function submit() {
+  async function submit() {
     const cronPattern = cron.trim();
     const created: BitbucketPipelineSchedule = {
       // The create call returns void, so synthesize a uuid; the reconcile refetch
@@ -284,18 +297,15 @@ function ScheduleForm({
       cronPattern,
       enabled: true,
     };
-    create.mutate(
-      { refName, cronPattern, enabled: true },
-      {
-        onSuccess: () => {
-          onPatch(created);
-          onReconcile();
-          toast.success("Schedule added");
-          onDone();
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await create.mutateAsync({ refName, cronPattern, enabled: true });
+      onPatch(created);
+      onReconcile();
+      toast.success("Schedule added");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/BitbucketVariablesSection.tsx
+++ b/src/features/repo-settings/BitbucketVariablesSection.tsx
@@ -29,8 +29,8 @@ function validKey(k: string): boolean {
 /** Bitbucket pipeline variables. A secured variable's value is write-only — the
  *  API never returns it, so secured rows show "Secured — value hidden" (never
  *  faked masked text). The list can lag a write by ~1s (server replication), so
- *  the created/edited row is patched into the cache in the mutation's onSuccess
- *  and reconciled by the invalidation refetch. */
+ *  the created/edited row is patched into the cache by the awaited mutation's
+ *  continuation and reconciled by the invalidation refetch. */
 export function BitbucketVariablesSection({
   repoPath,
   open,
@@ -51,16 +51,23 @@ export function BitbucketVariablesSection({
   const [secured, setSecured] = useState(false);
   const [confirming, setConfirming] = useState<string | null>(null);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleEnablePipelines() {
+    try {
+      await setEnabled.mutateAsync(true);
+      toast.success("Pipelines enabled");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (config.data && !enabled) {
     return (
       <PipelinesDisabledBanner
         pending={setEnabled.isPending}
-        onEnable={() =>
-          setEnabled.mutate(true, {
-            onSuccess: () => toast.success("Pipelines enabled"),
-            onError: toastError,
-          })
-        }
+        onEnable={handleEnablePipelines}
       />
     );
   }
@@ -102,7 +109,7 @@ export function BitbucketVariablesSection({
     }, 2500);
   }
 
-  function addVariable() {
+  async function addVariable() {
     const created: BitbucketPipelineVariable = {
       // The create call returns void, so synthesize a uuid keyed on the name;
       // the refetch replaces it with the server's real row shortly.
@@ -111,20 +118,27 @@ export function BitbucketVariablesSection({
       value: secured ? null : value,
       secured,
     };
-    create.mutate(
-      { key: key.trim(), value, secured },
-      {
-        onSuccess: () => {
-          patchRow(created);
-          reconcileAfterWrite();
-          toast.success(`Added ${key.trim()}`);
-          setKey("");
-          setValue("");
-          setSecured(false);
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await create.mutateAsync({ key: key.trim(), value, secured });
+      patchRow(created);
+      reconcileAfterWrite();
+      toast.success(`Added ${key.trim()}`);
+      setKey("");
+      setValue("");
+      setSecured(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRemove(uuid: string, variableKey: string) {
+    try {
+      await remove.mutateAsync(uuid);
+      toast.success(`Deleted ${variableKey}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -189,15 +203,7 @@ export function BitbucketVariablesSection({
             pending={remove.isPending}
             onConfirm={() => setConfirming(v.uuid)}
             onCancel={() => setConfirming(null)}
-            onRemove={() =>
-              remove.mutate(v.uuid, {
-                onSuccess: () => {
-                  toast.success(`Deleted ${v.key}`);
-                  setConfirming(null);
-                },
-                onError: toastError,
-              })
-            }
+            onRemove={() => handleRemove(v.uuid, v.key)}
           />
         ))}
       </AsyncListBody>
@@ -242,24 +248,25 @@ function VariableRow({
     ? draft.length > 0 || secure !== variable.secured
     : draft !== (variable.value ?? "") || secure !== variable.secured;
 
-  function save() {
-    update.mutate(
-      { uuid: variable.uuid, value: draft, secured: secure },
-      {
-        onSuccess: () => {
-          onPatch({
-            uuid: variable.uuid,
-            key: variable.key,
-            value: secure ? null : draft,
-            secured: secure,
-          });
-          onReconcile();
-          toast.success(`Updated ${variable.key}`);
-          setDraft("");
-        },
-        onError: toastError,
-      },
-    );
+  async function save() {
+    try {
+      await update.mutateAsync({
+        uuid: variable.uuid,
+        value: draft,
+        secured: secure,
+      });
+      onPatch({
+        uuid: variable.uuid,
+        key: variable.key,
+        value: secure ? null : draft,
+        secured: secure,
+      });
+      onReconcile();
+      toast.success(`Updated ${variable.key}`);
+      setDraft("");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/BitbucketWebhooksSection.tsx
+++ b/src/features/repo-settings/BitbucketWebhooksSection.tsx
@@ -62,6 +62,19 @@ export function BitbucketWebhooksSection({
   const [editing, setEditing] = useState<BitbucketHook | "new" | null>(null);
   const [confirming, setConfirming] = useState<string | null>(null);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleDelete(uuid: string) {
+    try {
+      await deleteHook.mutateAsync(uuid);
+      toast.success("Webhook deleted");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (editing) {
     return (
       <HookForm
@@ -116,15 +129,7 @@ export function BitbucketWebhooksSection({
                   actLabel="Delete"
                   pending={deleteHook.isPending}
                   onCancel={() => setConfirming(null)}
-                  onAct={() =>
-                    deleteHook.mutate(h.uuid, {
-                      onSuccess: () => {
-                        toast.success("Webhook deleted");
-                        setConfirming(null);
-                      },
-                      onError: toastError,
-                    })
-                  }
+                  onAct={() => handleDelete(h.uuid)}
                 />
               ) : (
                 <>
@@ -189,7 +194,7 @@ function HookForm({
     setEvents((prev) => (on ? [...prev, id] : prev.filter((e) => e !== id)));
   }
 
-  function save() {
+  async function save() {
     // Bitbucket requires the FULL shape on a PUT (a partial 400s), so create
     // and update send identical inputs.
     const input = {
@@ -199,15 +204,14 @@ function HookForm({
       events,
       skipCertVerification,
     };
-    const done = {
-      onSuccess: () => {
-        toast.success(hook ? "Webhook updated" : "Webhook created");
-        onDone();
-      },
-      onError: toastError,
-    };
-    if (hook) update.mutate({ uuid: hook.uuid, input }, done);
-    else create.mutate(input, done);
+    try {
+      if (hook) await update.mutateAsync({ uuid: hook.uuid, input });
+      else await create.mutateAsync(input);
+      toast.success(hook ? "Webhook updated" : "Webhook created");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/CollaboratorsSection.tsx
+++ b/src/features/repo-settings/CollaboratorsSection.tsx
@@ -90,17 +90,58 @@ export function CollaboratorsSection({
   const collabRows = collaborators.data ?? [];
   const inviteRows = invitations.data ?? [];
 
-  function addCollaborator() {
-    add.mutate(
-      { username: username.trim(), role },
-      {
-        onSuccess: (pending) => {
-          toast.success(pending ? "Invitation sent" : "Collaborator added");
-          setUsername("");
-        },
-        onError: toastError,
-      },
-    );
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function addCollaborator() {
+    try {
+      const pending = await add.mutateAsync({
+        username: username.trim(),
+        role,
+      });
+      toast.success(pending ? "Invitation sent" : "Collaborator added");
+      setUsername("");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function setCollaboratorRole(login: string, next: RepoRole) {
+    try {
+      await add.mutateAsync({ username: login, role: next });
+      toast.success(`${login} is now ${next}`);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function removeCollaborator(login: string) {
+    try {
+      await remove.mutateAsync(login);
+      toast.success(`Removed ${login}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function setInvitationRole(id: string, permission: RepoRole) {
+    try {
+      await updateInvite.mutateAsync({ id, permission });
+      toast.success("Invitation updated");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function cancelInvitation(id: string) {
+    try {
+      await cancelInvite.mutateAsync(id);
+      toast.success("Invitation canceled");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -114,7 +155,7 @@ export function CollaboratorsSection({
             autoComplete="off"
             spellCheck={false}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && canAdd) addCollaborator();
+              if (e.key === "Enter" && canAdd) void addCollaborator();
             }}
           />
           <Select
@@ -189,28 +230,12 @@ export function CollaboratorsSection({
                 roleValue={c.roleName}
                 roleDisabled={add.isPending}
                 roles={roles}
-                onRole={(r) =>
-                  add.mutate(
-                    { username: c.login, role: r },
-                    {
-                      onSuccess: () => toast.success(`${c.login} is now ${r}`),
-                      onError: toastError,
-                    },
-                  )
-                }
+                onRole={(r) => setCollaboratorRole(c.login, r)}
                 confirming={confirming === key}
                 pending={remove.isPending}
                 onConfirm={() => setConfirming(key)}
                 onCancel={() => setConfirming(null)}
-                onRemove={() =>
-                  remove.mutate(c.login, {
-                    onSuccess: () => {
-                      toast.success(`Removed ${c.login}`);
-                      setConfirming(null);
-                    },
-                    onError: toastError,
-                  })
-                }
+                onRemove={() => removeCollaborator(c.login)}
               />
             );
           })}
@@ -254,28 +279,12 @@ export function CollaboratorsSection({
                   roleValue={inv.permission}
                   roleDisabled={updateInvite.isPending}
                   roles={roles}
-                  onRole={(r) =>
-                    updateInvite.mutate(
-                      { id: inv.id, permission: r },
-                      {
-                        onSuccess: () => toast.success("Invitation updated"),
-                        onError: toastError,
-                      },
-                    )
-                  }
+                  onRole={(r) => setInvitationRole(inv.id, r)}
                   confirming={confirming === key}
                   pending={cancelInvite.isPending}
                   onConfirm={() => setConfirming(key)}
                   onCancel={() => setConfirming(null)}
-                  onRemove={() =>
-                    cancelInvite.mutate(inv.id, {
-                      onSuccess: () => {
-                        toast.success("Invitation canceled");
-                        setConfirming(null);
-                      },
-                      onError: toastError,
-                    })
-                  }
+                  onRemove={() => cancelInvitation(inv.id)}
                 />
               );
             })}

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -314,6 +314,18 @@ function RenameAction({
     : /^[A-Za-z0-9._-]+$/.test(name.trim());
   const changed = name.trim() !== current;
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleRename() {
+    try {
+      await rename.mutateAsync(name.trim());
+      toast.success(copy.toast(name.trim()));
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <Row
       title={isGitLab ? "Rename project" : "Rename repository"}
@@ -331,12 +343,7 @@ function RenameAction({
           variant="outline"
           size="sm"
           disabled={!valid || !changed || rename.isPending}
-          onClick={() =>
-            rename.mutate(name.trim(), {
-              onSuccess: () => toast.success(copy.toast(name.trim())),
-              onError: toastError,
-            })
-          }
+          onClick={handleRename}
         >
           {rename.isPending && <Spinner data-icon="inline-start" />}
           Rename
@@ -364,6 +371,16 @@ function ArchiveAction({
   const noun = isGitLab ? "project" : "repository";
   const nounCap = isGitLab ? "Project" : "Repository";
 
+  async function handleArchive() {
+    try {
+      await setArchived.mutateAsync(!archived);
+      toast.success(archived ? `${nounCap} unarchived` : `${nounCap} archived`);
+      setConfirming(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <Row
       title={archived ? `Unarchive ${noun}` : `Archive ${noun}`}
@@ -380,17 +397,7 @@ function ArchiveAction({
             actVariant={archived ? "default" : "destructive"}
             pending={setArchived.isPending}
             onCancel={() => setConfirming(false)}
-            onAct={() =>
-              setArchived.mutate(!archived, {
-                onSuccess: () => {
-                  toast.success(
-                    archived ? `${nounCap} unarchived` : `${nounCap} archived`,
-                  );
-                  setConfirming(false);
-                },
-                onError: toastError,
-              })
-            }
+            onAct={handleArchive}
           />
         </div>
       ) : (
@@ -421,6 +428,30 @@ function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
   const removeRemote = useRemoveRemote(repoPath);
   const [confirming, setConfirming] = useState(false);
 
+  async function handleRemoveUpstream() {
+    try {
+      await removeRemote.mutateAsync({ name: "upstream" });
+      // Hygiene: the persisted "upstream" lens no longer applies.
+      // Fire-and-forget — the lens read safe-defaults to origin,
+      // so a failure here is harmless. The CACHED lens drops with
+      // it: its key sits outside the repo subtree this mutation
+      // invalidates, so re-adding upstream in the same session
+      // would otherwise resurrect the preference just deleted.
+      deleteRepoLens(repoPath).catch(() => undefined);
+      clearRepoLensCache(queryClient, repoPath);
+      // Removing upstream collapses the lens to origin, so a still-
+      // selected remote number would resolve against the other repo.
+      // Same clears `useSetRepoLens` does on an explicit lens flip.
+      const ui = useUiStore.getState();
+      if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
+      if (ui.selectedIssue?.kind === "remote") ui.selectIssue(null);
+      toast.success("Upstream remote removed");
+      setConfirming(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (!remotes.data?.includes("upstream")) return null;
 
   return (
@@ -436,33 +467,7 @@ function RemoveUpstreamAction({ repoPath }: { repoPath: string }) {
               actLabel="Remove"
               pending={removeRemote.isPending}
               onCancel={() => setConfirming(false)}
-              onAct={() =>
-                removeRemote.mutate(
-                  { name: "upstream" },
-                  {
-                    onSuccess: () => {
-                      // Hygiene: the persisted "upstream" lens no longer applies.
-                      // Fire-and-forget — the lens read safe-defaults to origin,
-                      // so a failure here is harmless. The CACHED lens drops with
-                      // it: its key sits outside the repo subtree this mutation
-                      // invalidates, so re-adding upstream in the same session
-                      // would otherwise resurrect the preference just deleted.
-                      deleteRepoLens(repoPath).catch(() => undefined);
-                      clearRepoLensCache(queryClient, repoPath);
-                      // Removing upstream collapses the lens to origin, so a still-
-                      // selected remote number would resolve against the other repo.
-                      // Same clears `useSetRepoLens` does on an explicit lens flip.
-                      const ui = useUiStore.getState();
-                      if (ui.selectedPr?.kind === "remote") ui.selectPr(null);
-                      if (ui.selectedIssue?.kind === "remote")
-                        ui.selectIssue(null);
-                      toast.success("Upstream remote removed");
-                      setConfirming(false);
-                    },
-                    onError: toastError,
-                  },
-                )
-              }
+              onAct={handleRemoveUpstream}
             />
           </div>
         ) : (
@@ -557,6 +562,19 @@ function LeaveForkNetworkAction({
     }
   };
 
+  const handleRemoveFork = async () => {
+    try {
+      await removeFork.mutateAsync(undefined);
+      toast.success("Fork relationship removed");
+      setConfirming(false);
+      // Re-probe to flip the persisted badge; the row unmounts
+      // itself once `isFork` reads false.
+      reprobe();
+    } catch (e) {
+      toastError(e);
+    }
+  };
+
   // The provider's own way out of the network: GitLab detaches in-app behind an
   // inline confirm, the others link out to the page that owns the action.
   const forkAction: Record<ForgeProvider, () => ReactNode> = {
@@ -575,18 +593,7 @@ function LeaveForkNetworkAction({
           actLabel="Remove"
           pending={removeFork.isPending}
           onCancel={() => setConfirming(false)}
-          onAct={() =>
-            removeFork.mutate(undefined, {
-              onSuccess: () => {
-                toast.success("Fork relationship removed");
-                setConfirming(false);
-                // Re-probe to flip the persisted badge; the row unmounts
-                // itself once `isFork` reads false.
-                reprobe();
-              },
-              onError: toastError,
-            })
-          }
+          onAct={handleRemoveFork}
         />
       ) : (
         <DangerButton
@@ -655,6 +662,16 @@ function VisibilityAction({
   const copy = DANGER_COPY[provider].visibility;
   const visibilities = isBitbucket ? BB_VISIBILITIES : VISIBILITIES;
 
+  async function handleChangeVisibility() {
+    try {
+      await setVisibility.mutateAsync(target);
+      toast.success(copy.toast(target));
+      setOpen(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <Row
       title={
@@ -682,15 +699,7 @@ function VisibilityAction({
         confirmLabel="Change visibility"
         disabled={target === info.visibility}
         pending={setVisibility.isPending}
-        onConfirm={() =>
-          setVisibility.mutate(target, {
-            onSuccess: () => {
-              toast.success(copy.toast(target));
-              setOpen(false);
-            },
-            onError: toastError,
-          })
-        }
+        onConfirm={handleChangeVisibility}
       >
         <div className="space-y-1.5">
           <Label htmlFor="visibility-target" className="text-xs">
@@ -735,6 +744,16 @@ function TransferAction({
   const [newOwner, setNewOwner] = useState("");
   const copy = DANGER_COPY[provider].transfer;
 
+  async function handleTransfer() {
+    try {
+      await transfer.mutateAsync({ newOwner: newOwner.trim(), newName: null });
+      toast.success(copy.toast);
+      setOpen(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   // Bitbucket's REST API can't transfer a repo — send the user to the web
   // admin page instead of offering a form that would only error.
   if (provider === "bitbucket") {
@@ -774,18 +793,7 @@ function TransferAction({
         confirmLabel="Transfer"
         disabled={!newOwner.trim()}
         pending={transfer.isPending}
-        onConfirm={() =>
-          transfer.mutate(
-            { newOwner: newOwner.trim(), newName: null },
-            {
-              onSuccess: () => {
-                toast.success(copy.toast);
-                setOpen(false);
-              },
-              onError: toastError,
-            },
-          )
-        }
+        onConfirm={handleTransfer}
       >
         <div className="space-y-1.5">
           <Label htmlFor="transfer-owner" className="text-xs">
@@ -826,6 +834,21 @@ function DeleteAction({
   const copy = DANGER_COPY[provider].delete;
   const noun = isGitLab ? "project" : "repository";
 
+  async function handleDelete() {
+    try {
+      await del.mutateAsync(undefined);
+      toast.success(copy.toast);
+      setOpen(false);
+      // The remote is gone — re-probe the repo's hosted panels so they
+      // stop showing stale data, and close the settings dialog (it only
+      // offers actions against a repo that no longer exists).
+      queryClient.invalidateQueries({ queryKey: ["repo", repoPath] });
+      onRepoDeleted();
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <Row
       title={`Delete this ${noun}`}
@@ -847,20 +870,7 @@ function DeleteAction({
         confirmPhrase={info.fullName}
         confirmLabel="Delete forever"
         pending={del.isPending}
-        onConfirm={() =>
-          del.mutate(undefined, {
-            onSuccess: () => {
-              toast.success(copy.toast);
-              setOpen(false);
-              // The remote is gone — re-probe the repo's hosted panels so they
-              // stop showing stale data, and close the settings dialog (it only
-              // offers actions against a repo that no longer exists).
-              queryClient.invalidateQueries({ queryKey: ["repo", repoPath] });
-              onRepoDeleted();
-            },
-            onError: toastError,
-          })
-        }
+        onConfirm={handleDelete}
       >
         {!isGitLab && !isBitbucket && (
           <ScopeRefreshHint

--- a/src/features/repo-settings/FundingSection.tsx
+++ b/src/features/repo-settings/FundingSection.tsx
@@ -162,23 +162,27 @@ function FundingForm({
   const setField = (key: string, value: string) =>
     setFields((f) => ({ ...f, [key]: value }));
 
-  function save() {
-    set.mutate(generateFunding(fields), {
-      onSuccess: () =>
-        toast.success("Wrote .github/FUNDING.yml — commit it to publish"),
-      onError: toastError,
-    });
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function save() {
+    try {
+      await set.mutateAsync(generateFunding(fields));
+      toast.success("Wrote .github/FUNDING.yml — commit it to publish");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
-  function remove() {
+  async function remove() {
     if (!exists) return;
-    del.mutate(undefined, {
-      onSuccess: () => {
-        toast.success("Removed .github/FUNDING.yml — commit it to publish");
-        setConfirmingRemove(false);
-      },
-      onError: toastError,
-    });
+    try {
+      await del.mutateAsync(undefined);
+      toast.success("Removed .github/FUNDING.yml — commit it to publish");
+      setConfirmingRemove(false);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -263,6 +263,18 @@ function GeneralForm({
     ? branchNames
     : [form.defaultBranch, ...branchNames];
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleSave() {
+    try {
+      await update.mutateAsync(form);
+      toast.success("Repository settings saved");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="min-w-0 space-y-4">
       <DescriptionField
@@ -548,12 +560,7 @@ function GeneralForm({
           disabled={
             !dirty || !mergeValid || update.isPending || descGen.generating
           }
-          onClick={() =>
-            update.mutate(form, {
-              onSuccess: () => toast.success("Repository settings saved"),
-              onError: toastError,
-            })
-          }
+          onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}
           Save changes

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -197,6 +197,18 @@ function GitLabGeneralForm({
 
   const dirty = JSON.stringify(form) !== JSON.stringify(base);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleSave() {
+    try {
+      await update.mutateAsync(form);
+      toast.success("Settings saved");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   // Keep the current default selectable even if that branch isn't local; drop
   // agent-session branches (`gd/session/*`) — they're app-internal.
   const branchNames = branches
@@ -411,12 +423,7 @@ function GitLabGeneralForm({
       <div className="flex items-center justify-end gap-2 border-t pt-3">
         <Button
           disabled={!dirty || update.isPending || descGen.generating}
-          onClick={() =>
-            update.mutate(form, {
-              onSuccess: () => toast.success("Settings saved"),
-              onError: toastError,
-            })
-          }
+          onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}
           Save changes

--- a/src/features/repo-settings/GitLabMembersSection.tsx
+++ b/src/features/repo-settings/GitLabMembersSection.tsx
@@ -68,17 +68,36 @@ export function GitLabMembersSection({
 
   const memberRows = members.data ?? [];
 
-  function addMember() {
-    add.mutate(
-      { username: username.trim(), accessLevel: level },
-      {
-        onSuccess: () => {
-          toast.success("Member added");
-          setUsername("");
-        },
-        onError: toastError,
-      },
-    );
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function addMember() {
+    try {
+      await add.mutateAsync({ username: username.trim(), accessLevel: level });
+      toast.success("Member added");
+      setUsername("");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRole(member: GitLabMember, accessLevel: number) {
+    try {
+      await update.mutateAsync({ userId: member.id, accessLevel });
+      toast.success(`${member.username} is now ${roleLabel(accessLevel)}`);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRemove(member: GitLabMember) {
+    try {
+      await remove.mutateAsync(member.id);
+      toast.success(`Removed ${member.username}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -92,7 +111,7 @@ export function GitLabMembersSection({
             autoComplete="off"
             spellCheck={false}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && canAdd) addMember();
+              if (e.key === "Enter" && canAdd) void addMember();
             }}
           />
           <Select
@@ -155,31 +174,12 @@ export function GitLabMembersSection({
               active={i === activeIndex}
               onFocus={() => setActiveIndex(i)}
               updating={update.isPending}
-              onRole={(accessLevel) =>
-                update.mutate(
-                  { userId: m.id, accessLevel },
-                  {
-                    onSuccess: () =>
-                      toast.success(
-                        `${m.username} is now ${roleLabel(accessLevel)}`,
-                      ),
-                    onError: toastError,
-                  },
-                )
-              }
+              onRole={(accessLevel) => handleRole(m, accessLevel)}
               confirming={confirming === m.id}
               pending={remove.isPending}
               onConfirm={() => setConfirming(m.id)}
               onCancel={() => setConfirming(null)}
-              onRemove={() =>
-                remove.mutate(m.id, {
-                  onSuccess: () => {
-                    toast.success(`Removed ${m.username}`);
-                    setConfirming(null);
-                  },
-                  onError: toastError,
-                })
-              }
+              onRemove={() => handleRemove(m)}
             />
           ))}
         </div>

--- a/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
+++ b/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
@@ -77,6 +77,27 @@ export function GitLabProtectedBranchesSection({
   const [editing, setEditing] = useState(false);
   const [confirming, setConfirming] = useState<string | null>(null);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — a failure would revert silently on refetch.
+  async function handleToggleForcePush(name: string, allowForcePush: boolean) {
+    try {
+      await updateBranch.mutateAsync({ name, allowForcePush });
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleUnprotect(name: string) {
+    try {
+      await unprotect.mutateAsync(name);
+      toast.success(`Unprotected ${name}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (editing) {
     return (
       <ProtectBranchForm
@@ -117,24 +138,13 @@ export function GitLabProtectedBranchesSection({
               updateBranch.isPending && updateBranch.variables?.name === b.name
             }
             onToggleForcePush={(allowForcePush) =>
-              updateBranch.mutate(
-                { name: b.name, allowForcePush },
-                { onError: toastError },
-              )
+              handleToggleForcePush(b.name, allowForcePush)
             }
             confirming={confirming === b.name}
             unprotecting={unprotect.isPending}
             onConfirm={() => setConfirming(b.name)}
             onCancel={() => setConfirming(null)}
-            onUnprotect={() =>
-              unprotect.mutate(b.name, {
-                onSuccess: () => {
-                  toast.success(`Unprotected ${b.name}`);
-                  setConfirming(null);
-                },
-                onError: toastError,
-              })
-            }
+            onUnprotect={() => handleUnprotect(b.name)}
           />
         ))}
       </AsyncListBody>
@@ -265,22 +275,19 @@ function ProtectBranchForm({
       ? "This branch already has a protection rule."
       : null;
 
-  function submit() {
-    protectBranch.mutate(
-      {
+  async function submit() {
+    try {
+      await protectBranch.mutateAsync({
         name: trimmed,
         pushAccessLevel: Number(pushLevel),
         mergeAccessLevel: Number(mergeLevel),
         allowForcePush,
-      },
-      {
-        onSuccess: () => {
-          toast.success(`Protected ${trimmed}`);
-          onDone();
-        },
-        onError: toastError,
-      },
-    );
+      });
+      toast.success(`Protected ${trimmed}`);
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/GitLabVariablesSection.tsx
+++ b/src/features/repo-settings/GitLabVariablesSection.tsx
@@ -57,27 +57,56 @@ export function GitLabVariablesSection({
         : "Keys use only letters, digits, and underscores."
     : null;
 
-  function addVariable() {
-    setVariable.mutate(
-      {
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function addVariable() {
+    try {
+      await setVariable.mutateAsync({
         key: key.trim(),
         value,
         protected: isProtected,
         masked: isMasked,
         create: true,
         scope: "*",
-      },
-      {
-        onSuccess: () => {
-          toast.success(`Added ${key.trim()}`);
-          setKey("");
-          setValue("");
-          setIsProtected(false);
-          setIsMasked(false);
-        },
-        onError: toastError,
-      },
-    );
+      });
+      toast.success(`Added ${key.trim()}`);
+      setKey("");
+      setValue("");
+      setIsProtected(false);
+      setIsMasked(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleSave(variable: GitLabVariable, newValue: string) {
+    try {
+      await setVariable.mutateAsync({
+        key: variable.key,
+        value: newValue,
+        protected: variable.protected,
+        masked: variable.masked,
+        create: false,
+        scope: variable.environmentScope,
+      });
+      toast.success(`Updated ${variable.key}`);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleRemove(variable: GitLabVariable) {
+    try {
+      await deleteVariable.mutateAsync({
+        key: variable.key,
+        scope: variable.environmentScope,
+      });
+      toast.success(`Deleted ${variable.key}`);
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -145,38 +174,12 @@ export function GitLabVariablesSection({
               key={rowId}
               variable={v}
               saving={setVariable.isPending}
-              onSave={(newValue) =>
-                setVariable.mutate(
-                  {
-                    key: v.key,
-                    value: newValue,
-                    protected: v.protected,
-                    masked: v.masked,
-                    create: false,
-                    scope: v.environmentScope,
-                  },
-                  {
-                    onSuccess: () => toast.success(`Updated ${v.key}`),
-                    onError: toastError,
-                  },
-                )
-              }
+              onSave={(newValue) => handleSave(v, newValue)}
               confirming={confirming === rowId}
               pending={deleteVariable.isPending}
               onConfirm={() => setConfirming(rowId)}
               onCancel={() => setConfirming(null)}
-              onRemove={() =>
-                deleteVariable.mutate(
-                  { key: v.key, scope: v.environmentScope },
-                  {
-                    onSuccess: () => {
-                      toast.success(`Deleted ${v.key}`);
-                      setConfirming(null);
-                    },
-                    onError: toastError,
-                  },
-                )
-              }
+              onRemove={() => handleRemove(v)}
             />
           );
         })}

--- a/src/features/repo-settings/GitLabWebhooksSection.tsx
+++ b/src/features/repo-settings/GitLabWebhooksSection.tsx
@@ -71,6 +71,28 @@ export function GitLabWebhooksSection({
   const [viewingEvents, setViewingEvents] = useState<GitLabHook | null>(null);
   const [confirming, setConfirming] = useState<string | null>(null);
 
+  // Awaited, not per-call callbacks: this subtree unmounts when the dialog
+  // closes or the rail crossfades to another section, and react-query drops
+  // per-call callbacks on unmount — the outcome would never reach the user.
+  async function handleDelete(hookId: string) {
+    try {
+      await deleteHook.mutateAsync(hookId);
+      toast.success("Webhook deleted");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleTest(hookId: string) {
+    try {
+      await testHook.mutateAsync({ hookId, trigger: "push_events" });
+      toast.success("Test event sent");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (viewingEvents) {
     return (
       <HookDeliveries
@@ -143,15 +165,7 @@ export function GitLabWebhooksSection({
                   actLabel="Delete"
                   pending={deleteHook.isPending}
                   onCancel={() => setConfirming(null)}
-                  onAct={() =>
-                    deleteHook.mutate(h.id, {
-                      onSuccess: () => {
-                        toast.success("Webhook deleted");
-                        setConfirming(null);
-                      },
-                      onError: toastError,
-                    })
-                  }
+                  onAct={() => handleDelete(h.id)}
                 />
               ) : (
                 <>
@@ -160,15 +174,7 @@ export function GitLabWebhooksSection({
                     variant="ghost"
                     title="Send a test push event"
                     disabled={testHook.isPending}
-                    onClick={() =>
-                      testHook.mutate(
-                        { hookId: h.id, trigger: "push_events" },
-                        {
-                          onSuccess: () => toast.success("Test event sent"),
-                          onError: toastError,
-                        },
-                      )
-                    }
+                    onClick={() => handleTest(h.id)}
                   >
                     <ArrowClockwiseIcon />
                   </Button>
@@ -243,7 +249,7 @@ function HookForm({
     setEvents((prev) => (on ? [...prev, id] : prev.filter((e) => e !== id)));
   }
 
-  function save() {
+  async function save() {
     const input = {
       url: url.trim(),
       // Blank leaves an existing secret unchanged (GitLab never returns it).
@@ -251,15 +257,14 @@ function HookForm({
       enableSslVerification: sslVerify,
       events,
     };
-    const done = {
-      onSuccess: () => {
-        toast.success(hook ? "Webhook updated" : "Webhook created");
-        onDone();
-      },
-      onError: toastError,
-    };
-    if (hook) update.mutate({ hookId: hook.id, input }, done);
-    else create.mutate(input, done);
+    try {
+      if (hook) await update.mutateAsync({ hookId: hook.id, input });
+      else await create.mutateAsync(input);
+      toast.success(hook ? "Webhook updated" : "Webhook created");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -351,6 +356,15 @@ function HookDeliveries({
   const resend = useGlResendHookEvent(repoPath, hook.id);
   const [expanded, setExpanded] = useState<string | null>(null);
 
+  async function handleResend(eventId: string) {
+    try {
+      await resend.mutateAsync(eventId);
+      toast.success("Delivery re-sent");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="min-w-0 space-y-3">
       <div className="flex items-center justify-between gap-2">
@@ -381,12 +395,7 @@ function HookDeliveries({
             expanded={expanded === d.id}
             onToggle={() => setExpanded(expanded === d.id ? null : d.id)}
             resending={resend.isPending}
-            onResend={() =>
-              resend.mutate(d.id, {
-                onSuccess: () => toast.success("Delivery re-sent"),
-                onError: toastError,
-              })
-            }
+            onResend={() => handleResend(d.id)}
           />
         ))}
       </AsyncListBody>

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -92,6 +92,22 @@ function PagesDisabled({ repoPath }: { repoPath: string }) {
     .filter((n) => !n.startsWith("gd/session/"));
   const canEnable = (mode === "workflow" || !!branch) && !enable.isPending;
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleEnable() {
+    try {
+      await enable.mutateAsync({
+        buildType: mode === "workflow" ? "workflow" : "legacy",
+        branch: mode === "branch" ? branch : null,
+        path: mode === "branch" ? path : null,
+      });
+      toast.success("GitHub Pages enabled");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="min-w-0 space-y-3">
       <p className="text-xs text-muted-foreground">
@@ -150,23 +166,7 @@ function PagesDisabled({ repoPath }: { repoPath: string }) {
           </div>
         </div>
       )}
-      <Button
-        size="sm"
-        disabled={!canEnable}
-        onClick={() =>
-          enable.mutate(
-            {
-              buildType: mode === "workflow" ? "workflow" : "legacy",
-              branch: mode === "branch" ? branch : null,
-              path: mode === "branch" ? path : null,
-            },
-            {
-              onSuccess: () => toast.success("GitHub Pages enabled"),
-              onError: toastError,
-            },
-          )
-        }
-      >
+      <Button size="sm" disabled={!canEnable} onClick={handleEnable}>
         {enable.isPending && <Spinner data-icon="inline-start" />}
         Enable Pages
       </Button>
@@ -215,6 +215,43 @@ function PagesEnabled({
     : certFailed
       ? "HTTPS certificate provisioning failed — check the domain's DNS configuration"
       : "Waiting for the HTTPS certificate to be issued for this domain";
+
+  async function handleUpdateSource() {
+    try {
+      await update.mutateAsync({ buildType: "legacy", branch, path });
+      toast.success("Source updated");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleSaveDomain() {
+    try {
+      await update.mutateAsync({ cname });
+      toast.success(cname ? "Domain saved" : "Domain removed");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleHttpsEnforced(v: boolean) {
+    try {
+      await update.mutateAsync({ httpsEnforced: v });
+      toast.success("Updated");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleDisable() {
+    try {
+      await disable.mutateAsync(undefined);
+      toast.success("GitHub Pages disabled");
+      setConfirmingDisable(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
 
   return (
     <div className="min-w-0 space-y-4">
@@ -277,15 +314,7 @@ function PagesEnabled({
               size="sm"
               variant="outline"
               disabled={!sourceChanged || !branch || update.isPending}
-              onClick={() =>
-                update.mutate(
-                  { buildType: "legacy", branch, path },
-                  {
-                    onSuccess: () => toast.success("Source updated"),
-                    onError: toastError,
-                  },
-                )
-              }
+              onClick={handleUpdateSource}
             >
               Update
             </Button>
@@ -309,16 +338,7 @@ function PagesEnabled({
             size="sm"
             variant="outline"
             disabled={cname === pages.cname || update.isPending}
-            onClick={() =>
-              update.mutate(
-                { cname },
-                {
-                  onSuccess: () =>
-                    toast.success(cname ? "Domain saved" : "Domain removed"),
-                  onError: toastError,
-                },
-              )
-            }
+            onClick={handleSaveDomain}
           >
             Save
           </Button>
@@ -343,15 +363,7 @@ function PagesEnabled({
           <Switch
             checked={pages.httpsEnforced}
             disabled={update.isPending || !certReady}
-            onCheckedChange={(v) =>
-              update.mutate(
-                { httpsEnforced: v },
-                {
-                  onSuccess: () => toast.success("Updated"),
-                  onError: toastError,
-                },
-              )
-            }
+            onCheckedChange={handleHttpsEnforced}
           />
         </span>
       </label>
@@ -364,15 +376,7 @@ function PagesEnabled({
             actLabel="Disable Pages"
             pending={disable.isPending}
             onCancel={() => setConfirmingDisable(false)}
-            onAct={() =>
-              disable.mutate(undefined, {
-                onSuccess: () => {
-                  toast.success("GitHub Pages disabled");
-                  setConfirmingDisable(false);
-                },
-                onError: toastError,
-              })
-            }
+            onAct={handleDisable}
           />
         ) : (
           <Button

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -513,6 +513,36 @@ function WebhookRow({
         : "text-destructive";
   const canTest = hook.events.includes("push") || hook.events.includes("*");
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleDelete() {
+    try {
+      await del.mutateAsync(hook.id);
+      toast.success("Webhook removed");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handlePing() {
+    try {
+      await ping.mutateAsync(hook.id);
+      toast.success("Ping sent");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleTest() {
+    try {
+      await test.mutateAsync(hook.id);
+      toast.success("Test event sent");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="rounded-md border p-3 text-xs">
       <div className="flex items-start justify-between gap-2">
@@ -555,12 +585,7 @@ function WebhookRow({
             actLabel="Remove"
             pending={del.isPending}
             onCancel={() => setConfirmingDelete(false)}
-            onAct={() =>
-              del.mutate(hook.id, {
-                onSuccess: () => toast.success("Webhook removed"),
-                onError: toastError,
-              })
-            }
+            onAct={handleDelete}
           />
         ) : (
           <>
@@ -569,12 +594,7 @@ function WebhookRow({
               variant="ghost"
               disabled={ping.isPending}
               title="Send a ping event"
-              onClick={() =>
-                ping.mutate(hook.id, {
-                  onSuccess: () => toast.success("Ping sent"),
-                  onError: toastError,
-                })
-              }
+              onClick={handlePing}
             >
               <BroadcastIcon data-icon="inline-start" />
               Ping
@@ -585,12 +605,7 @@ function WebhookRow({
                 variant="ghost"
                 disabled={test.isPending}
                 title="Trigger a test push event"
-                onClick={() =>
-                  test.mutate(hook.id, {
-                    onSuccess: () => toast.success("Test event sent"),
-                    onError: toastError,
-                  })
-                }
+                onClick={handleTest}
               >
                 <ArrowClockwiseIcon data-icon="inline-start" />
                 Test
@@ -710,6 +725,15 @@ function DeliveryRow({
     ? `${delivery.event}.${delivery.action}`
     : delivery.event;
 
+  async function handleRedeliver() {
+    try {
+      await redeliver.mutateAsync(delivery.id);
+      toast.success("Redelivery queued");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="rounded-md border text-xs">
       <button
@@ -745,12 +769,7 @@ function DeliveryRow({
               size="xs"
               variant="ghost"
               disabled={redeliver.isPending}
-              onClick={() =>
-                redeliver.mutate(delivery.id, {
-                  onSuccess: () => toast.success("Redelivery queued"),
-                  onError: toastError,
-                })
-              }
+              onClick={handleRedeliver}
             >
               {redeliver.isPending ? (
                 <Spinner data-icon="inline-start" />
@@ -828,7 +847,7 @@ function WebhookForm({
     });
   }
 
-  function submit() {
+  async function submit() {
     const input: WebhookInput = {
       url: url.trim(),
       contentType,
@@ -837,15 +856,14 @@ function WebhookForm({
       events: allEvents ? ["*"] : [...events],
       active,
     };
-    const opts = {
-      onSuccess: () => {
-        toast.success(hook ? "Webhook updated" : "Webhook created");
-        onDone();
-      },
-      onError: toastError,
-    };
-    if (hook) update.mutate({ id: hook.id, input }, opts);
-    else create.mutate(input, opts);
+    try {
+      if (hook) await update.mutateAsync({ id: hook.id, input });
+      else await create.mutateAsync(input);
+      toast.success(hook ? "Webhook updated" : "Webhook created");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -240,6 +240,30 @@ function RulesetList({
   const del = useDeleteRuleset(repoPath);
   const [confirming, setConfirming] = useState<number | null>(null);
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleDelete(id: number) {
+    try {
+      await del.mutateAsync(id);
+      toast.success("Ruleset deleted");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleEnforcement(
+    id: number,
+    enforcement: RulesetEnforcement,
+  ) {
+    try {
+      await setEnforcement.mutateAsync({ id, enforcement });
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <div className="min-w-0 space-y-3">
       <div className="flex items-center justify-between gap-2">
@@ -286,15 +310,7 @@ function RulesetList({
                   actLabel="Delete"
                   pending={del.isPending}
                   onCancel={() => setConfirming(null)}
-                  onAct={() =>
-                    del.mutate(rs.id, {
-                      onSuccess: () => {
-                        toast.success("Ruleset deleted");
-                        setConfirming(null);
-                      },
-                      onError: toastError,
-                    })
-                  }
+                  onAct={() => handleDelete(rs.id)}
                 />
               ) : (
                 <>
@@ -303,11 +319,7 @@ function RulesetList({
                     value={rs.enforcement}
                     disabled={setEnforcement.isPending}
                     onValueChange={(v) =>
-                      v &&
-                      setEnforcement.mutate(
-                        { id: rs.id, enforcement: v as RulesetEnforcement },
-                        { onError: toastError },
-                      )
+                      v && handleEnforcement(rs.id, v as RulesetEnforcement)
                     }
                   >
                     <SelectTrigger size="sm" className="w-28">
@@ -392,17 +404,16 @@ function RulesetForm({
   const set = <K extends keyof Draft>(key: K, value: Draft[K]) =>
     setD((p) => ({ ...p, [key]: value }));
 
-  function save() {
+  async function save() {
     const body = draftToBody(d, original);
-    const opts = {
-      onSuccess: () => {
-        toast.success(id != null ? "Ruleset updated" : "Ruleset created");
-        onDone();
-      },
-      onError: toastError,
-    };
-    if (id != null) update.mutate({ id, body }, opts);
-    else create.mutate(body, opts);
+    try {
+      if (id != null) await update.mutateAsync({ id, body });
+      else await create.mutateAsync(body);
+      toast.success(id != null ? "Ruleset updated" : "Ruleset created");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -196,18 +196,28 @@ function SecretsList({
   const invalid = nameError(name);
   const canAdd = !!name && !!value && !invalid && !set.isPending;
 
-  function add() {
-    set.mutate(
-      { app, env, name: name.trim(), value },
-      {
-        onSuccess: () => {
-          toast.success("Secret saved");
-          setName("");
-          setValue("");
-        },
-        onError: toastError,
-      },
-    );
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function add() {
+    try {
+      await set.mutateAsync({ app, env, name: name.trim(), value });
+      toast.success("Secret saved");
+      setName("");
+      setValue("");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function remove(secretName: string) {
+    try {
+      await del.mutateAsync({ app, env, name: secretName });
+      toast.success("Secret removed");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -269,18 +279,7 @@ function SecretsList({
             pending={del.isPending}
             onConfirm={() => setConfirming(s.name)}
             onCancel={() => setConfirming(null)}
-            onDelete={() =>
-              del.mutate(
-                { app, env, name: s.name },
-                {
-                  onSuccess: () => {
-                    toast.success("Secret removed");
-                    setConfirming(null);
-                  },
-                  onError: toastError,
-                },
-              )
-            }
+            onDelete={() => remove(s.name)}
           />
         ))}
       </AsyncListBody>
@@ -307,18 +306,25 @@ function VariablesList({
   const invalid = nameError(name);
   const canAdd = !!name && !invalid && !set.isPending;
 
-  function add() {
-    set.mutate(
-      { env, name: name.trim(), value },
-      {
-        onSuccess: () => {
-          toast.success("Variable saved");
-          setName("");
-          setValue("");
-        },
-        onError: toastError,
-      },
-    );
+  async function add() {
+    try {
+      await set.mutateAsync({ env, name: name.trim(), value });
+      toast.success("Variable saved");
+      setName("");
+      setValue("");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function remove(variableName: string) {
+    try {
+      await del.mutateAsync({ env, name: variableName });
+      toast.success("Variable removed");
+      setConfirming(null);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (
@@ -379,18 +385,7 @@ function VariablesList({
               setName(v.name);
               setValue(v.value);
             }}
-            onDelete={() =>
-              del.mutate(
-                { env, name: v.name },
-                {
-                  onSuccess: () => {
-                    toast.success("Variable removed");
-                    setConfirming(null);
-                  },
-                  onError: toastError,
-                },
-              )
-            }
+            onDelete={() => remove(v.name)}
           />
         ))}
       </AsyncListBody>

--- a/src/features/repo-settings/SecuritySection.tsx
+++ b/src/features/repo-settings/SecuritySection.tsx
@@ -211,6 +211,29 @@ function DependabotVersionUpdates({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
 
+  // Awaited, not per-call callbacks: react-query drops those when this subtree
+  // unmounts mid-flight — closing the dialog or switching the rail's section —
+  // so the outcome would never reach the user.
+  async function handleRemove() {
+    try {
+      await del.mutateAsync(undefined);
+      toast.success("Removed .github/dependabot.yml — commit it");
+      setConfirmingRemove(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function handleCreate(content: string) {
+    try {
+      await set.mutateAsync(content);
+      toast.success("Wrote .github/dependabot.yml — commit it to enable");
+      setDialogOpen(false);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   if (config.isLoading) return null;
   const exists = config.data != null;
 
@@ -232,17 +255,7 @@ function DependabotVersionUpdates({
                 actLabel="Remove"
                 pending={del.isPending}
                 onCancel={() => setConfirmingRemove(false)}
-                onAct={() =>
-                  del.mutate(undefined, {
-                    onSuccess: () => {
-                      toast.success(
-                        "Removed .github/dependabot.yml — commit it",
-                      );
-                      setConfirmingRemove(false);
-                    },
-                    onError: toastError,
-                  })
-                }
+                onAct={handleRemove}
               />
             </div>
           ) : (
@@ -270,17 +283,7 @@ function DependabotVersionUpdates({
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         pending={set.isPending}
-        onCreate={(content) =>
-          set.mutate(content, {
-            onSuccess: () => {
-              toast.success(
-                "Wrote .github/dependabot.yml — commit it to enable",
-              );
-              setDialogOpen(false);
-            },
-            onError: toastError,
-          })
-        }
+        onCreate={handleCreate}
       />
     </div>
   );
@@ -427,14 +430,16 @@ function SecurityForm({
     });
   }
 
-  function save() {
+  async function save() {
     const changes = FEATURES.filter((f) => draft[f.key] !== seed[f.key]).map(
       (f) => ({ feature: f.key, enabled: draft[f.key] }),
     );
-    apply.mutate(changes, {
-      onSuccess: () => toast.success("Security settings saved"),
-      onError: toastError,
-    });
+    try {
+      await apply.mutateAsync(changes);
+      toast.success("Security settings saved");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -3,13 +3,16 @@ import { useForgeStatus } from "./queries";
 
 /**
  * Whether a host is safe to interpolate into a copyable `gh`/`glab auth …` command —
- * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`).
- * `remote_host` only splits a remote URL on `/` and `:`, so a crafted remote can carry
- * `;`, `$`, or a space into the host; the executed reconnect flow re-validates, but the
- * copy-paste command string is guarded here so it can never hand the user shell syntax.
+ * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`, plus
+ * an optional numeric port). The port belongs in the grammar: a self-hosted instance on
+ * one registers with the CLIs as `host:8443`, so rejecting it would deny the copyable
+ * fallback to the very users who need it. `remote_host` only splits a remote URL on `/`
+ * and `:`, so a crafted remote can carry `;`, `$`, or a space into the host; the executed
+ * reconnect flow re-validates, but the command string is guarded here so it can never
+ * hand the user shell syntax.
  */
 export function isReconnectHostSafe(host: string): boolean {
-  return /^[a-zA-Z0-9.-]+$/.test(host);
+  return /^[a-zA-Z0-9.-]+(:\d{1,5})?$/.test(host);
 }
 
 /**

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -5,7 +5,7 @@ import { useForgeStatus } from "./queries";
  * Whether a host is safe to interpolate into a copyable `gh`/`glab auth …` command —
  * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`, plus
  * an optional numeric port). The port belongs in the grammar: a self-hosted instance on
- * one registers with the CLIs as `host:8443`, so rejecting it would deny the copyable
+ * a non-default port registers with the CLIs as `host:8443`, so rejecting it would deny the copyable
  * fallback to the very users who need it. `remote_host` only splits a remote URL on `/`
  * and `:`, so a crafted remote can carry `;`, `$`, or a space into the host; the executed
  * reconnect flow re-validates, but the command string is guarded here so it can never

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -4,12 +4,12 @@ import { useForgeStatus } from "./queries";
 /**
  * Whether a host is safe to interpolate into a copyable `gh`/`glab auth …` command —
  * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`, plus
- * an optional numeric port). The port belongs in the grammar: a self-hosted instance on
- * a non-default port registers with the CLIs as `host:8443`, so rejecting it would deny the copyable
- * fallback to the very users who need it. `remote_host` only splits a remote URL on `/`
- * and `:`, so a crafted remote can carry `;`, `$`, or a space into the host; the executed
- * reconnect flow re-validates, but the command string is guarded here so it can never
- * hand the user shell syntax.
+ * an optional numeric port). The port belongs in the grammar: a self-hosted instance
+ * on a non-default port registers with the CLIs as `host:8443`, so rejecting it would
+ * deny the copyable fallback to the very users who need it. `remote_host` only splits a
+ * remote URL on `/` and `:`, so a crafted remote can carry `;`, `$`, or a space into the
+ * host; the executed reconnect flow re-validates, but the command string is guarded here
+ * so it can never hand the user shell syntax.
  */
 export function isReconnectHostSafe(host: string): boolean {
   return /^[a-zA-Z0-9.-]+(:\d{1,5})?$/.test(host);


### PR DESCRIPTION
Four related correctness fixes in the layers where a result gets lost: repository-settings mutations whose outcome vanished when the dialog closed mid-flight, shared app-data JSON stores that could drop each other's updates across processes, an MCP server whose `--repo` spelling diverged from the GUI's per-repo keys, and forge hosts on a non-default HTTPS port that never saw their CLI's token. Each ships with the tests and the changelog fragment it needs.

### Repository settings report their outcome after an unmount

- Converts every mutation under `src/features/repo-settings/` from `.mutate(vars, { onSuccess, onError })` to an awaited `mutateAsync` in `try`/`catch`, so the toast, form teardown, and confirm-state reset still run when the dialog closes or the rail crossfades to another section mid-flight. Touches all the section components (`GeneralSettingsSection.tsx`, `CollaboratorsSection.tsx`, `RulesetsSection.tsx`, `SecretsSection.tsx`, `SecuritySection.tsx`, `PagesSection.tsx`, `FundingSection.tsx`, the GitLab and Bitbucket sections, `DangerZone.tsx`) plus `RepoSettingsDialog.tsx`.
- Adds a `mutate-in-repo-settings` ratchet in `scripts/check-banned-patterns.mjs`: scoped by `appliesTo` to that directory, matching the `.mutate(` token itself (not the callbacks object, which no regex sees when the options are hoisted), with an empty allowlist so an exemption has to be written down.
- Covers the new check in `scripts/checks.test.mjs`: inline and hoisted callback objects, bare callback-less calls, and the awaited idiom plus comment mentions it must leave alone.

### Cross-process locking for the shared JSON stores

- Rebuilds `src-tauri/src/store_lock.rs` around an ownership token (`<pid>:<uuid>` stamped and flushed inside the exclusive create). `StoreLock` now owns a `(path, token)` pair and releases through `claim_by_rename`, so a holder evicted as stale can no longer delete the evictor's lock file and grant the store to two writers at once.
- Adds `store_lock::locked_store_task`, a `spawn_blocking` wrapper that keeps the blocking retry budget off tokio workers, and routes the store writers through it.
- Puts `local_prs.rs` and `local_issues.rs` under both locks: new `PRS_LOCK` / `ISSUES_LOCK` in-process mutexes outside the file lock, `*_sync` inner functions holding the pair, and async `create` / `add_comment` / `set_status` / `set_approved` / `mutate_*` / `consolidate`. Module docs state the remaining GUI-side limit (the plugin-store path takes neither lock).
- Applies the same pairing to `jira_field_maps::put` (new `write_lock()`, in-process cache warmed before the disk write) and converts `oplog.rs` (`begin`, `finish`, `pause`, `close_paused_pick`, `pre_op_tip`) and `review_notes.rs` (`set`, `rename_branch`) to the async, off-runtime form.
- Adds `TEST_STORE_DIR` / `swap_test_store_dir` in-process override seams to `local_prs.rs` and `local_issues.rs`, and an explicit-path `oplog::reconcile_at`, so tests can drive the public write paths without touching real app data.
- Updates the callers to await: `mcp_server/write_local.rs`, `git/branches.rs`, `forge/jira.rs`, and the `review_notes_set_branch` / `review_notes_delete_branch` commands.

### MCP server: canonical `--repo` with a legacy-key bridge

- Canonicalizes `--repo` at parse using the new `dunce` dependency (`src-tauri/Cargo.toml`), chosen over `std::fs::canonicalize` so Windows `\\?\` verbatim paths never land in per-repo store keys.
- Keeps the pre-canonicalization spelling on `GitDesktopMcp::raw_repo` (set via `with_raw_repo`) and probes it as a second, legacy key in `local_pr_key`, `local_issue_key`, and `jira_link`, with the canonical spelling always winning.
- Mirrors the cherry-pick close gate for that legacy spelling in `mcp_server/write_git.rs`, reading `cherry_pick_marker_present` before the commit clears it and only closing the paused record when the two spellings differ; `oplog::same_repo` is now `pub(crate)` to make that test possible.

### Forge auth on non-default HTTPS ports

- Adds `forge::remote_authority` in `src-tauri/src/forge/mod.rs`, returning `host[:port]` beside the existing `remote_host`, with documented scp-form and empty-port behavior.
- Keys the one-shot credential-helper entries on that authority in `forge/github.rs` and `forge/gitlab.rs` (`github_credential_entries`, `gitlab_credential_entries`), since git won't match a portless key against a ported request, while gating on whichever spelling each CLI registers: gh through the new `gh_authenticated_for` (authority first, then bare host), glab on its port-stripped `hosts:` key.
- Prefers the authority in `forge/session.rs::github_host_for_repo`, so a signed-in ported GitHub Enterprise instance no longer reports as signed out in Accounts.
- Matches the `https://` scheme case-insensitively in `forge::is_https_remote` and `bitbucket::strip_https_userinfo`, so an `HTTPS://` remote keeps its `insteadOf` rewrite instead of turning a credential prompt into a hard failure.
- Fails open on non-https remotes: `forge_clone` and GitLab's `publish_repo` / `create_mr` skip the inert `credential.https://…` injection rather than erroring with `GlabNotFound`, and `forge_clone`'s GitLab arm now falls back like the GitHub arm.
- Adds unit tests for ported authorities, the gate/key split, and mixed-case schemes.

### Changelog

- Four fragments under `changelog.d/`: `fixed-repo-settings-dismissed-outcomes.md`, `fixed-store-lock-hardening.md`, `fixed-mcp-repo-spelling.md`, `fixed-ported-host-credentials.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication for self-managed GitHub Enterprise and GitLab servers using custom HTTPS ports.
  * Repository history, local issues, and pull requests now remain synchronized across alternate path spellings and concurrent activity.
  * Repository settings actions now report accurate success or error results, even after navigating away.
  * Improved credential handling for mixed-case HTTPS URLs, plain-HTTP remotes, and custom ports.
  * Jira field mappings and review notes now save more reliably during asynchronous operations.
  * Improved protection against unsafe repository connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->