### PR TITLE
fix(pulls,forge,explore,repo-settings): report outcomes and preserve ruleset settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,8 +552,8 @@ search). Sort by best match, most stars, or recently updated. Open a
 result for its README preview, then **clone** it, **fork** it (with an
 offer to clone the fork), or **star** it (GitHub & GitLab), without ever
 knowing the URL. **Fork** only shows on a repository that isn't already
-yours, so on Bitbucket (where Explore lists just your own workspaces) it
-doesn't normally appear. Fully keyboard-navigable.
+yours, so on Bitbucket (where Explore lists just workspaces you belong to)
+it doesn't normally appear. Fully keyboard-navigable.
 
 ### GitLab
 

--- a/README.md
+++ b/README.md
@@ -547,9 +547,11 @@ it shows **your own repositories** (grouped by owner) and a **Popular**
 star-sorted feed (GitHub & GitLab); typing searches GitHub, all public
 GitLab projects, or your Bitbucket workspaces (Bitbucket retired global repo
 search). Sort by best match, most stars, or recently updated. Open a result
-for its README preview, then **clone** it, **fork** it (all three, with an
-offer to clone the fork), or **star** it (GitHub & GitLab), without ever
-knowing the URL. Fully keyboard-navigable.
+for its README preview, then **clone** it, **fork** it (with an offer to
+clone the fork), or **star** it (GitHub & GitLab), without ever knowing the
+URL. **Fork** only shows on a repository that isn't already yours, so on
+Bitbucket (where Explore lists just your own workspaces) it doesn't
+normally appear. Fully keyboard-navigable.
 
 ### GitLab
 

--- a/README.md
+++ b/README.md
@@ -542,16 +542,18 @@ navigation.
 
 ### Explore repositories
 
-A full-page browser across **GitHub, GitLab & Bitbucket**. Before you type,
-it shows **your own repositories** (grouped by owner) and a **Popular**
-star-sorted feed (GitHub & GitLab); typing searches GitHub, all public
-GitLab projects, or your Bitbucket workspaces (Bitbucket retired global repo
-search). Sort by best match, most stars, or recently updated. Open a result
-for its README preview, then **clone** it, **fork** it (with an offer to
-clone the fork), or **star** it (GitHub & GitLab), without ever knowing the
-URL. **Fork** only shows on a repository that isn't already yours, so on
-Bitbucket (where Explore lists just your own workspaces) it doesn't
-normally appear. Fully keyboard-navigable.
+A full-page browser across **GitHub, GitLab & Bitbucket**. Before you
+type, it shows **the repositories you have access to** (your own, ones you
+collaborate on, and those in an organization, group, or Bitbucket
+workspace you belong to), grouped by owner, plus a **Popular** star-sorted
+feed (GitHub & GitLab); typing searches GitHub, all public GitLab
+projects, or your Bitbucket workspaces (Bitbucket retired global repo
+search). Sort by best match, most stars, or recently updated. Open a
+result for its README preview, then **clone** it, **fork** it (with an
+offer to clone the fork), or **star** it (GitHub & GitLab), without ever
+knowing the URL. **Fork** only shows on a repository that isn't already
+yours, so on Bitbucket (where Explore lists just your own workspaces) it
+doesn't normally appear. Fully keyboard-navigable.
 
 ### GitLab
 

--- a/changelog.d/fixed-bitbucket-own-workspace-repos.md
+++ b/changelog.d/fixed-bitbucket-own-workspace-repos.md
@@ -1,0 +1,2 @@
+- Explore recognizes Bitbucket repositories in your own workspaces, so Fork no longer
+  appears on them.

--- a/changelog.d/fixed-bitbucket-own-workspace-repos.md
+++ b/changelog.d/fixed-bitbucket-own-workspace-repos.md
@@ -1,2 +1,2 @@
-- Explore recognizes Bitbucket repositories in your own workspaces, so Fork no longer
-  appears on them.
+- Explore recognizes Bitbucket repositories in workspaces you belong to, so Fork
+  no longer appears on them.

--- a/changelog.d/fixed-local-pr-outcomes.md
+++ b/changelog.d/fixed-local-pr-outcomes.md
@@ -1,0 +1,3 @@
+- Merges, conflict resolution, branch updates, and stash-and-reapply recoveries
+  on local pull requests report their outcome and update the pull request even
+  when you switch tabs or leave the pull request while they run.

--- a/changelog.d/fixed-repo-settings-instant-open.md
+++ b/changelog.d/fixed-repo-settings-instant-open.md
@@ -1,0 +1,2 @@
+- Repository settings opens straight away with a loading skeleton, and Esc
+  or a click outside cancels it while it's still loading.

--- a/changelog.d/fixed-required-check-latest-run.md
+++ b/changelog.d/fixed-required-check-latest-run.md
@@ -1,0 +1,3 @@
+- A pull request's blocked-merge line names what the base branch is waiting on:
+  it reads the newest run of each required check, and counts a run GitHub has
+  marked stale as still outstanding.

--- a/changelog.d/fixed-ruleset-save-preserves-settings.md
+++ b/changelog.d/fixed-ruleset-save-preserves-settings.md
@@ -1,0 +1,3 @@
+- Editing a ruleset preserves the settings its editor doesn't show: required
+  checks pinned to a specific app, required conversation resolution, and the
+  ruleset's target and excluded branch patterns.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -273,7 +273,10 @@ export const CHECKS = [
     name: "mutate-in-repo-settings",
     // Scoped to the settings dialog's own tree, whose sections unmount on BOTH
     // dialog close and every rail section switch (the keyed crossfade). The
-    // wider app's call sites are a separate tier and are not scanned here.
+    // wider app's call sites are a separate tier and are not scanned here —
+    // pulls/ and repository/ carry converted-but-unguarded surfaces whose
+    // remaining bare .mutate( calls are deliberately callback-free, which a
+    // per-file allowlist cannot express.
     appliesTo: (file) => file.startsWith("src/features/repo-settings/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -13,8 +13,9 @@
 //!
 //! Pagination default: one page at the endpoint's max `pagelen`, no `next`-following
 //! (the PR-list endpoint caps at 50; repos/pipelines allow 100). Readers that DO follow
-//! `next` go through [`bb_paginate`], which bounds them at [`BB_MAX_PAGES`]; each
-//! states that bound at its call site.
+//! `next` go through [`bb_paginate`], or walk inline when they need a different failure
+//! posture; either way [`BB_MAX_PAGES`] bounds them, and each states that bound at its
+//! call site.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -349,8 +350,9 @@ struct BbCloneLink {
 }
 
 /// A paginated envelope (`{values, next, …}`). `next` is an ABSOLUTE URL to the next
-/// page; only [`bb_paginate`] follows it — the many single-page reads deserialize the
-/// envelope and ignore it, per the module's pagination policy.
+/// page; the readers that follow it go through [`bb_paginate`] or an inline walk under
+/// the same bound — the many single-page reads deserialize the envelope and ignore it,
+/// per the module's pagination policy.
 #[derive(Deserialize)]
 struct BbPage<T> {
     #[serde(default = "Vec::new")]
@@ -493,7 +495,7 @@ fn from_bb_repo(r: BbRepo) -> ForgeRepo {
 /// One step of the workspace walk: absorb a fetched page and answer with the next URL
 /// to follow, `None` to stop, or an error to abort. Best-effort past the first page —
 /// a later page failing costs some namespaces (the Fork gate then fails open on their
-/// repos), while page one failing means no workspaces at all, a real error. Pure, so
+/// repos), while page one failing means no workspaces at all, a real error. No I/O, so
 /// the fallback is testable without an HTTP seam.
 fn best_effort_page_step<T>(
     fetched: AppResult<BbPage<T>>,
@@ -514,8 +516,8 @@ fn best_effort_page_step<T>(
 /// /2.0/repositories?role=member` AND `GET /2.0/workspaces` were removed (CHANGE-2770,
 /// Feb 2026); the replacement is `GET /2.0/user/workspaces` (CHANGE-3022), whose items
 /// are `workspace_access` membership wrappers (nested `workspace_base` with
-/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces
-/// (best-effort past the first page), then read each workspace's member repos as a
+/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces up to 5
+/// pages (best-effort past the first), then read each workspace's member repos as a
 /// single page at the max `pagelen` (100), sorted `-updated_on`, so repos past
 /// 100/workspace drop off.
 pub async fn list_repos() -> AppResult<ForgeRepoList> {

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -490,13 +490,34 @@ fn from_bb_repo(r: BbRepo) -> ForgeRepo {
     }
 }
 
+/// One step of the workspace walk: absorb a fetched page and answer with the next URL
+/// to follow, `None` to stop, or an error to abort. Best-effort past the first page —
+/// a later page failing costs some namespaces (the Fork gate then fails open on their
+/// repos), while page one failing means no workspaces at all, a real error. Pure, so
+/// the fallback is testable without an HTTP seam.
+fn best_effort_page_step<T>(
+    fetched: AppResult<BbPage<T>>,
+    out: &mut Vec<T>,
+    is_first_page: bool,
+) -> AppResult<Option<String>> {
+    match fetched {
+        Ok(page) => {
+            out.extend(page.values);
+            Ok(next_page_url(page.next))
+        }
+        Err(_) if !is_first_page => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 /// The signed-in user's repositories, for the clone browser. Both `GET
 /// /2.0/repositories?role=member` AND `GET /2.0/workspaces` were removed (CHANGE-2770,
 /// Feb 2026); the replacement is `GET /2.0/user/workspaces` (CHANGE-3022), whose items
 /// are `workspace_access` membership wrappers (nested `workspace_base` with
-/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces, then
-/// read each workspace's member repos as a single page at the max `pagelen` (100),
-/// sorted `-updated_on`, so repos past 100/workspace drop off.
+/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces
+/// (best-effort past the first page), then read each workspace's member repos as a
+/// single page at the max `pagelen` (100), sorted `-updated_on`, so repos past
+/// 100/workspace drop off.
 pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let creds = http::load_credentials().await?;
     let viewer = http::bb_get_json::<BbUser>(&creds, "user", "user")
@@ -507,13 +528,19 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
 
     // Follow `next` here, matching `workspaces()` (which Explore search pages through):
     // a short workspace list would leave a member workspace out of `owned_namespaces`,
-    // and the Fork gate would then fail open on a search row from that workspace.
-    let workspaces: Vec<BbWorkspaceAccess> = bb_paginate(
-        &creds,
-        "user/workspaces?pagelen=100".to_string(),
-        "workspaces",
-    )
-    .await?;
+    // and the Fork gate would then fail open on a search row from that workspace. Walked
+    // inline rather than through `bb_paginate` so a later page's failure degrades the way
+    // the per-workspace loop below does, instead of sinking the whole read.
+    let mut workspaces: Vec<BbWorkspaceAccess> = Vec::new();
+    let mut ws_url = "user/workspaces?pagelen=100".to_string();
+    for page in 0..BB_MAX_PAGES {
+        let fetched = http::bb_get_json::<BbPage<BbWorkspaceAccess>>(&creds, &ws_url, "workspaces")
+            .await;
+        match best_effort_page_step(fetched, &mut workspaces, page == 0)? {
+            Some(next) => ws_url = next,
+            None => break,
+        }
+    }
 
     let mut repos = Vec::new();
     // Bitbucket has no usable personal-workspace signal (`is_personal` reads false even
@@ -6041,6 +6068,32 @@ mod tests {
         assert!(!repo.private);
         assert!(!repo.fork);
         assert_eq!(repo.ssh_url, "");
+    }
+
+    /// The workspace walk degrades like the per-workspace loop: a page-2 failure keeps
+    /// what page one produced, while a page-1 failure is a real error — no workspaces at
+    /// all, so there is nothing to be best-effort about.
+    #[test]
+    fn a_later_workspace_page_failure_keeps_the_pages_already_read() {
+        let next = "https://api.bitbucket.org/2.0/user/workspaces?page=2";
+        let page_one = BbPage {
+            values: vec!["alpha".to_string()],
+            next: Some(next.to_string()),
+        };
+        let mut out: Vec<String> = Vec::new();
+        assert_eq!(
+            best_effort_page_step(Ok(page_one), &mut out, true).unwrap(),
+            Some(next.to_string())
+        );
+
+        let failed: AppResult<BbPage<String>> = Err(AppError::Bitbucket("HTTP 500".into()));
+        assert_eq!(best_effort_page_step(failed, &mut out, false).unwrap(), None);
+        assert_eq!(out, vec!["alpha".to_string()]);
+
+        let first_fails: AppResult<BbPage<String>> = Err(AppError::Bitbucket("HTTP 500".into()));
+        let mut empty: Vec<String> = Vec::new();
+        assert!(best_effort_page_step(first_fails, &mut empty, true).is_err());
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -494,9 +494,9 @@ fn from_bb_repo(r: BbRepo) -> ForgeRepo {
 /// /2.0/repositories?role=member` AND `GET /2.0/workspaces` were removed (CHANGE-2770,
 /// Feb 2026); the replacement is `GET /2.0/user/workspaces` (CHANGE-3022), whose items
 /// are `workspace_access` membership wrappers (nested `workspace_base` with
-/// uuid/slug/links — no `name`). We list the viewer's workspaces, then each workspace's
-/// member repos: one page each at the max `pagelen` (100), sorted `-updated_on`, so
-/// repos past 100/workspace drop off.
+/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces, then
+/// read each workspace's member repos as a single page at the max `pagelen` (100),
+/// sorted `-updated_on`, so repos past 100/workspace drop off.
 pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let creds = http::load_credentials().await?;
     let viewer = http::bb_get_json::<BbUser>(&creds, "user", "user")
@@ -505,8 +505,15 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         .and_then(|u| u.username.or(u.display_name))
         .unwrap_or_default();
 
-    let workspaces: BbPage<BbWorkspaceAccess> =
-        http::bb_get_json(&creds, "user/workspaces?pagelen=100", "workspaces").await?;
+    // Follow `next` here, matching `workspaces()` (which Explore search pages through):
+    // a short workspace list would leave a member workspace out of `owned_namespaces`,
+    // and the Fork gate would then fail open on a search row from that workspace.
+    let workspaces: Vec<BbWorkspaceAccess> = bb_paginate(
+        &creds,
+        "user/workspaces?pagelen=100".to_string(),
+        "workspaces",
+    )
+    .await?;
 
     let mut repos = Vec::new();
     // Bitbucket has no usable personal-workspace signal (`is_personal` reads false even
@@ -518,7 +525,7 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let mut workspace_count = 0usize;
     let mut any_ok = false;
     let mut last_err: Option<AppError> = None;
-    for access in workspaces.values {
+    for access in workspaces {
         // Skip an entry with no nested workspace or an empty slug rather than error.
         let Some(slug) = access.workspace.map(|w| w.slug).filter(|s| !s.is_empty()) else {
             continue;

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -29,8 +29,8 @@ use crate::forge::http::{
     KEY_USERNAME,
 };
 use crate::forge::model::{
-    Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList, ForgeSearchList,
-    ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    namespace_set, Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList,
+    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
 };
 use crate::forge::{
     cap_readme, validate_owner, validate_repo_name, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
@@ -509,6 +509,10 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         http::bb_get_json(&creds, "user/workspaces?pagelen=100", "workspaces").await?;
 
     let mut repos = Vec::new();
+    // Bitbucket has no usable personal-workspace signal (`is_personal` reads false even
+    // on it, and the user uuid 404s as a workspace), so "yours" here means a workspace
+    // you belong to — these same slugs, which `owner` already carries.
+    let mut slugs = Vec::new();
     // Best-effort per workspace (one erroring shouldn't sink the others), but if EVERY
     // fetch fails, surface the last error rather than an empty "no repositories" list.
     let mut workspace_count = 0usize;
@@ -524,6 +528,9 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
             "repositories/{}?role=member&sort=-updated_on&pagelen=100",
             encode_query_value(&slug)
         );
+        // Membership, not fetch success: a workspace you belong to stays yours even if
+        // its repo page errors, and its repos can still reach the gate via Explore search.
+        slugs.push(slug);
         match http::bb_get_json::<BbPage<BbRepo>>(&creds, &path, "repositories").await {
             Ok(page) => {
                 any_ok = true;
@@ -538,7 +545,11 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
             AppError::Bitbucket("could not list Bitbucket repositories".into())
         }));
     }
-    Ok(ForgeRepoList { viewer, repos })
+    Ok(ForgeRepoList {
+        viewer,
+        owned_namespaces: namespace_set(slugs),
+        repos,
+    })
 }
 
 // ── Pull requests (read) ───────────────────────────────────────────────────────
@@ -5081,10 +5092,10 @@ pub async fn search_repos(query: &str, _sort: &str, _page: u32) -> AppResult<For
     })
 }
 
-/// Fork a Bitbucket repo by `owner/name` into the caller's personal workspace
-/// (`POST repositories/{owner}/{name}/forks` with an empty body). The response is
-/// the new repo object; readiness is a bounded `GET` poll on the fork (5×2s → ready
-/// on 200).
+/// Fork a Bitbucket repo by `owner/name` — `POST repositories/{owner}/{name}/forks`
+/// with an empty body, which leaves the destination workspace to Bitbucket. The
+/// response is the new repo object (its `full_name` names where the fork actually
+/// landed); readiness is a bounded `GET` poll on the fork (5×2s → ready on 200).
 pub async fn fork_repo(owner: &str, name: &str) -> AppResult<ForgeForkResult> {
     use serde_json::Value;
     validate_owner(owner)?;

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -8,8 +8,8 @@ use serde_json::Value;
 
 use crate::error::{AppError, AppResult};
 use crate::forge::model::{
-    Capabilities, ForgeForkResult, ForgeRepo, ForgeRepoList, ForgeSearchList, ForgeSearchRepo,
-    ForgeStatus, Implemented, Provider,
+    namespace_set, Capabilities, ForgeForkResult, ForgeRepo, ForgeRepoList, ForgeSearchList,
+    ForgeSearchRepo, ForgeStatus, Implemented, Provider,
 };
 use crate::forge::{
     validate_owner, validate_repo_name, Forge, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
@@ -71,6 +71,9 @@ fn from_gh_repo(r: GhRepo) -> ForgeRepo {
 pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let gh = gh_list_repos().await?;
     Ok(ForgeRepoList {
+        // A GitHub login IS its personal namespace, so the viewer is the whole set;
+        // org repos stay forkable.
+        owned_namespaces: namespace_set([gh.viewer.clone()]),
         viewer: gh.viewer,
         repos: gh.repos.into_iter().map(from_gh_repo).collect(),
     })

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AppError, AppResult};
 use crate::forge::glab::{run_glab, run_glab_ex, run_glab_raw, GLAB_NETWORK_TIMEOUT, GLAB_TIMEOUT};
 use crate::forge::model::{
-    Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList, ForgeSearchList,
-    ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    namespace_set, Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList,
+    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
 };
 use crate::forge::{
     cap_readme, validate_owner, validate_repo_name, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
@@ -160,6 +160,9 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let projects: Vec<GlabProject> = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Glab(format!("could not parse your GitLab projects: {e}")))?;
     Ok(ForgeRepoList {
+        // A GitLab username IS the personal namespace's full path. Groups you own are a
+        // separate namespace and aren't resolved here, so Fork still shows on those.
+        owned_namespaces: namespace_set([viewer.clone()]),
         viewer,
         repos: projects.into_iter().map(from_glab_project).collect(),
     })
@@ -2596,10 +2599,11 @@ fn glab_http_status(stderr: &str) -> Option<u16> {
 /// cannot merge") and `409` ("SHA does not match HEAD of source branch") — GitLab's
 /// `doc/api/merge_requests.md`, "Merge a merge request".
 ///
-/// `arming_auto_merge` holds the 405 arm back as the conservative choice, NOT a
-/// documented distinction: arming rides the same endpoint and the same status table,
-/// and whether a finished head pipeline answers 405 there is unverified. Falling open
-/// to glab's own text on that path risks a worse message, never a wrong claim.
+/// `arming_auto_merge` holds the 405 arm back: on the arming path GitLab answers 405
+/// only when no auto-merge strategy is available AND the head pipeline isn't passing
+/// (a passing one merges immediately instead), per v19.3.0 `lib/api/merge_requests.rb`.
+/// Which strategies exist is version- and edition-dependent, so glab's own text stays
+/// the safer message there.
 ///
 /// The 405 message deliberately doesn't name WHICH requirement is unmet: the
 /// mergeability read owns that wording, and the refusal toast carries its line as a
@@ -2615,9 +2619,42 @@ fn classify_gl_merge_refusal(stderr: &str, arming_auto_merge: bool) -> Option<St
     }
 }
 
+/// The merge PUT's argv. `sha` is sent only when non-empty — an empty `sha=` would
+/// itself be rejected. Arming sends BOTH auto-merge params; the auto-merge section
+/// note below carries why.
+fn merge_mr_args(
+    endpoint: &str,
+    squash: bool,
+    delete_branch: bool,
+    sha: Option<&str>,
+    when_pipeline_succeeds: bool,
+) -> Vec<String> {
+    let mut args = vec![
+        "api".to_string(),
+        "--method".to_string(),
+        "PUT".to_string(),
+        endpoint.to_string(),
+        "-f".to_string(),
+        format!("squash={squash}"),
+        "-f".to_string(),
+        format!("should_remove_source_branch={delete_branch}"),
+    ];
+    if let Some(s) = sha.filter(|s| !s.is_empty()) {
+        args.push("-f".to_string());
+        args.push(format!("sha={s}"));
+    }
+    if when_pipeline_succeeds {
+        args.push("-f".to_string());
+        args.push("merge_when_pipeline_succeeds=true".to_string());
+        args.push("-f".to_string());
+        args.push("auto_merge=true".to_string());
+    }
+    args
+}
+
 /// The shared body behind `merge_mr` and `auto_merge_mr` — same endpoint, same
 /// strategy validation, same `sha` guard. The only difference is the extra
-/// `merge_when_pipeline_succeeds` flag, so both wrappers can't drift apart.
+/// auto-merge flags, so both wrappers can't drift apart.
 async fn merge_mr_inner(
     repo_path: &str,
     number: u64,
@@ -2665,30 +2702,9 @@ async fn merge_mr_inner(
     )
     .await?;
     let endpoint = format!("projects/{enc}/merge_requests/{number}/merge");
-    let squash_arg = format!("squash={squash}");
-    let remove_arg = format!("should_remove_source_branch={delete_branch}");
-    let mut args = vec![
-        "api",
-        "--method",
-        "PUT",
-        &endpoint,
-        "-f",
-        &squash_arg,
-        "-f",
-        &remove_arg,
-    ];
-    // Only guard on a non-empty SHA — an empty `sha=` would itself be rejected.
-    let sha_arg;
-    if let Some(s) = sha.filter(|s| !s.is_empty()) {
-        sha_arg = format!("sha={s}");
-        args.push("-f");
-        args.push(&sha_arg);
-    }
-    if when_pipeline_succeeds {
-        args.push("-f");
-        args.push("merge_when_pipeline_succeeds=true");
-    }
-    let out = run_glab_raw(Some(repo_path), &args, GLAB_NETWORK_TIMEOUT).await?;
+    let args = merge_mr_args(&endpoint, squash, delete_branch, sha, when_pipeline_succeeds);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = run_glab_raw(Some(repo_path), &arg_refs, GLAB_NETWORK_TIMEOUT).await?;
     if out.code != 0 {
         // Raw rather than `run_glab` only so a documented refusal can be reworded;
         // everything else keeps `run_glab`'s exact fallback.
@@ -2714,11 +2730,20 @@ async fn merge_mr_inner(
 //
 // GitLab's "auto-merge" (MWPS) arms the merge endpoint to complete server-side once
 // the head pipeline goes green — a GitLab-ONLY control (`mr_auto_merge`); GitHub has
-// no in-app PR auto-merge here. Arm reuses the merge endpoint with
-// `merge_when_pipeline_succeeds=true`; the read exposes the armed flag + detailed
-// merge status + head-pipeline summary so the UI can decide whether to offer it;
-// cancel disarms. A stale `sha` → 409 (propagates like merge); arming a FINISHED
-// pipeline → 405 (a race the UI gates against). Cancel's gotcha lives on
+// no in-app PR auto-merge here. Arm reuses the merge endpoint, sending BOTH
+// `merge_when_pipeline_succeeds=true` (deprecated as a REQUEST param in 17.11) and its
+// replacement `auto_merge=true`: pre-17.11 ignores the unknown `auto_merge` and honors
+// MWPS, 17.11+ ORs the two into one variable so both-true arms exactly once, and
+// `auto_merge` ALONE would merge a pre-17.11 MR immediately rather than arm it (v17.10
+// `immediately_mergeable?` falls through to `mergeable_state?`). Only the request param
+// moved: the RESPONSE field and the cancel endpoint's path both keep the MWPS name on
+// current GitLab (v19.3.0), with no replacement to migrate to.
+//
+// The read exposes the armed flag + detailed merge status + head-pipeline summary so
+// the UI can decide whether to offer it; cancel disarms. A stale `sha` → 409
+// (propagates like merge); arming 405s only when no auto-merge strategy is available
+// AND the head pipeline isn't passing — a passing one merges immediately instead
+// (v19.3.0 `lib/api/merge_requests.rb`). Cancel's gotcha lives on
 // `cancel_auto_merge_mr`.
 
 /// The head pipeline of an MR, as the slim MR GET embeds it (present only when
@@ -9292,9 +9317,9 @@ mod tests {
             .as_deref(),
             Some("The merge request changed while merging — refresh and retry.")
         );
-        // Arming rides the same endpoint and status table, so a 405 there may mean a
-        // race rather than a blocked merge. Unverified either way — that arm keeps
-        // glab's own wording rather than risking a wrong claim.
+        // A 405 on the arming path means no auto-merge strategy was available AND the
+        // head pipeline isn't passing; which strategies exist is version- and
+        // edition-dependent, so that arm keeps glab's own wording.
         assert_eq!(
             classify_gl_merge_refusal("glab: 405 Method Not Allowed (HTTP 405)\n", true),
             None
@@ -9315,6 +9340,98 @@ mod tests {
         ] {
             assert_eq!(classify_gl_merge_refusal(raw, false), None, "raw: {raw:?}");
         }
+    }
+
+    /// A plain merge sends neither auto-merge param, and `sha` rides along only when
+    /// non-empty — the stale-view guard is opt-in, an empty `sha=` would be rejected.
+    #[test]
+    fn merge_mr_args_send_no_auto_merge_params_unless_arming() {
+        let plain = merge_mr_args("projects/9/merge_requests/7/merge", true, false, None, false);
+        assert_eq!(
+            plain,
+            vec![
+                "api",
+                "--method",
+                "PUT",
+                "projects/9/merge_requests/7/merge",
+                "-f",
+                "squash=true",
+                "-f",
+                "should_remove_source_branch=false",
+            ]
+        );
+        assert!(!plain.iter().any(|a| a.contains("auto_merge")));
+        assert!(
+            !plain
+                .iter()
+                .any(|a| a.contains("merge_when_pipeline_succeeds"))
+        );
+
+        let empty_sha = merge_mr_args(
+            "projects/9/merge_requests/7/merge",
+            true,
+            false,
+            Some(""),
+            false,
+        );
+        assert_eq!(empty_sha, plain);
+
+        let guarded = merge_mr_args(
+            "projects/9/merge_requests/7/merge",
+            false,
+            true,
+            Some("abc123"),
+            false,
+        );
+        assert_eq!(
+            guarded,
+            vec![
+                "api",
+                "--method",
+                "PUT",
+                "projects/9/merge_requests/7/merge",
+                "-f",
+                "squash=false",
+                "-f",
+                "should_remove_source_branch=true",
+                "-f",
+                "sha=abc123",
+            ]
+        );
+    }
+
+    /// Arming sends BOTH `merge_when_pipeline_succeeds` (deprecated as a request param
+    /// in 17.11) and `auto_merge`, so pre-17.11 instances still arm and 17.11+ ones OR
+    /// the pair into a single arm. `auto_merge` alone would merge a pre-17.11 MR
+    /// outright. Everything else must be byte-identical to the plain merge.
+    #[test]
+    fn merge_mr_args_arm_with_both_auto_merge_params() {
+        let plain = merge_mr_args(
+            "projects/9/merge_requests/7/merge",
+            false,
+            true,
+            Some("abc123"),
+            false,
+        );
+        let arming = merge_mr_args(
+            "projects/9/merge_requests/7/merge",
+            false,
+            true,
+            Some("abc123"),
+            true,
+        );
+        assert_eq!(arming[..plain.len()], plain[..]);
+        assert_eq!(
+            arming[plain.len()..],
+            [
+                "-f",
+                "merge_when_pipeline_succeeds=true",
+                "-f",
+                "auto_merge=true",
+            ]
+        );
+        // `-f` is glab's raw field: no leading-`@` file-read magic on any value.
+        assert!(!arming.iter().any(|a| a == "-F"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -658,9 +658,24 @@ pub struct ForgeRepo {
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ForgeRepoList {
-    /// The signed-in user's login, so the UI lists their own repos first.
+    /// The signed-in user's login. Kept on the wire; no frontend consumer today.
     pub viewer: String,
+    /// The [`ForgeRepo::owner`] namespaces that count as the viewer's own — a SET
+    /// because "yours" is provider-shaped: a login on GitHub and GitLab, but any
+    /// workspace you belong to on Bitbucket, where the login resolves to the account's
+    /// username or display name while repo owners are workspace slugs — separate
+    /// namespaces that don't line up. Drives the own-repo Fork gate and the yours-first
+    /// grouping; empty means unresolved, so both fail open.
+    pub owned_namespaces: Vec<String>,
     pub repos: Vec<ForgeRepo>,
+}
+
+/// The [`ForgeRepoList::owned_namespaces`] set, with blanks dropped: every provider's
+/// viewer/slug probe ends in `unwrap_or_default`, and `ForgeRepo::owner` does too, so
+/// an empty namespace in the set would match an unresolved repo and hide its Fork
+/// instead of falling open.
+pub fn namespace_set(names: impl IntoIterator<Item = String>) -> Vec<String> {
+    names.into_iter().filter(|n| !n.is_empty()).collect()
 }
 
 /// One search-result repository for the Explore view — a superset of [`ForgeRepo`]
@@ -731,6 +746,37 @@ pub struct ProviderFeatures {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The clone browser and Explore key off these exact wire names; a TS mirror that
+    /// misses `ownedNamespaces` reads `undefined` silently, so pin the whole shape.
+    #[test]
+    fn repo_list_serializes_camel_case_wire_keys() {
+        let value = serde_json::to_value(ForgeRepoList {
+            viewer: "evangoldberg98".into(),
+            owned_namespaces: vec!["thebguy1".into(), "betabotsllc".into()],
+            repos: vec![],
+        })
+        .unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "viewer": "evangoldberg98",
+                "ownedNamespaces": ["thebguy1", "betabotsllc"],
+                "repos": [],
+            })
+        );
+    }
+
+    /// A provider whose viewer/workspace probe failed contributes nothing to the set:
+    /// an empty namespace would match a repo whose own `owner` fell back to "".
+    #[test]
+    fn namespace_set_drops_unresolved_probes() {
+        assert_eq!(namespace_set(["".to_string()]), Vec::<String>::new());
+        assert_eq!(
+            namespace_set(["".to_string(), "octocat".to_string()]),
+            vec!["octocat".to_string()]
+        );
+    }
 
     #[test]
     fn github_supports_everything() {

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2825,8 +2825,8 @@ struct RawComment {
 /// statusCheckRollup is a union of CheckRun (name/conclusion/detailsUrl) and
 /// StatusContext (context/state/targetUrl); accept any of the keys and normalize
 /// below. `details_url`/`target_url` are the two arms' link fields (whichever is
-/// present wins); `started_at`/`completed_at` are CheckRun-only timestamps that a
-/// StatusContext simply omits (they stay `None`).
+/// present wins); `started_at` arrives on both arms (`gh` aliases a StatusContext's
+/// creation time onto it), while `completed_at` is CheckRun-only.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawCheck {
@@ -3188,10 +3188,13 @@ pub struct PrCheckOut {
     /// `None` when the details URL has no job segment (or isn't an Actions URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_id: Option<String>,
-    /// CheckRun `startedAt`; `None` for a StatusContext (it has no start).
+    /// When the check began: a CheckRun `startedAt`, or a StatusContext's creation
+    /// time, which `gh` aliases onto this same key — so both rollup arms carry one.
+    /// `None` once the Go-zero sentinel is filtered (see `real_check_time`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
-    /// CheckRun `completedAt`; `None` for a StatusContext.
+    /// CheckRun `completedAt`. A StatusContext reports no completion at all, leaving
+    /// start time the only key both rollup arms can be ordered by.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<String>,
 }

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -39,21 +39,22 @@ import { starParts } from "./explore-utils";
 
 /** The Explore detail pane: the selected repo's header, actions (clone / fork /
  *  star / view), and its lazily-fetched README. `features` gates fork/star, and
- *  `viewer` (the screen's own-repos query) additionally gates fork; a selected
- *  repo drives the star + README queries. */
+ *  `ownedNamespaces` (the screen's own-repos query) additionally gates fork; a
+ *  selected repo drives the star + README queries. */
 export function ExploreDetail({
   provider,
   repo,
   features,
-  viewer,
+  ownedNamespaces,
   onClone,
 }: {
   provider: ForgeProvider;
   repo: ForgeSearchRepo | null;
   features: ForgeProviderFeatures | undefined;
-  /** The signed-in user's login; null while resolving, and may be "" when the
-   *  provider's viewer probe fails (both fall back to the capability-only gate). */
-  viewer: string | null;
+  /** The owner namespaces that count as the viewer's own; empty while the query
+   *  resolves or when the provider's probe failed (both fall back to the
+   *  capability-only gate). */
+  ownedNamespaces: readonly string[];
   onClone: (target: ExploreCloneTarget) => void;
 }) {
   if (!repo) {
@@ -76,7 +77,7 @@ export function ExploreDetail({
       provider={provider}
       repo={repo}
       features={features}
-      viewer={viewer}
+      ownedNamespaces={ownedNamespaces}
       onClone={onClone}
     />
   );
@@ -86,26 +87,26 @@ function ExploreDetailBody({
   provider,
   repo,
   features,
-  viewer,
+  ownedNamespaces,
   onClone,
 }: {
   provider: ForgeProvider;
   repo: ForgeSearchRepo;
   features: ForgeProviderFeatures | undefined;
-  viewer: string | null;
+  ownedNamespaces: readonly string[];
   onClone: (target: ExploreCloneTarget) => void;
 }) {
   const label = providerLabel(provider);
-  // Forking always creates the copy under your own account, so a repo you own
-  // personally is never a valid target — hidden, not disabled, since there's
-  // nothing actionable to explain. Personal ownership, not write access: org
-  // repos stay forkable; an unknown viewer (null, or the "" non-GitHub backends
-  // emit) falls back to the capability gate. On Bitbucket the compare is inert in
-  // practice — `owner` is a workspace slug, `viewer` a username — which is why the
-  // guide scopes this behavior to GitHub and GitLab.
+  // A repo already in a namespace of yours is never a valid fork target — hidden,
+  // not disabled, since there's nothing actionable to explain. The backend decides
+  // what "yours" means per provider: your login on GitHub and GitLab, so org and
+  // group repos stay forkable; on Bitbucket, any workspace you belong to, because it
+  // exposes no usable personal-workspace signal and a fork inside a workspace you
+  // already have access to carries no contribution meaning. An empty set (resolving,
+  // or a failed probe) falls back to the capability gate.
   const canFork =
     (features?.implemented.repoForkByName ?? false) &&
-    !(viewer && repo.owner === viewer);
+    !ownedNamespaces.includes(repo.owner);
   const canStar = features?.implemented.repoStar ?? false;
   const canReadme = features?.implemented.repoReadme ?? false;
 
@@ -134,7 +135,7 @@ function ExploreDetailBody({
   async function onFork() {
     const ok = await useConfirm.getState().ask({
       title: `Fork ${repo.fullName}?`,
-      body: `Creates a fork under your account on ${label} in the background. You can clone it once it's ready.`,
+      body: `Creates a fork on ${label} in the background. You can clone it once it's ready.`,
       confirmLabel: "Fork",
     });
     if (!ok) return;

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -49,6 +49,10 @@ import {
 type SortOption = "best" | "stars" | "updated";
 type ZeroMode = "yours" | "popular";
 
+/** Stable empty fallback, so a pending own-repos query doesn't hand the detail
+ *  pane a fresh array identity on every render. */
+const EMPTY_NAMESPACES: readonly string[] = [];
+
 const SORT_ITEMS: Record<SortOption, string> = {
   best: "Best match",
   stars: "Most stars",
@@ -100,7 +104,7 @@ export function ExploreScreen() {
   // refetch once the 5-minute staleTime lapsed — and on Bitbucket that read walks
   // every workspace.
   const ownRepos = useForgeRepos(provider, true);
-  const viewer = ownRepos.data?.viewer ?? null;
+  const ownedNamespaces = ownRepos.data?.ownedNamespaces ?? EMPTY_NAMESPACES;
 
   // Esc closes Explore. Guarded so Base UI popups (which mark the event consumed)
   // get first claim; an effect event reads the latest closeExplore.
@@ -259,7 +263,7 @@ export function ExploreScreen() {
               provider={provider}
               repo={selected}
               features={features.data}
-              viewer={viewer}
+              ownedNamespaces={ownedNamespaces}
               onClone={setCloneTarget}
             />
           </div>
@@ -297,7 +301,7 @@ function YoursResults({
     if (!data) return [];
     return groupReposByOwner(
       data.repos.map(forgeRepoToSearchRepo),
-      data.viewer,
+      data.ownedNamespaces,
     );
   }, [repos.data]);
 

--- a/src/features/explore/explore-utils.ts
+++ b/src/features/explore/explore-utils.ts
@@ -38,32 +38,46 @@ export function forgeRepoToSearchRepo(repo: ForgeRepo): ForgeSearchRepo {
 }
 
 /**
- * Group repos by owner — the viewer's own repos first, then other owners
- * alphabetically — and flatten to rows for the virtualizer. Each group keeps its
- * incoming order. Mirrors CloneRepoDialog's `rows` memo so the two surfaces order
- * identically.
+ * Group items by owner namespace — the namespaces you belong to first, then the rest
+ * alphabetically — keeping each group's incoming order. `ownerOf` lets the two
+ * surfaces that group this way (Explore's Yours list and CloneRepoDialog's rows)
+ * share one ordering across their different row shapes; an empty `ownedNamespaces`
+ * just falls back to alphabetical.
+ */
+export function groupByOwnerNamespace<T>(
+  items: readonly T[],
+  ownerOf: (item: T) => string,
+  ownedNamespaces: readonly string[],
+): [string, T[]][] {
+  const byOwner = new Map<string, T[]>();
+  for (const item of items) {
+    const owner = ownerOf(item);
+    const list = byOwner.get(owner);
+    if (list) list.push(item);
+    else byOwner.set(owner, [item]);
+  }
+  const owned = new Set(ownedNamespaces);
+  return [...byOwner.entries()].sort((a, b) => {
+    const aOwned = owned.has(a[0]);
+    if (aOwned !== owned.has(b[0])) return aOwned ? -1 : 1;
+    return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
+  });
+}
+
+/**
+ * Group repos by owner and flatten to rows for the virtualizer, ordered by
+ * {@link groupByOwnerNamespace}.
  */
 export function groupReposByOwner(
   repos: ForgeSearchRepo[],
-  viewer: string | null,
+  ownedNamespaces: readonly string[],
 ): ExploreRow[] {
-  const byOwner = new Map<string, ForgeSearchRepo[]>();
-  for (const r of repos) {
-    const list = byOwner.get(r.owner);
-    if (list) list.push(r);
-    else byOwner.set(r.owner, [r]);
-  }
-  const owners = [...byOwner.entries()].sort((a, b) => {
-    if (viewer) {
-      if (a[0] === viewer) return -1;
-      if (b[0] === viewer) return 1;
-    }
-    return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
-  });
-  return owners.flatMap(([owner, list]): ExploreRow[] => [
-    { kind: "header", owner },
-    ...list.map((repo) => ({ kind: "repo" as const, repo })),
-  ]);
+  return groupByOwnerNamespace(repos, (r) => r.owner, ownedNamespaces).flatMap(
+    ([owner, list]): ExploreRow[] => [
+      { kind: "header", owner },
+      ...list.map((repo) => ({ kind: "repo" as const, repo })),
+    ],
+  );
 }
 
 /**

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -196,8 +196,8 @@ From here:
   doesn't appear on a repository that already counts as yours, which each host defines
   its own way: on **GitHub** and **GitLab** that's your personal account or namespace
   (organization and group repositories stay forkable), and on **Bitbucket** it's any
-  workspace you belong to. Since Explore on Bitbucket lists only your own workspaces,
-  **Fork** doesn't normally come up there.
+  workspace you belong to. Since Explore on Bitbucket lists only workspaces you
+  belong to, **Fork** doesn't normally come up there.
 - **Star / Unstar** — on **GitHub and GitLab** only. Bitbucket has no stars, so this action
   doesn't appear on Bitbucket results.
 - **View on GitHub / GitLab / Bitbucket** — open the repository on its host in your browser.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -128,8 +128,10 @@ Click the **⋮** menu next to the repo name for repo-wide actions:
 - On the host: **Star** the repository, **create an issue**, or **Fork** it (on GitLab
   and Bitbucket, forking opens the web fork page). Bitbucket has no stars and its
   issue tracker is retired, so those two actions don't appear for Bitbucket repos.
-  **Fork** doesn't appear on a GitHub repository you own personally — a fork always
-  lands under your own account (organization repositories stay forkable).
+  **Fork** doesn't appear on a GitHub repository you own personally — the in-app fork
+  always lands under your own account (organization repositories stay forkable). The
+  web fork page asks where the fork should go, so the GitLab and Bitbucket items stay
+  available on any repository.
 - **Insights** (analytics), **manage files**, **submodules**, the **remote URL**,
   **branch rules**, **git hooks**, {{ai}}**automations**, {{/ai}}**repository settings**,
   an **alias**, copy the repo path, copy the branch name, copy the HEAD SHA, and
@@ -187,10 +189,12 @@ and **last-updated** time, plus a **README preview** (loaded when you open the r
 From here:
 
 - **Clone** — pick a folder to clone into; GitDesktop opens the repo once it finishes.
-- **Fork** — create a fork under your account (on **GitHub, GitLab, and Bitbucket**). The
-  fork is created in the background, and then you're offered to **clone** it. It doesn't
-  appear on repositories you own personally (GitHub and GitLab) — a fork always lands
-  under your own account.
+- **Fork** — create a fork under your account. The fork is created in the background, and
+  then you're offered to **clone** it. It doesn't appear on a repository that already
+  counts as yours, which each host defines its own way: on **GitHub** and **GitLab**
+  that's your personal account or namespace (organization and group repositories stay
+  forkable), and on **Bitbucket** it's any workspace you belong to. Since Explore on
+  Bitbucket lists only your own workspaces, **Fork** doesn't normally come up there.
 - **Star / Unstar** — on **GitHub and GitLab** only. Bitbucket has no stars, so this action
   doesn't appear on Bitbucket results.
 - **View on GitHub / GitLab / Bitbucket** — open the repository on its host in your browser.
@@ -887,12 +891,13 @@ on both **GitHub** and **GitLab**.
 On **GitHub** the refusal is the base branch's rules going unmet, and the line names
 what is outstanding: **Merge is blocked — waiting on: build, fragment.** GitDesktop
 asks GitHub what that branch requires and matches it against the checks on this pull
-request, counting one as outstanding when it has failed, is still running, or has
-never reported. Four are named, then *and N more*. Where the rules also require
-approving reviews, the count rides along: **The rules also require 2 approving
-reviews.** Wherever the specific requirements can't be named, the line falls back to
-**Merge is blocked by the base branch's protection rules.** When only the approval
-count is known it reads **…protection rules, which require 2 approving reviews.**
+request, counting a context as outstanding when it has never reported, or when its
+most recent run failed, is still running, or has gone stale. Four are named, then
+*and N more*. Where the rules also require approving reviews, the count rides along:
+**The rules also require 2 approving reviews.** Wherever the specific requirements
+can't be named, the line falls back to **Merge is blocked by the base branch's
+protection rules.** When only the approval count is known it reads **…protection
+rules, which require 2 approving reviews.**
 
 On **GitLab** the project's own answer supplies the reason, in the app's words:
 **Merge is blocked — needs approval before it can merge**, **the pipeline must pass

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -165,7 +165,8 @@ connected — see *Getting started*), a **search box**, and a **sort** control:
 
 With the search box empty, the page shows two sections:
 
-- **Your repositories** — the repos you own, grouped by owner.
+- **Your repositories** — grouped by owner: your own repos, ones you collaborate on, and
+  those in an organization, group, or Bitbucket workspace you belong to.
 - **Popular** — a star-sorted feed of popular repositories (**GitHub and GitLab** only;
   Bitbucket has no popular feed here).
 
@@ -189,12 +190,14 @@ and **last-updated** time, plus a **README preview** (loaded when you open the r
 From here:
 
 - **Clone** — pick a folder to clone into; GitDesktop opens the repo once it finishes.
-- **Fork** — create a fork under your account. The fork is created in the background, and
-  then you're offered to **clone** it. It doesn't appear on a repository that already
-  counts as yours, which each host defines its own way: on **GitHub** and **GitLab**
-  that's your personal account or namespace (organization and group repositories stay
-  forkable), and on **Bitbucket** it's any workspace you belong to. Since Explore on
-  Bitbucket lists only your own workspaces, **Fork** doesn't normally come up there.
+- **Fork** — create a fork of the repository. On **GitHub** and **GitLab** it lands
+  under your own account; on **Bitbucket** the host picks the destination workspace.
+  The fork is created in the background, and then you're offered to **clone** it. It
+  doesn't appear on a repository that already counts as yours, which each host defines
+  its own way: on **GitHub** and **GitLab** that's your personal account or namespace
+  (organization and group repositories stay forkable), and on **Bitbucket** it's any
+  workspace you belong to. Since Explore on Bitbucket lists only your own workspaces,
+  **Fork** doesn't normally come up there.
 - **Star / Unstar** — on **GitHub and GitLab** only. Bitbucket has no stars, so this action
   doesn't appear on Bitbucket results.
 - **View on GitHub / GitLab / Bitbucket** — open the repository on its host in your browser.

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -386,14 +386,14 @@ export function LocalPrView({
   /** Close/Reopen, carrying any typed note. The note is appended in the SAME
    *  record mutation as the status flip, so the store can never persist one
    *  without the other; the draft clears only once that write lands. */
-  function setStatus(next: "open" | "closed") {
+  async function setStatus(next: "open" | "closed") {
     // Appending the note makes this non-idempotent, and the mutate callback
     // re-reads the record from disk — so a second click lands after the first
     // note is already stored and would post it twice.
     if (!pr || update.isPending) return;
     const note = comment.trim();
-    update.mutate(
-      {
+    try {
+      await update.mutateAsync({
         id: pr.id,
         mutate: (cur) => ({
           ...cur,
@@ -410,14 +410,13 @@ export function LocalPrView({
           status: next,
           closedAt: next === "closed" ? new Date().toISOString() : undefined,
         }),
-      },
-      {
-        onSuccess: () => setComment(""),
-        // Nothing was written, the note included — say so rather than leave a
-        // silent no-op behind a button that promised to post it.
-        onError: toastError,
-      },
-    );
+      });
+      setComment("");
+    } catch (e) {
+      // Nothing was written, the note included — say so rather than leave a
+      // silent no-op behind a button that promised to post it.
+      toastError(e);
+    }
   }
 
   function openEdit() {
@@ -435,58 +434,96 @@ export function LocalPrView({
     }
   }
 
-  function doMerge(strategy: MergeStrategy) {
+  // Awaited, not per-call callbacks: this view's effects tear down when the
+  // selection or the repo tab changes, and react-query drops per-call callbacks
+  // once the observer has no listeners. Here that would lose the record write —
+  // a landed merge still reading open, or a paused one with no `pendingMerge`
+  // to reach its resolver by.
+  async function doMerge(strategy: MergeStrategy) {
     if (!pr) return;
     const message = pr.body.trim() ? `${pr.title}\n\n${pr.body}` : pr.title;
-    merge.mutate(
-      { base: pr.base, head: pr.head, message, strategy },
-      {
-        onSuccess: (outcome) => {
-          if (outcome.status === "merged") {
-            update.mutate({
-              id: pr.id,
-              mutate: (cur) => ({
-                ...cur,
-                status: "merged",
-                mergedAt: new Date().toISOString(),
-              }),
-            });
-            toast.success(
-              `${MERGED_VERB[strategy]} ${pr.head} into ${pr.base}`,
-            );
-            return;
-          }
-          // Conflicts: the merge is paused in an isolated worktree (the user's
-          // branch and working tree are untouched). Record it on the PR so this
-          // view swaps to the in-place ResolveConflictsView, where the conflict
-          // editor is pointed at that worktree.
-          if (!outcome.worktreePath || !outcome.worktreeId) {
-            toastError(
-              new Error("Merge paused on conflicts but returned no worktree"),
-            );
-            return;
-          }
-          update.mutate({
-            id: pr.id,
-            mutate: (cur) => ({
-              ...cur,
-              pendingMerge: {
-                base: pr.base,
-                head: pr.head,
-                strategy: strategy as "merge" | "squash" | "rebase",
-                message,
-                worktreePath: outcome.worktreePath as string,
-                worktreeId: outcome.worktreeId as string,
-                opId: outcome.opId,
-                startedAt: new Date().toISOString(),
-              },
-            }),
-          });
-          toast.warning("Merge has conflicts — resolve them to finish");
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      const outcome = await merge.mutateAsync({
+        base: pr.base,
+        head: pr.head,
+        message,
+        strategy,
+      });
+      if (outcome.status === "merged") {
+        // The record write is awaited ahead of its toast: a store write can
+        // reject (a concurrent MCP writer, a locked store), and a merge
+        // reported as landed while the record still reads open is the exact
+        // desync this view has no second chance to repair.
+        await update.mutateAsync({
+          id: pr.id,
+          mutate: (cur) => ({
+            ...cur,
+            status: "merged",
+            mergedAt: new Date().toISOString(),
+          }),
+        });
+        toast.success(`${MERGED_VERB[strategy]} ${pr.head} into ${pr.base}`);
+        return;
+      }
+      // Conflicts: the merge is paused in an isolated worktree (the user's
+      // branch and working tree are untouched). Record it on the PR so this
+      // view swaps to the in-place ResolveConflictsView, where the conflict
+      // editor is pointed at that worktree — awaited because a lost write
+      // strands that worktree with nothing left pointing at it.
+      if (!outcome.worktreePath || !outcome.worktreeId) {
+        toastError(
+          new Error("Merge paused on conflicts but returned no worktree"),
+        );
+        return;
+      }
+      await update.mutateAsync({
+        id: pr.id,
+        mutate: (cur) => ({
+          ...cur,
+          pendingMerge: {
+            base: pr.base,
+            head: pr.head,
+            strategy: strategy as "merge" | "squash" | "rebase",
+            message,
+            worktreePath: outcome.worktreePath as string,
+            worktreeId: outcome.worktreeId as string,
+            opId: outcome.opId,
+            startedAt: new Date().toISOString(),
+          },
+        }),
+      });
+      toast.warning("Merge has conflicts — resolve them to finish");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  /** The "Update branch" button's action. Awaited because the dirty-tree refusal
+   *  reaches the stash-and-reapply prompt only through this rejection; dropping
+   *  it on teardown would withdraw the offer entirely. */
+  async function doUpdateBranch() {
+    if (!pr) return;
+    try {
+      await updateBranchFrom.mutateAsync({ branch: pr.head, base: pr.base });
+      toast.success(`Updated ${pr.head} from ${pr.base}`);
+    } catch (e) {
+      // Only an in-place update (head IS the current branch) can be refused
+      // over uncommitted changes — the throwaway worktree path is always
+      // clean. Anything else toasts.
+      if (
+        status.data?.branch?.name === pr.head &&
+        recovery.handleError(e, {
+          operationLabel: "update",
+          detail: pr.base,
+          reappliedMessage: `Updated from ${pr.base} and reapplied your changes.`,
+          plainMessage: `Updated ${pr.head} from ${pr.base}`,
+          run: { op: "merge", ref: pr.base },
+        })
+      ) {
+        return;
+      }
+      toastError(e);
+    }
   }
 
   // A calm status block above the Merge button: up to three INDEPENDENT lines —
@@ -1046,7 +1083,7 @@ export function LocalPrView({
               size="sm"
               disabled={update.isPending}
               reason="Saving…"
-              onClick={() => setStatus("closed")}
+              onClick={() => void setStatus("closed")}
               title={
                 draftRidesStateChange
                   ? "Closes and posts your draft as a comment"
@@ -1088,33 +1125,7 @@ export function LocalPrView({
                   }
                 })()}
                 title={`Merge ${pr.base} into ${pr.head} to catch it up`}
-                onClick={() =>
-                  updateBranchFrom.mutate(
-                    { branch: pr.head, base: pr.base },
-                    {
-                      onSuccess: () =>
-                        toast.success(`Updated ${pr.head} from ${pr.base}`),
-                      // Only an in-place update (head IS the current branch) can
-                      // be refused over uncommitted changes — the throwaway
-                      // worktree path is always clean. Anything else toasts.
-                      onError: (e) => {
-                        if (
-                          status.data?.branch?.name === pr.head &&
-                          recovery.handleError(e, {
-                            operationLabel: "update",
-                            detail: pr.base,
-                            reappliedMessage: `Updated from ${pr.base} and reapplied your changes.`,
-                            plainMessage: `Updated ${pr.head} from ${pr.base}`,
-                            run: { op: "merge", ref: pr.base },
-                          })
-                        ) {
-                          return;
-                        }
-                        toastError(e);
-                      },
-                    },
-                  )
-                }
+                onClick={() => void doUpdateBranch()}
               >
                 <ArrowClockwiseIcon data-icon="inline-start" />
                 Update branch
@@ -1146,7 +1157,7 @@ export function LocalPrView({
                   disabled={
                     !isMergeMethodAllowed(rulesConfig, pr.base, "merge")
                   }
-                  onClick={() => doMerge("merge")}
+                  onClick={() => void doMerge("merge")}
                 >
                   Create a merge commit
                 </DropdownMenuItem>
@@ -1154,7 +1165,7 @@ export function LocalPrView({
                   disabled={
                     !isMergeMethodAllowed(rulesConfig, pr.base, "squash")
                   }
-                  onClick={() => doMerge("squash")}
+                  onClick={() => void doMerge("squash")}
                 >
                   Squash and merge
                 </DropdownMenuItem>
@@ -1162,7 +1173,7 @@ export function LocalPrView({
                   disabled={
                     !isMergeMethodAllowed(rulesConfig, pr.base, "rebase")
                   }
-                  onClick={() => doMerge("rebase")}
+                  onClick={() => void doMerge("rebase")}
                 >
                   Rebase and merge
                 </DropdownMenuItem>
@@ -1178,7 +1189,7 @@ export function LocalPrView({
               size="sm"
               disabled={update.isPending}
               reason="Saving…"
-              onClick={() => setStatus("open")}
+              onClick={() => void setStatus("open")}
               title={
                 draftRidesStateChange
                   ? "Reopens and posts your draft as a comment"

--- a/src/features/pulls/ResolveConflictsView.tsx
+++ b/src/features/pulls/ResolveConflictsView.tsx
@@ -110,58 +110,64 @@ export function ResolveConflictsView({
   const canResolveWithAi = aiEnabled && reviewConfigured && remaining > 0;
   const busy = finish.isPending || abort.isPending;
 
-  function onFinish() {
+  // Awaited, not per-call callbacks: this surface unmounts the moment
+  // `pendingMerge` clears or the repo tab changes, and react-query drops
+  // per-call callbacks once the observer has no listeners — the PR record would
+  // keep pointing at a worktree the merge already finished with or threw away.
+  async function onFinish() {
     if (!pending) return;
-    finish.mutate(
-      {
+    try {
+      const outcome = await finish.mutateAsync({
         base: pr.base,
         strategy: pending.strategy,
         message: pending.message,
         worktreePath: pending.worktreePath,
         worktreeId: pending.worktreeId,
         opId: pending.opId,
-      },
-      {
-        onSuccess: (outcome) => {
-          if (outcome.status === "merged") {
-            update.mutate({
-              id: pr.id,
-              mutate: (cur) => ({
-                ...cur,
-                status: "merged",
-                mergedAt: new Date().toISOString(),
-                pendingMerge: undefined,
-              }),
-            });
-            toast.success(`Merged ${pr.head} into ${pr.base}`);
-            return;
-          }
-          // A multi-step rebase re-paused on the next commit's conflicts, still
-          // in the same worktree. Leave `pendingMerge` untouched — the live
-          // worktree status already drives this surface.
-          toast("More conflicts to resolve");
-        },
-        onError: toastError,
-      },
-    );
+      });
+      if (outcome.status === "merged") {
+        // Awaited ahead of its toast: a store write can reject (a concurrent
+        // MCP writer, a locked store), and a `pendingMerge` left behind points
+        // this surface at a worktree the merge has already consumed.
+        await update.mutateAsync({
+          id: pr.id,
+          mutate: (cur) => ({
+            ...cur,
+            status: "merged",
+            mergedAt: new Date().toISOString(),
+            pendingMerge: undefined,
+          }),
+        });
+        toast.success(`Merged ${pr.head} into ${pr.base}`);
+        return;
+      }
+      // A multi-step rebase re-paused on the next commit's conflicts, still
+      // in the same worktree. Leave `pendingMerge` untouched — the live
+      // worktree status already drives this surface.
+      toast("More conflicts to resolve");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   async function onAbort() {
     if (!pending) return;
     if (!(await useConfirm.getState().ask(DISCARD_MERGE_CONFIRM))) return;
-    abort.mutate(
-      { worktreePath: pending.worktreePath, opId: pending.opId },
-      {
-        onSuccess: () => {
-          update.mutate({
-            id: pr.id,
-            mutate: (cur) => ({ ...cur, pendingMerge: undefined }),
-          });
-          toast.success("Merge discarded");
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await abort.mutateAsync({
+        worktreePath: pending.worktreePath,
+        opId: pending.opId,
+      });
+      // Same ordering as Finish: the worktree is already gone, so a record
+      // still naming it must surface as an error rather than a success toast.
+      await update.mutateAsync({
+        id: pr.id,
+        mutate: (cur) => ({ ...cur, pendingMerge: undefined }),
+      });
+      toast.success("Merge discarded");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   const activeIndex = selectedPath ? conflictedPaths.indexOf(selectedPath) : -1;
@@ -207,7 +213,7 @@ export function ResolveConflictsView({
             size="xs"
             disabled={busy || remaining > 0}
             reason={remaining > 0 ? "Resolve every conflict first" : undefined}
-            onClick={onFinish}
+            onClick={() => void onFinish()}
           >
             {finish.isPending && <Spinner data-icon="inline-start" />}
             Finish merge

--- a/src/features/pulls/useBranchRequiredChecks.ts
+++ b/src/features/pulls/useBranchRequiredChecks.ts
@@ -34,6 +34,42 @@ export function useBranchRequiredChecks(
   });
 }
 
+/** When a run reported, for ordering same-named runs. Start time is the one key
+ *  both rollup shapes carry: a status context reports when it was created but never
+ *  a completion. NaN when the run is undated, which the API permits. */
+const reportedAt = (run: PrCheckOut) =>
+  Date.parse(run.startedAt ?? run.completedAt ?? "");
+
+/**
+ * The most recent of several same-named runs, or null when none of them is dated.
+ * Newest-wins is MEASURED, not GitHub's documented contract: a workflow that
+ * cancels its own in-progress runs on re-trigger leaves the superseded run in the
+ * rollup, and GitHub reports such a branch mergeable anyway. Ties keep the later
+ * entry, the order the rollup itself supplied.
+ */
+export function latestReportedRun(runs: PrCheckOut[]): PrCheckOut | null {
+  let latest: PrCheckOut | null = null;
+  let latestAt = Number.NEGATIVE_INFINITY;
+  for (const run of runs) {
+    const at = reportedAt(run);
+    if (Number.isNaN(at)) continue;
+    if (at >= latestAt) {
+      latest = run;
+      latestAt = at;
+    }
+  }
+  return latest;
+}
+
+/** Whether one run leaves its context still to come. STALE counts here but not in
+ *  the rollup's presentation: GitHub's passing set is success, skipped or neutral,
+ *  so a stale run holds the merge even though it reads as a finished result. */
+function isOutstanding(check: PrCheckOut, provider: ForgeProvider): boolean {
+  if (check.status.toUpperCase() === "STALE") return true;
+  const { bucket } = checkPresentation(check.status, provider);
+  return bucket === "failed" || bucket === "pending";
+}
+
 /**
  * Which required contexts the PR's own checks have not satisfied, in the order the
  * rules named them. Joined by NAME — the rules speak in contexts and the rollup in
@@ -45,8 +81,8 @@ export function unmetRequiredChecks(
   provider: ForgeProvider,
 ): string[] {
   if (required.length === 0) return [];
-  // Indexed once: GitHub allows several checks under one name, and every run of a
-  // required context has to be consulted before that context counts as satisfied.
+  // Indexed once: GitHub allows several runs under one name, and one of them
+  // decides the context — which one is resolved per group below.
   const runs = new Map<string, PrCheckOut[]>();
   for (const check of checks) {
     const existing = runs.get(check.name);
@@ -55,13 +91,18 @@ export function unmetRequiredChecks(
   }
   return required.filter((context) => {
     const named = runs.get(context);
+    // Unmet = never reported, still running, failed, or gone stale — what a viewer
+    // is waiting on. A skipped or neutral run has reported a conclusion GitHub
+    // accepts, so naming it as something still to come would be wrong.
     if (!named) return true;
-    // Unmet = never reported, still running, or failed — the three a viewer is
-    // waiting on. A skipped or neutral run has reported a conclusion, so naming
-    // it as something still to come would be wrong.
-    return named.some((check) => {
-      const { bucket } = checkPresentation(check.status, provider);
-      return bucket === "failed" || bucket === "pending";
-    });
+    // The newest DATED run decides, and an undated one is never overruled by it:
+    // nothing orders that run against the others, so it has to clear on its own.
+    // A group with no dated run at all therefore keeps the old rule — all of them.
+    const decisive = latestReportedRun(named);
+    const undated = named.some(
+      (check) =>
+        Number.isNaN(reportedAt(check)) && isOutstanding(check, provider),
+    );
+    return undated || (decisive !== null && isOutstanding(decisive, provider));
   });
 }

--- a/src/features/pulls/useBranchRequiredChecks.ts
+++ b/src/features/pulls/useBranchRequiredChecks.ts
@@ -47,7 +47,7 @@ const reportedAt = (run: PrCheckOut) =>
  * rollup, and GitHub reports such a branch mergeable anyway. Ties keep the later
  * entry, the order the rollup itself supplied.
  */
-export function latestReportedRun(runs: PrCheckOut[]): PrCheckOut | null {
+function latestReportedRun(runs: PrCheckOut[]): PrCheckOut | null {
   let latest: PrCheckOut | null = null;
   let latestAt = Number.NEGATIVE_INFINITY;
   for (const run of runs) {

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -312,6 +312,7 @@ export function RepoSettingsDialog({
   open,
   onOpenChange,
   initialSection,
+  subdueEntrance,
 }: {
   repoPath: string;
   open: boolean;
@@ -319,6 +320,10 @@ export function RepoSettingsDialog({
   /** Section to land on. An initializer is enough: the dialog mounts fresh on
    *  each open, so a later open with no request starts at "general" again. */
   initialSection?: SectionId;
+  /** Skip the open animation. A caller that reaches this dialog through a
+   *  Suspense fallback mounts a second Dialog root over one that already played
+   *  the entrance, and only that caller wants the replay suppressed. */
+  subdueEntrance?: boolean;
 }) {
   const [section, setSection] = useState<SectionId>(
     initialSection ?? "general",
@@ -362,7 +367,13 @@ export function RepoSettingsDialog({
           body column scrolls (overflow-y-auto) so a long form / many webhooks
           stay contained while the rail stays put. Caps to 85vh on short screens. */}
       <DialogContent
-        className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl"
+        className={cn(
+          "flex h-150 max-h-[85vh] flex-col sm:max-w-3xl",
+          // tailwind-merge treats animate-in and animate-none as unrelated, so
+          // neither class removes the other; `!` decides it on the cascade
+          // rather than on which rule the stylesheet happens to emit last.
+          subdueEntrance && "data-open:animate-none!",
+        )}
         onKeyDown={generateChord.onKeyDown}
       >
         <DialogHeader>

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -177,15 +177,19 @@ function draftToBody(
   }
   if (d.requireChecks) {
     const checks = storedParameters(original, "required_status_checks");
-    // A kept context keeps its whole stored entry: the entry can pin the check to
-    // one app (`integration_id`), which this editor cannot display and a save must
-    // not silently drop. A context typed in fresh has nothing to preserve.
-    const storedChecks = new Map<string, { context: string }>(
-      (
-        (checks?.required_status_checks as { context: string }[] | undefined) ??
-        []
-      ).map((c) => [c.context, c]),
-    );
+    // Kept lines consume their stored entries in order. An entry can pin the check
+    // to one app (`integration_id`) and GitHub accepts several pins under a single
+    // context, neither of which this editor displays, so a save must preserve every
+    // entry rather than reduce a context to one. Fresh lines have no pin to keep.
+    const storedList =
+      (checks?.required_status_checks as { context: string }[] | undefined) ??
+      [];
+    const storedChecks = new Map<string, { context: string }[]>();
+    for (const entry of storedList) {
+      const queue = storedChecks.get(entry.context);
+      if (queue) queue.push(entry);
+      else storedChecks.set(entry.context, [entry]);
+    }
     rules.push({
       type: "required_status_checks",
       parameters: {
@@ -193,7 +197,7 @@ function draftToBody(
         ...checks,
         strict_required_status_checks_policy: d.strictChecks,
         required_status_checks: splitLines(d.checkContexts).map(
-          (context) => storedChecks.get(context) ?? { context },
+          (context) => storedChecks.get(context)?.shift() ?? { context },
         ),
       },
     });

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -102,6 +102,15 @@ const splitLines = (s: string) =>
     .map((x) => x.trim())
     .filter(Boolean);
 
+/** Check contexts split on newlines only: a context can carry a comma of its own,
+ *  because GitHub Actions builds a matrix job's name by joining its values with
+ *  ", ". Splitting there would save contexts no run will ever report. */
+const splitCheckLines = (s: string) =>
+  s
+    .split(/\r?\n/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+
 function rulesetToDraft(rs: RulesetFull): Draft {
   const include = rs.conditions?.ref_name?.include ?? [];
   const refScope = include.includes("~DEFAULT_BRANCH")
@@ -196,7 +205,7 @@ function draftToBody(
         do_not_enforce_on_create: false,
         ...checks,
         strict_required_status_checks_policy: d.strictChecks,
-        required_status_checks: splitLines(d.checkContexts).map(
+        required_status_checks: splitCheckLines(d.checkContexts).map(
           (context) => storedChecks.get(context)?.shift() ?? { context },
         ),
       },
@@ -577,7 +586,7 @@ function RulesetForm({
             <Textarea
               value={d.checkContexts}
               onChange={(e) => set("checkContexts", e.target.value)}
-              placeholder="check names, one per line (e.g. build, test)"
+              placeholder="check names, one per line"
               rows={2}
               autoComplete="off"
               spellCheck={false}

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -148,6 +148,12 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
     ),
 };
 
+/** The stored parameters of one rule on the ruleset being edited. A save is a full
+ *  PUT replace, so every managed rule is rebuilt FROM these rather than from the
+ *  draft alone — the draft models a subset of each rule's fields. */
+const storedParameters = (original: RulesetFull | undefined, type: string) =>
+  original?.rules?.find((r) => r.type === type)?.parameters;
+
 function draftToBody(
   d: Draft,
   original?: RulesetFull,
@@ -158,23 +164,37 @@ function draftToBody(
     rules.push({
       type: "pull_request",
       parameters: {
+        // Seeds a new ruleset only: GitHub's schema demands the field and the
+        // editor has no control for it, so a stored value must win the spread.
+        required_review_thread_resolution: false,
+        ...storedParameters(original, "pull_request"),
         required_approving_review_count: d.approvals,
         dismiss_stale_reviews_on_push: d.dismissStale,
         require_code_owner_review: d.codeOwner,
         require_last_push_approval: d.lastPush,
-        required_review_thread_resolution: false,
       },
     });
   }
   if (d.requireChecks) {
+    const checks = storedParameters(original, "required_status_checks");
+    // A kept context keeps its whole stored entry: the entry can pin the check to
+    // one app (`integration_id`), which this editor cannot display and a save must
+    // not silently drop. A context typed in fresh has nothing to preserve.
+    const storedChecks = new Map<string, { context: string }>(
+      (
+        (checks?.required_status_checks as { context: string }[] | undefined) ??
+        []
+      ).map((c) => [c.context, c]),
+    );
     rules.push({
       type: "required_status_checks",
       parameters: {
-        strict_required_status_checks_policy: d.strictChecks,
         do_not_enforce_on_create: false,
-        required_status_checks: splitLines(d.checkContexts).map((context) => ({
-          context,
-        })),
+        ...checks,
+        strict_required_status_checks_policy: d.strictChecks,
+        required_status_checks: splitLines(d.checkContexts).map(
+          (context) => storedChecks.get(context) ?? { context },
+        ),
       },
     });
   }
@@ -188,10 +208,18 @@ function draftToBody(
   );
   return {
     name: d.name.trim(),
-    target: "branch",
+    // Target, ref excludes and any other condition are the ruleset's own state,
+    // not the draft's: an edit rewrites what it models and resends the rest.
+    target: original?.target ?? "branch",
     enforcement: d.enforcement,
     bypass_actors: original?.bypass_actors ?? [],
-    conditions: { ref_name: { include, exclude: [] } },
+    conditions: {
+      ...original?.conditions,
+      ref_name: {
+        include,
+        exclude: original?.conditions?.ref_name?.exclude ?? [],
+      },
+    },
     rules: [...rules, ...extra],
   };
 }
@@ -405,8 +433,10 @@ function RulesetForm({
     setD((p) => ({ ...p, [key]: value }));
 
   async function save() {
-    const body = draftToBody(d, original);
     try {
+      // Inside the try: building the body reads the stored ruleset's own shape, so
+      // a malformed one must surface as a toast rather than a silent no-op.
+      const body = draftToBody(d, original);
       if (id != null) await update.mutateAsync({ id, body });
       else await create.mutateAsync(body);
       toast.success(id != null ? "Ruleset updated" : "Ruleset created");

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -1,0 +1,64 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/** Six rows: the shortest provider rail (GitLab) offers six sections, and the
+ *  real count isn't knowable until the provider tables load with the chunk. */
+const RAIL_ROW_WIDTHS = ["w-16", "w-20", "w-14", "w-24", "w-12", "w-18"];
+
+/**
+ * The repository-settings dialog's frame while its lazy chunk loads, so the
+ * click paints a dialog instead of nothing and the loaded dialog fills the same
+ * frame rather than arriving from an empty screen. Provider-worded copy (the
+ * description, the rail's section names) lives inside the lazy module, so it
+ * stays skeletal here rather than flashing a label the repo's forge contradicts.
+ */
+export function RepoSettingsDialogFallback({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      {/* Frame classes mirror RepoSettingsDialog's DialogContent: the swap to
+          the loaded dialog must not resize or reposition the box. */}
+      <DialogContent className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Repository settings</DialogTitle>
+          <Skeleton className="h-4 w-2/3" />
+        </DialogHeader>
+        <div className="flex min-h-0 min-w-0 flex-1 gap-4">
+          <div className="w-40 shrink-0 space-y-0.5">
+            {RAIL_ROW_WIDTHS.map((width) => (
+              // Mirrors a rail row's geometry (h-7 row, px-2 label inset); the
+              // loaded rail is taller, since its groups carry headers.
+              <div key={width} className="flex h-7 items-center px-2">
+                <Skeleton className={cn("h-3", width)} />
+              </div>
+            ))}
+          </div>
+          <div
+            aria-busy
+            className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1"
+          >
+            {/* aria-busy alone announces nothing outside a live region, so the
+                state gets words a screen reader will actually read. */}
+            <span className="sr-only">Loading repository settings…</span>
+            {/* The General section's own loading shape, so fallback → dialog →
+                section reads as one progressive fill, not three layouts. */}
+            <div className="min-w-0 space-y-3">
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -46,7 +46,10 @@ import { RepoAutomationsDialog } from "@/features/automations/RepoAutomationsDia
 import { BranchRulesDialog } from "@/features/branch-rules/BranchRulesDialog";
 import { HooksDialog } from "@/features/hooks/HooksDialog";
 import { RepoJiraDialog } from "@/features/issues/RepoJiraDialog";
-import type { SectionId } from "@/features/repo-settings/RepoSettingsDialog";
+import type {
+  RepoSettingsDialog as RepoSettingsDialogComponent,
+  SectionId,
+} from "@/features/repo-settings/RepoSettingsDialog";
 import { copyText } from "@/lib/clipboard";
 import {
   forgeRepoUrl,
@@ -74,23 +77,38 @@ import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { RemoteUrlDialog } from "./RemoteUrlDialog";
 import { RemoveRepoDialog, RepoAliasDialog } from "./RepoDialogs";
+import { RepoSettingsDialogFallback } from "./RepoSettingsDialogFallback";
 import { RepositoryFilesDialog } from "./RepositoryFilesDialog";
 import { SubmodulesDialog } from "./SubmodulesDialog";
 import { WorktreesDialog } from "./WorktreesDialog";
+
+// Named so the menu can warm the chunk while the dropdown is up: the warm call
+// and the lazy mount go through the same dynamic import, so they share one fetch.
+const loadRepoSettingsDialog = () =>
+  import("@/features/repo-settings/RepoSettingsDialog");
+
+/** Resolve the chunk and hand the component back, so an open that follows can
+ *  render it directly instead of suspending. Best-effort: a failed warm stays
+ *  silent and the lazy path still surfaces the import error. */
+const warmRepoSettingsDialog = (
+  onReady: (dialog: typeof RepoSettingsDialogComponent) => void,
+) => {
+  loadRepoSettingsDialog()
+    .then((m) => onReady(m.RepoSettingsDialog))
+    .catch(() => undefined);
+};
 
 // RepoSettingsDialog's tree pulls in the Shiki highlighter (via parts.tsx →
 // shiki-highlighter's highlightJson), which is heavy and only needed once an
 // admin opens repository settings. Loading it lazily keeps that chunk off the
 // boot path. The dialog is rendered ONLY while open (not always-mounted like
 // the sibling dialogs): a lazy component that is always rendered loads its
-// chunk immediately, defeating the split — the open-gate is what defers the
-// import to first open. Trade-off: the dialog no longer stays mounted across
+// chunk immediately, defeating the split — the open-gate is what keeps the
+// import on demand. Trade-off: the dialog no longer stays mounted across
 // close/reopen, so its remembered rail section resets to "general" each open
 // (see the state note at its render site).
 const RepoSettingsDialog = lazy(() =>
-  import("@/features/repo-settings/RepoSettingsDialog").then((m) => ({
-    default: m.RepoSettingsDialog,
-  })),
+  loadRepoSettingsDialog().then((m) => ({ default: m.RepoSettingsDialog })),
 );
 
 export function RepositoryMenu({ repoPath }: { repoPath: string }) {
@@ -105,6 +123,18 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [jiraOpen, setJiraOpen] = useState(false);
   const [repoSettingsOpen, setRepoSettingsOpen] = useState(false);
+  // React's `lazy` suspends on its first element render even when the shared
+  // import has already resolved, so a warmed open would still flash the
+  // fallback for a commit. Holding the resolved component lets a warmed open
+  // render it directly; only the two warm triggers below ever fill this, so the
+  // chunk still stays off the boot path.
+  const [ReadyDialog, setReadyDialog] = useState<
+    typeof RepoSettingsDialogComponent | null
+  >(null);
+  // Which tree an open renders, fixed at the moment it opens: swapping trees
+  // mid-open would unmount one Dialog root and mount another, which is the
+  // doubled entrance this avoids.
+  const [openPath, setOpenPath] = useState<"direct" | "lazy" | null>(null);
   const [repoSettingsSection, setRepoSettingsSection] =
     useState<SectionId | null>(null);
   const repoSettingsRequest = useUiStore((s) => s.repoSettingsRequest);
@@ -157,6 +187,10 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     !!gh.data?.login &&
     gh.data.repo.split("/")[0] === gh.data.login;
   // One predicate for the menu item and its palette twin, so the two can't drift.
+  // Bitbucket bypasses the ownership test rather than trusting `ownRepo` to fall
+  // false: its `login` is a /user username (a display name where that's absent), which
+  // doesn't line up with the workspace slug a repo's owner carries. Explore's Fork
+  // gate needs the real answer and gets it from a membership set instead.
   const canForkHere = canGh && (isGitLab || isBitbucket || !ownRepo);
   const starStatus = useRepoStarStatus(repoPath, canStar);
   const setStar = useSetRepoStar(repoPath);
@@ -184,13 +218,20 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // and the dialog opens in edit mode.
   const jiraLink = useJiraLink(repoPath);
 
+  // Every route opens through here, so the render path is captured once per
+  // open and holds for that whole open.
+  const openRepoSettings = () => {
+    setOpenPath(ReadyDialog ? "direct" : "lazy");
+    setRepoSettingsOpen(true);
+  };
+
   // A request that arrives while the dialog is already open is dropped, not
   // queued: the section is seeded at mount, so it couldn't be applied, and
   // deferring it would reopen the dialog the moment the user closed it.
   const openRepoSettingsAt = useEffectEvent((section: SectionId) => {
     if (repoSettingsOpen) return;
     setRepoSettingsSection(section);
-    setRepoSettingsOpen(true);
+    openRepoSettings();
   });
 
   // A one-shot deep link raised by another surface (the Findings tab's "turn on
@@ -204,6 +245,27 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     if (canOpenRepoSettings) openRepoSettingsAt(repoSettingsRequest);
     clearRepoSettingsRequest();
   }, [repoSettingsRequest, clearRepoSettingsRequest, canOpenRepoSettings]);
+
+  // The palette and the Findings deep link have no menu to warm on, so the open
+  // itself warms too; the shared import means this and the menu preload resolve
+  // from one fetch. Gated on the dialog being open, so it can only run after a
+  // route the admin gate already guards has opened it.
+  useEffect(() => {
+    if (repoSettingsOpen) {
+      warmRepoSettingsDialog((dialog) => setReadyDialog(() => dialog));
+    }
+  }, [repoSettingsOpen]);
+
+  // Shared by the loading frame and the loaded dialog, so Esc or the backdrop
+  // cancels an open that is still fetching its chunk. Closing drops the
+  // deep-linked section so a later plain open starts at "general".
+  const closeRepoSettings = (open: boolean) => {
+    setRepoSettingsOpen(open);
+    if (!open) {
+      setRepoSettingsSection(null);
+      setOpenPath(null);
+    }
+  };
 
   const onError = (e: unknown) => toastError(e);
 
@@ -250,11 +312,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("manage-files", () => setFilesOpen(true));
   useHotkeyAction("automations", () => setAutomationsOpen(true), aiEnabled);
   useHotkeyAction("link-jira-project", () => setJiraOpen(true));
-  useHotkeyAction(
-    "repository-settings",
-    () => setRepoSettingsOpen(true),
-    canOpenRepoSettings,
-  );
+  useHotkeyAction("repository-settings", openRepoSettings, canOpenRepoSettings);
   useHotkeyAction("branch-rules", () => setBranchRulesOpen(true));
   useHotkeyAction("git-hooks", () => setHooksOpen(true));
   useHotkeyAction("submodules", () => setSubmodulesOpen(true), hasSubmodules);
@@ -291,7 +349,16 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("remove-repository", () => setRemoveTarget(repoEntry));
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={(menuOpen) => {
+        // Warm the repo-settings chunk while the menu is up, so the click that
+        // opens the dialog renders it directly instead of suspending on it.
+        // Gated like the item itself: a non-admin has nothing to open.
+        if (menuOpen && canOpenRepoSettings) {
+          warmRepoSettingsDialog((dialog) => setReadyDialog(() => dialog));
+        }
+      }}
+    >
       <DropdownMenuTrigger
         render={
           <Button
@@ -404,7 +471,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
           {jiraLink.data ? "Change Jira project…" : "Link Jira project…"}
         </DropdownMenuItem>
         {canOpenRepoSettings && (
-          <DropdownMenuItem onClick={() => setRepoSettingsOpen(true)}>
+          <DropdownMenuItem onClick={openRepoSettings}>
             <GearSixIcon />
             Repository settings…
           </DropdownMenuItem>
@@ -479,27 +546,39 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
         existingLink={jiraLink.data ?? null}
       />
       {/* Open-gated (unlike the always-mounted siblings above) so its lazy
-          chunk loads on first open, not on boot. `open` stays true while
+          chunk loads on demand, not on boot. `open` stays true while
           mounted; `onOpenChange(false)` flips the gate, unmounting the subtree
           — the same immediate-unmount-on-close idiom the other open-gated
           dialogs in this app use (e.g. ImportMcpDialog). The dialog's remembered
           rail section (its internal `section` state) no longer persists across
-          close/reopen and resets to "general" each open. */}
-      {repoSettingsOpen && (
-        <Suspense fallback={null}>
-          <RepoSettingsDialog
+          close/reopen and resets to "general" each open.
+          Two shapes of the same dialog: a warmed open renders the resolved
+          component straight (one mount, one entrance), while a cold one
+          suspends behind the loading frame and skips the entrance the frame
+          already played. */}
+      {repoSettingsOpen &&
+        (openPath === "direct" && ReadyDialog ? (
+          <ReadyDialog
             repoPath={repoPath}
             open={repoSettingsOpen}
-            onOpenChange={(o) => {
-              setRepoSettingsOpen(o);
-              // Drop the deep-linked section on close so a later plain open
-              // starts at "general".
-              if (!o) setRepoSettingsSection(null);
-            }}
+            onOpenChange={closeRepoSettings}
             initialSection={repoSettingsSection ?? undefined}
           />
-        </Suspense>
-      )}
+        ) : (
+          <Suspense
+            fallback={
+              <RepoSettingsDialogFallback onOpenChange={closeRepoSettings} />
+            }
+          >
+            <RepoSettingsDialog
+              repoPath={repoPath}
+              open={repoSettingsOpen}
+              onOpenChange={closeRepoSettings}
+              initialSection={repoSettingsSection ?? undefined}
+              subdueEntrance
+            />
+          </Suspense>
+        ))}
       <BranchRulesDialog
         repoPath={repoPath}
         open={branchRulesOpen}

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -46,6 +46,8 @@ import { RepoAutomationsDialog } from "@/features/automations/RepoAutomationsDia
 import { BranchRulesDialog } from "@/features/branch-rules/BranchRulesDialog";
 import { HooksDialog } from "@/features/hooks/HooksDialog";
 import { RepoJiraDialog } from "@/features/issues/RepoJiraDialog";
+// Type-only, so the chunk stays split; `typeof` queries on these bindings are
+// type-space only and legal — value-position use is what `import type` forbids.
 import type {
   RepoSettingsDialog as RepoSettingsDialogComponent,
   SectionId,

--- a/src/features/repository/useStashReapplyRecovery.tsx
+++ b/src/features/repository/useStashReapplyRecovery.tsx
@@ -144,45 +144,46 @@ export function useStashReapplyRecovery(repoPath: string) {
     rebaseAutostash.isPending ||
     rebaseOntoAutostash.isPending;
 
-  function runRecovery(req: StashReapplyRequest) {
+  function runCompound(run: StashReapplyRun): Promise<AutostashOutcome> {
+    switch (run.op) {
+      case "pull":
+        return pullAutostash.mutateAsync(run.mode);
+      case "merge":
+        return mergeAutostash.mutateAsync(run.ref);
+      case "rebase":
+        return rebaseAutostash.mutateAsync(run.ref);
+      case "rebaseOnto":
+        return rebaseOntoAutostash.mutateAsync({
+          newBase: run.newBase,
+          oldBase: run.oldBase,
+        });
+    }
+  }
+
+  // Awaited, not per-call callbacks: a host can lose its effects mid-compound
+  // (the pull-request selection or the repo tab changes), and react-query drops
+  // per-call callbacks once the observer has no listeners — the report of a
+  // recovery the user explicitly asked for would never arrive, stash included.
+  async function runRecovery(req: StashReapplyRequest) {
     const copy: AutostashCopy = {
       operation: capitalize(req.operationLabel),
       reapplied: req.reappliedMessage,
       plain: req.plainMessage,
     };
-    const opts = {
-      onSuccess: (outcome: AutostashOutcome) => {
-        setRequest(null);
-        reportAutostashOutcome(outcome, copy);
-      },
-      onError: (e: Error) => {
-        setRequest(null);
-        toastError(e);
-      },
-    };
-    const run = req.run;
-    switch (run.op) {
-      case "pull":
-        pullAutostash.mutate(run.mode, opts);
-        return;
-      case "merge":
-        mergeAutostash.mutate(run.ref, opts);
-        return;
-      case "rebase":
-        rebaseAutostash.mutate(run.ref, opts);
-        return;
-      case "rebaseOnto":
-        rebaseOntoAutostash.mutate(
-          { newBase: run.newBase, oldBase: run.oldBase },
-          opts,
-        );
-        return;
+    try {
+      reportAutostashOutcome(await runCompound(req.run), copy);
+    } catch (e) {
+      toastError(e);
+    } finally {
+      setRequest(null);
     }
   }
 
   /** Start the recovery for an already-classified refusal. */
   function begin(req: StashReapplyRequest) {
-    if (settings.data?.autoStashOnPull) runRecovery(req);
+    // Fire-and-forget: `handleError` is a synchronous guard expression for its
+    // callers, so the compound can't be awaited from here.
+    if (settings.data?.autoStashOnPull) void runRecovery(req);
     else setRequest(req);
   }
 
@@ -201,7 +202,7 @@ export function useStashReapplyRecovery(repoPath: string) {
     if (always && settings.data && !settings.data.autoStashOnPull) {
       saveSettings.mutate({ ...settings.data, autoStashOnPull: true });
     }
-    runRecovery(request);
+    void runRecovery(request);
   }
 
   return {

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { groupByOwnerNamespace } from "@/features/explore/explore-utils";
 import { useAppForm } from "@/lib/form";
 import { cloneRepo, forgeClone, validateRepo } from "@/lib/git/api";
 import { useForgeRepos } from "@/lib/git/queries";
@@ -129,9 +130,9 @@ export function CloneRepoDialog({
   const values = useSelector(form.store, (s) => s.values);
   const isSubmitting = useSelector(form.store, (s) => s.isSubmitting);
 
-  // Group by owner — the viewer's own repos first, then other owners
-  // alphabetically — and flatten to rows for the virtualizer. Each group keeps
-  // the API's order.
+  // Group by owner and flatten to rows for the virtualizer, sharing Explore's
+  // ordering so the two surfaces list the same repos in the same order. Each group
+  // keeps the API's order.
   const rows = useMemo<Row[]>(() => {
     const data = repos.data;
     if (!data) return [];
@@ -142,18 +143,11 @@ export function CloneRepoDialog({
         r.name.toLowerCase().includes(q) ||
         r.fullName.toLowerCase().includes(q),
     );
-    const byOwner = new Map<string, ForgeRepo[]>();
-    for (const r of matched) {
-      const list = byOwner.get(r.owner);
-      if (list) list.push(r);
-      else byOwner.set(r.owner, [r]);
-    }
-    const owners = [...byOwner.entries()].sort((a, b) => {
-      if (a[0] === data.viewer) return -1;
-      if (b[0] === data.viewer) return 1;
-      return a[0].toLowerCase().localeCompare(b[0].toLowerCase());
-    });
-    return owners.flatMap(([owner, list]): Row[] => [
+    return groupByOwnerNamespace(
+      matched,
+      (r) => r.owner,
+      data.ownedNamespaces,
+    ).flatMap(([owner, list]): Row[] => [
       { kind: "header", owner },
       ...list.map((repo) => ({ kind: "repo" as const, repo })),
     ]);

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2485,7 +2485,8 @@ export const forgeGlMrMergeState = (repoPath: string, number: number) =>
 
 // Arm auto-merge with a strategy ("merge" | "squash"; "rebase" is rejected
 // backend-side). `sha` is the same stale-view guard as a plain merge — GitLab
-// 409s if the head moved. 405s when the pipeline already finished (a race).
+// 409s if the head moved. 405s only when no auto-merge strategy is available and
+// the head pipeline isn't passing; a passing one merges immediately instead.
 export const forgeGlMrAutoMerge = (
   repoPath: string,
   number: number,

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -537,8 +537,13 @@ export interface ForgeRepo {
 }
 
 export interface ForgeRepoList {
-  /** The signed-in user's login, so the UI lists their own repos first. */
+  /** The signed-in user's login. Kept on the wire; no frontend consumer today. */
   viewer: string;
+  /** The `owner` namespaces that count as the viewer's own — a set because "yours" is
+   *  provider-shaped: a login on GitHub and GitLab, any workspace you belong to on
+   *  Bitbucket. Drives the own-repo Fork gate and the yours-first grouping; empty
+   *  means unresolved, so both fail open. */
+  ownedNamespaces: string[];
   repos: ForgeRepo[];
 }
 
@@ -1690,9 +1695,12 @@ export interface PrCheckOut {
   /** GitHub Actions job id, parsed from `.../actions/runs/<runId>/job/<jobId>`.
    *  Absent when the URL has no job segment (or isn't an Actions URL). */
   jobId?: string;
-  /** CheckRun `startedAt`; absent for a StatusContext (it has no start). */
+  /** When the check began — a CheckRun `startedAt`, or a StatusContext's creation
+   *  time, which gh reports under this same key. Absent only when the rollup
+   *  carried no real time. */
   startedAt?: string;
-  /** CheckRun `completedAt`; absent for a StatusContext. */
+  /** CheckRun `completedAt`. A StatusContext reports no completion at all, so start
+   *  time is the only key both rollup arms can be ordered by. */
   completedAt?: string;
 }
 

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1408,13 +1408,17 @@ export interface RulesetSummary {
   sourceType: string;
 }
 
-/** The full ruleset object (raw GitHub schema, snake_case) for the editor. */
+/** The full ruleset object (raw GitHub schema, snake_case) for the editor. Only what
+ *  the editor reads is modelled; the object carries the rest of GitHub's schema, and
+ *  a save spreads those fields back so the full PUT replace doesn't drop them. */
 export interface RulesetFull {
   id: number;
   name: string;
   target?: string;
   enforcement: string;
-  conditions?: { ref_name?: { include?: string[]; exclude?: string[] } };
+  conditions?: {
+    ref_name?: { include?: string[]; exclude?: string[] };
+  } & Record<string, unknown>;
   bypass_actors?: unknown[];
   rules?: { type: string; parameters?: Record<string, unknown> }[];
 }


### PR DESCRIPTION
A batch of fixes for places where a user action silently lost its result: local pull-request operations dropped their record write when the view unmounted, ruleset saves discarded settings the editor never shows, required-check lines counted superseded runs, Explore's Fork gate misjudged Bitbucket ownership, and repository settings opened onto nothing while its lazy chunk loaded.

### Local pull request outcomes

- Converts the merge, close/reopen, conflict-finish and abort paths in `src/features/pulls/LocalPrView.tsx` and `src/features/pulls/ResolveConflictsView.tsx` from `mutate` with per-call callbacks to awaited `mutateAsync`, so a merge that lands while the user switches tabs still writes `status: "merged"` (or the `pendingMerge` worktree pointer) instead of losing it when react-query drops the observer's listeners.
- Awaits the record write *before* its toast, so a rejected store write (concurrent MCP writer, locked store) surfaces as an error rather than a success toast over a stale record.
- Reworks `src/features/repository/useStashReapplyRecovery.tsx` the same way: a new `runCompound` returns the mutation promise per op and `runRecovery` awaits it, reporting the autostash outcome and clearing the request in a `finally`.

### Own-repo detection across forges

- Adds `owned_namespaces` to `ForgeRepoList` plus a `namespace_set` helper in `src-tauri/src/forge/model.rs` that drops empty (unresolved) probes, with tests pinning the camelCase wire shape and the blank-dropping behavior.
- Fills the set per provider: the viewer login in `src-tauri/src/forge/github.rs` and `src-tauri/src/forge/gitlab.rs`, and every workspace slug the user belongs to in `src-tauri/src/forge/bitbucket.rs` (collected on membership, not fetch success, since Bitbucket exposes no usable personal-workspace signal).
- Switches Explore's Fork gate from a `viewer` string compare to `ownedNamespaces.includes(repo.owner)` in `src/features/explore/ExploreDetail.tsx`, with `ExploreScreen.tsx` supplying a stable `EMPTY_NAMESPACES` fallback while the query resolves.
- Extracts a generic `groupByOwnerNamespace` in `src/features/explore/explore-utils.ts` and reuses it from `src/features/welcome/CloneRepoDialog.tsx`, so Explore's "Yours" list and the clone browser share one yours-first ordering.
- Mirrors the new field in `src/lib/git/types.ts` and notes in `src/features/repository/RepositoryMenu.tsx` why the Bitbucket menu bypasses the `ownRepo` test.

### Required-check reporting

- `src/features/pulls/useBranchRequiredChecks.ts` now resolves same-named runs to the newest dated one via a new `latestReportedRun`, keeps undated runs deciding on their own, and counts a `STALE` run as outstanding through the new `isOutstanding` helper — so the blocked-merge line names what the base branch is actually waiting on.
- Corrects the `RawCheck` / `PrCheckOut` docs in `src-tauri/src/github/pr.rs` and `src/lib/git/types.ts`: `startedAt` arrives on both rollup arms (gh aliases a StatusContext's creation time onto it), while `completedAt` stays CheckRun-only.

### Ruleset saves

- `src/features/repo-settings/RulesetsSection.tsx` gains a `storedParameters` reader and rebuilds each managed rule from the stored ruleset: kept check contexts retain their whole stored entry (including an `integration_id` app pin), `required_review_thread_resolution` only seeds a brand-new ruleset, and `target` plus the ruleset's other conditions and `ref_name.exclude` patterns are resent rather than reset.
- Moves the `draftToBody` call inside `save`'s `try`, so a malformed stored ruleset surfaces as a toast instead of a silent no-op.

### Repository settings dialog

- Adds `src/features/repository/RepoSettingsDialogFallback.tsx`, a skeleton dialog frame matching `RepoSettingsDialog`'s geometry (with `aria-busy` and an `sr-only` loading line), so the click paints a dialog immediately and Esc / outside-click can cancel while the chunk loads.
- `src/features/repository/RepositoryMenu.tsx` warms the lazy chunk from the open dropdown through the same dynamic import, holds the resolved component in `ReadyDialog`, and fixes the render path per open via `openPath` so the dialog root isn't swapped mid-open.
- `src/features/repo-settings/RepoSettingsDialog.tsx` takes a `subdueEntrance` prop that suppresses the open animation replay for the Suspense-fallback route.

### GitLab merge

- Extracts the merge PUT's argv into a `merge_mr_args` helper in `src-tauri/src/forge/gitlab.rs`, keeping the `sha` guard and sending both auto-merge params when arming.
- Corrects the 405 documentation there and the matching comment in `src/lib/git/api.ts`: GitLab answers 405 on the arming path only when no auto-merge strategy is available *and* the head pipeline isn't passing.

### Documentation

- Updates the Explore fork wording in `README.md` and both the repository-menu and Explore sections of `src/features/help/content.ts`, plus the blocked-merge paragraph describing newest-run and stale handling.
- Adds five fragments under `changelog.d/`: `fixed-local-pr-outcomes.md`, `fixed-ruleset-save-preserves-settings.md`, `fixed-required-check-latest-run.md`, `fixed-repo-settings-instant-open.md`, and `fixed-bitbucket-own-workspace-repos.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fork options now reflect repository ownership and provider-specific workspace behavior.
  - Explore and repository cloning now include accessible collaborative, organization, group, and workspace repositories.
  - Local pull request and recovery actions report outcomes reliably across navigation.
  - Required-check results use the latest run, including stale or outstanding checks.
  - Repository settings open with a loading state and can be canceled while loading.
  - Editing rulesets preserves hidden and existing configuration.
  - Pull request timestamps and GitLab merge behavior are handled more accurately.

- **Documentation**
  - Updated guidance for repository access, forking, branch protection, and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->