### PR TITLE
fix(explore,repository,repo-settings): report fork outcomes and guard ruleset editing

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -136,6 +136,9 @@ route to one of those ops imports the existing prompt, never re-spells it.
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled
 clickables add `cursor-pointer` at the call site (vendored Button sets none).
+Tailwind animation overrides need the `!` important modifier — tw-merge doesn't
+dedupe the animate group, so `animate-none` vs an existing `animate-in` is a
+build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
 
 **State & rendering gotchas.**
 - **`gd/session/*` branches are filtered from every branch surface** (lists,

--- a/changelog.d/fixed-fork-outcomes.md
+++ b/changelog.d/fixed-fork-outcomes.md
@@ -1,0 +1,3 @@
+- Forking from Explore or the repository menu reports its outcome even if you
+  navigate away while the fork is being prepared, and the new fork shows up under
+  Your repositories; a star that can't be saved now says so.

--- a/changelog.d/fixed-ruleset-load-guard.md
+++ b/changelog.d/fixed-ruleset-load-guard.md
@@ -1,0 +1,2 @@
+- Opening a ruleset that can't be loaded shows the error and the way back to the
+  list, and the editor opens only once the ruleset's own settings are in hand.

--- a/changelog.d/fixed-ruleset-save-preserves-settings.md
+++ b/changelog.d/fixed-ruleset-save-preserves-settings.md
@@ -1,3 +1,3 @@
-- Editing a ruleset preserves the settings its editor doesn't show: required
-  checks pinned to a specific app, required conversation resolution, and the
-  ruleset's target and excluded branch patterns.
+- Editing a ruleset preserves the settings its editor doesn't show, including
+  required checks pinned to a specific app, required conversation resolution,
+  and excluded branch patterns.

--- a/changelog.d/fixed-ruleset-target-editing.md
+++ b/changelog.d/fixed-ruleset-target-editing.md
@@ -1,0 +1,3 @@
+- The ruleset editor covers branch rulesets: tag and push rulesets keep their
+  enforcement control in the list and say where to edit them. Custom branch
+  patterns are read one per line, so a pattern containing a comma stays intact.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -191,9 +191,9 @@ const SET_QUERY_DATA_RE =
 // reaches the call: inline literal, hoisted variable (`.mutate(v, opts)` — the
 // shape 5 of the settings sections used, and still live elsewhere under src/),
 // spread, shorthand keys. The token has no such surface, and it costs nothing
-// here because the directory this check applies to has no `.mutate(` calls left
-// at all — every mutation there is awaited. `.mutateAsync(` does not match: the
-// `(` must follow `mutate` directly.
+// here because the directories this check applies to have no `.mutate(` calls
+// left at all — every mutation there is awaited. `.mutateAsync(` does not match:
+// the `(` must follow `mutate` directly.
 const MUTATE_CALL_RE = /\.mutate\s*\(/;
 
 // The dot-less route to the same call: `const { mutate } = useX()` (a live idiom
@@ -271,13 +271,16 @@ export const CHECKS = [
   },
   {
     name: "mutate-in-repo-settings",
-    // Scoped to the settings dialog's own tree, whose sections unmount on BOTH
-    // dialog close and every rail section switch (the keyed crossfade). The
-    // wider app's call sites are a separate tier and are not scanned here —
-    // pulls/ and repository/ carry converted-but-unguarded surfaces whose
-    // remaining bare .mutate( calls are deliberately callback-free, which a
-    // per-file allowlist cannot express.
-    appliesTo: (file) => file.startsWith("src/features/repo-settings/"),
+    // Scoped to the two trees that are fully converted, so the check can only
+    // ever see a NEW site: the settings dialog's own sections (which unmount on
+    // BOTH dialog close and every rail section switch — the keyed crossfade),
+    // and Explore, whose detail pane is keyed per repo. The wider app is a
+    // separate tier: pulls/ and repository/ still carry per-call callback sites
+    // in bulk, so scanning them would report a backlog rather than a regression.
+    // Each tree joins this check on the change that converts it.
+    appliesTo: (file) =>
+      file.startsWith("src/features/repo-settings/") ||
+      file.startsWith("src/features/explore/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],
     message:

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -270,7 +270,7 @@ export const CHECKS = [
       "setQueryData(key, undefined) is a silent no-op in TanStack v5 — snapshot and restore the previous value instead",
   },
   {
-    name: "mutate-in-repo-settings",
+    name: "bare-mutate-in-converted-trees",
     // Scoped to the two trees that are fully converted, so the check can only
     // ever see a NEW site: the settings dialog's own sections (which unmount on
     // BOTH dialog close and every rail section switch — the keyed crossfade),
@@ -284,7 +284,7 @@ export const CHECKS = [
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],
     message:
-      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close or rail section switch mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
+      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -43,7 +43,7 @@ function scanner(name) {
 const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
 const setQueryData = scanner("setQueryData-noop");
-const repoSettingsMutate = scanner("mutate-in-repo-settings");
+const bareMutate = scanner("bare-mutate-in-converted-trees");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -165,12 +165,12 @@ test("setQueryData-noop does not reach across a `;` statement boundary", () => {
   assert.deepEqual(setQueryData(source), []);
 });
 
-test("mutate-in-repo-settings flags every way a call reaches its callbacks", () => {
+test("bare-mutate-in-converted-trees flags every way a call reaches its callbacks", () => {
   // The reason this check matches the CALL and not the callbacks object: the
   // hoisted-options pair is the shape most of these sections used, and no
   // regex anchored on `onSuccess`/`onError` sees it.
   assert.deepEqual(
-    repoSettingsMutate(
+    bareMutate(
       'del.mutate(hook.id, { onSuccess: () => toast.success("x"), onError: e });',
     ),
     [1],
@@ -179,34 +179,34 @@ test("mutate-in-repo-settings flags every way a call reaches its callbacks", () 
     "const opts = { onSuccess: done, onError: toastError };",
     "update.mutate({ id, body }, opts);",
   ].join("\n");
-  assert.deepEqual(repoSettingsMutate(hoisted), [2]);
+  assert.deepEqual(bareMutate(hoisted), [2]);
   assert.deepEqual(
-    repoSettingsMutate("setEnforcement.mutate(vars, { onError: toastError });"),
+    bareMutate("setEnforcement.mutate(vars, { onError: toastError });"),
     [1],
   );
 });
 
-test("mutate-in-repo-settings flags a bare call carrying no callbacks", () => {
+test("bare-mutate-in-converted-trees flags a bare call carrying no callbacks", () => {
   // Deliberate: a fire-and-forget mutation here still loses nothing to the
   // unmount, but the ratchet stays a token match — an exemption is an
   // allowlist entry with rationale, not a hole in the pattern.
-  assert.deepEqual(repoSettingsMutate("ping.mutate(hook.id);"), [1]);
-  assert.deepEqual(repoSettingsMutate("refresh.mutate ();"), [1]);
+  assert.deepEqual(bareMutate("ping.mutate(hook.id);"), [1]);
+  assert.deepEqual(bareMutate("refresh.mutate ();"), [1]);
 });
 
-test("mutate-in-repo-settings catches the dot-less destructured route", () => {
+test("bare-mutate-in-converted-trees catches the dot-less destructured route", () => {
   // `const { mutate } = useX()` reaches the same call with no `.mutate` token
   // for the first pattern to see — a live idiom elsewhere under src/.
   assert.deepEqual(
-    repoSettingsMutate("const { mutate } = useUpdateLocalPr(repo);"),
+    bareMutate("const { mutate } = useUpdateLocalPr(repo);"),
     [1],
   );
   assert.deepEqual(
-    repoSettingsMutate("const { mutate: save } = useUpdateThing(repo);"),
+    bareMutate("const { mutate: save } = useUpdateThing(repo);"),
     [1],
   );
   assert.deepEqual(
-    repoSettingsMutate("const { isPending, mutate } = useX(repo);"),
+    bareMutate("const { isPending, mutate } = useX(repo);"),
     [1],
   );
   // Wrapped by the formatter: caught because this pattern reads the whole-file
@@ -217,23 +217,23 @@ test("mutate-in-repo-settings catches the dot-less destructured route", () => {
     "  isPending,",
     "} = useUpdateSomethingWithALongName(repoPath);",
   ].join("\n");
-  assert.deepEqual(repoSettingsMutate(wrapped), [1]);
+  assert.deepEqual(bareMutate(wrapped), [1]);
 });
 
-test("mutate-in-repo-settings leaves the awaited idiom and comments alone", () => {
+test("bare-mutate-in-converted-trees leaves the awaited idiom and comments alone", () => {
   const awaited = [
     "await update.mutateAsync(form);",
     'toast.success("Repository settings saved");',
   ].join("\n");
-  assert.deepEqual(repoSettingsMutate(awaited), []);
+  assert.deepEqual(bareMutate(awaited), []);
   // The `\b` after `mutate` is the whole reason the destructure pattern can
   // coexist with the idiom it is enforcing.
   assert.deepEqual(
-    repoSettingsMutate("const { mutateAsync } = useUpdateRepoSettings(repo);"),
+    bareMutate("const { mutateAsync } = useUpdateRepoSettings(repo);"),
     [],
   );
   assert.deepEqual(
-    repoSettingsMutate("const { mutateAsync, isPending } = useX(repo);"),
+    bareMutate("const { mutateAsync, isPending } = useX(repo);"),
     [],
   );
   const documented = [
@@ -241,7 +241,28 @@ test("mutate-in-repo-settings leaves the awaited idiom and comments alone", () =
     "// dropped when the observer unmounts.",
     "await save.mutateAsync(vars);",
   ].join("\n");
-  assert.deepEqual(repoSettingsMutate(documented), []);
+  assert.deepEqual(bareMutate(documented), []);
+});
+
+test("bare-mutate-in-converted-trees applies to the converted trees only", () => {
+  // The tier boundary is the deliberate part: the two converted trees are in,
+  // and the ones still carrying per-call callbacks in bulk are out until their
+  // own conversion lands. Widening this is a decision, not a drive-by.
+  const { appliesTo } = CHECKS.find(
+    (c) => c.name === "bare-mutate-in-converted-trees",
+  );
+  for (const file of [
+    "src/features/repo-settings/RulesetsSection.tsx",
+    "src/features/explore/ExploreDetail.tsx",
+  ]) {
+    assert.equal(appliesTo(file), true, `should scan ${file}`);
+  }
+  for (const file of [
+    "src/features/pulls/LocalPrView.tsx",
+    "src/features/repository/ChangesPanel.tsx",
+  ]) {
+    assert.equal(appliesTo(file), false, `should not scan ${file}`);
+  }
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -38,6 +38,10 @@ import { toastError } from "@/lib/toast";
 import type { ExploreCloneTarget } from "./ExploreCloneDialog";
 import { starParts } from "./explore-utils";
 
+/** The not-yet-clonable note, shared by the fork toast and the inline fork card
+ *  so the two can't drift. */
+const FORK_NOT_READY = "It may take a moment before the fork can be cloned.";
+
 /** The Explore detail pane: the selected repo's header, actions (clone / fork /
  *  star / view), and its lazily-fetched README. `features` gates fork/star, and
  *  `ownedNamespaces` (the screen's own-repos query) additionally gates fork; a
@@ -157,9 +161,7 @@ function ExploreDetailBody({
       });
       setForked(result);
       toast.success(`Forked to ${result.fullName}`, {
-        description: result.ready
-          ? undefined
-          : "It may take a moment before the fork can be cloned.",
+        description: result.ready ? undefined : FORK_NOT_READY,
       });
     } catch (e) {
       toastError(e);
@@ -296,7 +298,7 @@ function ExploreDetailBody({
           <p className="text-xs font-medium">Forked to {forked.fullName}</p>
           {!forked.ready && (
             <p className="text-[11px] text-muted-foreground">
-              It may take a moment before the fork can be cloned.
+              {FORK_NOT_READY}
             </p>
           )}
           <Button

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -5,6 +5,7 @@ import {
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
+import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
@@ -123,15 +124,24 @@ function ExploreDetailBody({
     canReadme,
   );
 
-  function toggleStar() {
-    starMutation.mutate({
-      provider,
-      owner: repo.owner,
-      name: repo.name,
-      star: !starred.data,
-    });
+  async function toggleStar() {
+    try {
+      await starMutation.mutateAsync({
+        provider,
+        owner: repo.owner,
+        name: repo.name,
+        star: !starred.data,
+      });
+    } catch (e) {
+      // The optimistic flip rolls back on failure, so without this the icon
+      // snaps back with nothing explaining why.
+      toastError(e);
+    }
   }
 
+  // Awaited, not per-call callbacks: this pane is keyed per repo and unmounts on
+  // a switch while the fork's readiness poll still runs, and react-query drops
+  // per-call callbacks once the observer has no listeners.
   async function onFork() {
     const ok = await useConfirm.getState().ask({
       title: `Fork ${repo.fullName}?`,
@@ -139,13 +149,21 @@ function ExploreDetailBody({
       confirmLabel: "Fork",
     });
     if (!ok) return;
-    fork.mutate(
-      { provider, owner: repo.owner, name: repo.name },
-      {
-        onSuccess: (result) => setForked(result),
-        onError: (e) => toastError(e),
-      },
-    );
+    try {
+      const result = await fork.mutateAsync({
+        provider,
+        owner: repo.owner,
+        name: repo.name,
+      });
+      setForked(result);
+      toast.success(`Forked to ${result.fullName}`, {
+        description: result.ready
+          ? undefined
+          : "It may take a moment before the fork can be cloned.",
+      });
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   // Only actionable once the starred state has resolved — a click on `undefined`

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -192,7 +192,8 @@ From here:
 - **Clone** — pick a folder to clone into; GitDesktop opens the repo once it finishes.
 - **Fork** — create a fork of the repository. On **GitHub** and **GitLab** it lands
   under your own account; on **Bitbucket** the host picks the destination workspace.
-  The fork is created in the background, and then you're offered to **clone** it. It
+  The fork is created in the background, and you'll be told how it went even if you've
+  moved on; while you're still on the repository, you're offered to **clone** it. It
   doesn't appear on a repository that already counts as yours, which each host defines
   its own way: on **GitHub** and **GitLab** that's your personal account or namespace
   (organization and group repositories stay forkable), and on **Bitbucket** it's any
@@ -223,10 +224,13 @@ like this:
 - **Access** — collaborators and their roles; invite someone at any level
   (Read / Triage / Write / Maintain / Admin), change a role inline, remove access, and
   manage pending invitations.
-- **Rules** — GitHub's branch **rulesets**: list them, flip enforcement
-  (Active / Evaluate / Disabled), and create or edit one (require a PR with approvals /
-  code-owner review, required status checks, block force pushes, restrict deletions,
-  linear history, signed commits).
+- **Rules** — GitHub's **rulesets**: list them, flip enforcement
+  (Active / Evaluate / Disabled), and create or edit a **branch** ruleset (require a PR
+  with approvals / code-owner review, required status checks, block force pushes,
+  restrict deletions, linear history, signed commits). Tag and push rulesets appear in
+  the list with the same enforcement control, and are edited on GitHub. Rulesets
+  inherited from an **organization** are read-only here, with their enforcement
+  shown as a badge.
 - **Security** — secret scanning (with AI detection and non-provider-pattern
   sub-toggles), push protection, code scanning, Dependabot alerts and security updates,
   and private vulnerability reporting, behind a save/discard bar. Dependabot **version

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -1,6 +1,7 @@
 import { CaretLeftIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -96,16 +97,12 @@ const BLANK: Draft = {
   requireSignatures: false,
 };
 
-const splitLines = (s: string) =>
-  s
-    .split(/[\n,]+/)
-    .map((x) => x.trim())
-    .filter(Boolean);
-
-/** Check contexts split on newlines only: a context can carry a comma of its own,
- *  because GitHub Actions builds a matrix job's name by joining its values with
- *  ", ". Splitting there would save contexts no run will ever report. */
-const splitCheckLines = (s: string) =>
+/** The one-per-line textareas split on newlines only, never commas: a check
+ *  context can carry one because GitHub Actions builds a matrix job's name by
+ *  joining its values with ", ", and a ref pattern can carry one because git
+ *  permits commas in refnames. Splitting there would save entries that nothing
+ *  ever matches. */
+const splitNonEmptyLines = (s: string) =>
   s
     .split(/\r?\n/)
     .map((x) => x.trim())
@@ -152,7 +149,7 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
   default: () => ["~DEFAULT_BRANCH"],
   all: () => ["~ALL"],
   custom: (d) =>
-    splitLines(d.customPatterns).map((p) =>
+    splitNonEmptyLines(d.customPatterns).map((p) =>
       p.startsWith("refs/") ? p : `refs/heads/${p}`,
     ),
 };
@@ -162,6 +159,19 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
  *  draft alone — the draft models a subset of each rule's fields. */
 const storedParameters = (original: RulesetFull | undefined, type: string) =>
   original?.rules?.find((r) => r.type === type)?.parameters;
+
+/** Whether the stored ruleset requires one check context through several entries
+ *  — GitHub allows a context per app (`integration_id`), which this editor shows
+ *  as repeated lines with nothing to tell them apart. */
+const hasRepeatedCheckContexts = (original: RulesetFull | undefined) => {
+  const stored =
+    (storedParameters(original, "required_status_checks")
+      ?.required_status_checks as { context: string }[] | undefined) ?? [];
+  const contexts = stored
+    .map((c) => c.context)
+    .filter((c) => typeof c === "string");
+  return new Set(contexts).size !== contexts.length;
+};
 
 function draftToBody(
   d: Draft,
@@ -205,7 +215,7 @@ function draftToBody(
         do_not_enforce_on_create: false,
         ...checks,
         strict_required_status_checks_policy: d.strictChecks,
-        required_status_checks: splitCheckLines(d.checkContexts).map(
+        required_status_checks: splitNonEmptyLines(d.checkContexts).map(
           (context) => storedChecks.get(context)?.shift() ?? { context },
         ),
       },
@@ -329,6 +339,9 @@ function RulesetList({
       >
         {rulesets.data?.map((rs) => {
           const org = rs.sourceType === "Organization";
+          // The editor models branch rulesets only — its scope control and rules
+          // are branch-shaped, and saving one converts a tag/push ruleset's target.
+          const canEdit = rs.target === "branch";
           return (
             <div
               key={rs.id}
@@ -374,13 +387,19 @@ function RulesetList({
                       ))}
                     </SelectContent>
                   </Select>
-                  <Button
+                  <DisabledReasonButton
                     size="sm"
                     variant="ghost"
+                    disabled={!canEdit}
+                    reason={
+                      canEdit
+                        ? null
+                        : "Only branch rulesets can be edited here — manage tag and push rulesets on GitHub."
+                    }
                     onClick={() => onEdit(rs.id)}
                   >
                     Edit
-                  </Button>
+                  </DisabledReasonButton>
                   <Button
                     size="sm"
                     variant="ghost"
@@ -410,16 +429,56 @@ function RulesetEditor({
   onDone: () => void;
 }) {
   const existing = useRuleset(repoPath, id);
-  if (id != null && existing.isLoading) {
-    return <Skeleton className="h-64 w-full" />;
-  }
+  // The form only ever mounts on loaded data: a save is a full-replace PUT built
+  // from `original`, so a form seeded blank would wipe the ruleset's bypass
+  // actors, unmodeled rules and conditions. (The create path fetches nothing.)
+  const body = (() => {
+    switch (true) {
+      case id != null && existing.isLoading:
+        return <Skeleton className="h-64 w-full" />;
+      // Gated on absent data, not on `isError`: a failed background refetch keeps
+      // the last good ruleset, and unmounting the form there would silently
+      // discard a half-authored draft.
+      case id != null && !existing.data:
+        return (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
+            <p className="font-medium text-destructive">
+              Couldn't load this ruleset.
+            </p>
+            {existing.error instanceof Error && (
+              <p className="mt-1 text-muted-foreground">
+                {existing.error.message}
+              </p>
+            )}
+            <p className="mt-2 text-muted-foreground">
+              Managing rulesets needs repo-admin access.
+            </p>
+          </div>
+        );
+      default:
+        return (
+          <RulesetForm
+            repoPath={repoPath}
+            id={id}
+            original={existing.data}
+            onDone={onDone}
+          />
+        );
+    }
+  })();
+
   return (
-    <RulesetForm
-      repoPath={repoPath}
-      id={id}
-      original={id != null ? existing.data : undefined}
-      onDone={onDone}
-    />
+    <div className="min-w-0 space-y-4">
+      <button
+        type="button"
+        onClick={onDone}
+        className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <CaretLeftIcon />
+        Back to rulesets
+      </button>
+      {body}
+    </div>
   );
 }
 
@@ -442,6 +501,7 @@ function RulesetForm({
     [original],
   );
   const [d, setD] = useState<Draft>(seed);
+  const repeatedChecks = hasRepeatedCheckContexts(original);
   const set = <K extends keyof Draft>(key: K, value: Draft[K]) =>
     setD((p) => ({ ...p, [key]: value }));
 
@@ -461,15 +521,6 @@ function RulesetForm({
 
   return (
     <div className="min-w-0 space-y-4">
-      <button
-        type="button"
-        onClick={onDone}
-        className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <CaretLeftIcon />
-        Back to rulesets
-      </button>
-
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label htmlFor="ruleset-name">Name</Label>
@@ -591,6 +642,12 @@ function RulesetForm({
               autoComplete="off"
               spellCheck={false}
             />
+            {repeatedChecks && (
+              <p className="text-[11px] text-muted-foreground">
+                This ruleset requires the same check from more than one app —
+                keep every line to keep them all.
+              </p>
+            )}
             <RuleToggle
               label="Require branches to be up to date before merging"
               checked={d.strictChecks}

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -125,11 +125,13 @@ function rulesetToDraft(rs: RulesetFull): Draft {
     : include.includes("~ALL")
       ? "all"
       : "custom";
-  const byType = (t: string) => rs.rules?.find((r) => r.type === t);
+  const rules = storedRules(rs);
+  const byType = (t: string) => rules.find((r) => r.type === t);
   const pr = byType("pull_request")?.parameters ?? {};
   const checks = byType("required_status_checks")?.parameters ?? {};
-  // A non-numeric stored count would reach the number Input as NaN and serialize
-  // back as null, so it falls back to the same 1 an absent value seeds.
+  // Seeds only a count the editor's own input accepts (a whole 0–10): anything
+  // else would reach the number Input as NaN or out of range and serialize back
+  // as null, so it falls back to the same 1 an absent value seeds.
   const approvals = Number(pr.required_approving_review_count ?? 1);
   return {
     name: rs.name ?? "",
@@ -140,7 +142,10 @@ function rulesetToDraft(rs: RulesetFull): Draft {
         ? include.map((p) => p.replace(/^refs\/heads\//, "")).join("\n")
         : "",
     requirePr: !!byType("pull_request"),
-    approvals: Number.isFinite(approvals) ? approvals : 1,
+    approvals:
+      Number.isInteger(approvals) && approvals >= 0 && approvals <= 10
+        ? approvals
+        : 1,
     dismissStale: !!pr.dismiss_stale_reviews_on_push,
     codeOwner: !!pr.require_code_owner_review,
     lastPush: !!pr.require_last_push_approval,
@@ -167,11 +172,25 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
     ),
 };
 
+type StoredRule = NonNullable<RulesetFull["rules"]>[number];
+
+/** The stored rules, normalized: a non-array `rules` or an element without a
+ *  string `type` throws on the render path, where the seed runs inside a useMemo
+ *  with no toast to catch it. Neither shape is reachable from GitHub, which types
+ *  every rule — and a typeless element is unusable anyway, since the editor and
+ *  the unmodeled-rule `extra` pass both key on `type`. */
+const storedRules = (original: RulesetFull | undefined): StoredRule[] => {
+  const rules = original?.rules;
+  return Array.isArray(rules)
+    ? rules.filter((r) => typeof r?.type === "string")
+    : [];
+};
+
 /** The stored parameters of one rule on the ruleset being edited. A save is a full
  *  PUT replace, so every managed rule is rebuilt FROM these rather than from the
  *  draft alone — the draft models a subset of each rule's fields. */
 const storedParameters = (original: RulesetFull | undefined, type: string) =>
-  original?.rules?.find((r) => r.type === type)?.parameters;
+  storedRules(original).find((r) => r.type === type)?.parameters;
 
 /** The stored required-status-check entries — the frontend's one reader of that
  *  raw array (the branch-rules surface reads it again in `github/rulesets.rs`),
@@ -253,7 +272,7 @@ function draftToBody(
   if (d.linearHistory) rules.push({ type: "required_linear_history" });
   if (d.requireSignatures) rules.push({ type: "required_signatures" });
   // Preserve rule types the editor doesn't model.
-  const extra = (original?.rules ?? []).filter(
+  const extra = storedRules(original).filter(
     (r) => !MANAGED_RULE_TYPES.includes(r.type),
   );
   return {

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -113,7 +113,13 @@ const splitNonEmptyLines = (s: string) =>
     .filter(Boolean);
 
 function rulesetToDraft(rs: RulesetFull): Draft {
-  const include = rs.conditions?.ref_name?.include ?? [];
+  // Stored JSON, checked at the array AND the element: this runs in a useMemo on
+  // the render path, where a throw reaches no toast — and the patterns below are
+  // string-replaced.
+  const storedInclude = rs.conditions?.ref_name?.include;
+  const include = Array.isArray(storedInclude)
+    ? storedInclude.filter((p): p is string => typeof p === "string")
+    : [];
   const refScope = include.includes("~DEFAULT_BRANCH")
     ? "default"
     : include.includes("~ALL")
@@ -178,8 +184,10 @@ const storedParameters = (original: RulesetFull | undefined, type: string) =>
 const storedCheckEntries = (
   original: RulesetFull | undefined,
 ): { context: string }[] => {
-  const stored = storedParameters(original, "required_status_checks")
-    ?.required_status_checks;
+  const stored = storedParameters(
+    original,
+    "required_status_checks",
+  )?.required_status_checks;
   if (!Array.isArray(stored)) return [];
   return stored.filter(
     (entry): entry is { context: string } => typeof entry?.context === "string",
@@ -449,7 +457,10 @@ function RulesetEditor({
   // actors, unmodeled rules and conditions. (The create path fetches nothing.)
   const body = (() => {
     switch (true) {
-      case id != null && existing.isLoading:
+      // `isPending`, not `isLoading`: a fetch react-query paused for being
+      // offline is neither loading nor errored, and the error arm below would
+      // blame permissions for it.
+      case id != null && existing.isPending:
         return <Skeleton className="h-64 w-full" />;
       // Gated on absent data, not on `isError`: a failed background refetch keeps
       // the last good ruleset, and unmounting the form there would silently

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/lib/git/queries";
 import type { RulesetEnforcement, RulesetFull } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { AsyncListBody, InlineConfirm } from "./parts";
+import { AsyncErrorCard, AsyncListBody, InlineConfirm } from "./parts";
 
 const ENFORCEMENTS: { value: RulesetEnforcement; label: string }[] = [
   { value: "active", label: "Active" },
@@ -47,6 +47,10 @@ const REF_SCOPE_ITEMS: Record<string, string> = {
   all: "All branches",
   custom: "Custom patterns…",
 };
+
+/** Shown by both ruleset surfaces when a load fails — a 403 is the likeliest
+ *  reason, and rulesets are admin-only on GitHub. */
+const ADMIN_HINT = "Managing rulesets needs repo-admin access.";
 
 /** Rule types we model in the editor. Any others on an edited ruleset are
  *  preserved untouched (so advanced rules aren't dropped). */
@@ -118,8 +122,9 @@ function rulesetToDraft(rs: RulesetFull): Draft {
   const byType = (t: string) => rs.rules?.find((r) => r.type === t);
   const pr = byType("pull_request")?.parameters ?? {};
   const checks = byType("required_status_checks")?.parameters ?? {};
-  const contexts =
-    (checks.required_status_checks as { context: string }[] | undefined) ?? [];
+  const contexts = (
+    (checks.required_status_checks as { context: string }[] | undefined) ?? []
+  ).filter((c): c is { context: string } => typeof c?.context === "string");
   return {
     name: rs.name ?? "",
     enforcement: (rs.enforcement as RulesetEnforcement) ?? "active",
@@ -160,16 +165,16 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
 const storedParameters = (original: RulesetFull | undefined, type: string) =>
   original?.rules?.find((r) => r.type === type)?.parameters;
 
-/** Whether the stored ruleset requires one check context through several entries
- *  — GitHub allows a context per app (`integration_id`), which this editor shows
- *  as repeated lines with nothing to tell them apart. */
+/** Whether the stored ruleset requires one check context through several entries.
+ *  Those usually differ only by their app pin (`integration_id`), which this
+ *  editor doesn't show — so they read as identical repeated lines. */
 const hasRepeatedCheckContexts = (original: RulesetFull | undefined) => {
   const stored =
     (storedParameters(original, "required_status_checks")
       ?.required_status_checks as { context: string }[] | undefined) ?? [];
   const contexts = stored
-    .map((c) => c.context)
-    .filter((c) => typeof c === "string");
+    .filter((c): c is { context: string } => typeof c?.context === "string")
+    .map((c) => c.context);
   return new Set(contexts).size !== contexts.length;
 };
 
@@ -335,7 +340,7 @@ function RulesetList({
         emptyLabel="No rulesets yet."
         skeletonClassName="h-12 w-full"
         errorTitle="Couldn't load rulesets."
-        errorHint="Managing rulesets needs repo-admin access."
+        errorHint={ADMIN_HINT}
       >
         {rulesets.data?.map((rs) => {
           const org = rs.sourceType === "Organization";
@@ -391,11 +396,7 @@ function RulesetList({
                     size="sm"
                     variant="ghost"
                     disabled={!canEdit}
-                    reason={
-                      canEdit
-                        ? null
-                        : "Only branch rulesets can be edited here — manage tag and push rulesets on GitHub."
-                    }
+                    reason="Only branch rulesets can be edited here — manage tag and push rulesets on GitHub."
                     onClick={() => onEdit(rs.id)}
                   >
                     Edit
@@ -441,19 +442,11 @@ function RulesetEditor({
       // discard a half-authored draft.
       case id != null && !existing.data:
         return (
-          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-            <p className="font-medium text-destructive">
-              Couldn't load this ruleset.
-            </p>
-            {existing.error instanceof Error && (
-              <p className="mt-1 text-muted-foreground">
-                {existing.error.message}
-              </p>
-            )}
-            <p className="mt-2 text-muted-foreground">
-              Managing rulesets needs repo-admin access.
-            </p>
-          </div>
+          <AsyncErrorCard
+            title="Couldn't load this ruleset."
+            error={existing.error}
+            hint={ADMIN_HINT}
+          />
         );
       default:
         return (
@@ -644,8 +637,8 @@ function RulesetForm({
             />
             {repeatedChecks && (
               <p className="text-[11px] text-muted-foreground">
-                This ruleset requires the same check from more than one app —
-                keep every line to keep them all.
+                This ruleset requires the same check more than once — keep every
+                line to keep them all.
               </p>
             )}
             <RuleToggle

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -129,9 +129,9 @@ function rulesetToDraft(rs: RulesetFull): Draft {
   const byType = (t: string) => rules.find((r) => r.type === t);
   const pr = byType("pull_request")?.parameters ?? {};
   const checks = byType("required_status_checks")?.parameters ?? {};
-  // A non-integer coercion (NaN) is the one stored count that must not seed the
-  // number Input: it renders blank and serializes back as null. The >= 0 floor is
-  // the only other normalization — a negative count is unproducible and invalid.
+  // The number Input seeds only from a whole count of 0 or more; anything else
+  // (NaN, a fraction, Infinity, a negative) falls back to 1. draftToBody refuses
+  // anything but a whole 0-10 on save, so no rejected shape reaches the wire.
   const approvals = Number(pr.required_approving_review_count ?? 1);
   return {
     name: rs.name ?? "",

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -129,9 +129,9 @@ function rulesetToDraft(rs: RulesetFull): Draft {
   const byType = (t: string) => rules.find((r) => r.type === t);
   const pr = byType("pull_request")?.parameters ?? {};
   const checks = byType("required_status_checks")?.parameters ?? {};
-  // Seeds only a count the editor's own input accepts (a whole 0–10): anything
-  // else would reach the number Input as NaN or out of range and serialize back
-  // as null, so it falls back to the same 1 an absent value seeds.
+  // A non-integer coercion (NaN) is the one stored count that must not seed the
+  // number Input: it renders blank and serializes back as null. The >= 0 floor is
+  // the only other normalization — a negative count is unproducible and invalid.
   const approvals = Number(pr.required_approving_review_count ?? 1);
   return {
     name: rs.name ?? "",
@@ -142,10 +142,7 @@ function rulesetToDraft(rs: RulesetFull): Draft {
         ? include.map((p) => p.replace(/^refs\/heads\//, "")).join("\n")
         : "",
     requirePr: !!byType("pull_request"),
-    approvals:
-      Number.isInteger(approvals) && approvals >= 0 && approvals <= 10
-        ? approvals
-        : 1,
+    approvals: Number.isInteger(approvals) && approvals >= 0 ? approvals : 1,
     dismissStale: !!pr.dismiss_stale_reviews_on_push,
     codeOwner: !!pr.require_code_owner_review,
     lastPush: !!pr.require_last_push_approval,
@@ -174,11 +171,11 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
 
 type StoredRule = NonNullable<RulesetFull["rules"]>[number];
 
-/** The stored rules, normalized: a non-array `rules` or an element without a
- *  string `type` throws on the render path, where the seed runs inside a useMemo
- *  with no toast to catch it. Neither shape is reachable from GitHub, which types
- *  every rule — and a typeless element is unusable anyway, since the editor and
- *  the unmodeled-rule `extra` pass both key on `type`. */
+/** The stored rules, normalized: a non-array `rules` or a null element throws on
+ *  the render path, where the seed runs inside a useMemo with no toast to catch
+ *  it. Neither shape is reachable from GitHub, which types every rule — and a
+ *  typeless element is unusable anyway, since the editor and the unmodeled-rule
+ *  `extra` pass both key on `type`. */
 const storedRules = (original: RulesetFull | undefined): StoredRule[] => {
   const rules = original?.rules;
   return Array.isArray(rules)
@@ -225,6 +222,14 @@ function draftToBody(
   d: Draft,
   original?: RulesetFull,
 ): Record<string, unknown> {
+  // Refused at the boundary the approvals input already draws, so a count outside
+  // it fails loudly here rather than as a 422 from GitHub.
+  if (
+    d.requirePr &&
+    (!Number.isInteger(d.approvals) || d.approvals < 0 || d.approvals > 10)
+  ) {
+    throw new Error("Required approvals must be a whole number from 0 to 10.");
+  }
   const include = REF_INCLUDES[d.refScope](d);
   const rules: Record<string, unknown>[] = [];
   if (d.requirePr) {
@@ -545,9 +550,9 @@ function RulesetForm({
   async function save() {
     try {
       // Inside the try: building the body reads the stored ruleset's own shape,
-      // and a malformed one (a `rules` that isn't an array, say) throws here —
-      // a toast beats a silent no-op. Check entries are the exception, being
-      // normalized before they reach this.
+      // and a malformed one (a `rules` that isn't an array, say) throws here, as
+      // does an out-of-range approval count in the draft — a toast beats both a
+      // silent no-op and a 422. Check entries are the exception, normalized first.
       const body = draftToBody(d, original);
       if (id != null) await update.mutateAsync({ id, body });
       else await create.mutateAsync(body);

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -122,9 +122,9 @@ function rulesetToDraft(rs: RulesetFull): Draft {
   const byType = (t: string) => rs.rules?.find((r) => r.type === t);
   const pr = byType("pull_request")?.parameters ?? {};
   const checks = byType("required_status_checks")?.parameters ?? {};
-  const contexts = (
-    (checks.required_status_checks as { context: string }[] | undefined) ?? []
-  ).filter((c): c is { context: string } => typeof c?.context === "string");
+  // A non-numeric stored count would reach the number Input as NaN and serialize
+  // back as null, so it falls back to the same 1 an absent value seeds.
+  const approvals = Number(pr.required_approving_review_count ?? 1);
   return {
     name: rs.name ?? "",
     enforcement: (rs.enforcement as RulesetEnforcement) ?? "active",
@@ -134,12 +134,14 @@ function rulesetToDraft(rs: RulesetFull): Draft {
         ? include.map((p) => p.replace(/^refs\/heads\//, "")).join("\n")
         : "",
     requirePr: !!byType("pull_request"),
-    approvals: Number(pr.required_approving_review_count ?? 1),
+    approvals: Number.isFinite(approvals) ? approvals : 1,
     dismissStale: !!pr.dismiss_stale_reviews_on_push,
     codeOwner: !!pr.require_code_owner_review,
     lastPush: !!pr.require_last_push_approval,
     requireChecks: !!byType("required_status_checks"),
-    checkContexts: contexts.map((c) => c.context).join("\n"),
+    checkContexts: storedCheckEntries(rs)
+      .map((c) => c.context)
+      .join("\n"),
     strictChecks: !!checks.strict_required_status_checks_policy,
     blockForcePush: !!byType("non_fast_forward"),
     restrictDeletions: !!byType("deletion"),
@@ -165,16 +167,30 @@ const REF_INCLUDES: Record<Draft["refScope"], (d: Draft) => string[]> = {
 const storedParameters = (original: RulesetFull | undefined, type: string) =>
   original?.rules?.find((r) => r.type === type)?.parameters;
 
+/** The stored required-status-check entries — the frontend's one reader of that
+ *  raw array (the branch-rules surface reads it again in `github/rulesets.rs`),
+ *  so the seed, the repeat check and the save can't diverge on its shape. An
+ *  entry without a string context is dropped rather than rebuilt into the PUT:
+ *  it names no check and carries no pin worth keeping (unmodeled RULES still
+ *  ride along via `extra`). A non-array value — never seen from GitHub, whose
+ *  schema always sends an array — normalizes to empty instead of blocking the
+ *  editor. */
+const storedCheckEntries = (
+  original: RulesetFull | undefined,
+): { context: string }[] => {
+  const stored = storedParameters(original, "required_status_checks")
+    ?.required_status_checks;
+  if (!Array.isArray(stored)) return [];
+  return stored.filter(
+    (entry): entry is { context: string } => typeof entry?.context === "string",
+  );
+};
+
 /** Whether the stored ruleset requires one check context through several entries.
  *  Those usually differ only by their app pin (`integration_id`), which this
  *  editor doesn't show — so they read as identical repeated lines. */
 const hasRepeatedCheckContexts = (original: RulesetFull | undefined) => {
-  const stored =
-    (storedParameters(original, "required_status_checks")
-      ?.required_status_checks as { context: string }[] | undefined) ?? [];
-  const contexts = stored
-    .filter((c): c is { context: string } => typeof c?.context === "string")
-    .map((c) => c.context);
+  const contexts = storedCheckEntries(original).map((c) => c.context);
   return new Set(contexts).size !== contexts.length;
 };
 
@@ -205,11 +221,8 @@ function draftToBody(
     // to one app (`integration_id`) and GitHub accepts several pins under a single
     // context, neither of which this editor displays, so a save must preserve every
     // entry rather than reduce a context to one. Fresh lines have no pin to keep.
-    const storedList =
-      (checks?.required_status_checks as { context: string }[] | undefined) ??
-      [];
     const storedChecks = new Map<string, { context: string }[]>();
-    for (const entry of storedList) {
+    for (const entry of storedCheckEntries(original)) {
       const queue = storedChecks.get(entry.context);
       if (queue) queue.push(entry);
       else storedChecks.set(entry.context, [entry]);
@@ -220,6 +233,7 @@ function draftToBody(
         do_not_enforce_on_create: false,
         ...checks,
         strict_required_status_checks_policy: d.strictChecks,
+        // After the spread on purpose: it replaces the raw stored array.
         required_status_checks: splitNonEmptyLines(d.checkContexts).map(
           (context) => storedChecks.get(context)?.shift() ?? { context },
         ),
@@ -500,8 +514,10 @@ function RulesetForm({
 
   async function save() {
     try {
-      // Inside the try: building the body reads the stored ruleset's own shape, so
-      // a malformed one must surface as a toast rather than a silent no-op.
+      // Inside the try: building the body reads the stored ruleset's own shape,
+      // and a malformed one (a `rules` that isn't an array, say) throws here —
+      // a toast beats a silent no-op. Check entries are the exception, being
+      // normalized before they reach this.
       const body = draftToBody(d, original);
       if (id != null) await update.mutateAsync({ id, body });
       else await create.mutateAsync(body);

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { highlightJson } from "@/features/diff/shiki-highlighter";
 import { copyText } from "@/lib/clipboard";
+import { presentError } from "@/lib/error-summary";
 import {
   isReconnectHostSafe,
   reconnectHostArg,
@@ -16,9 +17,11 @@ import { cn } from "@/lib/utils";
 
 /**
  * The destructive error card the repo-settings surfaces share: a title, the
- * rejection's message when it carries one (a Tauri IPC rejection is often a bare
- * string), then any hint. `children` render between the two — the slot the scope
- * note takes, which needs hooks the card itself has no business owning.
+ * failure as one humanized line, then any hint. `presentError` is what makes the
+ * line humanized, and it also reads the plain `AppError` object every `invoke`
+ * rejection carries, which an `instanceof Error` check would show nothing for.
+ * `children` render between message and hint — the slot the scope note takes,
+ * which needs hooks this card shouldn't own.
  */
 export function AsyncErrorCard({
   title,
@@ -35,8 +38,10 @@ export function AsyncErrorCard({
   return (
     <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
       <p className="font-medium text-destructive">{title}</p>
-      {error instanceof Error && (
-        <p className="mt-1 text-muted-foreground">{error.message}</p>
+      {error != null && (
+        <p className="mt-1 text-muted-foreground">
+          {presentError(error).summary}
+        </p>
       )}
       {children}
       {hint && <div className="mt-2 text-muted-foreground">{hint}</div>}

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -15,6 +15,36 @@ import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 
 /**
+ * The destructive error card the repo-settings surfaces share: a title, the
+ * rejection's message when it carries one (a Tauri IPC rejection is often a bare
+ * string), then any hint. `children` render between the two — the slot the scope
+ * note takes, which needs hooks the card itself has no business owning.
+ */
+export function AsyncErrorCard({
+  title,
+  error,
+  hint,
+  children,
+}: {
+  title: ReactNode;
+  error: unknown;
+  /** A closing note in the card's own muted style (permissions, next steps). */
+  hint?: ReactNode;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
+      <p className="font-medium text-destructive">{title}</p>
+      {error instanceof Error && (
+        <p className="mt-1 text-muted-foreground">{error.message}</p>
+      )}
+      {children}
+      {hint && <div className="mt-2 text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}
+
+/**
  * The shared loading / error / empty / list shell for the repo-settings async
  * lists (secrets, collaborators, rulesets, webhooks). Renders skeletons while
  * loading, a destructive error card (optionally with a `gh auth refresh` scope
@@ -57,16 +87,9 @@ export function AsyncListBody({
   }
   if (error) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">{errorTitle}</p>
-        {error instanceof Error && (
-          <p className="mt-1 text-muted-foreground">{error.message}</p>
-        )}
+      <AsyncErrorCard title={errorTitle} error={error} hint={errorHint}>
         {errorScope && <ScopeErrorHint scope={errorScope} />}
-        {errorHint && (
-          <div className="mt-2 text-muted-foreground">{errorHint}</div>
-        )}
-      </div>
+      </AsyncErrorCard>
     );
   }
   if (empty) {

--- a/src/features/repo-settings/parts.tsx
+++ b/src/features/repo-settings/parts.tsx
@@ -18,8 +18,8 @@ import { cn } from "@/lib/utils";
 /**
  * The destructive error card the repo-settings surfaces share: a title, the
  * failure as one humanized line, then any hint. `presentError` is what makes the
- * line humanized, and it also reads the plain `AppError` object every `invoke`
- * rejection carries, which an `instanceof Error` check would show nothing for.
+ * line humanized, and it reads the plain `AppError` object every `invoke`
+ * rejection carries, which is not an `Error` instance.
  * `children` render between message and hint — the slot the scope note takes,
  * which needs hooks this card shouldn't own.
  */

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -289,6 +289,38 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     return setForkOpen(true);
   };
 
+  // Awaited, not per-call callbacks: leaving the repository view (closing the
+  // repo, or moving to Explore/Settings/Help) unmounts this menu while the fork
+  // still polls for readiness, and react-query then drops per-call callbacks —
+  // origin is rewired either way, so the outcome must not depend on the menu.
+  async function doFork() {
+    try {
+      const url = await fork.mutateAsync(forkIntent === "contribute");
+      setForkOpen(false);
+      toast.success(
+        url
+          ? "Forked — your fork is now origin"
+          : "Fork already existed — remotes updated",
+        { description: url || undefined },
+      );
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  // Shared by the menu item and the hotkey so the two can't diverge, and awaited
+  // for the same reason as the fork above.
+  async function doStar() {
+    try {
+      await setStar.mutateAsync(!starred);
+      toast.success(
+        starred ? "Star removed" : `Starred ${gh.data?.repo ?? "repository"}`,
+      );
+    } catch (e) {
+      onError(e);
+    }
+  }
+
   // Every menu entry doubles as a hotkey/palette action with the same gates.
   useHotkeyAction("view-on-github", () => openWeb(), canGh);
   // create-issue is the in-app dialog (registered in RepositoryView + IssuesPanel);
@@ -319,20 +351,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("git-hooks", () => setHooksOpen(true));
   useHotkeyAction("submodules", () => setSubmodulesOpen(true), hasSubmodules);
   useHotkeyAction("worktrees", () => setWorktreesOpen(true));
-  useHotkeyAction(
-    "star-repository",
-    () =>
-      setStar.mutate(!starred, {
-        onSuccess: () =>
-          toast.success(
-            starred
-              ? "Star removed"
-              : `Starred ${gh.data?.repo ?? "repository"}`,
-          ),
-        onError,
-      }),
-    canStar && !setStar.isPending,
-  );
+  useHotkeyAction("star-repository", doStar, canStar && !setStar.isPending);
   useHotkeyAction("change-remote-url", () => setRemoteUrlOpen(true));
   useHotkeyAction("repo-alias", () => setAliasTarget(repoEntry));
   useHotkeyAction("copy-repo-path", () =>
@@ -380,20 +399,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
               View on {remoteLabel}
             </DropdownMenuItem>
             {canStar && (
-              <DropdownMenuItem
-                disabled={setStar.isPending}
-                onClick={() =>
-                  setStar.mutate(!starred, {
-                    onSuccess: () =>
-                      toast.success(
-                        starred
-                          ? "Star removed"
-                          : `Starred ${gh.data?.repo ?? "repository"}`,
-                      ),
-                    onError,
-                  })
-                }
-              >
+              <DropdownMenuItem disabled={setStar.isPending} onClick={doStar}>
                 <StarIcon weight={starred ? "fill" : "regular"} />
                 {starred ? "Unstar repository" : "Star repository"}
               </DropdownMenuItem>
@@ -674,23 +680,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
             >
               Cancel
             </Button>
-            <Button
-              disabled={fork.isPending}
-              onClick={() =>
-                fork.mutate(forkIntent === "contribute", {
-                  onSuccess: (url) => {
-                    setForkOpen(false);
-                    toast.success(
-                      url
-                        ? "Forked — your fork is now origin"
-                        : "Fork already existed — remotes updated",
-                      { description: url || undefined },
-                    );
-                  },
-                  onError,
-                })
-              }
-            >
+            <Button disabled={fork.isPending} onClick={doFork}>
               {fork.isPending && <Spinner data-icon="inline-start" />}
               Fork repository
             </Button>

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4967,8 +4967,14 @@ export function useCheckoutPr(repo: string, lens: RemoteLens) {
 }
 
 export function useForkRepo(repo: string) {
-  return useRepoMutation(repo, (contributeToParent: boolean) =>
-    api.ghRepoFork(repo, contributeToParent),
+  return useRepoMutation(
+    repo,
+    (contributeToParent: boolean) => api.ghRepoFork(repo, contributeToParent),
+    // `invalidate` replaces the default, so the repo subtree is named again
+    // alongside the own-repos list the new fork joins. GitHub by construction:
+    // the GitLab and Bitbucket menu arms open the host's fork page instead, so
+    // only GitHub reaches this gh-backed command.
+    { invalidate: [repoKeys.all(repo), ["forge-repos", "github"]] },
   );
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3099,14 +3099,21 @@ export function useStarRepo() {
 }
 
 /** Fork a repo by owner/name. Returns the {@link ForgeForkResult} so the caller
- *  can offer "Clone the fork" (and warn when it's not yet clonable). */
+ *  can offer "Clone the fork" (and warn when it's not yet clonable). The new fork
+ *  belongs in the provider's own-repos list; invalidating at the mutation level
+ *  keeps that refresh alive after the calling pane unmounts. */
 export function useForkRepoByName() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
       provider: ForgeProvider;
       owner: string;
       name: string;
     }) => api.forgeForkRepo(args.provider, args.owner, args.name),
+    onSettled: (_d, _e, args) =>
+      void queryClient.invalidateQueries({
+        queryKey: ["forge-repos", args.provider],
+      }),
   });
 }
 


### PR DESCRIPTION
Fork and star actions reported their outcome through per-call mutation callbacks, which react-query drops once the calling component unmounts, so navigating away mid-fork left the user with no result at all. This converts those call sites to awaited `mutateAsync`, moves the fork's cache refresh onto the mutation itself, and fixes a set of ruleset-editor defects around non-branch targets, load failures, and comma-containing patterns.

### Fork and star outcomes

- Rewrites `toggleStar` and `onFork` in `src/features/explore/ExploreDetail.tsx` to await `mutateAsync` inside `try`/`catch`; a successful fork now toasts `Forked to <fullName>` and notes when the fork isn't clonable yet, and a failed star reports the error instead of silently rolling the optimistic flip back.
- Extracts `doFork` and `doStar` in `src/features/repository/RepositoryMenu.tsx`, both awaited, and shares `doStar` between the `star-repository` hotkey action and the dropdown item so the two paths can't drift.
- Moves the own-repos refresh into `useForkRepoByName` in `src/lib/git/queries.ts`: an `onSettled` handler invalidates `["forge-repos", provider]` so the new fork appears even after the calling pane is gone.

### Ruleset editor (`src/features/repo-settings/RulesetsSection.tsx`)

- Restricts editing to branch rulesets: the Edit action becomes a `DisabledReasonButton` gated on `rs.target === "branch"`, since saving builds a branch-shaped body and would convert a tag or push ruleset's target. Enforcement stays editable in the list for every target.
- Hoists the "Back to rulesets" link out of `RulesetForm` into `RulesetEditor` so it's reachable while loading and on failure, and adds an error panel when the ruleset can't be loaded. The panel is gated on absent data rather than `isError`, keeping a half-authored draft alive through a failed background refetch.
- Replaces `splitLines` and `splitCheckLines` with a single newline-only `splitNonEmptyLines`, used for both custom ref patterns and required check contexts, so a comma inside a pattern or a matrix job name no longer splits it into entries nothing matches.
- Adds `hasRepeatedCheckContexts` and a hint under the check-contexts textarea explaining that duplicate lines represent the same check required from more than one app.

### Guardrails and documentation

- Extends the `mutate-in-repo-settings` check in `scripts/check-banned-patterns.mjs` to `src/features/explore/`, now that the tree is fully converted, and rewrites the scoping comment to explain why `pulls/` and `repository/` stay out.
- Updates the fork and Rules entries in `src/features/help/content.ts`: forks report their outcome even after you move on, and the Rules bullet distinguishes editable branch rulesets from tag/push rulesets and organization-inherited ones.
- Adds three fragments under `changelog.d/` (`fixed-fork-outcomes`, `fixed-ruleset-load-guard`, `fixed-ruleset-target-editing`).
- Records the Tailwind animation-override gotcha (`animate-none!`, since tw-merge doesn't dedupe the animate group) in `.claude/skills/gd-conventions/SKILL.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fork creation now shows readiness details, supports cloning while waiting, and refreshes repository listings automatically.
  * Star and fork actions provide clearer success and error notifications.
  * Ruleset editing supports branch patterns, preserves commas and hidden settings, and detects duplicate checks.
* **Bug Fixes**
  * Improved handling of unloadable rulesets and ruleset loading errors.
  * Non-branch rulesets are now protected from unsupported editing.
  * Improved display of actionable error details in repository settings.
* **Documentation**
  * Updated guidance for background forks, cloning, and tag, push, and inherited rulesets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->