### PR TITLE
fix(actions,explore,repo-settings,repository): report async outcomes after unmount

### DIFF
--- a/changelog.d/fixed-explore-fork-confirmation.md
+++ b/changelog.d/fixed-explore-fork-confirmation.md
@@ -1,0 +1,3 @@
+- Forking from Explore confirms once: the pane's fork card carries the result
+  and its Clone button, and a toast steps in only when you have already moved on
+  to another repository.

--- a/changelog.d/fixed-repo-menu-fork-gate.md
+++ b/changelog.d/fixed-repo-menu-fork-gate.md
@@ -1,0 +1,3 @@
+- On **Bitbucket**, the repository menu's **Fork** action goes by the workspaces you
+  belong to, so it's offered on repositories from elsewhere and stays out of the way
+  on the ones you already have access to.

--- a/changelog.d/fixed-repo-settings-error-messages.md
+++ b/changelog.d/fixed-repo-settings-error-messages.md
@@ -1,0 +1,3 @@
+- Repository settings name the reason a section failed to load: the message from
+  GitHub, GitLab, or Bitbucket now appears under the error heading, so a
+  permissions gap reads differently from a signed-out CLI or a network drop.

--- a/changelog.d/fixed-repo-settings-offline-loading.md
+++ b/changelog.d/fixed-repo-settings-offline-loading.md
@@ -1,3 +1,3 @@
 - Repository settings sections and lists keep their loading skeletons up while
   a fetch waits on a connection, so an offline or paused request reads as work
-  in progress rather than an empty panel.
+  in progress.

--- a/changelog.d/fixed-repo-settings-offline-loading.md
+++ b/changelog.d/fixed-repo-settings-offline-loading.md
@@ -1,0 +1,3 @@
+- Repository settings sections and lists keep their loading skeletons up while
+  a fetch waits on a connection, so an offline or paused request reads as work
+  in progress rather than an empty panel.

--- a/changelog.d/fixed-ruleset-editor-input-polish.md
+++ b/changelog.d/fixed-ruleset-editor-input-polish.md
@@ -1,0 +1,2 @@
+- The ruleset editor's required-approvals field settles on a whole number from 0
+  to 10 when you leave it, so you can clear it and retype freely while editing.

--- a/changelog.d/fixed-ruleset-editor-input-polish.md
+++ b/changelog.d/fixed-ruleset-editor-input-polish.md
@@ -1,2 +1,3 @@
-- The ruleset editor's required-approvals field settles on a whole number from 0
-  to 10 when you leave it, so you can clear it and retype freely while editing.
+- The ruleset editor keeps a required-approvals count you type to a whole number
+  from 0 to 10, and a stored count outside that range stays visible until you
+  correct it.

--- a/changelog.d/fixed-run-action-outcomes.md
+++ b/changelog.d/fixed-run-action-outcomes.md
@@ -1,0 +1,4 @@
+- Workflow-run actions report their outcome even if you move on while they're in
+  flight: re-running, cancelling, approving a held run, starting a manual job, or
+  dispatching a workflow now confirms (or explains a failure) after you switch
+  runs or close the dialog.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -271,16 +271,18 @@ export const CHECKS = [
   },
   {
     name: "bare-mutate-in-converted-trees",
-    // Scoped to the two trees that are fully converted, so the check can only
-    // ever see a NEW site: the settings dialog's own sections (which unmount on
-    // BOTH dialog close and every rail section switch — the keyed crossfade),
-    // and Explore, whose detail pane is keyed per repo. The wider app is a
-    // separate tier: pulls/ and repository/ still carry per-call callback sites
-    // in bulk, so scanning them would report a backlog rather than a regression.
-    // Each tree joins this check on the change that converts it.
+    // Scoped to the trees that are fully converted, so the check can only ever
+    // see a NEW site: the settings dialog's own sections (which unmount on BOTH
+    // dialog close and every rail section switch — the keyed crossfade), Explore,
+    // whose detail pane is keyed per repo, and Actions, whose run detail is keyed
+    // per run. The wider app is a separate tier: pulls/ and repository/ still
+    // carry per-call callback sites in bulk, so scanning them would report a
+    // backlog rather than a regression. Each tree joins this check on the change
+    // that converts it.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
-      file.startsWith("src/features/explore/"),
+      file.startsWith("src/features/explore/") ||
+      file.startsWith("src/features/actions/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],
     message:

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -275,10 +275,10 @@ export const CHECKS = [
     // see a NEW site: the settings dialog's own sections (which unmount on BOTH
     // dialog close and every rail section switch — the keyed crossfade), Explore,
     // whose detail pane is keyed per repo, and Actions, whose run detail is keyed
-    // per run. The wider app is a separate tier: pulls/ and repository/ still
-    // carry per-call callback sites in bulk, so scanning them would report a
-    // backlog rather than a regression. Each tree joins this check on the change
-    // that converts it.
+    // per run and whose dispatch dialog unmounts with the repo view. The wider app
+    // is a separate tier: pulls/ and repository/ still carry per-call callback
+    // sites in bulk, so scanning them would report a backlog rather than a
+    // regression. Each tree joins this check on the change that converts it.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -245,15 +245,16 @@ test("bare-mutate-in-converted-trees leaves the awaited idiom and comments alone
 });
 
 test("bare-mutate-in-converted-trees applies to the converted trees only", () => {
-  // The tier boundary is the deliberate part: the two converted trees are in,
-  // and the ones still carrying per-call callbacks in bulk are out until their
-  // own conversion lands. Widening this is a decision, not a drive-by.
+  // The tier boundary is the deliberate part: the converted trees are in, and
+  // the ones still carrying per-call callbacks in bulk are out until their own
+  // conversion lands. Widening this is a decision, not a drive-by.
   const { appliesTo } = CHECKS.find(
     (c) => c.name === "bare-mutate-in-converted-trees",
   );
   for (const file of [
     "src/features/repo-settings/RulesetsSection.tsx",
     "src/features/explore/ExploreDetail.tsx",
+    "src/features/actions/RunDetailView.tsx",
   ]) {
     assert.equal(appliesTo(file), true, `should scan ${file}`);
   }

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -361,49 +361,58 @@ export function RunDetailView({
   const canApprove =
     tabActive && approvalPending && !writeBlocked && !approveRun.isPending;
 
-  function doRerun(failedOnly: boolean) {
-    rerun.mutate(
-      { runId, failed: failedOnly },
-      {
-        onSuccess: () =>
-          toast.success(
-            provider === "gitlab"
-              ? "Retrying pipeline"
-              : provider === "bitbucket"
-                ? "Triggering a new pipeline"
-                : failedOnly
-                  ? "Re-running failed jobs"
-                  : "Re-running workflow",
-          ),
-        onError: toastError,
-      },
-    );
+  // Awaited, not per-call callbacks: this view is keyed per run and unmounts the
+  // moment another run is selected, and react-query drops per-call callbacks once
+  // the observer has no listeners.
+  async function doRerun(failedOnly: boolean) {
+    try {
+      await rerun.mutateAsync({ runId, failed: failedOnly });
+      toast.success(
+        (() => {
+          switch (true) {
+            case provider === "gitlab":
+              return "Retrying pipeline";
+            case provider === "bitbucket":
+              return "Triggering a new pipeline";
+            case failedOnly:
+              return "Re-running failed jobs";
+            default:
+              return "Re-running workflow";
+          }
+        })(),
+      );
+    } catch (e) {
+      toastError(e);
+    }
   }
 
-  function doCancel() {
-    cancel.mutate(runId, {
-      onSuccess: () => toast.success("Cancelling run…"),
-      onError: toastError,
-    });
+  async function doCancel() {
+    try {
+      await cancel.mutateAsync(runId);
+      toast.success("Cancelling run…");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
-  function doPlay(jobId: number) {
-    playJob.mutate(jobId, {
-      onSuccess: () => toast.success("Starting job…"),
-      onError: toastError,
-    });
+  async function doPlay(jobId: number) {
+    try {
+      await playJob.mutateAsync(jobId);
+      toast.success("Starting job…");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   async function doApprove() {
     const ok = await useConfirm.getState().ask(APPROVE_RUN_CONFIRM);
     if (!ok) return;
-    approveRun.mutate(
-      { runId },
-      {
-        onSuccess: () => toast.success("Workflow run approved."),
-        onError: toastError,
-      },
-    );
+    try {
+      await approveRun.mutateAsync({ runId });
+      toast.success("Workflow run approved.");
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   useHotkeyAction("approve-workflow-run", () => void doApprove(), canApprove);

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -367,20 +367,19 @@ export function RunDetailView({
   async function doRerun(failedOnly: boolean) {
     try {
       await rerun.mutateAsync({ runId, failed: failedOnly });
-      toast.success(
-        (() => {
-          switch (true) {
-            case provider === "gitlab":
-              return "Retrying pipeline";
-            case provider === "bitbucket":
-              return "Triggering a new pipeline";
-            case failedOnly:
-              return "Re-running failed jobs";
-            default:
-              return "Re-running workflow";
-          }
-        })(),
-      );
+      const message = (() => {
+        switch (true) {
+          case provider === "gitlab":
+            return "Retrying pipeline";
+          case provider === "bitbucket":
+            return "Triggering a new pipeline";
+          case failedOnly:
+            return "Re-running failed jobs";
+          default:
+            return "Re-running workflow";
+        }
+      })();
+      toast.success(message);
     } catch (e) {
       toastError(e);
     }

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -57,15 +57,14 @@ export function RunWorkflowDialog({
   const hasCustomPipelines = isBitbucket && pipelineNames.length > 0;
   const runWorkflow = useRunWorkflow(repoPath);
   const selectRun = useUiStore((s) => s.selectRun);
-  // Identity of the current open session: a fresh number on each open, null while
+  // Identity of the current open session: a fresh object on each open, null while
   // closed or unmounted. A mounted ref can't stand in for it — the panel renders
   // this dialog unconditionally, so closing it leaves the component mounted. Any
   // lifecycle that re-runs this effect also ends the session, landing the safe
   // arm: the toast still fires, only the navigation is skipped.
-  const openSeq = useRef(0);
-  const session = useRef<number | null>(null);
+  const session = useRef<object | null>(null);
   useEffect(() => {
-    session.current = open ? ++openSeq.current : null;
+    session.current = open ? {} : null;
     return () => {
       session.current = null;
     };

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -57,6 +57,19 @@ export function RunWorkflowDialog({
   const hasCustomPipelines = isBitbucket && pipelineNames.length > 0;
   const runWorkflow = useRunWorkflow(repoPath);
   const selectRun = useUiStore((s) => s.selectRun);
+  // Identity of the current open session: a fresh number on each open, null while
+  // closed or unmounted. A mounted ref can't stand in for it — the panel renders
+  // this dialog unconditionally, so closing it leaves the component mounted. Any
+  // lifecycle that re-runs this effect also ends the session, landing the safe
+  // arm: the toast still fires, only the navigation is skipped.
+  const openSeq = useRef(0);
+  const session = useRef<number | null>(null);
+  useEffect(() => {
+    session.current = open ? ++openSeq.current : null;
+    return () => {
+      session.current = null;
+    };
+  }, [open]);
 
   // Only active workflows are dispatchable.
   const dispatchable = (workflows.data ?? []).filter(
@@ -96,38 +109,54 @@ export function RunWorkflowDialog({
     }
   }, [open, workflow, dispatchable]);
 
-  function submit() {
+  // Awaited, not per-call callbacks: leaving the repo view mid-dispatch unmounts
+  // this panel, and react-query drops per-call callbacks once the observer has no
+  // listeners.
+  async function submit() {
     if ((!isPipelineProvider && !workflow) || !gitRef.trim()) return;
     const record: Record<string, string> = {};
     for (const { key, value } of inputs) {
       const k = key.trim();
       if (k) record[k] = value;
     }
-    runWorkflow.mutate(
-      {
-        // Bitbucket rides a custom-pipeline selector (or "" for the default) through
-        // the `workflow` arg; GitLab always sends "" (byte-identical); GitHub sends
-        // the selected workflow id.
-        workflow: isBitbucket ? pipeline : isPipelineProvider ? "" : workflow,
+    const dispatchedFrom = session.current;
+    // Bitbucket rides a custom-pipeline selector (or "" for the default) through
+    // the `workflow` arg; GitLab always sends "" (byte-identical); GitHub sends
+    // the selected workflow id.
+    const workflowArg = (() => {
+      switch (true) {
+        case isBitbucket:
+          return pipeline;
+        case isPipelineProvider:
+          return "";
+        default:
+          return workflow;
+      }
+    })();
+    try {
+      await runWorkflow.mutateAsync({
+        workflow: workflowArg,
         gitRef: gitRef.trim(),
         inputs: record,
-      },
-      {
-        onSuccess: () => {
-          toast.success(
-            isPipelineProvider ? "Pipeline started" : "Workflow dispatched",
-            {
-              description:
-                "It may take a few seconds to appear in the runs list.",
-            },
-          );
-          // Clear any stale selection so the new run is easy to spot.
-          selectRun(null);
-          onOpenChange(false);
+      });
+      toast.success(
+        isPipelineProvider ? "Pipeline started" : "Workflow dispatched",
+        {
+          description: "It may take a few seconds to appear in the runs list.",
         },
-        onError: toastError,
-      },
-    );
+      );
+      // The toast reports the dispatch wherever the user went; the navigation only
+      // applies to the dialog they are still in, so it is gated on the session that
+      // started it — a close, a reopen, or a tab switch mid-dispatch would
+      // otherwise wipe the run they picked meanwhile or close a reopened dialog.
+      if (dispatchedFrom !== null && session.current === dispatchedFrom) {
+        // Clear any stale selection so the new run is easy to spot.
+        selectRun(null);
+        onOpenChange(false);
+      }
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   const noneDispatchable =

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -4,7 +4,7 @@ import {
   StarIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
@@ -119,6 +119,16 @@ function ExploreDetailBody({
   const starMutation = useStarRepo();
   const fork = useForkRepoByName();
   const [forked, setForked] = useState<ForgeForkResult | null>(null);
+  // The fork card below is the in-pane confirmation, but this pane is keyed per
+  // repo and unmounts on a switch — so the toast covers only that case, and the
+  // ref is what tells the two apart once the fork resolves.
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   const readme = useRepoReadme(
     provider,
@@ -160,9 +170,13 @@ function ExploreDetailBody({
         name: repo.name,
       });
       setForked(result);
-      toast.success(`Forked to ${result.fullName}`, {
-        description: result.ready ? undefined : FORK_NOT_READY,
-      });
+      // Still here: the card says it, with the Clone action attached. Gone: the
+      // toast is the only surface left to say it.
+      if (!mounted.current) {
+        toast.success(`Forked to ${result.fullName}`, {
+          description: result.ready ? undefined : FORK_NOT_READY,
+        });
+      }
     } catch (e) {
       toastError(e);
     }
@@ -294,7 +308,13 @@ function ExploreDetailBody({
       </div>
 
       {forked && (
-        <div className="space-y-2 border border-success/40 bg-success/10 p-3">
+        // The card is the only confirmation while the pane is mounted, so it has to
+        // announce itself: the toast that would otherwise carry it fires only once
+        // this pane is gone.
+        <div
+          role="status"
+          className="space-y-2 border border-success/40 bg-success/10 p-3"
+        >
           <p className="text-xs font-medium">Forked to {forked.fullName}</p>
           {!forked.ready && (
             <p className="text-[11px] text-muted-foreground">

--- a/src/features/explore/ExploreDetail.tsx
+++ b/src/features/explore/ExploreDetail.tsx
@@ -169,10 +169,11 @@ function ExploreDetailBody({
         owner: repo.owner,
         name: repo.name,
       });
-      setForked(result);
       // Still here: the card says it, with the Clone action attached. Gone: the
       // toast is the only surface left to say it.
-      if (!mounted.current) {
+      if (mounted.current) {
+        setForked(result);
+      } else {
         toast.success(`Forked to ${result.fullName}`, {
           description: result.ready ? undefined : FORK_NOT_READY,
         });
@@ -307,38 +308,46 @@ function ExploreDetailBody({
         )}
       </div>
 
-      {forked && (
-        // The card is the only confirmation while the pane is mounted, so it has to
-        // announce itself: the toast that would otherwise carry it fires only once
-        // this pane is gone.
-        <div
-          role="status"
-          className="space-y-2 border border-success/40 bg-success/10 p-3"
-        >
-          <p className="text-xs font-medium">Forked to {forked.fullName}</p>
-          {!forked.ready && (
-            <p className="text-[11px] text-muted-foreground">
-              {FORK_NOT_READY}
-            </p>
-          )}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() =>
-              onClone({
-                provider,
-                cloneUrl: forked.cloneUrl,
-                // Use the fork's OWN name, not repo.name: GitHub renames a
-                // colliding fork (rust → rust-1), so the local folder must
-                // follow the fork's actual name segment.
-                name: forked.fullName.split("/").pop() ?? repo.name,
-              })
-            }
-          >
-            Clone the fork
-          </Button>
-        </div>
-      )}
+      {/* The card is the only confirmation while the pane is mounted (the toast
+          that would otherwise carry it fires once this pane is gone), so it has to
+          announce itself. Mounted unconditionally: a live region created together
+          with its text announces unreliably, so the region pre-exists and only its
+          CONTENT changes, and `sr-only` keeps the empty state out of layout. */}
+      <div
+        role="status"
+        className={
+          forked
+            ? "space-y-2 border border-success/40 bg-success/10 p-3"
+            : "sr-only"
+        }
+      >
+        {forked && (
+          <>
+            <p className="text-xs font-medium">Forked to {forked.fullName}</p>
+            {!forked.ready && (
+              <p className="text-[11px] text-muted-foreground">
+                {FORK_NOT_READY}
+              </p>
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                onClone({
+                  provider,
+                  cloneUrl: forked.cloneUrl,
+                  // Use the fork's OWN name, not repo.name: GitHub renames a
+                  // colliding fork (rust → rust-1), so the local folder must
+                  // follow the fork's actual name segment.
+                  name: forked.fullName.split("/").pop() ?? repo.name,
+                })
+              }
+            >
+              Clone the fork
+            </Button>
+          </>
+        )}
+      </div>
 
       {canReadme && (
         <>

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  EMPTY_NAMESPACES,
   useForgeProviderFeatures,
   useForgeRepos,
   useForgeSearchRepos,
@@ -48,10 +49,6 @@ import {
 
 type SortOption = "best" | "stars" | "updated";
 type ZeroMode = "yours" | "popular";
-
-/** Stable empty fallback, so a pending own-repos query doesn't hand the detail
- *  pane a fresh array identity on every render. */
-const EMPTY_NAMESPACES: readonly string[] = [];
 
 const SORT_ITEMS: Record<SortOption, string> = {
   best: "Best match",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -132,8 +132,8 @@ Click the **⋮** menu next to the repo name for repo-wide actions:
   **GitHub** repository you own personally, since the in-app fork always lands under
   your own account (organization repositories stay forkable), or on a **Bitbucket**
   repository in a workspace you belong to, which GitDesktop reads from your workspaces
-  on the host. The **GitLab** and **Bitbucket** fork pages ask where the fork should
-  go, so on GitLab the item stays offered on any project, including your own.
+  on the host. GitLab's fork page asks where the fork should go, so the item stays
+  offered on any project, including your own.
 - **Insights** (analytics), **manage files**, **submodules**, the **remote URL**,
   **branch rules**, **git hooks**, {{ai}}**automations**, {{/ai}}**repository settings**,
   an **alias**, copy the repo path, copy the branch name, copy the HEAD SHA, and

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -128,10 +128,12 @@ Click the **⋮** menu next to the repo name for repo-wide actions:
 - On the host: **Star** the repository, **create an issue**, or **Fork** it (on GitLab
   and Bitbucket, forking opens the web fork page). Bitbucket has no stars and its
   issue tracker is retired, so those two actions don't appear for Bitbucket repos.
-  **Fork** doesn't appear on a GitHub repository you own personally — the in-app fork
-  always lands under your own account (organization repositories stay forkable). The
-  web fork page asks where the fork should go, so the GitLab and Bitbucket items stay
-  available on any repository.
+  **Fork** is for repositories outside your own space. It doesn't come up on a
+  **GitHub** repository you own personally, since the in-app fork always lands under
+  your own account (organization repositories stay forkable), or on a **Bitbucket**
+  repository in a workspace you belong to, which GitDesktop reads from your workspaces
+  on the host. The **GitLab** and **Bitbucket** fork pages ask where the fork should
+  go, so on GitLab the item stays offered on any project, including your own.
 - **Insights** (analytics), **manage files**, **submodules**, the **remote URL**,
   **branch rules**, **git hooks**, {{ai}}**automations**, {{/ai}}**repository settings**,
   an **alias**, copy the repo path, copy the branch name, copy the HEAD SHA, and

--- a/src/features/repo-settings/BitbucketBranchRestrictionsSection.tsx
+++ b/src/features/repo-settings/BitbucketBranchRestrictionsSection.tsx
@@ -112,7 +112,7 @@ export function BitbucketBranchRestrictionsSection({
       </div>
 
       <AsyncListBody
-        loading={restrictions.isLoading}
+        loading={restrictions.isPending}
         error={restrictions.error}
         empty={restrictions.data?.length === 0}
         emptyLabel="No branch restrictions yet."

--- a/src/features/repo-settings/BitbucketDefaultReviewersSection.tsx
+++ b/src/features/repo-settings/BitbucketDefaultReviewersSection.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { presentError } from "@/lib/error-summary";
 import {
   useBbAddDefaultReviewer,
   useBbDefaultReviewers,
@@ -75,7 +76,7 @@ export function BitbucketDefaultReviewersSection({
       </div>
 
       <AsyncListBody
-        loading={reviewers.isLoading}
+        loading={reviewers.isPending}
         error={reviewers.error}
         empty={rows.length === 0}
         emptyLabel="No default reviewers — new pull requests start with no reviewers."
@@ -271,16 +272,14 @@ function AddReviewerPopover({
               aria-label="Member suggestions"
               className="mt-2 space-y-px"
             >
-              {candidates.isLoading && (
+              {candidates.isPending && (
                 <p className="px-2 py-1.5 text-xs text-muted-foreground">
                   Loading members…
                 </p>
               )}
               {candidates.isError && (
                 <p className="px-2 py-1.5 text-xs text-destructive">
-                  {candidates.error instanceof Error
-                    ? candidates.error.message
-                    : "Couldn't load members."}
+                  {presentError(candidates.error).summary}
                 </p>
               )}
               {suggestions.map((c, i) => {
@@ -311,7 +310,7 @@ function AddReviewerPopover({
                   </button>
                 );
               })}
-              {!candidates.isLoading &&
+              {!candidates.isPending &&
                 !candidates.isError &&
                 suggestions.length === 0 && (
                   <p className="px-2 py-1.5 text-xs text-muted-foreground">

--- a/src/features/repo-settings/BitbucketEnvironmentsSection.tsx
+++ b/src/features/repo-settings/BitbucketEnvironmentsSection.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/lib/git/queries";
 import type { BbEnvironment } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { PipelinesDisabledBanner } from "./BitbucketVariablesSection";
+import {
+  PipelinesConfigErrorCard,
+  PipelinesDisabledBanner,
+} from "./BitbucketVariablesSection";
 import { AsyncListBody } from "./parts";
 
 /** Bitbucket deployment environments (read-only). Environments are created and
@@ -41,6 +44,10 @@ export function BitbucketEnvironmentsSection({
     } catch (e) {
       toastError(e);
     }
+  }
+
+  if (config.isError && !config.data) {
+    return <PipelinesConfigErrorCard error={config.error} />;
   }
 
   if (config.data && !enabled) {
@@ -75,7 +82,7 @@ export function BitbucketEnvironmentsSection({
       </div>
 
       <AsyncListBody
-        loading={environments.isLoading}
+        loading={environments.isPending}
         error={environments.error}
         empty={environments.data?.length === 0}
         emptyLabel="No deployment environments."

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -28,6 +28,7 @@ import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
+import { AsyncErrorCard } from "./parts";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
 /** The Bitbucket counterpart of {@link GeneralSettingsSection}: Bitbucket's
@@ -44,7 +45,7 @@ export function BitbucketGeneralSection({
   const settings = useBbRepoSettings(repoPath, open);
   const branches = useBranches(repoPath);
 
-  if (settings.isLoading) {
+  if (settings.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-20 w-full" />
@@ -56,12 +57,7 @@ export function BitbucketGeneralSection({
 
   if (settings.isError || !settings.data) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load settings.</p>
-        <p className="mt-1 text-muted-foreground">
-          {settings.error instanceof Error ? settings.error.message : null}
-        </p>
-      </div>
+      <AsyncErrorCard title="Couldn't load settings." error={settings.error} />
     );
   }
 

--- a/src/features/repo-settings/BitbucketSchedulesSection.tsx
+++ b/src/features/repo-settings/BitbucketSchedulesSection.tsx
@@ -26,7 +26,10 @@ import {
 } from "@/lib/git/queries";
 import type { BitbucketPipelineSchedule } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { PipelinesDisabledBanner } from "./BitbucketVariablesSection";
+import {
+  PipelinesConfigErrorCard,
+  PipelinesDisabledBanner,
+} from "./BitbucketVariablesSection";
 import { AsyncListBody, InlineConfirm } from "./parts";
 
 const bbSchedulesKey = (repo: string) => ["repo", repo, "bb-schedules"];
@@ -113,6 +116,13 @@ export function BitbucketSchedulesSection({
     }
   }
 
+  // Ahead of the `creating` form as well as the banner: only a config that never
+  // loaded reaches here, and until it does this section can't tell whether
+  // schedules are available to create at all.
+  if (config.isError && !config.data) {
+    return <PipelinesConfigErrorCard error={config.error} />;
+  }
+
   if (config.data && !enabled) {
     return (
       <PipelinesDisabledBanner
@@ -149,7 +159,7 @@ export function BitbucketSchedulesSection({
       </div>
 
       <AsyncListBody
-        loading={schedules.isLoading}
+        loading={schedules.isPending}
         error={schedules.error}
         empty={schedules.data?.length === 0}
         emptyLabel="No schedules yet — a schedule runs a branch's pipeline on a recurring cron."

--- a/src/features/repo-settings/BitbucketVariablesSection.tsx
+++ b/src/features/repo-settings/BitbucketVariablesSection.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/lib/git/queries";
 import type { BitbucketPipelineVariable } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { AsyncListBody, InlineConfirm } from "./parts";
+import { AsyncErrorCard, AsyncListBody, InlineConfirm } from "./parts";
 
 function validKey(k: string): boolean {
   return /^[A-Za-z0-9_]{1,255}$/.test(k);
@@ -61,6 +61,10 @@ export function BitbucketVariablesSection({
     } catch (e) {
       toastError(e);
     }
+  }
+
+  if (config.isError && !config.data) {
+    return <PipelinesConfigErrorCard error={config.error} />;
   }
 
   if (config.data && !enabled) {
@@ -184,7 +188,7 @@ export function BitbucketVariablesSection({
       </div>
 
       <AsyncListBody
-        loading={variables.isLoading}
+        loading={variables.isPending}
         error={variables.error}
         empty={variables.data?.length === 0}
         emptyLabel="No pipeline variables yet."
@@ -351,6 +355,22 @@ function VariableRow({
         {variable.secured ? " (secured variables can't be un-secured)" : ""}
       </Label>
     </div>
+  );
+}
+
+/** The card the three Pipelines sections show when the availability check itself
+ *  failed. Every call site gates it on ABSENT config data, ahead of the disabled
+ *  banner: a read that never landed leaves `enabled` false with nothing to tell
+ *  it apart from "pipelines are off", and the section's list query stays
+ *  disabled while it is, so no other surface reports the failure. A failed
+ *  background REFETCH keeps the last good config, where tearing a working
+ *  section down would be wrong. */
+export function PipelinesConfigErrorCard({ error }: { error: unknown }) {
+  return (
+    <AsyncErrorCard
+      title="Couldn't check whether Pipelines are enabled."
+      error={error}
+    />
   );
 }
 

--- a/src/features/repo-settings/BitbucketWebhooksSection.tsx
+++ b/src/features/repo-settings/BitbucketWebhooksSection.tsx
@@ -98,7 +98,7 @@ export function BitbucketWebhooksSection({
       </div>
 
       <AsyncListBody
-        loading={hooks.isLoading}
+        loading={hooks.isPending}
         error={hooks.error}
         empty={hooks.data?.length === 0}
         emptyLabel="No webhooks yet."

--- a/src/features/repo-settings/CollaboratorsSection.tsx
+++ b/src/features/repo-settings/CollaboratorsSection.tsx
@@ -195,7 +195,7 @@ export function CollaboratorsSection({
       </div>
 
       <AsyncListBody
-        loading={collaborators.isLoading}
+        loading={collaborators.isPending}
         error={collaborators.error}
         empty={collaborators.data?.length === 0}
         emptyLabel="No collaborators yet."

--- a/src/features/repo-settings/FundingSection.tsx
+++ b/src/features/repo-settings/FundingSection.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { useDeleteFunding, useFunding, useSetFunding } from "@/lib/git/queries";
 import { toastError } from "@/lib/toast";
-import { InlineConfirm } from "./parts";
+import { AsyncErrorCard, InlineConfirm } from "./parts";
 
 const GITHUB_KEY = "github";
 const CUSTOM_KEY = "custom";
@@ -114,7 +114,7 @@ export function FundingSection({
 }) {
   const funding = useFunding(repoPath, open);
 
-  if (funding.isLoading) {
+  if (funding.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-9 w-full" />
@@ -125,12 +125,7 @@ export function FundingSection({
   }
   if (funding.isError) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load funding.</p>
-        <p className="mt-1 text-muted-foreground">
-          {funding.error instanceof Error ? funding.error.message : null}
-        </p>
-      </div>
+      <AsyncErrorCard title="Couldn't load funding." error={funding.error} />
     );
   }
 

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -29,6 +29,7 @@ import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
+import { AsyncErrorCard } from "./parts";
 import { GITHUB_TOPIC_RULES, TopicsField } from "./TopicsField";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
@@ -42,7 +43,7 @@ export function GeneralSettingsSection({
   const settings = useRepoSettings(repoPath, open);
   const branches = useBranches(repoPath);
 
-  if (settings.isLoading) {
+  if (settings.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-9 w-full" />
@@ -54,12 +55,7 @@ export function GeneralSettingsSection({
 
   if (settings.isError || !settings.data) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load settings.</p>
-        <p className="mt-1 text-muted-foreground">
-          {settings.error instanceof Error ? settings.error.message : null}
-        </p>
-      </div>
+      <AsyncErrorCard title="Couldn't load settings." error={settings.error} />
     );
   }
 

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -28,6 +28,7 @@ import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
+import { AsyncErrorCard } from "./parts";
 import { GITLAB_TOPIC_RULES, TopicsField } from "./TopicsField";
 import { useGenerateRepoDescription } from "./useGenerateRepoDescription";
 
@@ -45,7 +46,7 @@ export function GitLabGeneralSection({
   const settings = useGlRepoSettings(repoPath, open);
   const branches = useBranches(repoPath);
 
-  if (settings.isLoading) {
+  if (settings.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-9 w-full" />
@@ -57,12 +58,7 @@ export function GitLabGeneralSection({
 
   if (settings.isError || !settings.data) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load settings.</p>
-        <p className="mt-1 text-muted-foreground">
-          {settings.error instanceof Error ? settings.error.message : null}
-        </p>
-      </div>
+      <AsyncErrorCard title="Couldn't load settings." error={settings.error} />
     );
   }
 

--- a/src/features/repo-settings/GitLabMembersSection.tsx
+++ b/src/features/repo-settings/GitLabMembersSection.tsx
@@ -146,7 +146,7 @@ export function GitLabMembersSection({
       </div>
 
       <AsyncListBody
-        loading={members.isLoading}
+        loading={members.isPending}
         error={members.error}
         empty={members.data?.length === 0}
         emptyLabel="No members yet."

--- a/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
+++ b/src/features/repo-settings/GitLabProtectedBranchesSection.tsx
@@ -122,7 +122,7 @@ export function GitLabProtectedBranchesSection({
       </div>
 
       <AsyncListBody
-        loading={branches.isLoading}
+        loading={branches.isPending}
         error={branches.error}
         empty={branches.data?.length === 0}
         emptyLabel="No protected branches."

--- a/src/features/repo-settings/GitLabVariablesSection.tsx
+++ b/src/features/repo-settings/GitLabVariablesSection.tsx
@@ -158,7 +158,7 @@ export function GitLabVariablesSection({
       </div>
 
       <AsyncListBody
-        loading={variables.isLoading}
+        loading={variables.isPending}
         error={variables.error}
         empty={variables.data?.length === 0}
         emptyLabel="No CI/CD variables yet."

--- a/src/features/repo-settings/GitLabWebhooksSection.tsx
+++ b/src/features/repo-settings/GitLabWebhooksSection.tsx
@@ -126,7 +126,7 @@ export function GitLabWebhooksSection({
       </div>
 
       <AsyncListBody
-        loading={hooks.isLoading}
+        loading={hooks.isPending}
         error={hooks.error}
         empty={hooks.data?.length === 0}
         emptyLabel="No webhooks yet."
@@ -381,7 +381,7 @@ function HookDeliveries({
       </div>
 
       <AsyncListBody
-        loading={events.isLoading}
+        loading={events.isPending}
         error={events.error}
         empty={events.data?.length === 0}
         emptyLabel="No deliveries recorded yet — send a test event."

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/lib/git/queries";
 import type { PagesInfo } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { InlineConfirm } from "./parts";
+import { AsyncErrorCard, InlineConfirm } from "./parts";
 
 const PATHS = ["/", "/docs"];
 
@@ -46,7 +46,7 @@ export function PagesSection({
 }) {
   const pages = usePages(repoPath, open);
 
-  if (pages.isLoading) {
+  if (pages.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-9 w-full" />
@@ -56,14 +56,11 @@ export function PagesSection({
   }
   if (pages.isError) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load Pages.</p>
-        <p className="mt-1 text-muted-foreground">
-          {pages.error instanceof Error
-            ? pages.error.message
-            : "This needs repo-admin access."}
-        </p>
-      </div>
+      <AsyncErrorCard
+        title="Couldn't load Pages."
+        error={pages.error}
+        hint="This needs repo-admin access."
+      />
     );
   }
 

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { copyText } from "@/lib/clipboard";
+import { presentError } from "@/lib/error-summary";
 import {
   useCreateWebhook,
   useDeleteWebhook,
@@ -477,7 +478,7 @@ function WebhooksSection({
       </div>
 
       <AsyncListBody
-        loading={hooks.isLoading}
+        loading={hooks.isPending}
         error={hooks.error}
         empty={hooks.data?.length === 0}
         emptyLabel="No webhooks yet."
@@ -681,7 +682,7 @@ function DeliveriesView({
         </p>
       </div>
 
-      {deliveries.isLoading && (
+      {deliveries.isPending && (
         <div className="space-y-2">
           <Skeleton className="h-9 w-full" />
           <Skeleton className="h-9 w-full" />
@@ -689,9 +690,7 @@ function DeliveriesView({
       )}
       {deliveries.isError && (
         <p className="text-xs text-destructive">
-          {deliveries.error instanceof Error
-            ? deliveries.error.message
-            : "Couldn't load deliveries."}
+          {presentError(deliveries.error).summary}
         </p>
       )}
       {deliveries.data?.length === 0 && (
@@ -790,12 +789,10 @@ function DeliveryRow({
               Redeliver
             </Button>
           </div>
-          {detail.isLoading && <Skeleton className="h-16 w-full" />}
+          {detail.isPending && <Skeleton className="h-16 w-full" />}
           {detail.isError && (
             <p className="text-[11px] text-destructive">
-              {detail.error instanceof Error
-                ? detail.error.message
-                : "Couldn't load the payload."}
+              {presentError(detail.error).summary}
             </p>
           )}
           {detail.data && (

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -192,9 +192,12 @@ const storedParameters = (original: RulesetFull | undefined, type: string) =>
 /** The stored required-status-check entries — the frontend's one reader of that
  *  raw array (the branch-rules surface reads it again in `github/rulesets.rs`),
  *  so the seed, the repeat check and the save can't diverge on its shape. An
- *  entry without a string context is dropped rather than rebuilt into the PUT:
- *  it names no check and carries no pin worth keeping (unmodeled RULES still
- *  ride along via `extra`). A non-array value — never seen from GitHub, whose
+ *  entry whose context is missing or blank is dropped rather than rebuilt into
+ *  the PUT: it names no check and carries no pin worth keeping, and a blank one
+ *  would seed an invisible textarea line and count toward the repeated-context
+ *  hint (unmodeled RULES still ride along via `extra`). `splitNonEmptyLines`
+ *  drops the same lines on save, so seed and save stay in step. A non-array
+ *  value — never seen from GitHub, whose
  *  schema always sends an array — normalizes to empty instead of blocking the
  *  editor. */
 const storedCheckEntries = (
@@ -206,7 +209,8 @@ const storedCheckEntries = (
   )?.required_status_checks;
   if (!Array.isArray(stored)) return [];
   return stored.filter(
-    (entry): entry is { context: string } => typeof entry?.context === "string",
+    (entry): entry is { context: string } =>
+      typeof entry?.context === "string" && entry.context !== "",
   );
 };
 
@@ -380,7 +384,7 @@ function RulesetList({
       </div>
 
       <AsyncListBody
-        loading={rulesets.isLoading}
+        loading={rulesets.isPending}
         error={rulesets.error}
         empty={rulesets.data?.length === 0}
         emptyLabel="No rulesets yet."
@@ -563,8 +567,10 @@ function RulesetForm({
     }
   }
 
+  // No wrapper of its own: RulesetEditor, the only place this renders, already
+  // owns the `min-w-0 space-y-4` column these fields flow in.
   return (
-    <div className="min-w-0 space-y-4">
+    <>
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label htmlFor="ruleset-name">Name</Label>
@@ -643,14 +649,9 @@ function RulesetForm({
               <Label htmlFor="ruleset-approvals" className="text-xs">
                 Required approvals
               </Label>
-              <Input
-                id="ruleset-approvals"
-                type="number"
-                min={0}
-                max={10}
+              <ApprovalsInput
                 value={d.approvals}
-                onChange={(e) => set("approvals", Number(e.target.value))}
-                className="h-7 w-16"
+                onChange={(n) => set("approvals", n)}
               />
             </div>
             <RuleToggle
@@ -731,7 +732,55 @@ function RulesetForm({
           {id != null ? "Save ruleset" : "Create ruleset"}
         </Button>
       </div>
-    </div>
+    </>
+  );
+}
+
+const clampApprovals = (n: number) => Math.min(10, Math.max(0, Math.round(n)));
+
+/**
+ * The required-approvals count. `typed` holds the raw string while the field is
+ * edited, so the display never rewrites itself mid-entry; every value committed
+ * to the draft is clamped instead, so no save can carry an out-of-range count
+ * whatever order a blur and a click arrive in — deliberately: a save that beats
+ * the blur lands the clamped count, not the raw text still shown. Blur then
+ * normalizes the display, falling back to the committed count for an emptied
+ * field.
+ */
+function ApprovalsInput({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (n: number) => void;
+}) {
+  const [typed, setTyped] = useState<string | null>(null);
+  return (
+    <Input
+      id="ruleset-approvals"
+      type="number"
+      min={0}
+      max={10}
+      value={typed ?? value}
+      onChange={(e) => {
+        setTyped(e.target.value);
+        const n = Number(e.target.value);
+        if (e.target.value.trim() !== "" && Number.isFinite(n))
+          onChange(clampApprovals(n));
+      }}
+      onBlur={() => {
+        // `null` means untouched: no keystroke landed, so nothing was committed
+        // and a focus-then-leave must not rewrite a stored count the user hasn't
+        // edited (`draftToBody` refuses one above 10 at save).
+        if (typed === null) return;
+        const parsed = Number(typed);
+        const base =
+          typed.trim() !== "" && Number.isFinite(parsed) ? parsed : value;
+        onChange(clampApprovals(base));
+        setTyped(null);
+      }}
+      className="h-7 w-16"
+    />
   );
 }
 

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -202,7 +202,7 @@ const storedParameters = (original: RulesetFull | undefined, type: string) =>
  *  sends an array — normalizes to empty instead of blocking the editor. */
 const storedCheckEntries = (
   original: RulesetFull | undefined,
-): { context: string }[] => {
+): ({ context: string } & Record<string, unknown>)[] => {
   const stored = storedParameters(
     original,
     "required_status_checks",
@@ -260,7 +260,10 @@ function draftToBody(
     // to one app (`integration_id`) and GitHub accepts several pins under a single
     // context, neither of which this editor displays, so a save must preserve every
     // entry rather than reduce a context to one. Fresh lines have no pin to keep.
-    const storedChecks = new Map<string, { context: string }[]>();
+    const storedChecks = new Map<
+      string,
+      ({ context: string } & Record<string, unknown>)[]
+    >();
     for (const entry of storedCheckEntries(original)) {
       const queue = storedChecks.get(entry.context);
       if (queue) queue.push(entry);

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -191,14 +191,15 @@ const storedParameters = (original: RulesetFull | undefined, type: string) =>
 
 /** The stored required-status-check entries — the frontend's one reader of that
  *  raw array (the branch-rules surface reads it again in `github/rulesets.rs`),
- *  so the seed, the repeat check and the save can't diverge on its shape. An
- *  entry whose context is missing or blank is dropped rather than rebuilt into
- *  the PUT: it names no check and carries no pin worth keeping, and a blank one
- *  would seed an invisible textarea line and count toward the repeated-context
- *  hint (unmodeled RULES still ride along via `extra`). `splitNonEmptyLines`
- *  drops the same lines on save, so seed and save stay in step. A non-array
- *  value — never seen from GitHub, whose schema always sends an array —
- *  normalizes to empty instead of blocking the editor. */
+ *  so the seed, the repeat check and the save can't diverge on its shape.
+ *  Contexts are trimmed here and blank ones dropped, matching
+ *  `splitNonEmptyLines` on both axes: the save looks a stored entry up BY this
+ *  context, so an untrimmed " ci " would miss the lookup for the "ci" its own
+ *  textarea line round-trips and rebuild the entry without its `integration_id`
+ *  pin. A blank entry names no check and would seed an invisible line that still
+ *  counts toward the repeated-context hint (unmodeled RULES ride along via
+ *  `extra`). A non-array value — never seen from GitHub, whose schema always
+ *  sends an array — normalizes to empty instead of blocking the editor. */
 const storedCheckEntries = (
   original: RulesetFull | undefined,
 ): { context: string }[] => {
@@ -207,10 +208,13 @@ const storedCheckEntries = (
     "required_status_checks",
   )?.required_status_checks;
   if (!Array.isArray(stored)) return [];
-  return stored.filter(
-    (entry): entry is { context: string } =>
-      typeof entry?.context === "string" && entry.context !== "",
-  );
+  return stored.flatMap((entry) => {
+    if (typeof entry?.context !== "string") return [];
+    const context = entry.context.trim();
+    // Spread first: an entry's unmodeled fields (`integration_id`) are the whole
+    // reason the save reuses it rather than rebuilding from the context alone.
+    return context === "" ? [] : [{ ...entry, context }];
+  });
 };
 
 /** Whether the stored ruleset requires one check context through several entries.

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -197,9 +197,8 @@ const storedParameters = (original: RulesetFull | undefined, type: string) =>
  *  would seed an invisible textarea line and count toward the repeated-context
  *  hint (unmodeled RULES still ride along via `extra`). `splitNonEmptyLines`
  *  drops the same lines on save, so seed and save stay in step. A non-array
- *  value — never seen from GitHub, whose
- *  schema always sends an array — normalizes to empty instead of blocking the
- *  editor. */
+ *  value — never seen from GitHub, whose schema always sends an array —
+ *  normalizes to empty instead of blocking the editor. */
 const storedCheckEntries = (
   original: RulesetFull | undefined,
 ): { context: string }[] => {

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -260,7 +260,7 @@ function SecretsList({
       </div>
 
       <AsyncListBody
-        loading={secrets.isLoading}
+        loading={secrets.isPending}
         error={secrets.error}
         empty={secrets.data?.length === 0}
         emptyLabel="No secrets here yet."
@@ -365,7 +365,7 @@ function VariablesList({
       </div>
 
       <AsyncListBody
-        loading={variables.isLoading}
+        loading={variables.isPending}
         error={variables.error}
         empty={variables.data?.length === 0}
         emptyLabel="No variables here yet."

--- a/src/features/repo-settings/SecuritySection.tsx
+++ b/src/features/repo-settings/SecuritySection.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/lib/git/queries";
 import type { SecurityFeature, SecurityStatus } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
-import { InlineConfirm } from "./parts";
+import { AsyncErrorCard, InlineConfirm } from "./parts";
 
 /** Dependabot / dependency-graph options GitHub exposes to NO repo-level API —
  *  they're web-UI-only. (Version updates is handled by the dependabot.yml
@@ -158,7 +158,7 @@ export function SecuritySection({
 }) {
   const security = useSecurity(repoPath, open);
 
-  if (security.isLoading) {
+  if (security.isPending) {
     return (
       <div className="min-w-0 space-y-3">
         <Skeleton className="h-12 w-full" />
@@ -169,15 +169,11 @@ export function SecuritySection({
   }
   if (security.isError || !security.data) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs">
-        <p className="font-medium text-destructive">Couldn't load security.</p>
-        <p className="mt-1 text-muted-foreground">
-          {security.error instanceof Error ? security.error.message : null}
-        </p>
-        <p className="mt-2 text-muted-foreground">
-          These settings need repo-admin access.
-        </p>
-      </div>
+      <AsyncErrorCard
+        title="Couldn't load security."
+        error={security.error}
+        hint="These settings need repo-admin access."
+      />
     );
   }
 
@@ -234,7 +230,7 @@ function DependabotVersionUpdates({
     }
   }
 
-  if (config.isLoading) return null;
+  if (config.isPending) return null;
   const exists = config.data != null;
 
   return (

--- a/src/features/repository/GenerateBranchNameButton.tsx
+++ b/src/features/repository/GenerateBranchNameButton.tsx
@@ -195,10 +195,10 @@ export function GenerateBranchNameButton({
           size="xs"
           className="text-muted-foreground"
           disabled={!action.enabled}
+          reason={reason}
           // `reason` doubles as the enabled-state hint ("Suggest a name from…"),
           // which is where the chord belongs — a disabled button's shortcut does
           // nothing, so it isn't offered.
-          reason={action.enabled ? null : reason}
           title={action.enabled ? `${reason}${hint}` : reason}
           onClick={action.run}
         >

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -60,8 +60,10 @@ import {
   openWithProgram,
 } from "@/lib/git/api";
 import {
+  EMPTY_NAMESPACES,
   forgeFeatureReady,
   forgeSupports,
+  useForgeRepos,
   useForgeStatus,
   useForkRepo,
   useRepoAdmin,
@@ -122,6 +124,8 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const repoName = useUiStore((s) => s.repoName);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
   const fork = useForkRepo(repoPath);
+  // The Fork item's verdict, sampled when the dropdown opens (see `canForkHere`).
+  const [forkWhileOpen, setForkWhileOpen] = useState(false);
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [jiraOpen, setJiraOpen] = useState(false);
   const [repoSettingsOpen, setRepoSettingsOpen] = useState(false);
@@ -181,19 +185,24 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const remoteLabel = providerLabel(provider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");
-  // The in-app fork dialog always creates the fork under your own account, so a
-  // repo you own personally is never a valid target (org repos stay forkable).
-  // The GitLab/Bitbucket web arms offer a namespace choice, so they stay put.
-  const ownRepo =
-    !!gh.data?.repo &&
-    !!gh.data?.login &&
-    gh.data.repo.split("/")[0] === gh.data.login;
+  const owner = gh.data?.repo?.split("/")[0];
+  const ownRepo = !!owner && !!gh.data?.login && owner === gh.data.login;
+  // Bitbucket's `login` is a /user username (a display name where that's absent) and
+  // never matches the workspace slug a repo carries, so its ownership answer can only
+  // come from the workspaces you belong to. Fetched for every Bitbucket repo rather
+  // than on menu-open, because the palette twin below reads the verdict with no menu
+  // to trigger one. Unresolved (empty) falls open.
+  const ownRepos = useForgeRepos("bitbucket", canGh && isBitbucket);
+  const ownedNamespaces = ownRepos.data?.ownedNamespaces ?? EMPTY_NAMESPACES;
+  // GitHub: the in-app dialog always forks under your own account, so a repo you own
+  // personally is never a target (org repos stay forkable). GitLab: its fork page picks
+  // the destination namespace, and forking your own project into a group you own is
+  // supported, so the web arm stays offered on everything.
+  const ownedHere = isBitbucket
+    ? ownedNamespaces.length > 0 && !!owner && ownedNamespaces.includes(owner)
+    : ownRepo && !isGitLab;
   // One predicate for the menu item and its palette twin, so the two can't drift.
-  // Bitbucket bypasses the ownership test rather than trusting `ownRepo` to fall
-  // false: its `login` is a /user username (a display name where that's absent), which
-  // doesn't line up with the workspace slug a repo's owner carries. Explore's Fork
-  // gate needs the real answer and gets it from a membership set instead.
-  const canForkHere = canGh && (isGitLab || isBitbucket || !ownRepo);
+  const canForkHere = canGh && !ownedHere;
   const starStatus = useRepoStarStatus(repoPath, canStar);
   const setStar = useSetRepoStar(repoPath);
   const starred = starStatus.data ?? false;
@@ -371,11 +380,16 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
 
   return (
     <DropdownMenu
-      onOpenChange={(menuOpen) => {
+      onOpenChange={(open) => {
+        // Two sampling points, one predicate: the palette reads `canForkHere` live,
+        // while the menu renders the value it opened with, so a Bitbucket workspace
+        // read landing mid-open can't drop an item out from under the cursor (and out
+        // from under the arrow-key index).
+        setForkWhileOpen(open && canForkHere);
         // Warm the repo-settings chunk while the menu is up, so the click that
         // opens the dialog renders it directly instead of suspending on it.
         // Gated like the item itself: a non-admin has nothing to open.
-        if (menuOpen && canOpenRepoSettings) {
+        if (open && canOpenRepoSettings) {
           warmRepoSettingsDialog((dialog) => setReadyDialog(() => dialog));
         }
       }}
@@ -414,7 +428,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
                 Create issue on {remoteLabel}
               </DropdownMenuItem>
             )}
-            {canForkHere &&
+            {forkWhileOpen &&
               (isGitLab || isBitbucket ? (
                 // The fork dialog's flow (fork + rewire remotes + set-default) is
                 // GitHub-only; GitLab/Bitbucket fork from their web page instead of

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -198,8 +198,11 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // personally is never a target (org repos stay forkable). GitLab: its fork page picks
   // the destination namespace, and forking your own project into a group you own is
   // supported, so the web arm stays offered on everything.
+  // Case-folded: the API's slugs are canonical lowercase, while `owner` is whatever
+  // the origin remote spells (`workspace_slug` hands back the URL segment verbatim).
+  const ownerKey = owner?.toLowerCase();
   const ownedHere = isBitbucket
-    ? ownedNamespaces.length > 0 && !!owner && ownedNamespaces.includes(owner)
+    ? ownedNamespaces.some((n) => n.toLowerCase() === ownerKey)
     : ownRepo && !isGitLab;
   // One predicate for the menu item and its palette twin, so the two can't drift.
   const canForkHere = canGh && !ownedHere;

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2984,6 +2984,10 @@ export function useGhRepos(enabled: boolean) {
   });
 }
 
+/** Stable fallback for an unresolved {@link useForgeRepos} read, so a pending
+ *  query doesn't hand its consumers a fresh array identity every render. */
+export const EMPTY_NAMESPACES: readonly string[] = [];
+
 /** The signed-in user's repositories on a provider (GitHub via gh, GitLab via
  *  glab), for the clone browser. The provider-neutral successor to
  *  {@link useGhRepos} on that surface. */

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2989,8 +2989,9 @@ export function useGhRepos(enabled: boolean) {
 export const EMPTY_NAMESPACES: readonly string[] = [];
 
 /** The signed-in user's repositories on a provider (GitHub via gh, GitLab via
- *  glab), for the clone browser. The provider-neutral successor to
- *  {@link useGhRepos} on that surface. */
+ *  glab), for the clone browser — and its `ownedNamespaces` feeds the repo
+ *  menu's Fork gate. The provider-neutral successor to {@link useGhRepos} on
+ *  that surface. */
 export function useForgeRepos(provider: ForgeProvider, enabled: boolean) {
   return useQuery({
     queryKey: ["forge-repos", provider] as const,


### PR DESCRIPTION
Mutations in Actions and Explore hung their success/error toasts off per-call react-query callbacks, which the library drops once the observer loses its last listener, so switching runs or closing a dialog mid-flight swallowed the result. This converts those call sites to awaited `mutateAsync` and tightens the async state around them: repository settings keep skeletons up while a fetch is paused and surface the host's error message, and the repo menu's Fork item goes by real Bitbucket workspace membership.

### Workflow-run actions

- Rewrites `doRerun`, `doCancel`, `doPlay` and `doApprove` in `src/features/actions/RunDetailView.tsx` as awaited `mutateAsync` calls in `try`/`catch`, so re-running, cancelling, starting a manual job and approving a held run still confirm (or explain a failure) after the run-keyed view unmounts.
- `submit` in `src/features/actions/RunWorkflowDialog.tsx` awaits the dispatch the same way, and gates the follow-up navigation (`selectRun(null)` + `onOpenChange(false)`) on an open-session id held in the new `openSeq`/`session` refs, so a close, reopen or tab switch mid-dispatch keeps the toast while leaving the current selection alone.
- Replaces the nested ternaries in both files (the rerun toast copy, the `workflow` argument) with the `switch (true)` IIFE idiom.

### Explore fork confirmation

- `ExploreDetailBody` in `src/features/explore/ExploreDetail.tsx` tracks a `mounted` ref and fires the "Forked to …" toast only once the per-repo pane has been keyed away; while it is up, the fork card carries the result and its Clone button, now with `role="status"` so it announces itself.

### Repository menu Fork gate

- `src/features/repository/RepositoryMenu.tsx` derives Bitbucket ownership from `useForgeRepos("bitbucket")`'s `ownedNamespaces` instead of bypassing the ownership test, so Fork appears on repositories outside your workspaces and stays hidden on the ones you belong to; GitHub keeps the personal-account rule and GitLab's web arm stays offered on every project.
- Samples that verdict into `forkWhileOpen` in `onOpenChange`, so a workspace read landing mid-open can't drop the item out from under the cursor or the arrow-key index, while the palette twin keeps reading `canForkHere` live.
- Moves `EMPTY_NAMESPACES` out of `ExploreScreen.tsx` into `src/lib/git/queries.ts` as a shared export, so both consumers get a stable identity for an unresolved read.
- `GenerateBranchNameButton.tsx` passes `reason` to `DisabledReasonButton` in both states rather than only when disabled.

### Repository settings async state

- Swaps `isLoading` for `isPending` across the sections and lists — the `AsyncListBody` `loading` props plus the section guards in `GeneralSettingsSection`, `GitLabGeneralSection`, `BitbucketGeneralSection`, `FundingSection`, `PagesSection`, `SecuritySection`, `SecretsSection`, `RulesetsSection`, `CollaboratorsSection`, the GitLab/Bitbucket webhook, member, variable, restriction and schedule sections, and `RepoSettingsDialog`'s webhook and delivery views — so a request waiting on a connection reads as work in progress instead of an empty panel.
- Routes bespoke error markup through the shared `AsyncErrorCard` (with `hint` for the admin-access notes in `PagesSection` and `SecuritySection`) and through `presentError(...).summary` in `BitbucketDefaultReviewersSection` and `RepoSettingsDialog`, so the provider's message reaches the user.
- Adds `PipelinesConfigErrorCard` to `BitbucketVariablesSection` and renders it from the Variables, Schedules and Environments sections when the pipelines-availability check fails with no cached config, a case that previously fell through to the "pipelines are off" banner.

### Ruleset editor

- Extracts `ApprovalsInput` in `RulesetsSection.tsx`: the raw string lives in local state while the field is edited and every committed value is clamped to a whole 0–10, so the count can be cleared and retyped without the display rewriting itself, and a save that beats the blur still lands a clamped value.
- `storedCheckEntries` now drops blank status-check contexts as well as missing ones, matching what `splitNonEmptyLines` drops on save; `RulesetForm` returns a fragment since `RulesetEditor` already owns the `min-w-0 space-y-4` column.

### Guardrails and docs

- Widens the `bare-mutate-in-converted-trees` check in `scripts/check-banned-patterns.mjs` to `src/features/actions/` now that the tree is converted, with the matching case added in `scripts/checks.test.mjs`.
- Updates the repository-menu Fork paragraph in `src/features/help/content.ts` to describe the per-provider gate, including the Bitbucket workspace rule.
- Adds six `changelog.d/fixed-*.md` fragments covering the run actions, the Explore fork confirmation, the Bitbucket fork gate, settings error messages, offline loading and the approvals field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fork confirmations with clearer in-page results and appropriately timed notifications.
  - Refined repository fork availability across GitHub, GitLab, and Bitbucket.
  - Improved repository settings loading states and error messages, including offline and pipeline configuration failures.
  - Workflow actions now report success or failure reliably, including reruns, cancellations, approvals, and dispatches.
  - Prevented stale workflow dialogs from changing after being reopened.
  - Improved ruleset approval input handling and validation.
  - Preserved helpful branch-name guidance when buttons are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->