### PR TITLE
fix(forge,accounts,repo-settings): parse bracketed IPv6 remote authorities

### DIFF
--- a/changelog.d/fixed-ipv6-remote-authority.md
+++ b/changelog.d/fixed-ipv6-remote-authority.md
@@ -1,0 +1,3 @@
+- Remotes hosted at a bracketed IPv6 address, like
+  `https://[2001:db8::1]:8443/group/repo`, are recognized as the host they name, so
+  provider detection, credential handling, and the reconnect commands see the real host.

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -1319,6 +1319,10 @@ mod tests {
         // No host is special-cased: a port rides through on the canonical host too.
         let ported = github_credential_entries("github.com:8443", "/abs/gh");
         assert_eq!(ported[0], "credential.https://github.com:8443.helper=");
+        // git spells an IPv6 credential context bracketed (measured against git 2.51),
+        // so the key must carry the brackets to match the request.
+        let v6 = github_credential_entries("[::1]:8443", "/abs/gh");
+        assert_eq!(v6[0], "credential.https://[::1]:8443.helper=");
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -8462,6 +8462,10 @@ mod tests {
             ported[1],
             "credential.https://gitlab.example.com:8443.helper=!\"/abs/glab\" auth git-credential"
         );
+        // git spells an IPv6 credential context bracketed (measured against git 2.51),
+        // so the key must carry the brackets to match the request.
+        let v6 = gitlab_credential_entries("[::1]:8443", "/abs/glab");
+        assert_eq!(v6[0], "credential.https://[::1]:8443.helper=");
     }
 
     #[test]

--- a/src-tauri/src/forge/glab.rs
+++ b/src-tauri/src/forge/glab.rs
@@ -168,10 +168,16 @@ fn glab_config_paths() -> Vec<PathBuf> {
 
 /// A bare lowercase hostname from a config value that may carry a scheme, a
 /// port, or a path (`https://gitlab.example.com:8443/` → `gitlab.example.com`).
-/// Ports are stripped to match what `remote_host` yields for remote URLs.
+/// Ports are stripped to match what `remote_host` yields for remote URLs — a
+/// bracketed IPv6 literal keeps its brackets for the same reason, and shares
+/// `remote_host`'s span parser so the two spellings can compare equal. A malformed
+/// bracket falls through to the plain split: the key then simply never matches.
 fn normalize_host(value: &str) -> Option<String> {
     let rest = value.trim();
     let rest = rest.split_once("://").map_or(rest, |(_, after)| after);
+    if let Some((span, _)) = crate::forge::bracketed_split(rest) {
+        return Some(span.to_ascii_lowercase());
+    }
     let host = rest.split(['/', ':']).next().unwrap_or("");
     (!host.is_empty()).then(|| host.to_ascii_lowercase())
 }
@@ -536,6 +542,18 @@ hosts:
             Some("gitlab.example.com".into())
         );
         assert_eq!(normalize_host("  "), None);
+        // A bracketed IPv6 key keeps its brackets, so it can compare equal to what
+        // `remote_host` yields; a port after `]` still drops.
+        assert_eq!(
+            normalize_host("[2001:DB8::1]"),
+            Some("[2001:db8::1]".into())
+        );
+        assert_eq!(
+            normalize_host("[2001:db8::1]:8443"),
+            Some("[2001:db8::1]".into())
+        );
+        // A malformed bracket folds exactly as it does today — it just never matches.
+        assert_eq!(normalize_host("[2001"), Some("[2001".into()));
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -138,8 +138,10 @@ pub(crate) fn is_safe_authority(value: &str) -> bool {
 /// match a `:8443` request — so the authority is the only key that always matches.
 ///
 /// A bracketed IPv6 literal yields `[addr]` or `[addr]:port`, git's own spelling for
-/// those requests (same measurement); a remainder after `]` that is neither empty nor a
-/// `:port` is no authority at all, and an unterminated `[` or empty `[]` is no host.
+/// those requests (same measurement). After `]`, only the `:`-led port slot may follow —
+/// a real port is carried, a non-port there falls back to the bare host (same posture as
+/// the unbracketed arm), and any other remainder is no authority at all, in both the
+/// scheme and scp regimes. An unterminated `[` or an empty `[]` is no host.
 pub(crate) fn remote_authority(url: &str) -> Option<String> {
     let url = url.trim();
     let (had_scheme, rest) = match url.split_once("://") {
@@ -154,6 +156,10 @@ pub(crate) fn remote_authority(url: &str) -> Option<String> {
     if authority.starts_with('[') {
         let (host, after) = bracketed_split(authority)?;
         let host = host.to_ascii_lowercase();
+        // Either regime: a remainder that isn't the `:`-led port slot is no authority.
+        if !after.is_empty() && !after.starts_with(':') {
+            return None;
+        }
         // scp `git@[addr]:path` has no port slot — that `:` is the path separator.
         if !had_scheme || after.is_empty() {
             return Some(host);
@@ -4091,6 +4097,7 @@ mod tests {
     fn remote_host_and_authority_agree_on_having_a_host() {
         for url in [
             "https://[::1]junk/o/r",
+            "git@[2001:db8::1]junk:o/r.git",
             "https://[::1/o]/r",
             "https://[::1",
             "https://[]",
@@ -4184,8 +4191,9 @@ mod tests {
             remote_authority("https://[2001:db8::1]:443.helper=!evil/o/r").as_deref(),
             Some("[2001:db8::1]"),
         );
-        // A remainder after `]` that isn't a `:port` is no authority.
+        // A remainder after `]` that isn't a `:port` is no authority, in either regime.
         assert_eq!(remote_authority("https://[2001:db8::1]junk/o/r"), None);
+        assert_eq!(remote_authority("git@[2001:db8::1]junk:o/r.git"), None);
         assert_eq!(remote_authority("https://[::1"), None);
         assert_eq!(remote_authority("https://[]"), None);
         assert_eq!(

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -84,7 +84,9 @@ fn is_port(s: &str) -> bool {
 /// whose interior is non-empty, drawn from `[0-9A-Fa-f:.]`, and carries at least one `:`
 /// (RFC 3986 brackets are IPv6-only, so requiring the colon costs nothing and tightens
 /// the gate); either form plus an optional numeric port. A zone id (`%eth0`) is
-/// deliberately NOT admitted — no CLI takes one, so fail closed. THE
+/// deliberately NOT admitted: `%` is encoding/config syntax in a credential key, and the
+/// CLIs don't police it themselves (glab 1.105 accepts a zone-id hostname, measured), so
+/// this gate is the layer that keeps it out of keys and argv. THE
 /// reconnect/credential host grammar — `valid_reconnect_host` delegates here and
 /// `isReconnectHostSafe` (`src/lib/git/host.ts`) mirrors it, so the three can't drift.
 /// Needed because `remote_host`/`remote_authority` only split on `/`, `:` and the

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -4327,7 +4327,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_path_counts_the_scp_separator_past_the_bracket() {
+    fn remote_path_parses_bracketed_hosts_and_refuses_malformed_ones() {
         assert_eq!(
             remote_path("git@[2001:db8::1]:group/sub/repo.git").as_deref(),
             Some("group/sub/repo"),
@@ -4347,6 +4347,9 @@ mod tests {
         // so fork_url_from_origin can't splice onto a malformed origin.
         assert_eq!(remote_path("https://[2001:db8::1/path]:8443/group/repo"), None);
         assert_eq!(remote_path("git@[::1]junk:group/repo"), None);
+        // The gate also refuses an EMPTY authority, so a file:// remote no longer
+        // yields its filesystem path as a bogus owner/repo slug.
+        assert_eq!(remote_path("file:///srv/repos/x"), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -62,13 +62,9 @@ pub(crate) fn bracketed_split(rest: &str) -> Option<(&str, &str)> {
 /// read as host `2001` plus a garbage port to every downstream `host[:port]` splitter.
 pub(crate) fn remote_host(url: &str) -> Option<String> {
     let authority = remote_authority(url)?;
-    let host = if authority.starts_with('[') {
-        // A bracketed literal's host is the span through `]`; only a `:port` follows it.
-        authority.split_inclusive(']').next().unwrap_or(&authority)
-    } else {
-        // Otherwise the first `:` opens the port.
-        authority.split(':').next().unwrap_or(&authority)
-    };
+    // A bracketed literal's host is its span; otherwise the first `:` opens the port.
+    let host = bracketed_split(&authority)
+        .map_or_else(|| authority.split(':').next().unwrap_or(&authority), |(span, _)| span);
     Some(host.to_string())
 }
 

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -36,19 +36,40 @@ pub trait Forge {
     async fn status(&self, repo_path: &str) -> AppResult<ForgeStatus>;
 }
 
+/// Split a leading bracketed IPv6 literal off an authority, yielding the `[…]` span
+/// (brackets included) and whatever follows the `]`. `None` for an unterminated `[` or
+/// an empty `[]`. The URL-decomposition idioms, the authority gate, and glab's
+/// hosts-key normalizer share it so a literal's own `:`s can never be mistaken for a
+/// port or an scp path separator.
+pub(crate) fn bracketed_split(rest: &str) -> Option<(&str, &str)> {
+    let after_open = rest.strip_prefix('[')?;
+    let close = after_open.find(']')?;
+    // `[]` carries no address, so it's no host either.
+    (close > 0).then(|| (&rest[..close + 2], &after_open[close + 1..]))
+}
+
 /// The host of a remote URL — both `https://host[:port]/…` and scp-style
 /// `git@host:owner/…`. Lowercased; `None` when there's no parseable host (a local
 /// path, say). Tolerates an optional `user@` and a `:port`.
+///
+/// Derived from [`remote_authority`] minus its port, so a URL has a host EXACTLY when it
+/// has an authority: the session health probe reads the two side by side under paired
+/// `unwrap_or_else` fallbacks, and any Some/None asymmetry there would probe one repo's
+/// host against the github.com default.
+///
+/// A bracketed IPv6 literal keeps its brackets (`[2001:db8::1]`) — git's own
+/// credential-context spelling (measured against git 2.51); a bare `2001:db8::1` would
+/// read as host `2001` plus a garbage port to every downstream `host[:port]` splitter.
 pub(crate) fn remote_host(url: &str) -> Option<String> {
-    let url = url.trim();
-    // `scheme://[user@]host[:port]/…` → strip the scheme; otherwise treat it as a
-    // scp-like `[user@]host:path` and operate on the whole string.
-    let rest = url.split_once("://").map_or(url, |(_, after)| after);
-    // Drop an optional `user@` (rsplit so `user@host` keeps `host`).
-    let rest = rest.rsplit_once('@').map_or(rest, |(_, host)| host);
-    // The host ends at the first `/` (path) or `:` (port / scp path separator).
-    let host = rest.split(['/', ':']).next().unwrap_or("");
-    (!host.is_empty()).then(|| host.to_ascii_lowercase())
+    let authority = remote_authority(url)?;
+    let host = if authority.starts_with('[') {
+        // A bracketed literal's host is the span through `]`; only a `:port` follows it.
+        authority.split_inclusive(']').next().unwrap_or(&authority)
+    } else {
+        // Otherwise the first `:` opens the port.
+        authority.split(':').next().unwrap_or(&authority)
+    };
+    Some(host.to_string())
 }
 
 /// A TCP port as a URL spells one: 1-5 ASCII digits. Deliberately not range-checked —
@@ -59,12 +80,38 @@ fn is_port(s: &str) -> bool {
 }
 
 /// Whether a string is safe to interpolate as the authority of a `credential.https://…`
-/// config key or a `--hostname` argv: host `[A-Za-z0-9.-]+` plus an optional numeric
-/// port. THE reconnect/credential host grammar — `valid_reconnect_host` delegates here
-/// and `isReconnectHostSafe` (`src/lib/git/host.ts`) mirrors it, so the three can't
-/// drift. Needed because `remote_host`/`remote_authority` only split on `/` and `:`, so
-/// a crafted remote can carry `=`, `;`, `$`, or a space through them.
+/// config key or a `--hostname` argv: host `[A-Za-z0-9.-]+`, or a bracketed IPv6 literal
+/// whose interior is non-empty, drawn from `[0-9A-Fa-f:.]`, and carries at least one `:`
+/// (RFC 3986 brackets are IPv6-only, so requiring the colon costs nothing and tightens
+/// the gate); either form plus an optional numeric port. A zone id (`%eth0`) is
+/// deliberately NOT admitted — no CLI takes one, so fail closed. THE
+/// reconnect/credential host grammar — `valid_reconnect_host` delegates here and
+/// `isReconnectHostSafe` (`src/lib/git/host.ts`) mirrors it, so the three can't drift.
+/// Needed because `remote_host`/`remote_authority` only split on `/`, `:` and the
+/// bracket span, so a crafted remote can carry `=`, `;`, `$`, or a space through them.
+/// A charset gate, not an IPv6 validator: `[:]` passes both sides, and that's fine —
+/// it's injection-safe garbage git will reject on its own.
 pub(crate) fn is_safe_authority(value: &str) -> bool {
+    // Bracketed literals resolve first: their own `:`s make a first-`:` split wrong.
+    // Sharing `bracketed_split` keeps the gate's idea of the span identical to the
+    // parsers' (it already refuses an unterminated `[` and an empty `[]`).
+    if value.starts_with('[') {
+        let Some((span, after)) = bracketed_split(value) else {
+            return false;
+        };
+        let inner = &span[1..span.len() - 1];
+        if !inner.contains(':')
+            || !inner
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() || b == b':' || b == b'.')
+        {
+            return false;
+        }
+        return match after.strip_prefix(':') {
+            Some(port) => is_port(port),
+            None => after.is_empty(),
+        };
+    }
     let (host, port) = match value.split_once(':') {
         Some((h, p)) => (h, Some(p)),
         None => (value, None),
@@ -91,6 +138,10 @@ pub(crate) fn is_safe_authority(value: &str) -> bool {
 /// 2.51 (`git credential fill`, isolated config), a `host:port` key matches a ported
 /// request, git normalizes the DEFAULT port both directions, and a portless key does NOT
 /// match a `:8443` request — so the authority is the only key that always matches.
+///
+/// A bracketed IPv6 literal yields `[addr]` or `[addr]:port`, git's own spelling for
+/// those requests (same measurement); a remainder after `]` that is neither empty nor a
+/// `:port` is no authority at all, and an unterminated `[` or empty `[]` is no host.
 pub(crate) fn remote_authority(url: &str) -> Option<String> {
     let url = url.trim();
     let (had_scheme, rest) = match url.split_once("://") {
@@ -99,9 +150,25 @@ pub(crate) fn remote_authority(url: &str) -> Option<String> {
     };
     // Drop an optional `user@` (rsplit so `user@host` keeps `host`).
     let rest = rest.rsplit_once('@').map_or(rest, |(_, host)| host);
-    // The authority ends at the first `/`; without a scheme the remaining `:` is scp's
-    // path separator, so trim there too.
+    // The authority ends at the first `/`; a bracketed literal can't contain one, so
+    // this split is safe to take before the bracket span is resolved.
     let authority = rest.split('/').next().unwrap_or("");
+    if authority.starts_with('[') {
+        let (host, after) = bracketed_split(authority)?;
+        let host = host.to_ascii_lowercase();
+        // scp `git@[addr]:path` has no port slot — that `:` is the path separator.
+        if !had_scheme || after.is_empty() {
+            return Some(host);
+        }
+        let after = after.strip_prefix(':')?;
+        // Same posture as the non-bracketed arm below: only a real port is carried.
+        return Some(if is_port(after) {
+            format!("{host}:{after}")
+        } else {
+            host
+        });
+    }
+    // Without a scheme the remaining `:` is scp's path separator, so trim there too.
     let authority = if had_scheme {
         authority
     } else {
@@ -132,7 +199,9 @@ pub(crate) fn remote_authority(url: &str) -> Option<String> {
 /// Complements [`remote_host`]; `None` when there's no path. Handles both
 /// `https://host[:port]/path` and scp-style `git@host:path`: with a scheme a `:`
 /// is a port (path starts after the next `/`), without one it's the scp path
-/// separator. Used to address a repo on a provider's API (e.g. a GitLab project).
+/// separator — counted past a bracketed IPv6 literal, whose own `:`s would otherwise
+/// cut the host short. Used to address a repo on a provider's API (e.g. a GitLab
+/// project).
 pub(crate) fn remote_path(url: &str) -> Option<String> {
     let url = url.trim();
     let (had_scheme, rest) = match url.split_once("://") {
@@ -145,8 +214,14 @@ pub(crate) fn remote_path(url: &str) -> Option<String> {
         // `host[:port]/path` → everything after the first `/`.
         rest.split_once('/').map(|(_, after)| after)?
     } else {
-        // scp `host:path` → everything after the first `:`.
-        rest.split_once(':').map(|(_, after)| after)?
+        // scp `host:path` → everything after the first `:`, counted past a bracketed
+        // IPv6 literal so the address's own `:`s aren't read as the separator.
+        let after_host = if rest.starts_with('[') {
+            bracketed_split(rest)?.1
+        } else {
+            rest
+        };
+        after_host.split_once(':').map(|(_, after)| after)?
     };
     let path = path.trim_matches('/');
     let path = path.strip_suffix(".git").unwrap_or(path);
@@ -3983,6 +4058,52 @@ mod tests {
     }
 
     #[test]
+    fn remote_host_keeps_bracketed_ipv6_literals_whole() {
+        // The brackets ride along — they're git's own spelling and the only form a
+        // downstream `host[:port]` splitter reads correctly.
+        assert_eq!(
+            remote_host("https://[2001:db8::1]:8443/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        assert_eq!(
+            remote_host("https://[2001:DB8::1]/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        assert_eq!(
+            remote_host("ssh://git@[2001:db8::1]/g/r.git").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        // scp form: the `:` after `]` is the path separator.
+        assert_eq!(
+            remote_host("git@[2001:db8::1]:o/r.git").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        assert_eq!(
+            remote_host("https://user@[2001:db8::1]:8443/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        // An unterminated bracket or an empty one is no host at all.
+        assert_eq!(remote_host("https://[2001:db8::1/o/r"), None);
+        assert_eq!(remote_host("https://[]/o/r"), None);
+    }
+
+    /// The session health probe reads host and authority side by side under paired
+    /// github.com fallbacks, so a URL must yield both or neither.
+    #[test]
+    fn remote_host_and_authority_agree_on_having_a_host() {
+        for url in [
+            "https://[::1]junk/o/r",
+            "https://[::1/o]/r",
+            "https://[::1",
+            "https://[]",
+            "/local/path",
+        ] {
+            assert_eq!(remote_host(url), None, "host {url}");
+            assert_eq!(remote_authority(url), None, "authority {url}");
+        }
+    }
+
+    #[test]
     fn remote_authority_keeps_the_port_remote_host_drops() {
         // The whole point: a non-default port survives, verbatim.
         assert_eq!(
@@ -4034,6 +4155,48 @@ mod tests {
     }
 
     #[test]
+    fn remote_authority_brackets_ipv6_hosts_and_their_ports() {
+        assert_eq!(
+            remote_authority("https://[2001:db8::1]:8443/o/r").as_deref(),
+            Some("[2001:db8::1]:8443"),
+        );
+        assert_eq!(
+            remote_authority("https://[2001:db8::1]/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        assert_eq!(
+            remote_authority("HTTPS://[2001:DB8::1]:8443/o/r").as_deref(),
+            Some("[2001:db8::1]:8443"),
+        );
+        assert_eq!(
+            remote_authority("https://user@[::1]:8443/o/r").as_deref(),
+            Some("[::1]:8443"),
+        );
+        // scp form: the `:` after `]` is the path separator, never a port.
+        assert_eq!(
+            remote_authority("git@[2001:db8::1]:o/r.git").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        // A non-port segment falls back to the bare host, injection shapes included.
+        assert_eq!(
+            remote_authority("https://[2001:db8::1]:8443x/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        assert_eq!(
+            remote_authority("https://[2001:db8::1]:443.helper=!evil/o/r").as_deref(),
+            Some("[2001:db8::1]"),
+        );
+        // A remainder after `]` that isn't a `:port` is no authority.
+        assert_eq!(remote_authority("https://[2001:db8::1]junk/o/r"), None);
+        assert_eq!(remote_authority("https://[::1"), None);
+        assert_eq!(remote_authority("https://[]"), None);
+        assert_eq!(
+            remote_authority("https://[::1]:65535/o/r").as_deref(),
+            Some("[::1]:65535"),
+        );
+    }
+
+    #[test]
     fn a_crafted_port_segment_never_reaches_a_credential_key() {
         // A remote URL any opened repo's .git/config can carry. git splits a `-c` at its
         // FIRST `=`, so keeping this port verbatim would key an attacker-chosen `!`-shell
@@ -4058,6 +4221,32 @@ mod tests {
         assert!(!is_safe_authority("host:123456"));
         assert!(!is_safe_authority(":8443"));
         assert!(!is_safe_authority(""));
+    }
+
+    #[test]
+    fn is_safe_authority_admits_bracketed_ipv6_literals() {
+        assert!(is_safe_authority("[2001:db8::1]"));
+        assert!(is_safe_authority("[::1]"));
+        assert!(is_safe_authority("[2001:db8::1]:8443"));
+        assert!(is_safe_authority("[::ffff:192.0.2.1]"));
+        assert!(is_safe_authority("[::1]:65535"));
+        // Malformed brackets, and the unbracketed spelling no splitter reads right.
+        assert!(!is_safe_authority("[]"));
+        assert!(!is_safe_authority("[::1"));
+        assert!(!is_safe_authority("::1]"));
+        assert!(!is_safe_authority("2001:db8::1"));
+        // Brackets are IPv6-only, so an interior without a `:` is not one.
+        assert!(!is_safe_authority("[gh.com]"));
+        // The port rules are the bare host's, applied after the bracket close.
+        assert!(!is_safe_authority("[::1]:"));
+        assert!(!is_safe_authority("[::1]:123456"));
+        assert!(!is_safe_authority("[::1]:8443x"));
+        assert!(!is_safe_authority("[::1]x"));
+        assert!(!is_safe_authority("[::1] "));
+        // Config/shell syntax stays out, and a zone id fails closed.
+        assert!(!is_safe_authority("[::1];rm -rf /"));
+        assert!(!is_safe_authority("[::1%25eth0]"));
+        assert!(!is_safe_authority("[2001:db8::1]:443.helper=!evil #"));
     }
 
     #[test]
@@ -4118,6 +4307,20 @@ mod tests {
         // host only → no path.
         assert_eq!(remote_path("https://gitlab.com"), None);
         assert_eq!(remote_path("/local/path"), None);
+    }
+
+    #[test]
+    fn remote_path_counts_the_scp_separator_past_the_bracket() {
+        assert_eq!(
+            remote_path("git@[2001:db8::1]:group/sub/repo.git").as_deref(),
+            Some("group/sub/repo"),
+        );
+        assert_eq!(
+            remote_path("https://[2001:db8::1]:8443/g/r.git").as_deref(),
+            Some("g/r"),
+        );
+        // Host and separator but no path.
+        assert_eq!(remote_path("git@[::1]:"), None);
     }
 
     #[test]
@@ -4354,6 +4557,15 @@ mod tests {
         // No repo path to splice → None, so the caller errors instead of guessing.
         assert_eq!(f("https://github.com"), None);
         assert_eq!(f(""), None);
+    }
+
+    #[test]
+    fn fork_url_splices_a_bracketed_ipv6_origin() {
+        assert_eq!(
+            fork_url_from_origin("https://[2001:db8::1]:8443/old/repo.git", "owner", "repo")
+                .as_deref(),
+            Some("https://[2001:db8::1]:8443/owner/repo.git"),
+        );
     }
 
     /// The frontend keys off these exact names, and an unknown probe must travel

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -37,13 +37,18 @@ pub trait Forge {
 }
 
 /// Split a leading bracketed IPv6 literal off an authority, yielding the `[…]` span
-/// (brackets included) and whatever follows the `]`. `None` for an unterminated `[` or
-/// an empty `[]`. The URL-decomposition idioms, the authority gate, and glab's
-/// hosts-key normalizer share it so a literal's own `:`s can never be mistaken for a
-/// port or an scp path separator.
+/// (brackets included) and whatever follows the `]`. `None` for an unterminated `[`,
+/// an empty `[]`, or a `/` inside the span — no IPv6 literal carries one, and refusing
+/// it here keeps callers that pre-split on `/` and callers that don't (`remote_path`'s
+/// scp arm) agreeing on malformed spans. The URL-decomposition idioms, the authority
+/// gate, and glab's hosts-key normalizer share it so a literal's own `:`s can never be
+/// mistaken for a port or an scp path separator.
 pub(crate) fn bracketed_split(rest: &str) -> Option<(&str, &str)> {
     let after_open = rest.strip_prefix('[')?;
     let close = after_open.find(']')?;
+    if after_open[..close].contains('/') {
+        return None;
+    }
     // `[]` carries no address, so it's no host either.
     (close > 0).then(|| (&rest[..close + 2], &after_open[close + 1..]))
 }
@@ -138,10 +143,11 @@ pub(crate) fn is_safe_authority(value: &str) -> bool {
 /// match a `:8443` request — so the authority is the only key that always matches.
 ///
 /// A bracketed IPv6 literal yields `[addr]` or `[addr]:port`, git's own spelling for
-/// those requests (same measurement). After `]`, only the `:`-led port slot may follow —
-/// a real port is carried, a non-port there falls back to the bare host (same posture as
-/// the unbracketed arm), and any other remainder is no authority at all, in both the
-/// scheme and scp regimes. An unterminated `[` or an empty `[]` is no host.
+/// those requests (same measurement). After `]`, only the `:`-led port slot may follow;
+/// any other remainder is no authority, in either regime. A scheme URL carries a real
+/// port and drops a non-port to the bare host (same posture as the unbracketed arm);
+/// in scp form the `:` after `]` opens the path, so the bare host comes back. An
+/// unterminated `[` or an empty `[]` is no host.
 pub(crate) fn remote_authority(url: &str) -> Option<String> {
     let url = url.trim();
     let (had_scheme, rest) = match url.split_once("://") {
@@ -4327,6 +4333,11 @@ mod tests {
         );
         // Host and separator but no path.
         assert_eq!(remote_path("git@[::1]:"), None);
+        // The scp arm's own fail-closed refusals: an unterminated bracket, and a `/`
+        // inside the span (no IPv6 literal has one — remote_authority refuses it too,
+        // so the pair can't disagree and feed fork_url_from_origin a half-parse).
+        assert_eq!(remote_path("git@[::1:o/r"), None);
+        assert_eq!(remote_path("git@[2001:db8::1/path]:group/repo"), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -212,8 +212,13 @@ pub(crate) fn remote_authority(url: &str) -> Option<String> {
 /// separator — counted past a bracketed IPv6 literal, whose own `:`s would otherwise
 /// cut the host short. Used to address a repo on a provider's API (e.g. a GitLab
 /// project).
+///
+/// Gated on [`remote_authority`]: a URL it refuses has no path either, so the pair
+/// can't diverge — [`fork_url_from_origin`] splices from this path alone, and a
+/// divergence would build a fork URL on a malformed origin.
 pub(crate) fn remote_path(url: &str) -> Option<String> {
     let url = url.trim();
+    remote_authority(url)?;
     let (had_scheme, rest) = match url.split_once("://") {
         Some((_, after)) => (true, after),
         None => (false, url),
@@ -4338,6 +4343,10 @@ mod tests {
         // so the pair can't disagree and feed fork_url_from_origin a half-parse).
         assert_eq!(remote_path("git@[::1:o/r"), None);
         assert_eq!(remote_path("git@[2001:db8::1/path]:group/repo"), None);
+        // The remote_authority gate: URLs it refuses yield no path from either arm,
+        // so fork_url_from_origin can't splice onto a malformed origin.
+        assert_eq!(remote_path("https://[2001:db8::1/path]:8443/group/repo"), None);
+        assert_eq!(remote_path("git@[::1]junk:group/repo"), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -1855,6 +1855,9 @@ mod tests {
         // A ported instance registers with gh/glab under `host:port`, so the reconnect
         // flow must accept the same spelling the health check reports.
         assert!(valid_reconnect_host("gitlab.example.com:8443"));
+        // A bracketed IPv6 literal is what the health check reports for such a remote.
+        assert!(valid_reconnect_host("[2001:db8::1]:8443"));
+        assert!(!valid_reconnect_host("[::1")); // unterminated bracket
         assert!(!valid_reconnect_host("")); // empty
         assert!(!valid_reconnect_host("gitlab.example.com:8443x")); // not a port
         assert!(!valid_reconnect_host("https://gitlab.example.com")); // scheme

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -788,11 +788,12 @@ impl Drop for ReconnectGuard {
     }
 }
 
-/// A reconnect host is a hostname, or a bracketed IPv6 literal, with an optional numeric
-/// port — no scheme, no path, no shell syntax. The port is allowed because `gh auth login --hostname host:8443` is
-/// exactly how a ported instance registers, and the value becomes a `--hostname`
-/// argument the CLIs key their stored credentials by. One grammar, shared with the
-/// credential-key guard so the two can't drift.
+/// A reconnect host is a hostname, or a bracketed IPv6 literal, with an optional
+/// numeric port — no scheme, no path, no shell syntax. The port is allowed because
+/// `gh auth login --hostname host:8443` is exactly how a ported instance registers,
+/// and the value becomes a `--hostname` argument the CLIs key their stored
+/// credentials by. One grammar, shared with the credential-key guard so the two
+/// can't drift.
 fn valid_reconnect_host(host: &str) -> bool {
     crate::forge::is_safe_authority(host)
 }

--- a/src-tauri/src/forge/session.rs
+++ b/src-tauri/src/forge/session.rs
@@ -788,8 +788,8 @@ impl Drop for ReconnectGuard {
     }
 }
 
-/// A reconnect host is a hostname with an optional numeric port — no scheme, no path,
-/// no shell syntax. The port is allowed because `gh auth login --hostname host:8443` is
+/// A reconnect host is a hostname, or a bracketed IPv6 literal, with an optional numeric
+/// port — no scheme, no path, no shell syntax. The port is allowed because `gh auth login --hostname host:8443` is
 /// exactly how a ported instance registers, and the value becomes a `--hostname`
 /// argument the CLIs key their stored credentials by. One grammar, shared with the
 /// credential-key guard so the two can't drift.

--- a/src-tauri/src/git/repo.rs
+++ b/src-tauri/src/git/repo.rs
@@ -56,10 +56,13 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
     // Strip credentials and a port from the host.
     let host = host.rsplit('@').next().unwrap_or(host);
     // A bracketed IPv6 literal keeps its brackets — this host is persisted and compared
-    // against `remote_host`'s spelling by the provider routing. A malformed bracket
-    // yields no host rather than a truncated one that would mismatch silently.
+    // against `remote_host`'s spelling by the provider routing. A malformed bracket, or
+    // a suffix after `]` that isn't a port, yields no host rather than a truncated one
+    // that would mismatch silently.
     let host = if host.starts_with('[') {
-        crate::forge::bracketed_split(host).map_or("", |(span, _)| span)
+        crate::forge::bracketed_split(host)
+            .filter(|(_, suffix)| suffix.is_empty() || suffix.starts_with(':'))
+            .map_or("", |(span, _)| span)
     } else {
         host.split(':').next().unwrap_or(host)
     };
@@ -454,6 +457,11 @@ mod owner_tests {
         // A malformed bracket is no host at all — the path still parses.
         assert_eq!(
             parse_owner_host("https://[2001:db8::1/owner/repo"),
+            (Some("owner".into()), None)
+        );
+        // Nor is a span followed by something that isn't a port.
+        assert_eq!(
+            parse_owner_host("https://[2001:db8::1]junk/owner/repo"),
             (Some("owner".into()), None)
         );
     }

--- a/src-tauri/src/git/repo.rs
+++ b/src-tauri/src/git/repo.rs
@@ -55,7 +55,15 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
     };
     // Strip credentials and a port from the host.
     let host = host.rsplit('@').next().unwrap_or(host);
-    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    // A bracketed IPv6 literal keeps its brackets — this host is persisted and compared
+    // against `remote_host`'s spelling by the provider routing. A malformed bracket
+    // yields no host rather than a truncated one that would mismatch silently.
+    let host = if host.starts_with('[') {
+        crate::forge::bracketed_split(host).map_or("", |(span, _)| span)
+    } else {
+        host.split(':').next().unwrap_or(host)
+    };
+    let host = host.to_ascii_lowercase();
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
     // owner is the segment immediately before the repo name.
     let owner = (segs.len() >= 2).then(|| segs[segs.len() - 2].to_string());
@@ -428,6 +436,26 @@ mod owner_tests {
             (Some("g".into()), Some("gitlab.acme.com".into()))
         );
         assert_eq!(parse_owner_host("not-a-url"), (None, None));
+    }
+
+    #[test]
+    fn bracketed_ipv6_hosts_keep_their_brackets() {
+        // The persisted host must be spelled as `remote_host` spells it, or the
+        // provider routing compares two different strings for the same instance.
+        assert_eq!(
+            parse_owner_host("https://[2001:DB8::1]:8443/owner/repo.git"),
+            (Some("owner".into()), Some("[2001:db8::1]".into()))
+        );
+        // scp form: `rfind(':')` lands past the address, on the path separator.
+        assert_eq!(
+            parse_owner_host("git@[2001:db8::1]:owner/repo.git"),
+            (Some("owner".into()), Some("[2001:db8::1]".into()))
+        );
+        // A malformed bracket is no host at all — the path still parses.
+        assert_eq!(
+            parse_owner_host("https://[2001:db8::1/owner/repo"),
+            (Some("owner".into()), None)
+        );
     }
 
     #[test]

--- a/src-tauri/src/git/repo.rs
+++ b/src-tauri/src/git/repo.rs
@@ -56,9 +56,10 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
     // Strip credentials and a port from the host.
     let host = host.rsplit('@').next().unwrap_or(host);
     // A bracketed IPv6 literal keeps its brackets — this host is persisted and compared
-    // against `remote_host`'s spelling by the provider routing. A malformed bracket, or
-    // a suffix after `]` that isn't a port, yields no host rather than a truncated one
-    // that would mismatch silently.
+    // against `remote_host`'s spelling by the provider routing. A `:`-led suffix rides
+    // the port slot and is dropped, like the bare arm drops it; a malformed bracket or
+    // any other suffix yields no host rather than a truncated one that would mismatch
+    // silently.
     let host = if host.starts_with('[') {
         crate::forge::bracketed_split(host)
             .filter(|(_, suffix)| suffix.is_empty() || suffix.starts_with(':'))

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -38,12 +38,17 @@ struct RepoView {
 
 /// The host of a repo URL like `https://github.acme.com/owner/repo` →
 /// `github.acme.com`. None when it isn't an http(s)-style URL. Tolerates an
-/// optional `user@` prefix and `:port` suffix.
+/// optional `user@` prefix and `:port` suffix. A bracketed IPv6 literal keeps its
+/// brackets, matching `remote_host`'s spelling; a malformed bracket is no host.
 fn host_from_url(url: &str) -> Option<String> {
     let after = url.split_once("://").map(|(_, rest)| rest)?;
     let authority = after.split('/').next().unwrap_or("");
     let host = authority.rsplit('@').next().unwrap_or(authority);
-    let host = host.split(':').next().unwrap_or(host);
+    let host = if host.starts_with('[') {
+        crate::forge::bracketed_split(host)?.0
+    } else {
+        host.split(':').next().unwrap_or(host)
+    };
     (!host.is_empty()).then(|| host.to_string())
 }
 
@@ -7151,6 +7156,18 @@ mod tests {
         );
         // Not an http(s)-style URL → no host.
         assert_eq!(host_from_url("git@github.com:owner/repo.git"), None);
+        // A bracketed IPv6 literal survives whole, with or without a port.
+        assert_eq!(
+            host_from_url("https://[2001:db8::1]:8443/o/r").as_deref(),
+            Some("[2001:db8::1]")
+        );
+        assert_eq!(
+            host_from_url("https://[2001:db8::1]/o/r").as_deref(),
+            Some("[2001:db8::1]")
+        );
+        // A malformed bracket fails closed rather than yielding a truncated host.
+        assert_eq!(host_from_url("https://[2001:db8::1/o/r"), None);
+        assert_eq!(host_from_url("https://[]/o/r"), None);
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -46,7 +46,8 @@ fn host_from_url(url: &str) -> Option<String> {
     let host = authority.rsplit('@').next().unwrap_or(authority);
     let host = if host.starts_with('[') {
         let (span, suffix) = crate::forge::bracketed_split(host)?;
-        // Only a `:port` may follow the span; any other suffix is no host at all.
+        // A `:`-led suffix rides the port slot and is dropped, like the bare arm drops
+        // it; any other suffix is no host.
         if !suffix.is_empty() && !suffix.starts_with(':') {
             return None;
         }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -45,7 +45,12 @@ fn host_from_url(url: &str) -> Option<String> {
     let authority = after.split('/').next().unwrap_or("");
     let host = authority.rsplit('@').next().unwrap_or(authority);
     let host = if host.starts_with('[') {
-        crate::forge::bracketed_split(host)?.0
+        let (span, suffix) = crate::forge::bracketed_split(host)?;
+        // Only a `:port` may follow the span; any other suffix is no host at all.
+        if !suffix.is_empty() && !suffix.starts_with(':') {
+            return None;
+        }
+        span
     } else {
         host.split(':').next().unwrap_or(host)
     };
@@ -7168,6 +7173,8 @@ mod tests {
         // A malformed bracket fails closed rather than yielding a truncated host.
         assert_eq!(host_from_url("https://[2001:db8::1/o/r"), None);
         assert_eq!(host_from_url("https://[]/o/r"), None);
+        // So does a suffix after `]` that isn't a port.
+        assert_eq!(host_from_url("https://[2001:db8::1]junk/o/r"), None);
     }
 
     #[test]

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -604,12 +604,13 @@ fn split_url(url: &str) -> Option<(String, &str)> {
     let (authority, path) =
         hierarchical.split_at(hierarchical.find('/').unwrap_or(hierarchical.len()));
     let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    // A bracketed IPv6 literal carries its own colons, so its span is taken before
+    // the port strip; `www.` can never prefix one.
+    let bare = crate::forge::bracketed_split(host)
+        .map_or_else(|| host.split_once(':').map_or(host, |(h, _)| h), |(s, _)| s);
     // Case-fold before stripping `www.`: hosts are case-insensitive, so an
     // upper-case prefix has to fall away too.
-    let lower = host
-        .split_once(':')
-        .map_or(host, |(h, _)| h)
-        .to_ascii_lowercase();
+    let lower = bare.to_ascii_lowercase();
     let host = lower.strip_prefix("www.").unwrap_or(&lower);
     (!host.is_empty()).then(|| (host.to_string(), path))
 }
@@ -2035,6 +2036,8 @@ mod tests {
                 "lists.debian.org",
             ),
             ("http://EXAMPLE.COM/x", "example.com"),
+            // A bracketed IPv6 literal labels whole — its colons aren't a port.
+            ("https://[2001:DB8::1]:8443/x", "[2001:db8::1]"),
             ("https://WWW.Example.com/x", "example.com"),
             // Nothing parseable to name it by: the URL labels itself.
             ("not a url", "not a url"),

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -607,7 +607,8 @@ fn split_url(url: &str) -> Option<(String, &str)> {
     // A bracketed IPv6 literal carries its own colons, so its span is taken before
     // the port strip; `www.` can never prefix one.
     let bare = match crate::forge::bracketed_split(host) {
-        // Only a `:port` may follow the span; any other suffix is no authority.
+        // A `:`-led suffix rides the port slot and is dropped, like the bare arm drops
+        // it; any other suffix is no authority.
         Some((_, suffix)) if !suffix.is_empty() && !suffix.starts_with(':') => return None,
         Some((span, _)) => span,
         None => host.split_once(':').map_or(host, |(h, _)| h),

--- a/src-tauri/src/github/security_findings.rs
+++ b/src-tauri/src/github/security_findings.rs
@@ -606,8 +606,12 @@ fn split_url(url: &str) -> Option<(String, &str)> {
     let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
     // A bracketed IPv6 literal carries its own colons, so its span is taken before
     // the port strip; `www.` can never prefix one.
-    let bare = crate::forge::bracketed_split(host)
-        .map_or_else(|| host.split_once(':').map_or(host, |(h, _)| h), |(s, _)| s);
+    let bare = match crate::forge::bracketed_split(host) {
+        // Only a `:port` may follow the span; any other suffix is no authority.
+        Some((_, suffix)) if !suffix.is_empty() && !suffix.starts_with(':') => return None,
+        Some((span, _)) => span,
+        None => host.split_once(':').map_or(host, |(h, _)| h),
+    };
     // Case-fold before stripping `www.`: hosts are case-insensitive, so an
     // upper-case prefix has to fall away too.
     let lower = bare.to_ascii_lowercase();
@@ -2038,6 +2042,8 @@ mod tests {
             ("http://EXAMPLE.COM/x", "example.com"),
             // A bracketed IPv6 literal labels whole — its colons aren't a port.
             ("https://[2001:DB8::1]:8443/x", "[2001:db8::1]"),
+            // A non-port suffix after `]` is no authority: the URL labels itself.
+            ("https://[2001:DB8::1]junk/x", "https://[2001:DB8::1]junk/x"),
             ("https://WWW.Example.com/x", "example.com"),
             // Nothing parseable to name it by: the URL labels itself.
             ("not a url", "not a url"),

--- a/src/features/accounts/ReconnectDialog.tsx
+++ b/src/features/accounts/ReconnectDialog.tsx
@@ -98,6 +98,7 @@ function ReconnectFlow({
   const primaryRef = useRef<HTMLButtonElement>(null);
   const autoCloseRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const hostArg = reconnectHostArg(host);
   // The copy-paste fallback must match the flow the dialog was driving, argv spelling
   // included: a GitHub "refresh" maps to `gh auth refresh` (preserves granted scopes,
   // plus one `-s` per requested scope), everything else to `auth login --web` (glab has
@@ -106,7 +107,6 @@ function ReconnectFlow({
   // wherever `gh auth switch` last pointed.
   // Null when the host fails the reconnect grammar, so a crafted remote host can't
   // put shell syntax into the copyable command (the in-app flow re-validates anyway).
-  const hostArg = reconnectHostArg(host);
   const fallbackCommand = !isReconnectHostSafe(host)
     ? null
     : isGitHub && mode === "refresh"

--- a/src/features/accounts/ReconnectDialog.tsx
+++ b/src/features/accounts/ReconnectDialog.tsx
@@ -16,7 +16,7 @@ import {
   forgeReconnectCancel,
   openInTerminal,
 } from "@/lib/git/api";
-import { isReconnectHostSafe } from "@/lib/git/host";
+import { isReconnectHostSafe, reconnectHostArg } from "@/lib/git/host";
 import { useInvalidateAfterReconnect } from "@/lib/git/queries";
 import { providerLabel, type ReconnectEvent } from "@/lib/git/types";
 import { useSettings } from "@/lib/settings/queries";
@@ -106,11 +106,12 @@ function ReconnectFlow({
   // wherever `gh auth switch` last pointed.
   // Null when the host fails the reconnect grammar, so a crafted remote host can't
   // put shell syntax into the copyable command (the in-app flow re-validates anyway).
+  const hostArg = reconnectHostArg(host);
   const fallbackCommand = !isReconnectHostSafe(host)
     ? null
     : isGitHub && mode === "refresh"
-      ? `gh auth refresh --hostname ${host}${(scopes ?? []).map((s) => ` -s ${s}`).join("")}`
-      : `${isGitHub ? "gh" : "glab"} auth login --hostname ${host} --web`;
+      ? `gh auth refresh --hostname ${hostArg}${(scopes ?? []).map((s) => ` -s ${s}`).join("")}`
+      : `${isGitHub ? "gh" : "glab"} auth login --hostname ${hostArg} --web`;
 
   // Handle streamed events without re-subscribing the channel on every render:
   // useEffectEvent reads the latest closures (invalidate/settings) but stays

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -1,7 +1,11 @@
 import { CopyIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { copyText } from "@/lib/clipboard";
-import { isReconnectHostSafe, useActiveGhHost } from "@/lib/git/host";
+import {
+  isReconnectHostSafe,
+  reconnectHostArg,
+  useActiveGhHost,
+} from "@/lib/git/host";
 import { useGhScopes } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
 
@@ -30,7 +34,7 @@ export function ScopeRefreshHint({
   const hostSafe = isReconnectHostSafe(host);
   // Spelled as the reconnect flow spawns it (`--hostname`, one `-s` per scope), so
   // the copied command and the button do the same thing.
-  const cmd = `gh auth refresh --hostname ${host} -s ${scope}`;
+  const cmd = `gh auth refresh --hostname ${reconnectHostArg(host)} -s ${scope}`;
   return (
     <div className="rounded-md border border-warning/40 bg-warning/10 p-2.5 text-[11px]">
       <p className="text-muted-foreground">

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -5,7 +5,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { highlightJson } from "@/features/diff/shiki-highlighter";
 import { copyText } from "@/lib/clipboard";
-import { isReconnectHostSafe, useActiveGhHost } from "@/lib/git/host";
+import {
+  isReconnectHostSafe,
+  reconnectHostArg,
+  useActiveGhHost,
+} from "@/lib/git/host";
 import { useGhScopes } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
@@ -126,7 +130,7 @@ function ScopeErrorHint({ scope }: { scope: string }) {
         <p className="mt-2">
           {canRefresh ? "Or run" : "Run"}{" "}
           <span className="font-mono">
-            gh auth refresh --hostname {host} -s {scope}
+            gh auth refresh --hostname {reconnectHostArg(host)} -s {scope}
           </span>{" "}
           in a terminal, then reopen this dialog.
         </p>

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -3,16 +3,32 @@ import { useForgeStatus } from "./queries";
 
 /**
  * Whether a host is safe to interpolate into a copyable `gh`/`glab auth …` command —
- * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`, plus
- * an optional numeric port). The port belongs in the grammar: a self-hosted instance
- * on a non-default port registers with the CLIs as `host:8443`, so rejecting it would
- * deny the copyable fallback to the very users who need it. `remote_host` only splits a
- * remote URL on `/` and `:`, so a crafted remote can carry `;`, `$`, or a space into the
- * host; the executed reconnect flow re-validates, but the command string is guarded here
- * so it can never hand the user shell syntax.
+ * the same ASCII grammar `forge_reconnect` validates backend-side (alnum, `.`, `-`, or a
+ * bracketed IPv6 literal of hex/`:`/`.` carrying at least one `:`, plus an optional
+ * numeric port). The port belongs in the grammar: a self-hosted instance on a
+ * non-default port registers with the CLIs as `host:8443`, so rejecting it would deny
+ * the copyable fallback to the very users who need it. A crafted remote can carry `;`,
+ * `$`, or a space through the URL parse; the executed reconnect flow re-validates, but
+ * the command string is guarded here so it can never hand the user shell syntax. This
+ * must stay byte-equivalent to Rust's `is_safe_authority` — a charset gate, not an IPv6
+ * validator, so `[:]` passes both sides and that's fine; only drift between them matters.
  */
 export function isReconnectHostSafe(host: string): boolean {
-  return /^[a-zA-Z0-9.-]+(:\d{1,5})?$/.test(host);
+  return /^([a-zA-Z0-9.-]+|\[[0-9a-fA-F.]*:[0-9a-fA-F:.]*\])(:\d{1,5})?$/.test(
+    host,
+  );
+}
+
+/**
+ * A host spelled for a copy-pasteable command. A bracketed IPv6 literal is quoted:
+ * zsh (the macOS default) and fish read `[…]` as a glob character class, so with
+ * `nomatch` on the pasted command dies with "no matches found". Bare hosts stay
+ * unquoted — cmd.exe passes single quotes through literally, which would break the
+ * common case. No escaping is needed: {@link isReconnectHostSafe} has already banned
+ * `'` from every host that reaches a command string.
+ */
+export function reconnectHostArg(host: string): string {
+  return host.includes("[") ? `'${host}'` : host;
 }
 
 /**

--- a/src/lib/git/host.ts
+++ b/src/lib/git/host.ts
@@ -1,3 +1,4 @@
+import { isWindows } from "@/lib/hotkeys/binding";
 import { useUiStore } from "@/lib/stores/ui";
 import { useForgeStatus } from "./queries";
 
@@ -22,13 +23,13 @@ export function isReconnectHostSafe(host: string): boolean {
 /**
  * A host spelled for a copy-pasteable command. A bracketed IPv6 literal is quoted:
  * zsh (the macOS default) and fish read `[…]` as a glob character class, so with
- * `nomatch` on the pasted command dies with "no matches found". Bare hosts stay
- * unquoted — cmd.exe passes single quotes through literally, which would break the
- * common case. No escaping is needed: {@link isReconnectHostSafe} has already banned
- * `'` from every host that reaches a command string.
+ * `nomatch` on the pasted command dies with "no matches found". Unquoted on Windows,
+ * where cmd.exe passes `'` through literally and neither shell globs `[` in a native
+ * command's arguments. No escaping is needed: {@link isReconnectHostSafe} has already
+ * banned `'` from every host that reaches a command string.
  */
 export function reconnectHostArg(host: string): string {
-  return host.includes("[") ? `'${host}'` : host;
+  return !isWindows && host.startsWith("[") ? `'${host}'` : host;
 }
 
 /**


### PR DESCRIPTION
A remote like `https://[2001:db8::1]:8443/group/repo` parsed as host `[2001`, because every URL splitter in `src-tauri/src/forge/mod.rs` stopped at the first `:`. Provider detection, credential-context keys, and the reconnect commands all keyed off that garbage host. This change teaches the parsers that a bracketed IPv6 literal spans through its `]`, keeps the brackets (git's own credential-context spelling), and carries that shape through the reconnect host grammar on both sides of the IPC boundary.

### URL parsing (`src-tauri/src/forge/mod.rs`)

- Adds `bracketed_split`, a shared helper that peels a leading `[…]` span off an authority and returns the remainder, refusing an unterminated `[` and an empty `[]`. Every parser below plus glab's hosts-key normalizer go through it, so they can't disagree about where a literal ends.
- Rewrites `remote_host` to derive from `remote_authority` minus the port, so a URL yields a host exactly when it yields an authority. The new `remote_host_and_authority_agree_on_having_a_host` test pins that invariant, since the session health probe reads the two side by side under paired `github.com` fallbacks and any asymmetry would probe one repo's host against the default.
- Teaches `remote_authority` the bracketed forms: `[addr]` and `[addr]:port` under a scheme, no port slot for scp-style `git@[addr]:path` (that `:` is the path separator), and `None` when the remainder after `]` is neither empty nor a `:port`. A non-port segment still degrades to the bare host, matching the unbracketed arm.
- Counts the scp path separator past the literal in `remote_path`, so the address's own colons no longer cut the host short.

### Reconnect / credential host grammar

- Extends `is_safe_authority` in `mod.rs` to admit a bracketed literal whose interior is non-empty, drawn from `[0-9A-Fa-f:.]`, and carries at least one `:`, followed by the existing optional numeric port. A zone id (`%eth0`) fails closed, since no CLI accepts one.
- Mirrors the same grammar in `isReconnectHostSafe` (`src/lib/git/host.ts`) so the frontend guard, `valid_reconnect_host`, and `is_safe_authority` stay equivalent.
- Adds `reconnectHostArg` to `src/lib/git/host.ts` and routes every copyable `gh`/`glab auth …` string through it — `src/features/accounts/ReconnectDialog.tsx`, `src/features/repo-settings/ScopeRefreshHint.tsx`, and `src/features/repo-settings/parts.tsx`. It single-quotes bracketed hosts, because zsh and fish read `[…]` as a glob character class and the pasted command dies with "no matches found"; bare hosts stay unquoted so cmd.exe doesn't receive literal quotes.

### glab host matching (`src-tauri/src/forge/glab.rs`)

- `normalize_host` resolves a bracketed hosts-config key through `bracketed_split`, keeping the brackets and dropping a port after `]`, so the key can compare equal to what `remote_host` reports for the remote. A malformed bracket falls through to the previous plain split and simply never matches.

### Tests and changelog

- New unit tests in `mod.rs` cover bracketed hosts and authorities (`user@` prefixes, uppercase input, scp form, injection-shaped port segments such as `:443.helper=!evil`), the `is_safe_authority` bracket rules, `remote_path`'s scp separator, and `fork_url_from_origin` splicing over a bracketed origin.
- `session.rs` adds `valid_reconnect_host` cases for `[2001:db8::1]:8443` and an unterminated bracket; `glab.rs` adds the `normalize_host` bracket cases.
- Adds `changelog.d/fixed-ipv6-remote-authority.md`. The fix sits below the bar for README, marketing-site, and in-app guide updates, so the fragment is its documentation record.

Closes #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for bracketed IPv6 remote addresses, including optional ports, across provider detection, credential handling, reconnect flows, and repository URLs.
  * Reconnect and authentication commands now safely format IPv6 hosts for copy-and-paste use.

* **Bug Fixes**
  * Improved handling of IPv6 addresses containing colons without confusing them with ports or URL separators.
  * Added validation to reject malformed IPv6 authorities, invalid ports, zone IDs, and unsafe syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->