### PR TITLE
feat(conversations,markdown): add mention autocomplete and a collapsible comment composer

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -177,6 +177,14 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   that lived in them silently never runs. The house idiom is `form.ts`'s
   awaited-submit convention (`SquashDialog` in
   `src/features/history/RewriteDialogs.tsx` is the reference).
+- A follow-up that needs the DOM from a state flip (focus a just-revealed
+  input, re-pin a grown scroll region) never rides a bare
+  `requestAnimationFrame` from the event handler: when the state lives in
+  react-query, the notify-batched re-render can land AFTER that rAF, so the
+  callback hits a still-hidden node and silently no-ops. Arm a pending ref and
+  consume it in a `useLayoutEffect` keyed on the flipped state's commit
+  (reference: `CommentComposer`'s collapse/expand pending flags); an rAF
+  belongs inside that effect only to outlast Base UI's close-time focus-return.
 
 ## Rust / Tauri conventions
 

--- a/README.md
+++ b/README.md
@@ -813,6 +813,15 @@ review via its subscription login. The full list is under
   release-notes field, rendered to match GitHub's own styling: task lists,
   heading hierarchy, and syntax-highlighted code in ~190 languages (light
   and dark).
+- **Mention & reference autocomplete**: on GitHub and GitLab repos, type
+  `@` in a comment box, reply, edit, diff line comment, or release notes to
+  pick a person and `#` to pick an issue or pull request, with arrow keys and
+  Enter to accept. GitLab adds `!` for merge requests; each forge offers only
+  the references it links.
+- **Collapsible comment box**: fold the comment box on a pull request, issue,
+  discussion, or commit down to a one-line strip to read more of the thread.
+  Approve, Review, and Close stay on the strip, a saved draft shows its first
+  line there, and the choice is remembered until you expand it again.
 - **Keyboard-first**: rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (`Ctrl`/`⌘`+`/`), a command palette
   (`Ctrl`/`⌘`+`K`), and arrow-key navigation everywhere.

--- a/README.md
+++ b/README.md
@@ -815,13 +815,14 @@ review via its subscription login. The full list is under
   and dark).
 - **Mention & reference autocomplete**: on GitHub and GitLab repos, type
   `@` in a comment box, reply, edit, diff line comment, or release notes to
-  pick a person and `#` to pick an issue or pull request, with arrow keys and
-  Enter to accept. GitLab adds `!` for merge requests; each forge offers only
-  the references it links.
-- **Collapsible comment box**: fold the comment box on a pull request, issue,
-  discussion, or commit down to a one-line strip to read more of the thread.
-  Approve, Review, and Close stay on the strip, a saved draft shows its first
-  line there, and the choice is remembered until you expand it again.
+  pick a person and `#` to pick from the recently updated open issues and pull
+  requests, with arrow keys and Enter to accept. GitLab adds `!` for merge
+  requests; each forge offers only the references it links.
+- **Collapsible comment box**: fold the comment box down to a one-line strip to
+  read more of the thread, on every conversation surface — pull requests and
+  issues (local, on the forge, and Jira), discussions, and commits. Approve,
+  Review, and Close stay on the strip, a saved draft shows its first line there,
+  and the choice is remembered until you expand it again.
 - **Keyboard-first**: rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (`Ctrl`/`⌘`+`/`), a command palette
   (`Ctrl`/`⌘`+`K`), and arrow-key navigation everywhere.

--- a/changelog.d/added-collapsible-comment-composer.md
+++ b/changelog.d/added-collapsible-comment-composer.md
@@ -1,0 +1,6 @@
+- **Collapsible comment box.** Fold the comment box on a pull request, issue,
+  discussion, or commit down to a one-line strip to read more of the thread.
+  Approve, Review, and Close stay on the strip, a saved draft shows its first
+  line there, and the choice is remembered across every conversation surface and
+  across restarts. **Collapse or expand the comment box** is in the command
+  palette.

--- a/changelog.d/added-collapsible-comment-composer.md
+++ b/changelog.d/added-collapsible-comment-composer.md
@@ -1,6 +1,6 @@
-- **Collapsible comment box.** Fold the comment box on a pull request, issue,
-  discussion, or commit down to a one-line strip to read more of the thread.
-  Approve, Review, and Close stay on the strip, a saved draft shows its first
-  line there, and the choice is remembered across every conversation surface and
-  across restarts. **Collapse or expand the comment box** is in the command
-  palette.
+- **Collapsible comment box.** Fold the comment box down to a one-line strip to
+  read more of the thread, on every conversation surface — pull requests and
+  issues (local, on the forge, and Jira), discussions, and commits. Approve,
+  Review, and Close stay on the strip, a saved draft shows its first line there,
+  and the choice is remembered across every surface and across restarts.
+  **Collapse or expand the comment box** is in the command palette.

--- a/changelog.d/added-mention-autocomplete.md
+++ b/changelog.d/added-mention-autocomplete.md
@@ -1,6 +1,6 @@
 - **Mention & reference autocomplete on GitHub and GitLab.** Type `@` in a
   comment box, a reply, an edit, a diff line comment, or a release's notes to
-  pick a person, and `#` to pick an open issue or pull request — GitLab also
-  offers `!` for merge requests. Arrow keys move through the suggestions, Enter
-  or Tab accepts one, and Esc dismisses. Each forge offers only the references
-  it turns into links.
+  pick a person, and `#` to pick from the recently updated open issues and pull
+  requests — GitLab also offers `!` for merge requests. Arrow keys move through
+  the suggestions, Enter or Tab accepts one, and Esc dismisses. Each forge
+  offers only the references it turns into links.

--- a/changelog.d/added-mention-autocomplete.md
+++ b/changelog.d/added-mention-autocomplete.md
@@ -1,0 +1,6 @@
+- **Mention & reference autocomplete on GitHub and GitLab.** Type `@` in a
+  comment box, a reply, an edit, a diff line comment, or a release's notes to
+  pick a person, and `#` to pick an open issue or pull request — GitLab also
+  offers `!` for merge requests. Arrow keys move through the suggestions, Enter
+  or Tab accepts one, and Esc dismisses. Each forge offers only the references
+  it turns into links.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -451,6 +451,16 @@ export const capabilities: Capability[] = [
     label: "Markdown editor — formatting toolbar & live preview",
     highlight: true,
   },
+  {
+    group: "Keyboard & Markdown",
+    label:
+      "Collapsible comment box — reclaim reading space, actions stay docked",
+  },
+  {
+    group: "Keyboard & Markdown",
+    label:
+      "@mention & #reference autocomplete — GitHub & GitLab comments, replies, release notes",
+  },
 
   // — AI · generate & review —
   {

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import type { MentionSource } from "@/features/conversations/useMentionCandidates";
 import { useFieldContext } from "@/lib/form-context";
 
 /**
@@ -115,6 +116,7 @@ export function MarkdownField({
   disabled,
   textareaClassName,
   actions,
+  mentions,
 }: {
   label?: ReactNode;
   placeholder?: string;
@@ -122,6 +124,9 @@ export function MarkdownField({
   disabled?: boolean;
   textareaClassName?: string;
   actions?: ReactNode;
+  /** Opt in to `@`/`#`/`!` autocomplete — only forms whose forge autolinks the
+   *  completed reference pass one. */
+  mentions?: MentionSource;
 }) {
   const field = useFieldContext<string>();
   const id = useId();
@@ -135,6 +140,7 @@ export function MarkdownField({
         disabled={disabled}
         textareaClassName={textareaClassName}
         actions={actions}
+        mentions={mentions}
         value={field.state.value}
         onChange={field.handleChange}
       />

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -21,9 +21,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { useMentionAutocomplete } from "@/components/mention-autocomplete";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Textarea } from "@/components/ui/textarea";
+import type { MentionSource } from "@/features/conversations/useMentionCandidates";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { cn } from "@/lib/utils";
 
@@ -233,6 +235,7 @@ export function MarkdownEditor({
   fill,
   textareaClassName,
   actions,
+  mentions,
   "aria-label": ariaLabel,
 }: {
   ref?: Ref<MarkdownEditorHandle>;
@@ -253,6 +256,10 @@ export function MarkdownEditor({
   fill?: boolean;
   textareaClassName?: string;
   actions?: ReactNode;
+  /** Opt in to `@`/`#`/`!` autocomplete. Omitted — as it is on every surface whose
+   *  forge wouldn't autolink the result — the editor adds no listener, query or
+   *  node for it. */
+  mentions?: MentionSource;
   "aria-label"?: string;
 }) {
   const [mode, setMode] = useState<"write" | "preview">("write");
@@ -261,6 +268,14 @@ export function MarkdownEditor({
   const pendingSelection = useRef<[number, number] | null>(null);
   // A focus() requested while in Preview mode, honored once Write remounts.
   const pendingFocus = useRef(false);
+
+  const mention = useMentionAutocomplete({
+    mentions,
+    textareaRef,
+    value,
+    onChange,
+    suspended: mode === "preview" || !!disabled,
+  });
 
   // Focus the textarea without the native scroll-alignment jump ("flash"), then
   // bring it into view only if it's actually off-screen, by the minimum distance
@@ -365,6 +380,9 @@ export function MarkdownEditor({
         return;
       }
     }
+    // The suggestion popover owns arrows/Enter/Tab/Escape while a token is open,
+    // between the formatting chords and the consumer's own handler.
+    if (mention.onKeyDown(e)) return;
     onKeyDown?.(e);
   }
 
@@ -464,7 +482,13 @@ export function MarkdownEditor({
         placeholder={placeholder}
         aria-label={ariaLabel}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          onChange(e.target.value);
+          mention.sync(
+            e.target.value,
+            e.target.selectionStart ?? e.target.value.length,
+          );
+        }}
         onKeyDown={handleKeyDown}
         rows={rows}
         disabled={disabled}
@@ -473,7 +497,9 @@ export function MarkdownEditor({
           textareaClassName,
           mode === "preview" && "hidden",
         )}
+        {...mention.textareaProps}
       />
+      {mention.popover}
       {mode === "preview" && (
         <div
           className={cn(

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -29,7 +29,8 @@ const ALL_TRIGGERS = "@#!";
 
 /** `w-72` — the popover's fixed width, needed before it is laid out to clamp it. */
 const POPOVER_WIDTH = 288;
-/** `max-h-56` — the ceiling the viewport clamp works down from. */
+/** Ceiling the viewport clamp works down from, in px: no class carries it, the
+ *  placement applies the clamped result as an inline `maxHeight`. */
 const MAX_LIST_HEIGHT = 224;
 /** Keeps the popover off the viewport edges. */
 const GUTTER = 8;
@@ -54,6 +55,9 @@ const RESYNC_KEYS = new Set([
   "Home",
   "End",
 ]);
+
+/** Whether the text after a completed token already begins with whitespace. */
+const FOLLOWED_BY_SPACE = /^\s/;
 
 /** Cached per trigger set: the token regexes are rebuilt on every keystroke otherwise. */
 const REGEX_CACHE = new Map<string, RegExp>();
@@ -124,16 +128,6 @@ function place(
   };
 }
 
-/** Re-place an open token's box against the caret it already names, for the two
- *  things that move the box without moving the token: the anchor scrolling under
- *  it, and candidates arriving and changing the list's height. */
-function reposition(textarea: HTMLTextAreaElement, rowCount: number) {
-  return (t: ActiveToken | null): ActiveToken | null =>
-    t
-      ? { ...t, ...place(textarea, t.start + 1 + t.query.length, rowCount) }
-      : t;
-}
-
 /**
  * GitHub-style `@`/`#`/`!` completion for a textarea: token detection, the caret-
  * anchored listbox, and the keyboard contract the popover owns while a token is
@@ -167,11 +161,31 @@ export function useMentionAutocomplete({
   // Which keys the popover consumed, each read and cleared by its own keyup —
   // one shared flag would let a second key's keydown clear the first key's mark.
   const consumedKeys = useRef(new Set<string>());
+  // A token the user dismissed at this index, so a caret move inside it doesn't
+  // reopen what they just closed.
+  const dismissed = useRef<{ start: number; trigger: MentionTrigger } | null>(
+    null,
+  );
+  // The committed token, for the effects that re-place it: placement measures the
+  // DOM, which a state updater (run during render, twice under StrictMode) can't.
+  const tokenRef = useRef<ActiveToken | null>(null);
+  tokenRef.current = token;
   const listId = useId();
 
-  // Render-time reset rather than an effect: a popover must never paint over a
-  // preview pane or a frozen editor, not even for one commit.
-  if (token && (suspended || !mentions)) setToken(null);
+  // Render-time reset, not an effect — neither state may survive a commit. A
+  // popover must never paint over a preview pane or a frozen editor; and external
+  // writes to `value` (a submit clearing the draft, a quote-reply fill, an
+  // error restore) never reach `sync`, so the token's validity derives from
+  // `value` rather than from the events that set it.
+  if (
+    token &&
+    (suspended ||
+      !mentions ||
+      value.slice(token.start, token.start + 1 + token.query.length) !==
+        token.trigger + token.query)
+  ) {
+    setToken(null);
+  }
 
   const open = token !== null && !suspended && !!mentions;
   const result = open ? mentions.query(token.trigger, token.query) : null;
@@ -185,8 +199,9 @@ export function useMentionAutocomplete({
   // paint, or the box keeps the flip and height it chose for zero rows.
   useLayoutEffect(() => {
     const ta = textareaRef.current;
-    if (!open || !ta) return;
-    setToken(reposition(ta, rowCount));
+    const t = tokenRef.current;
+    if (!open || !ta || !t) return;
+    setToken({ ...t, ...place(ta, t.start + 1 + t.query.length, rowCount) });
   }, [open, rowCount, textareaRef]);
 
   useEffect(() => {
@@ -197,22 +212,26 @@ export function useMentionAutocomplete({
       const list = listRef.current;
       if (list && e.target instanceof Node && list.contains(e.target)) return;
       const ta = textareaRef.current;
-      if (ta && e.target === ta) {
+      const t = tokenRef.current;
+      if (ta && t && e.target === ta) {
         // The anchor scrolled, not the page — typing across a wrap boundary in a
         // capped composer does this. Placement nets out scrollTop, so following
         // the caret is correct where dismissing would drop the query mid-word.
-        setToken(reposition(ta, rowCount));
+        setToken({
+          ...t,
+          ...place(ta, t.start + 1 + t.query.length, rowCount),
+        });
         return;
       }
       setToken(null);
     };
-    const dismiss = () => setToken(null);
+    const onResize = () => setToken(null);
     const opts = { capture: true, passive: true } as const;
     window.addEventListener("scroll", onScroll, opts);
-    window.addEventListener("resize", dismiss, { passive: true });
+    window.addEventListener("resize", onResize, { passive: true });
     return () => {
       window.removeEventListener("scroll", onScroll, opts);
-      window.removeEventListener("resize", dismiss);
+      window.removeEventListener("resize", onResize);
     };
   }, [open, rowCount, textareaRef]);
 
@@ -222,13 +241,18 @@ export function useMentionAutocomplete({
     if (!open) consumedKeys.current.clear();
   }, [open]);
 
-  /** Recompute the token from the text up to the caret, and re-place the popover. */
-  function sync(next: string, caret: number) {
+  /**
+   * Recompute the token from the text up to the caret, and re-place the popover.
+   * `fromInput` distinguishes typing from a bare caret move: typing always reopens
+   * a dismissed token (as github.com does), a caret move never does.
+   */
+  function sync(next: string, caret: number, fromInput = true) {
     const ta = textareaRef.current;
     if (skipSync.current) {
       setToken(null);
       return;
     }
+    if (fromInput) dismissed.current = null;
     if (!mentions || suspended || !ta || mentions.triggers.length === 0) {
       setToken(null);
       return;
@@ -240,12 +264,19 @@ export function useMentionAutocomplete({
     }
     const trigger = m[1] as MentionTrigger;
     const query = m[2];
+    const start = caret - query.length - 1;
+    const wasDismissed = dismissed.current;
+    if (wasDismissed?.start === start && wasDismissed.trigger === trigger) {
+      return;
+    }
+    // A token at another index is a different one, so the old dismissal lapses.
+    dismissed.current = null;
     mentions.onActive();
     setIndex(0);
     setToken({
       trigger,
       query,
-      start: caret - query.length - 1,
+      start,
       ...place(ta, caret, mentions.query(trigger, query).items.length),
     });
   }
@@ -253,7 +284,14 @@ export function useMentionAutocomplete({
   /** Re-sync from the live caret — for the keys that move it without editing. */
   function resync() {
     const ta = textareaRef.current;
-    if (ta) sync(ta.value, ta.selectionStart ?? ta.value.length);
+    if (ta) sync(ta.value, ta.selectionStart ?? ta.value.length, false);
+  }
+
+  /** Close the popover and remember the token, so only typing reopens it. */
+  function dismiss() {
+    if (token)
+      dismissed.current = { start: token.start, trigger: token.trigger };
+    setToken(null);
   }
 
   function insert(candidate: MentionCandidate) {
@@ -261,8 +299,10 @@ export function useMentionAutocomplete({
     if (!token || !ta) return;
     const end = token.start + 1 + token.query.length;
     const rest = value.slice(end);
-    // No double space when completing mid-sentence.
-    const text = `${token.trigger}${candidate.insert}${rest.startsWith(" ") ? "" : " "}`;
+    // The completion supplies its own separator only when nothing already
+    // separates it from what follows — a newline or tab counts.
+    const text = `${token.trigger}${candidate.insert}${FOLLOWED_BY_SPACE.test(rest) ? "" : " "}`;
+    dismissed.current = null;
     setToken(null);
     ta.focus({ preventScroll: true });
     ta.setSelectionRange(token.start, end);
@@ -287,7 +327,7 @@ export function useMentionAutocomplete({
   }
 
   function handleKey(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
-    if (!open) return false;
+    if (!open || !token) return false;
     // The submit chord always reaches the consumer, popover or not.
     if (e.key === "Enter" && eventToBinding(e)?.startsWith("mod+"))
       return false;
@@ -301,7 +341,7 @@ export function useMentionAutocomplete({
       // The line-widget composers close themselves on Escape; dismissing a
       // suggestion must not also throw away the box it was typed in.
       e.stopPropagation();
-      setToken(null);
+      dismiss();
       return true;
     }
     if (items.length > 0) {
@@ -327,7 +367,7 @@ export function useMentionAutocomplete({
       // Token open with nothing to complete: dismiss rather than submit the
       // half-typed reference.
       e.preventDefault();
-      setToken(null);
+      dismiss();
       return true;
     }
     return false;
@@ -347,13 +387,15 @@ export function useMentionAutocomplete({
 
   const textareaProps = wired
     ? {
+        // No `aria-expanded`: the textarea's implicit textbox role doesn't support
+        // it, so it announces nothing; the three below carry the pattern.
         "aria-autocomplete": "list" as const,
-        "aria-expanded": open,
         "aria-controls": open ? listId : undefined,
         "aria-activedescendant":
           open && items.length > 0 ? `${listId}-${activeIndex}` : undefined,
         onBlur: () => {
           consumedKeys.current.clear();
+          dismissed.current = null;
           setToken(null);
         },
         onMouseDown: () => setToken(null),
@@ -373,6 +415,7 @@ export function useMentionAutocomplete({
         listRef={listRef}
         items={items}
         loading={result?.loading ?? false}
+        isError={result?.isError ?? false}
         activeIndex={activeIndex}
         ghHost={mentions.ghHost}
         token={token}
@@ -408,6 +451,14 @@ function RefGlyph({ state, isPr }: { state: string; isPr: boolean }) {
   );
 }
 
+/** The one muted row shown when there is nothing to pick. A list still loading
+ *  outranks a failed one: a merged list whose halves resolve separately is worth
+ *  waiting on before it is called broken. */
+function emptyMessage(loading: boolean, isError: boolean): string {
+  if (loading) return "Loading…";
+  return isError ? "Couldn't load suggestions" : "No matches";
+}
+
 /** The caret-anchored suggestion listbox. Portalled to the body and fixed-
  *  positioned: the composer sits inside overflow containers that would clip it. */
 function MentionPopover({
@@ -415,6 +466,7 @@ function MentionPopover({
   listRef,
   items,
   loading,
+  isError,
   activeIndex,
   ghHost,
   token,
@@ -425,6 +477,8 @@ function MentionPopover({
   listRef: RefObject<HTMLDivElement | null>;
   items: MentionCandidate[];
   loading: boolean;
+  /** A backing list failed — say so instead of reporting a confident "No matches". */
+  isError: boolean;
   activeIndex: number;
   ghHost: string | null;
   token: ActiveToken;
@@ -456,7 +510,7 @@ function MentionPopover({
     >
       {items.length === 0 ? (
         <p className="px-2.5 py-2 text-[11px] text-muted-foreground">
-          {loading ? "Loading…" : "No matches"}
+          {emptyMessage(loading, isError)}
         </p>
       ) : (
         items.map((c, i) => (

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
   type RefObject,
   useEffect,
+  useEffectEvent,
   useId,
   useLayoutEffect,
   useRef,
@@ -57,7 +58,7 @@ const RESYNC_KEYS = new Set([
 ]);
 
 /** Whether the text after a completed token already begins with whitespace. */
-const FOLLOWED_BY_SPACE = /^\s/;
+const FOLLOWED_BY_WHITESPACE = /^\s/;
 
 /** Cached per trigger set: the token regexes are rebuilt on every keystroke otherwise. */
 const REGEX_CACHE = new Map<string, RegExp>();
@@ -166,10 +167,6 @@ export function useMentionAutocomplete({
   const dismissed = useRef<{ start: number; trigger: MentionTrigger } | null>(
     null,
   );
-  // The committed token, for the effects that re-place it: placement measures the
-  // DOM, which a state updater (run during render, twice under StrictMode) can't.
-  const tokenRef = useRef<ActiveToken | null>(null);
-  tokenRef.current = token;
   const listId = useId();
 
   // Render-time reset, not an effect — neither state may survive a commit. A
@@ -194,14 +191,25 @@ export function useMentionAutocomplete({
   const activeIndex = items.length > 0 ? Math.min(index, items.length - 1) : 0;
   const rowCount = items.length;
 
+  // Re-place the open token's box against the caret it already names. Placement
+  // measures the DOM, so it must run from the effect rather than from a state
+  // updater (React runs those during render, twice under StrictMode).
+  const replace = useEffectEvent((ta: HTMLTextAreaElement) => {
+    if (!token) return;
+    setToken({
+      ...token,
+      ...place(ta, token.start + 1 + token.query.length, rowCount),
+    });
+  });
+
   // The lazy queries only enable as the first token opens, so a token is always
   // placed against an empty list first; re-place once the candidates land, before
   // paint, or the box keeps the flip and height it chose for zero rows.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `rowCount` is the trigger — the effect event reads it live, so dropping it here would stop the re-place from ever running.
   useLayoutEffect(() => {
     const ta = textareaRef.current;
-    const t = tokenRef.current;
-    if (!open || !ta || !t) return;
-    setToken({ ...t, ...place(ta, t.start + 1 + t.query.length, rowCount) });
+    if (!open || !ta) return;
+    replace(ta);
   }, [open, rowCount, textareaRef]);
 
   useEffect(() => {
@@ -212,15 +220,11 @@ export function useMentionAutocomplete({
       const list = listRef.current;
       if (list && e.target instanceof Node && list.contains(e.target)) return;
       const ta = textareaRef.current;
-      const t = tokenRef.current;
-      if (ta && t && e.target === ta) {
+      if (ta && e.target === ta) {
         // The anchor scrolled, not the page — typing across a wrap boundary in a
         // capped composer does this. Placement nets out scrollTop, so following
         // the caret is correct where dismissing would drop the query mid-word.
-        setToken({
-          ...t,
-          ...place(ta, t.start + 1 + t.query.length, rowCount),
-        });
+        replace(ta);
         return;
       }
       setToken(null);
@@ -233,7 +237,7 @@ export function useMentionAutocomplete({
       window.removeEventListener("scroll", onScroll, opts);
       window.removeEventListener("resize", onResize);
     };
-  }, [open, rowCount, textareaRef]);
+  }, [open, textareaRef]);
 
   // The consumed set lives per interaction: a closed token must not leave a key
   // marked, or the next one's keyup would skip the re-sync it needs.
@@ -301,7 +305,7 @@ export function useMentionAutocomplete({
     const rest = value.slice(end);
     // The completion supplies its own separator only when nothing already
     // separates it from what follows — a newline or tab counts.
-    const text = `${token.trigger}${candidate.insert}${FOLLOWED_BY_SPACE.test(rest) ? "" : " "}`;
+    const text = `${token.trigger}${candidate.insert}${FOLLOWED_BY_WHITESPACE.test(rest) ? "" : " "}`;
     dismissed.current = null;
     setToken(null);
     ta.focus({ preventScroll: true });
@@ -499,6 +503,9 @@ function MentionPopover({
       id={listId}
       role="listbox"
       aria-label="Mention suggestions"
+      // Dragging the list's own scrollbar must not blur the textarea, which would
+      // dismiss the popover out from under the drag.
+      onMouseDown={(e) => e.preventDefault()}
       style={{
         position: "fixed",
         left: token.left,

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -194,7 +194,7 @@ export function useMentionAutocomplete({
   // Re-place the open token's box against the caret it already names. Placement
   // measures the DOM, so it must run from the effect rather than from a state
   // updater (React runs those during render, twice under StrictMode).
-  const replace = useEffectEvent((ta: HTMLTextAreaElement) => {
+  const rePlace = useEffectEvent((ta: HTMLTextAreaElement) => {
     if (!token) return;
     setToken({
       ...token,
@@ -209,7 +209,7 @@ export function useMentionAutocomplete({
   useLayoutEffect(() => {
     const ta = textareaRef.current;
     if (!open || !ta) return;
-    replace(ta);
+    rePlace(ta);
   }, [open, rowCount, textareaRef]);
 
   useEffect(() => {
@@ -224,7 +224,7 @@ export function useMentionAutocomplete({
         // The anchor scrolled, not the page — typing across a wrap boundary in a
         // capped composer does this. Placement nets out scrollTop, so following
         // the caret is correct where dismissing would drop the query mid-word.
-        replace(ta);
+        rePlace(ta);
         return;
       }
       setToken(null);

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -1,0 +1,457 @@
+import {
+  CheckCircleIcon,
+  CircleDashedIcon,
+  GitPullRequestIcon,
+} from "@phosphor-icons/react";
+import {
+  type KeyboardEvent,
+  type RefObject,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import type {
+  MentionCandidate,
+  MentionSource,
+  MentionTrigger,
+} from "@/features/conversations/useMentionCandidates";
+import { eventToBinding } from "@/lib/hotkeys/binding";
+import { getCaretCoordinates } from "@/lib/textarea-caret";
+import { cn } from "@/lib/utils";
+
+/** Every trigger char, whichever provider is in play: a token's query never spans
+ *  one, so `@a#b` opens on `#b` rather than completing `a#b`. */
+const ALL_TRIGGERS = "@#!";
+
+/** `w-72` — the popover's fixed width, needed before it is laid out to clamp it. */
+const POPOVER_WIDTH = 288;
+/** `max-h-56` — the ceiling the viewport clamp works down from. */
+const MAX_LIST_HEIGHT = 224;
+/** Keeps the popover off the viewport edges. */
+const GUTTER = 8;
+/** Enough of a row to estimate the list's height before it renders. */
+const ROW_HEIGHT = 28;
+/** Below this the flipped side is not worth taking. */
+const MIN_LIST_HEIGHT = 72;
+
+/** Keys that can move the caret without changing the text — the token has to be
+ *  recomputed after them or a popover outlives the token it belongs to. The
+ *  vertical arrows only qualify when the popover declined them (no matches to
+ *  walk), which is when the caret actually moves. */
+const RESYNC_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+]);
+
+/** Cached per trigger set: the token regexes are rebuilt on every keystroke otherwise. */
+const REGEX_CACHE = new Map<string, RegExp>();
+
+/** A trigger char at the start of the text or after whitespace, then the query. */
+function tokenRegex(triggers: readonly MentionTrigger[]): RegExp {
+  const key = triggers.join("");
+  const cached = REGEX_CACHE.get(key);
+  if (cached) return cached;
+  const re = new RegExp(`(?:^|\\s)([${key}])([^\\s${ALL_TRIGGERS}]*)$`);
+  REGEX_CACHE.set(key, re);
+  return re;
+}
+
+/** An open token plus the viewport-fixed box the popover was placed in for it. */
+interface ActiveToken {
+  trigger: MentionTrigger;
+  query: string;
+  /** Index of the trigger char in the draft. */
+  start: number;
+  left: number;
+  /** Set when the popover hangs below the caret line; `bottom` is set instead when
+   *  it was flipped above. */
+  top: number | null;
+  bottom: number | null;
+  maxHeight: number;
+}
+
+/** Place the popover against the caret: below its line by default, flipped above
+ *  when the space under it can't hold the list, and always inside the gutters. */
+function place(
+  textarea: HTMLTextAreaElement,
+  caret: number,
+  rowCount: number,
+): Omit<ActiveToken, "trigger" | "query" | "start"> {
+  const rect = textarea.getBoundingClientRect();
+  const coords = getCaretCoordinates(textarea, caret);
+  const caretTop = rect.top + coords.top - textarea.scrollTop;
+  const caretBottom = caretTop + coords.height;
+  const left = Math.min(
+    Math.max(rect.left + coords.left - textarea.scrollLeft, GUTTER),
+    Math.max(window.innerWidth - POPOVER_WIDTH - GUTTER, GUTTER),
+  );
+  const wanted = Math.min(
+    MAX_LIST_HEIGHT,
+    Math.max(rowCount, 1) * ROW_HEIGHT + GUTTER,
+  );
+  const spaceBelow = window.innerHeight - caretBottom - 2 - GUTTER;
+  const spaceAbove = caretTop - 2 - GUTTER;
+  // Flip only when the space above is actually the better of the two — a caret with
+  // no room on either side keeps the reading direction it started in.
+  if (spaceBelow < wanted && spaceAbove > spaceBelow) {
+    return {
+      left,
+      top: null,
+      bottom: window.innerHeight - caretTop + 2,
+      maxHeight: Math.max(
+        Math.min(MAX_LIST_HEIGHT, spaceAbove),
+        MIN_LIST_HEIGHT,
+      ),
+    };
+  }
+  return {
+    left,
+    top: caretBottom + 2,
+    bottom: null,
+    maxHeight: Math.max(Math.min(MAX_LIST_HEIGHT, spaceBelow), MIN_LIST_HEIGHT),
+  };
+}
+
+/**
+ * GitHub-style `@`/`#`/`!` completion for a textarea: token detection, the caret-
+ * anchored listbox, and the keyboard contract the popover owns while a token is
+ * open. Opt-in — with no `mentions` source nothing is rendered, listened to, or
+ * queried, which is what keeps the surfaces that don't wire it byte-identical.
+ *
+ * Ported from the session composer's mention mechanics; two details there are
+ * load-bearing and kept verbatim: rows commit on `mousedown` with `preventDefault`
+ * so the textarea never blurs before the splice lands, and the insert goes through
+ * `document.execCommand` so one undo reverts the whole completion.
+ */
+export function useMentionAutocomplete({
+  mentions,
+  textareaRef,
+  value,
+  onChange,
+  suspended,
+}: {
+  mentions: MentionSource | undefined;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onChange: (value: string) => void;
+  /** Preview mode or a disabled editor: no token opens and an open one closes. */
+  suspended: boolean;
+}) {
+  const [token, setToken] = useState<ActiveToken | null>(null);
+  const [index, setIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  // Swallows the one onChange an accepted completion produces (see `insert`).
+  const skipSync = useRef(false);
+  // Whether the popover took the last keydown, read by its keyup twin.
+  const lastConsumed = useRef(false);
+  const listId = useId();
+
+  // Render-time reset rather than an effect: a popover must never paint over a
+  // preview pane or a frozen editor, not even for one commit.
+  if (token && (suspended || !mentions)) setToken(null);
+
+  const open = token !== null && !suspended && !!mentions;
+  const result = open ? mentions.query(token.trigger, token.query) : null;
+  const items = result?.items ?? [];
+  // The list can shrink under a stale index while data arrives.
+  const activeIndex = items.length > 0 ? Math.min(index, items.length - 1) : 0;
+
+  useEffect(() => {
+    if (!open) return;
+    const onScroll = (e: Event) => {
+      // The listbox scrolls itself as you arrow through it; only the page moving
+      // underneath invalidates the caret anchor.
+      const list = listRef.current;
+      if (list && e.target instanceof Node && list.contains(e.target)) return;
+      setToken(null);
+    };
+    const dismiss = () => setToken(null);
+    const opts = { capture: true, passive: true } as const;
+    window.addEventListener("scroll", onScroll, opts);
+    window.addEventListener("resize", dismiss, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll, opts);
+      window.removeEventListener("resize", dismiss);
+    };
+  }, [open]);
+
+  /** Recompute the token from the text up to the caret, and re-place the popover. */
+  function sync(next: string, caret: number) {
+    const ta = textareaRef.current;
+    if (skipSync.current) {
+      setToken(null);
+      return;
+    }
+    if (!mentions || suspended || !ta || mentions.triggers.length === 0) {
+      setToken(null);
+      return;
+    }
+    const m = next.slice(0, caret).match(tokenRegex(mentions.triggers));
+    if (!m) {
+      setToken(null);
+      return;
+    }
+    const trigger = m[1] as MentionTrigger;
+    const query = m[2];
+    mentions.onActive();
+    setIndex(0);
+    setToken({
+      trigger,
+      query,
+      start: caret - query.length - 1,
+      ...place(ta, caret, mentions.query(trigger, query).items.length),
+    });
+  }
+
+  /** Re-sync from the live caret — for the keys that move it without editing. */
+  function resync() {
+    const ta = textareaRef.current;
+    if (ta) sync(ta.value, ta.selectionStart ?? ta.value.length);
+  }
+
+  function insert(candidate: MentionCandidate) {
+    const ta = textareaRef.current;
+    if (!token || !ta) return;
+    const end = token.start + 1 + token.query.length;
+    const rest = value.slice(end);
+    // No double space when completing mid-sentence.
+    const text = `${token.trigger}${candidate.insert}${rest.startsWith(" ") ? "" : " "}`;
+    setToken(null);
+    ta.focus({ preventScroll: true });
+    ta.setSelectionRange(token.start, end);
+    // execCommand keeps the textarea's native undo stack intact, so one Ctrl+Z
+    // reverts the whole completion (see the editor's runAction for the same reason).
+    // Its synchronous `input` event reaches the editor's onChange, which would
+    // re-open the token it just completed when the completion needed no trailing
+    // space (the caret then still sits at the end of `@login`).
+    skipSync.current = true;
+    const ok = document.execCommand("insertText", false, text);
+    skipSync.current = false;
+    if (!ok) {
+      // Fallback (not expected on our webviews): a controlled rewrite, which lands
+      // one frame later and so has to restore the caret itself.
+      onChange(value.slice(0, token.start) + text + rest);
+      const pos = token.start + text.length;
+      requestAnimationFrame(() => {
+        ta.focus({ preventScroll: true });
+        ta.setSelectionRange(pos, pos);
+      });
+    }
+  }
+
+  function handleKey(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    if (!open) return false;
+    // The submit chord always reaches the consumer, popover or not.
+    if (e.key === "Enter" && eventToBinding(e)?.startsWith("mod+"))
+      return false;
+    // An Enter that commits an IME composition belongs to the composition: the
+    // reference titles searched here are frequently CJK, so consuming it would
+    // splice a suggestion in place of the text being typed. The token survives and
+    // re-syncs on the commit's own onChange.
+    if (e.key === "Enter" && e.nativeEvent.isComposing) return false;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      // The line-widget composers close themselves on Escape; dismissing a
+      // suggestion must not also throw away the box it was typed in.
+      e.stopPropagation();
+      setToken(null);
+      return true;
+    }
+    if (items.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setIndex((i) => (Math.min(i, items.length - 1) + 1) % items.length);
+        return true;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setIndex(
+          (i) =>
+            (Math.min(i, items.length - 1) - 1 + items.length) % items.length,
+        );
+        return true;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        insert(items[activeIndex]);
+        return true;
+      }
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      // Token open with nothing to complete: dismiss rather than submit the
+      // half-typed reference.
+      e.preventDefault();
+      setToken(null);
+      return true;
+    }
+    return false;
+  }
+
+  /** Returns true when the popover consumed the key. */
+  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    const consumed = handleKey(e);
+    lastConsumed.current = consumed;
+    return consumed;
+  }
+
+  // A source whose provider offers no trigger never opens a token, so it gets no
+  // handlers and advertises no autocomplete.
+  const wired = !!mentions && mentions.triggers.length > 0;
+
+  const textareaProps = wired
+    ? {
+        "aria-autocomplete": "list" as const,
+        "aria-expanded": open,
+        "aria-controls": open ? listId : undefined,
+        "aria-activedescendant":
+          open && items.length > 0 ? `${listId}-${activeIndex}` : undefined,
+        onBlur: () => setToken(null),
+        onMouseDown: () => setToken(null),
+        onKeyUp: (e: KeyboardEvent<HTMLTextAreaElement>) => {
+          // Only an arrow the popover declined moved the caret; re-syncing after
+          // one it consumed would reset the row that arrow just highlighted.
+          if (!lastConsumed.current && RESYNC_KEYS.has(e.key)) resync();
+        },
+      }
+    : undefined;
+
+  const popover =
+    open && token ? (
+      <MentionPopover
+        listId={listId}
+        listRef={listRef}
+        items={items}
+        loading={result?.loading ?? false}
+        activeIndex={activeIndex}
+        ghHost={mentions.ghHost}
+        token={token}
+        onPick={insert}
+        onHover={setIndex}
+      />
+    ) : null;
+
+  return { textareaProps, sync, onKeyDown, popover };
+}
+
+/** Open/closed glyph for a suggested reference. Mirrors the Issues panel's
+ *  `StateIcon` (shape carries the state, not the tint alone); local rather than
+ *  imported so the editor doesn't pull the issue-relations module into its chunk. */
+function RefGlyph({ state, isPr }: { state: string; isPr: boolean }) {
+  if (isPr) {
+    return (
+      <GitPullRequestIcon
+        className={cn(
+          "size-3.5 shrink-0",
+          state === "OPEN" ? "text-success" : "text-merged",
+        )}
+      />
+    );
+  }
+  return state === "CLOSED" ? (
+    <CheckCircleIcon className="size-3.5 shrink-0 text-merged" />
+  ) : (
+    <CircleDashedIcon className="size-3.5 shrink-0 text-success" />
+  );
+}
+
+/** The caret-anchored suggestion listbox. Portalled to the body and fixed-
+ *  positioned: the composer sits inside overflow containers that would clip it. */
+function MentionPopover({
+  listId,
+  listRef,
+  items,
+  loading,
+  activeIndex,
+  ghHost,
+  token,
+  onPick,
+  onHover,
+}: {
+  listId: string;
+  listRef: RefObject<HTMLDivElement | null>;
+  items: MentionCandidate[];
+  loading: boolean;
+  activeIndex: number;
+  ghHost: string | null;
+  token: ActiveToken;
+  onPick: (candidate: MentionCandidate) => void;
+  onHover: (i: number) => void;
+}) {
+  // Keep the keyboard-highlighted row visible while arrowing through a list that
+  // is taller than the box.
+  useEffect(() => {
+    document
+      .getElementById(`${listId}-${activeIndex}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [listId, activeIndex]);
+
+  return createPortal(
+    <div
+      ref={listRef}
+      id={listId}
+      role="listbox"
+      aria-label="Mention suggestions"
+      style={{
+        position: "fixed",
+        left: token.left,
+        top: token.top ?? undefined,
+        bottom: token.bottom ?? undefined,
+        maxHeight: token.maxHeight,
+      }}
+      className="z-50 w-72 overflow-y-auto border bg-popover shadow-md ring-1 ring-foreground/10"
+    >
+      {items.length === 0 ? (
+        <p className="px-2.5 py-2 text-[11px] text-muted-foreground">
+          {loading ? "Loading…" : "No matches"}
+        </p>
+      ) : (
+        items.map((c, i) => (
+          <button
+            key={c.key}
+            id={`${listId}-${i}`}
+            role="option"
+            aria-selected={i === activeIndex}
+            type="button"
+            // mousedown (not click) so the textarea doesn't blur before the insert
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onPick(c);
+            }}
+            onMouseMove={() => onHover(i)}
+            className={cn(
+              "flex w-full min-w-0 items-center gap-1.5 px-2.5 py-1.5 text-left text-xs",
+              i === activeIndex
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-muted/60",
+            )}
+          >
+            {c.user && (
+              <ForgeUserAvatar user={c.user} ghHost={ghHost} decorative />
+            )}
+            {c.refGlyph && (
+              <>
+                <RefGlyph state={c.refGlyph.state} isPr={c.refGlyph.isPr} />
+                <span className="shrink-0 font-mono text-muted-foreground">
+                  {c.refGlyph.numberLabel}
+                </span>
+              </>
+            )}
+            <span className="truncate">{c.label}</span>
+            {c.detail && (
+              <span className="truncate text-[11px] text-muted-foreground">
+                {c.detail}
+              </span>
+            )}
+          </button>
+        ))
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -8,6 +8,7 @@ import {
   type RefObject,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -34,7 +35,9 @@ const MAX_LIST_HEIGHT = 224;
 const GUTTER = 8;
 /** Enough of a row to estimate the list's height before it renders. */
 const ROW_HEIGHT = 28;
-/** Below this the flipped side is not worth taking. */
+/** Floor under the computed `maxHeight` on whichever side is chosen, so a caret
+ *  with almost no room still shows a usable list — at extreme heights it wins over
+ *  the gutter and the box overhangs the viewport edge. No input to the flip test. */
 const MIN_LIST_HEIGHT = 72;
 
 /** Keys that can move the caret without changing the text — the token has to be
@@ -46,6 +49,8 @@ const RESYNC_KEYS = new Set([
   "ArrowRight",
   "ArrowUp",
   "ArrowDown",
+  "PageUp",
+  "PageDown",
   "Home",
   "End",
 ]);
@@ -119,6 +124,16 @@ function place(
   };
 }
 
+/** Re-place an open token's box against the caret it already names, for the two
+ *  things that move the box without moving the token: the anchor scrolling under
+ *  it, and candidates arriving and changing the list's height. */
+function reposition(textarea: HTMLTextAreaElement, rowCount: number) {
+  return (t: ActiveToken | null): ActiveToken | null =>
+    t
+      ? { ...t, ...place(textarea, t.start + 1 + t.query.length, rowCount) }
+      : t;
+}
+
 /**
  * GitHub-style `@`/`#`/`!` completion for a textarea: token detection, the caret-
  * anchored listbox, and the keyboard contract the popover owns while a token is
@@ -149,8 +164,9 @@ export function useMentionAutocomplete({
   const listRef = useRef<HTMLDivElement>(null);
   // Swallows the one onChange an accepted completion produces (see `insert`).
   const skipSync = useRef(false);
-  // Whether the popover took the last keydown, read by its keyup twin.
-  const lastConsumed = useRef(false);
+  // Which keys the popover consumed, each read and cleared by its own keyup —
+  // one shared flag would let a second key's keydown clear the first key's mark.
+  const consumedKeys = useRef(new Set<string>());
   const listId = useId();
 
   // Render-time reset rather than an effect: a popover must never paint over a
@@ -162,6 +178,16 @@ export function useMentionAutocomplete({
   const items = result?.items ?? [];
   // The list can shrink under a stale index while data arrives.
   const activeIndex = items.length > 0 ? Math.min(index, items.length - 1) : 0;
+  const rowCount = items.length;
+
+  // The lazy queries only enable as the first token opens, so a token is always
+  // placed against an empty list first; re-place once the candidates land, before
+  // paint, or the box keeps the flip and height it chose for zero rows.
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!open || !ta) return;
+    setToken(reposition(ta, rowCount));
+  }, [open, rowCount, textareaRef]);
 
   useEffect(() => {
     if (!open) return;
@@ -170,6 +196,14 @@ export function useMentionAutocomplete({
       // underneath invalidates the caret anchor.
       const list = listRef.current;
       if (list && e.target instanceof Node && list.contains(e.target)) return;
+      const ta = textareaRef.current;
+      if (ta && e.target === ta) {
+        // The anchor scrolled, not the page — typing across a wrap boundary in a
+        // capped composer does this. Placement nets out scrollTop, so following
+        // the caret is correct where dismissing would drop the query mid-word.
+        setToken(reposition(ta, rowCount));
+        return;
+      }
       setToken(null);
     };
     const dismiss = () => setToken(null);
@@ -180,6 +214,12 @@ export function useMentionAutocomplete({
       window.removeEventListener("scroll", onScroll, opts);
       window.removeEventListener("resize", dismiss);
     };
+  }, [open, rowCount, textareaRef]);
+
+  // The consumed set lives per interaction: a closed token must not leave a key
+  // marked, or the next one's keyup would skip the re-sync it needs.
+  useEffect(() => {
+    if (!open) consumedKeys.current.clear();
   }, [open]);
 
   /** Recompute the token from the text up to the caret, and re-place the popover. */
@@ -296,7 +336,8 @@ export function useMentionAutocomplete({
   /** Returns true when the popover consumed the key. */
   function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
     const consumed = handleKey(e);
-    lastConsumed.current = consumed;
+    if (consumed) consumedKeys.current.add(e.key);
+    else consumedKeys.current.delete(e.key);
     return consumed;
   }
 
@@ -311,12 +352,16 @@ export function useMentionAutocomplete({
         "aria-controls": open ? listId : undefined,
         "aria-activedescendant":
           open && items.length > 0 ? `${listId}-${activeIndex}` : undefined,
-        onBlur: () => setToken(null),
+        onBlur: () => {
+          consumedKeys.current.clear();
+          setToken(null);
+        },
         onMouseDown: () => setToken(null),
         onKeyUp: (e: KeyboardEvent<HTMLTextAreaElement>) => {
-          // Only an arrow the popover declined moved the caret; re-syncing after
-          // one it consumed would reset the row that arrow just highlighted.
-          if (!lastConsumed.current && RESYNC_KEYS.has(e.key)) resync();
+          // Only a key the popover declined moved the caret; re-syncing after one
+          // it consumed would reset the row that arrow just highlighted.
+          const consumed = consumedKeys.current.delete(e.key);
+          if (!consumed && RESYNC_KEYS.has(e.key)) resync();
         },
       }
     : undefined;
@@ -339,9 +384,12 @@ export function useMentionAutocomplete({
   return { textareaProps, sync, onKeyDown, popover };
 }
 
-/** Open/closed glyph for a suggested reference. Mirrors the Issues panel's
- *  `StateIcon` (shape carries the state, not the tint alone); local rather than
- *  imported so the editor doesn't pull the issue-relations module into its chunk. */
+/** Glyph for a suggested reference: the shape separates an issue from a PR, and
+ *  the issue arm mirrors the Issues panel's `StateIcon` (local rather than imported
+ *  so the editor doesn't pull the issue-relations module into its chunk). Both
+ *  closed-state arms are unreachable while the ref lists request the open state
+ *  only; the PR arm distinguishes state by tint alone, so an all-states list would
+ *  need a second glyph before it could be trusted to convey one. */
 function RefGlyph({ state, isPr }: { state: string; isPr: boolean }) {
   if (isPr) {
     return (
@@ -418,6 +466,9 @@ function MentionPopover({
             role="option"
             aria-selected={i === activeIndex}
             type="button"
+            // Selection rides aria-activedescendant on the textarea, which keeps
+            // focus; a portalled row in the tab order would be reachable behind it.
+            tabIndex={-1}
             // mousedown (not click) so the textarea doesn't blur before the insert
             onMouseDown={(e) => {
               e.preventDefault();

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -1,17 +1,44 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { ReactNode, Ref } from "react";
+import { useId, useImperativeHandle, useLayoutEffect, useRef } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
 } from "@/components/markdown-editor";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import { useComposerCollapsed } from "./useComposerCollapsed";
+import type { MentionSource } from "./useMentionCandidates";
+
+/**
+ * The scroll region the composer docks under, searched depth-first from the
+ * sibling above it (every surface lays the composer out as an in-flow sibling
+ * below its scrolling conversation). Null when there is none — the anchoring it
+ * feeds is best-effort.
+ */
+function findScrollRegion(el: Element | null): HTMLElement | null {
+  if (!(el instanceof HTMLElement)) return null;
+  const { overflowY } = getComputedStyle(el);
+  if (
+    (overflowY === "auto" || overflowY === "scroll") &&
+    el.scrollHeight > el.clientHeight
+  ) {
+    return el;
+  }
+  for (const child of el.children) {
+    const found = findScrollRegion(child);
+    if (found) return found;
+  }
+  return null;
+}
 
 /**
  * The bottom "leave a comment" bar every conversation surface ends with. Fully
  * controlled: the draft lives in CALLER state, keyed there per entity so a
  * switch retains it, which a composer-owned draft could not do. Per-surface
  * extras (Approve, Close, Review…) ride the `actions`/`leadingActions` slots
- * rather than growing the prop list.
+ * rather than growing the prop list — and they keep rendering while the box is
+ * collapsed, since they are the surface's primary write actions.
  */
 export function CommentComposer({
   ref,
@@ -27,9 +54,10 @@ export function CommentComposer({
   disabled,
   actions,
   leadingActions,
+  mentions,
 }: {
   /** The editor handle, so a caller can focus/fill the box from elsewhere
-   *  (quote reply). */
+   *  (quote reply). Both methods expand a collapsed box first. */
   ref?: Ref<MarkdownEditorHandle>;
   value: string;
   onChange: (value: string) => void;
@@ -53,46 +81,206 @@ export function CommentComposer({
    *  the row's first action. Everything up to that boundary is the caller's to
    *  lay out, spacers included. */
   leadingActions?: ReactNode;
+  /** Opt in to `@`/`#`/`!` autocomplete — only surfaces whose forge autolinks the
+   *  completed reference pass one. */
+  mentions?: MentionSource;
 }) {
   const hasDraft = value.trim().length > 0;
   // Only the `busy` hold gets words: an empty draft explains itself, and a reason
   // there would add a tab stop for every viewer who simply hasn't typed yet.
   const blockedReason = busy ? (reason ?? null) : null;
+  const showClear = !!onClear && hasDraft;
+  const editorId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<MarkdownEditorHandle>(null);
+  const editorWrapRef = useRef<HTMLDivElement>(null);
+  const peekRef = useRef<HTMLButtonElement>(null);
+  // Set by an expand that started with the conversation scrolled to its bottom,
+  // consumed by the layout effect that re-pins it.
+  const repinRef = useRef(false);
+  // What the expanded/collapsed render owes the user once it commits. The
+  // un-hide rides a react-query cache notify, whose batching can land after any
+  // frame we might have scheduled, so every follow-up is keyed on the render
+  // that actually flipped `collapsed` — never on wall clock.
+  const pendingRef = useRef<"focus" | "preview" | null>(null);
+  const pendingPeekRef = useRef(false);
+
+  const { collapsed, setCollapsed, toggle } = useComposerCollapsed(
+    () => expand("focus"),
+    collapse,
+  );
+
+  /** Reveal the box, and record what the expanded render owes: focus, or the
+   *  Preview tab. */
+  function expand(then: "focus" | "preview") {
+    // Growing the box shrinks the scroll region above it, which would carry the
+    // last comment off-screen for a reader sitting at the bottom.
+    const region = findScrollRegion(
+      rootRef.current?.previousElementSibling ?? null,
+    );
+    const pinned =
+      !!region &&
+      region.scrollHeight - region.scrollTop - region.clientHeight <= 8;
+    // Arm follow-ups only on a real transition: a write the hook declined leaves
+    // no commit to consume them, and a stale flag would fire on a later expand.
+    const changed = setCollapsed(false);
+    repinRef.current = changed && pinned;
+    pendingRef.current = changed ? then : null;
+  }
+
+  function collapse() {
+    // Both collapse routes destroy the control that fired them (the caret button
+    // unmounts with the expanded row; the palette closes), so focus would fall to
+    // <body> without re-homing it on the peek strip.
+    pendingPeekRef.current = setCollapsed(true);
+  }
+
+  // No dependency list: the handle closes over `collapsed` and over locals the
+  // compiler re-creates, and re-attaching it each render is cheaper than the
+  // stale-closure risk of pinning it.
+  useImperativeHandle(ref, () => ({
+    focus() {
+      if (collapsed) expand("focus");
+      else editorRef.current?.focus();
+    },
+    showPreview() {
+      if (collapsed) expand("preview");
+      else editorRef.current?.showPreview();
+    },
+  }));
+
+  // The collapse commit. Focus stranded inside the now-`display:none` editor is
+  // blurred first, so anything anchored to it (an open autocomplete popover)
+  // takes its own blur-dismiss path rather than relying on browser behavior.
+  useLayoutEffect(() => {
+    if (!collapsed) return;
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLElement &&
+      editorWrapRef.current?.contains(active)
+    ) {
+      active.blur();
+    }
+    if (!pendingPeekRef.current) return;
+    pendingPeekRef.current = false;
+    // One frame, inside the commit that mounted the strip: the palette dialog
+    // returns focus to its trigger as it closes, and would otherwise win.
+    requestAnimationFrame(() => peekRef.current?.focus());
+  }, [collapsed]);
+
+  // The expand commit. Re-pin before focusing — and the two can't fight anyway:
+  // the scroll region is the composer's SIBLING, not an ancestor, so the
+  // editor's `scrollIntoView({block:"nearest"})` cannot reach it.
+  useLayoutEffect(() => {
+    if (collapsed) return;
+    if (repinRef.current) {
+      repinRef.current = false;
+      const region = findScrollRegion(
+        rootRef.current?.previousElementSibling ?? null,
+      );
+      if (region) region.scrollTop = region.scrollHeight;
+    }
+    const pending = pendingRef.current;
+    if (!pending) return;
+    pendingRef.current = null;
+    // One frame, inside the commit that revealed the editor: a quote reply fires
+    // from a Base UI menu whose close-time focus-return would otherwise steal it.
+    requestAnimationFrame(() => {
+      if (pending === "preview") editorRef.current?.showPreview();
+      else editorRef.current?.focus();
+    });
+  }, [collapsed]);
+
   return (
-    <div className="space-y-2 border-t p-3">
-      <MarkdownEditor
-        ref={ref}
-        aria-label={ariaLabel}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        onKeyDown={(e) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-            // preventDefault unconditionally: `commit` is bound to mod+enter and
-            // fires inside editable targets, so a chord this handler declines to
-            // submit would otherwise reach the global action.
-            e.preventDefault();
-            if (hasDraft && !busy) onSubmit();
-          }
-        }}
-        rows={2}
-        disabled={disabled}
-        textareaClassName="max-h-32 min-h-12 resize-y"
-      />
+    <div ref={rootRef} className="border-t p-3">
+      {/* Hidden, not unmounted: the editor keeps its textarea mounted so a
+          collapse round-trip can't wipe the native undo stack, and `hidden` also
+          takes it out of the tab order and the accessibility tree. */}
+      <div
+        ref={editorWrapRef}
+        id={editorId}
+        hidden={collapsed}
+        className="mb-2"
+      >
+        <MarkdownEditor
+          ref={editorRef}
+          aria-label={ariaLabel}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onKeyDown={(e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+              // preventDefault unconditionally: `commit` is bound to mod+enter and
+              // fires inside editable targets, so a chord this handler declines to
+              // submit would otherwise reach the global action.
+              e.preventDefault();
+              if (hasDraft && !busy) onSubmit();
+            }
+          }}
+          rows={2}
+          disabled={disabled}
+          mentions={mentions}
+          textareaClassName="max-h-32 min-h-12 resize-y"
+        />
+      </div>
+      {/* One row in both states, so the caller's actions mount once and keep
+          their own state across a collapse — and the disclosure control holds the
+          same left-edge slot either way, so collapsing leaves the pointer on the
+          affordance that expands again rather than on a docked action. */}
       <div className="flex items-center gap-2">
+        {collapsed && (
+          <>
+            <button
+              ref={peekRef}
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-1 text-left text-muted-foreground text-xs hover:text-foreground"
+              aria-expanded={false}
+              aria-controls={editorId}
+              onClick={toggle}
+            >
+              <CaretRightIcon className="size-3 shrink-0" />
+              {hasDraft && (
+                <span className="shrink-0 rounded border px-1">Draft</span>
+              )}
+              <span className="truncate">
+                {hasDraft ? value.trim().split("\n", 1)[0] : placeholder}
+              </span>
+            </button>
+            {blockedReason && (
+              <span className="shrink-0 text-muted-foreground text-xs">
+                {blockedReason}
+              </span>
+            )}
+          </>
+        )}
+        {!collapsed && (
+          <button
+            type="button"
+            className="flex shrink-0 items-center text-muted-foreground hover:text-foreground"
+            aria-expanded
+            aria-controls={editorId}
+            aria-label="Collapse the comment box"
+            title="Collapse the comment box"
+            onClick={collapse}
+          >
+            <CaretDownIcon className="size-3" />
+          </button>
+        )}
         {leadingActions}
-        <DisabledReasonButton
-          variant="outline"
-          size="sm"
-          disabled={!hasDraft || busy}
-          reason={blockedReason}
-          onClick={onSubmit}
-          title={SUBMIT_HINT}
-        >
-          {submitLabel}
-        </DisabledReasonButton>
+        {!collapsed && (
+          <DisabledReasonButton
+            variant="outline"
+            size="sm"
+            disabled={!hasDraft || busy}
+            reason={blockedReason}
+            onClick={onSubmit}
+            title={SUBMIT_HINT}
+          >
+            {submitLabel}
+          </DisabledReasonButton>
+        )}
         {actions}
-        {onClear && hasDraft && (
+        {!collapsed && showClear && (
           <DisabledReasonButton
             variant="ghost"
             size="sm"

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -95,9 +95,12 @@ export function CommentComposer({
   const editorRef = useRef<MarkdownEditorHandle>(null);
   const editorWrapRef = useRef<HTMLDivElement>(null);
   const peekRef = useRef<HTMLButtonElement>(null);
-  // Set by an expand that started with the conversation scrolled to its bottom,
-  // consumed by the layout effect that re-pins it.
-  const repinRef = useRef(false);
+  // The scroll region measured at expand time, when the reader was sitting at
+  // its bottom — null otherwise. The ELEMENT is held rather than re-walked on
+  // the commit: un-hiding the editor changes which containers overflow, so a
+  // second walk can answer with a different element than the one the pin
+  // decision was made against.
+  const repinRef = useRef<HTMLElement | null>(null);
   // What the expanded/collapsed render owes the user once it commits. The
   // un-hide rides a react-query cache notify, whose batching can land after any
   // frame we might have scheduled, so every follow-up is keyed on the render
@@ -124,7 +127,7 @@ export function CommentComposer({
     // Arm follow-ups only on a real transition: a write the hook declined leaves
     // no commit to consume them, and a stale flag would fire on a later expand.
     const changed = setCollapsed(false);
-    repinRef.current = changed && pinned;
+    repinRef.current = changed && pinned ? region : null;
     pendingRef.current = changed ? then : null;
   }
 
@@ -137,7 +140,9 @@ export function CommentComposer({
 
   // No dependency list: the handle closes over `collapsed` and over locals the
   // compiler re-creates, and re-attaching it each render is cheaper than the
-  // stale-closure risk of pinning it.
+  // stale-closure risk of pinning it — which holds only while callers pass an
+  // OBJECT ref, since a callback ref would be invoked with null and the handle
+  // on every render.
   useImperativeHandle(ref, () => ({
     focus() {
       if (collapsed) expand("focus");
@@ -173,12 +178,10 @@ export function CommentComposer({
   // editor's `scrollIntoView({block:"nearest"})` cannot reach it.
   useLayoutEffect(() => {
     if (collapsed) return;
-    if (repinRef.current) {
-      repinRef.current = false;
-      const region = findScrollRegion(
-        rootRef.current?.previousElementSibling ?? null,
-      );
-      if (region) region.scrollTop = region.scrollHeight;
+    const region = repinRef.current;
+    if (region) {
+      repinRef.current = null;
+      region.scrollTop = region.scrollHeight;
     }
     const pending = pendingRef.current;
     if (!pending) return;

--- a/src/features/conversations/CommentEditor.tsx
+++ b/src/features/conversations/CommentEditor.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
+import type { MentionSource } from "./useMentionCandidates";
 
 /**
  * The inline comment editor: a markdown box with Save/Cancel swapped in for a
@@ -24,6 +25,7 @@ export function CommentEditor({
   pending,
   ariaLabel,
   textareaClassName,
+  mentions,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -36,6 +38,9 @@ export function CommentEditor({
   pending?: boolean;
   ariaLabel?: string;
   textareaClassName?: string;
+  /** Opt in to `@`/`#`/`!` autocomplete — only surfaces whose forge autolinks the
+   *  completed reference pass one. */
+  mentions?: MentionSource;
 }) {
   const editorRef = useRef<MarkdownEditorHandle>(null);
 
@@ -66,6 +71,7 @@ export function CommentEditor({
         rows={3}
         disabled={pending}
         textareaClassName={textareaClassName}
+        mentions={mentions}
       />
       <div className="flex items-center gap-2">
         <Button

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -14,6 +14,7 @@ import { required, useAppForm, withForm } from "@/lib/form";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { toastError } from "@/lib/toast";
+import type { MentionSource } from "./useMentionCandidates";
 
 /** Shared form shape so the hook's `useAppForm` and the `withForm` dialog agree. */
 export const editTitleBodyFormOpts = formOptions({
@@ -85,6 +86,10 @@ interface EditTitleBodyDialogProps {
    *  `onGenerate` — the issue views omit it, so they compile untouched and render
    *  byte-identically. */
   belowBody?: ReactNode;
+  /** Opt in to `@`/`#`/`!` autocomplete in the description field, matching the
+   *  composer below the thread. The local views omit it (nothing autolinks a
+   *  local body). */
+  mentions?: MentionSource;
 }
 
 export const EditTitleBodyDialog = withForm({
@@ -103,6 +108,7 @@ export const EditTitleBodyDialog = withForm({
     generating: undefined as boolean | undefined,
     generateDisabled: undefined as boolean | undefined,
     belowBody: undefined as ReactNode,
+    mentions: undefined as MentionSource | undefined,
   } as EditTitleBodyDialogProps,
   render: function EditTitleBodyDialogRender({
     form,
@@ -117,6 +123,7 @@ export const EditTitleBodyDialog = withForm({
     generating,
     generateDisabled,
     belowBody,
+    mentions,
   }) {
     // Context-sensitive reuse of the `generate-commit-message` binding while
     // this dialog is open. This dialog is shared with the ISSUE views, which
@@ -182,6 +189,7 @@ export const EditTitleBodyDialog = withForm({
                   rows={8}
                   textareaClassName={bodyTextareaClassName}
                   actions={bodyActions}
+                  mentions={mentions}
                 />
               )}
             </form.AppField>

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -22,6 +22,7 @@ import { useActiveForgeGhHost, useActiveGhHost } from "@/lib/git/host";
 import type { PrThreadOut, Reaction, RepoLabel } from "@/lib/git/types";
 import { CommentEditor } from "./CommentEditor";
 import { ReactionBar } from "./ReactionBar";
+import type { MentionSource } from "./useMentionCandidates";
 
 /**
  * Shared conversation primitives for any GitHub thread surface (pull requests,
@@ -101,6 +102,7 @@ export function Thread({
   renderBody,
   copyMarkdown,
   disabledReason,
+  mentions,
 }: {
   thread: PrThreadOut;
   onQuote?: () => void;
@@ -142,6 +144,9 @@ export function Thread({
   /** Why `reactionsHeld` holds — the bar shows and announces it on every control
    *  it disables. Absent leaves a plain disable no viewer can interrogate. */
   reactionsReason?: string | null;
+  /** Opt in to `@`/`#`/`!` autocomplete in the edit-in-place editor — only
+   *  surfaces whose forge autolinks the completed reference pass one. */
+  mentions?: MentionSource;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -276,6 +281,7 @@ export function Thread({
           }}
           onCancel={() => setEditing(false)}
           textareaClassName="max-h-48 min-h-16 resize-y font-mono"
+          mentions={mentions}
         />
       ) : minimized && !expanded ? (
         <button

--- a/src/features/conversations/useComposerCollapsed.ts
+++ b/src/features/conversations/useComposerCollapsed.ts
@@ -13,7 +13,7 @@ import {
  * palette action while a composer is mounted, so it is offered exactly where
  * there is a box to collapse.
  *
- * @param onExpand run when the palette action expands the box
+ * @param onExpand run when the box is expanded
  * @param onCollapse run when it collapses. Both directions re-home focus, but to
  *   different controls, so the hook delegates rather than picking one.
  */

--- a/src/features/conversations/useComposerCollapsed.ts
+++ b/src/features/conversations/useComposerCollapsed.ts
@@ -1,0 +1,55 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import {
+  settingsKeys,
+  useSaveSettings,
+  useSettings,
+} from "@/lib/settings/queries";
+
+/**
+ * Global, persisted collapse state for the docked comment composer, shared by
+ * every conversation surface (one preference, not one per entity — collapsing on
+ * a PR reclaims the same reading space on issues and discussions). Registers the
+ * palette action while a composer is mounted, so it is offered exactly where
+ * there is a box to collapse.
+ *
+ * @param onExpand run when the palette action expands the box
+ * @param onCollapse run when it collapses. Both directions re-home focus, but to
+ *   different controls, so the hook delegates rather than picking one.
+ */
+export function useComposerCollapsed(
+  onExpand: () => void,
+  onCollapse: () => void,
+) {
+  const settings = useSettings();
+  const saveSettings = useSaveSettings();
+  const queryClient = useQueryClient();
+  const collapsed = settings.data?.commentComposerCollapsed ?? false;
+
+  /** @returns whether the box actually changed state — false while settings are
+   *  still loading, or when the preference already held `next`. Callers that arm
+   *  follow-up work on the transition gate on it. */
+  function setCollapsed(next: boolean): boolean {
+    const current = settings.data;
+    if (!current || current.commentComposerCollapsed === next) return false;
+    const updated = { ...current, commentComposerCollapsed: next };
+    // Patch the cache before persisting: an expand focuses the editor one frame
+    // later, which the settings round-trip would not have landed in time for. A
+    // failed write refetches the stored truth back over the patch.
+    queryClient.setQueryData(settingsKeys.settings, updated);
+    saveSettings.mutate(updated, {
+      onError: () =>
+        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+    });
+    return true;
+  }
+
+  function toggle() {
+    if (collapsed) onExpand();
+    else onCollapse();
+  }
+
+  useHotkeyAction("toggle-comment-composer", toggle);
+
+  return { collapsed, setCollapsed, toggle };
+}

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -88,7 +88,8 @@ function rankUsers(
   const needle = query.toLowerCase();
   const scored: { user: ForgeUserRef; rank: number; order: number }[] = [];
   for (const [order, user] of users.entries()) {
-    // A user matches on either the display name or the handle, taking the better rank.
+    // Ranking both fields covers a provider whose display name differs from the
+    // handle; the wired ones set them equal, so today the two ranks agree.
     const ranks = [
       textRank(user.label, needle),
       textRank(user.id, needle),
@@ -128,9 +129,13 @@ function rankRefs(
     const rank = textRank(row.title, needle);
     if (rank !== -1) scored.push({ row, rank });
   }
-  scored.sort(
-    (a, b) => a.rank - b.rank || (a.row.sortAt < b.row.sortAt ? 1 : -1),
-  );
+  scored.sort((a, b) => {
+    if (a.rank !== b.rank) return a.rank - b.rank;
+    // Equal timestamps must compare equal, not -1 both ways: an inconsistent
+    // comparator lets the sort permute rows that should hold their input order.
+    if (a.row.sortAt === b.row.sortAt) return 0;
+    return a.row.sortAt < b.row.sortAt ? 1 : -1;
+  });
   return scored.slice(0, MAX_ROWS).map(({ row }) => ({
     key: `${row.isPr ? "pr" : "issue"}:${row.number}`,
     insert: String(row.number),

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -202,18 +202,22 @@ export function useMentionCandidates({
 
   const onActive = useCallback(() => setActive(true), []);
 
-  // Both list queries leave state and limit free in their placeholder comparators,
-  // so a panel's closed-tab rows can be served here until this key's own fetch
-  // lands. Read placeholder rows as "still loading" rather than suggesting a
-  // closed issue the completion promised would be open.
+  // The data/loading/error triples below are the whole of what `query` closes
+  // over — never the query result objects, which re-identify every render and
+  // would churn this source's identity downstream. Both list queries also leave
+  // state and limit free in their placeholder comparators, so a panel's closed-tab
+  // rows can be served here until this key's own fetch lands: placeholder rows
+  // read as "still loading" rather than suggesting a closed issue the completion
+  // promised would be open.
   const issueData = issues.isPlaceholderData ? undefined : issues.data;
   const prData = prs.isPlaceholderData ? undefined : prs.data;
   const issuesLoading = issues.isLoading || issues.isPlaceholderData;
   const prsLoading = prs.isLoading || prs.isPlaceholderData;
-  // `query` closes over these rather than the query results themselves, which
-  // re-identify every render and would churn this source's identity downstream.
+  const issuesError = issues.isError;
+  const prsError = prs.isError;
   const userData = users.data;
   const usersLoading = users.isLoading;
+  const usersError = users.isError;
 
   const query = (trigger: MentionTrigger, text: string) => {
     if (!provider) return { items: [], loading: false, isError: false };
@@ -221,14 +225,14 @@ export function useMentionCandidates({
       return {
         items: rankUsers(userData ?? [], text, provider),
         loading: usersLoading,
-        isError: users.isError,
+        isError: usersError,
       };
     }
     if (trigger === "!") {
       return {
         items: rankRefs(prRows(prData), text, (r) => `!${r.number}`),
         loading: prsLoading,
-        isError: prs.isError,
+        isError: prsError,
       };
     }
     // `#`: GitHub merges both lists into its shared number space; GitLab's `#`
@@ -240,7 +244,7 @@ export function useMentionCandidates({
     return {
       items: rankRefs(rows, text, (r) => `#${r.number}`),
       loading: issuesLoading || (provider === "github" && prsLoading),
-      isError: issues.isError || (provider === "github" && prs.isError),
+      isError: issuesError || (provider === "github" && prsError),
     };
   };
 

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -1,0 +1,238 @@
+import { useCallback, useState } from "react";
+import { useForgeGhHost } from "@/lib/git/host";
+import { useAssignableUsers, useIssueList, usePrList } from "@/lib/git/queries";
+import type {
+  ForgeProvider,
+  ForgeUserRef,
+  IssueInfo,
+  PrInfo,
+  RemoteLens,
+} from "@/lib/git/types";
+
+/** A character that opens the suggestion popover when typed at a word boundary. */
+export type MentionTrigger = "@" | "#" | "!";
+
+export interface MentionCandidate {
+  /** Stable React key, unique per row. */
+  key: string;
+  /** Spliced into the body AFTER the trigger char (login, number, or Bitbucket "{accountId}"). */
+  insert: string;
+  /** Primary row text (display name, or the title for refs). */
+  label: string;
+  /** Muted secondary (login for users; nothing for refs). */
+  detail?: string;
+  /** Present on user rows — drives ForgeUserAvatar. */
+  user?: ForgeUserRef;
+  /** Present on ref rows — drives the mono number and the state glyph. */
+  refGlyph?: { numberLabel: string; state: string; isPr: boolean };
+}
+
+export interface MentionSource {
+  triggers: readonly MentionTrigger[];
+  /** GitHub host for login-derived avatars; `null` off GitHub. */
+  ghHost: string | null;
+  /** First time a trigger token opens — flips the lazy queries on. Idempotent. */
+  onActive: () => void;
+  /** Pure filter over cached data; called during render. */
+  query: (
+    trigger: MentionTrigger,
+    query: string,
+  ) => { items: MentionCandidate[]; loading: boolean };
+}
+
+/**
+ * Which triggers each forge autolinks in a comment body. GitHub resolves `#N` from a
+ * single number space covering issues AND PRs; GitLab numbers them separately (`#`
+ * issues, `!` merge requests). Bitbucket autolinks neither a bare `#N` nor a plain
+ * `@nickname` written through its API — its mentions need `@{accountId}`, which
+ * `forge_assignable_users` has no Bitbucket arm to supply, so it offers none.
+ */
+const TRIGGERS: Record<ForgeProvider, readonly MentionTrigger[]> = {
+  github: ["@", "#"],
+  gitlab: ["@", "#", "!"],
+  bitbucket: [],
+};
+
+/** No provider resolved yet: the source is inert (no triggers, no queries). */
+const NO_TRIGGERS: readonly MentionTrigger[] = [];
+
+/** How many rows the popover shows, applied after ranking. */
+const MAX_ROWS = 8;
+
+const NUMERIC = /^\d+$/;
+
+/** A ref candidate before it becomes a row — the two lists share one ordering. */
+interface RefRow {
+  number: number;
+  title: string;
+  state: string;
+  isPr: boolean;
+  /** The freshest timestamp the source carries, for the recency ordering. */
+  sortAt: string;
+}
+
+/** Prefix matches outrank substring matches; -1 drops the row. `needle` must
+ *  already be lower-cased. */
+function textRank(haystack: string, needle: string): 0 | 1 | -1 {
+  if (!needle) return 0;
+  const i = haystack.toLowerCase().indexOf(needle);
+  if (i === 0) return 0;
+  return i > 0 ? 1 : -1;
+}
+
+function rankUsers(
+  users: ForgeUserRef[],
+  query: string,
+  provider: ForgeProvider,
+): MentionCandidate[] {
+  const needle = query.toLowerCase();
+  const scored: { user: ForgeUserRef; rank: number; order: number }[] = [];
+  for (const [order, user] of users.entries()) {
+    // A user matches on either the display name or the handle, taking the better rank.
+    const ranks = [
+      textRank(user.label, needle),
+      textRank(user.id, needle),
+    ].filter((r) => r !== -1);
+    if (ranks.length > 0) {
+      scored.push({ user, rank: Math.min(...ranks), order });
+    }
+  }
+  // Provider order is the tiebreak: the forge already returns its own relevance.
+  scored.sort((a, b) => a.rank - b.rank || a.order - b.order);
+  return scored.slice(0, MAX_ROWS).map(({ user }) => ({
+    key: `user:${user.id}`,
+    // Bitbucket resolves a mention by account id wrapped in braces; every other
+    // provider takes the handle verbatim.
+    insert: provider === "bitbucket" ? `{${user.id}}` : user.id,
+    label: user.label || user.id,
+    // Bitbucket's id is an opaque account uuid, so it stays out of the row.
+    detail:
+      provider !== "bitbucket" && user.id !== user.label ? user.id : undefined,
+    user,
+  }));
+}
+
+function rankRefs(
+  rows: RefRow[],
+  query: string,
+  numberLabel: (row: RefRow) => string,
+): MentionCandidate[] {
+  const numeric = NUMERIC.test(query);
+  const needle = query.toLowerCase();
+  const scored: { row: RefRow; rank: number }[] = [];
+  for (const row of rows) {
+    if (numeric) {
+      if (String(row.number).startsWith(query)) scored.push({ row, rank: 0 });
+      continue;
+    }
+    const rank = textRank(row.title, needle);
+    if (rank !== -1) scored.push({ row, rank });
+  }
+  scored.sort(
+    (a, b) => a.rank - b.rank || (a.row.sortAt < b.row.sortAt ? 1 : -1),
+  );
+  return scored.slice(0, MAX_ROWS).map(({ row }) => ({
+    key: `${row.isPr ? "pr" : "issue"}:${row.number}`,
+    insert: String(row.number),
+    label: row.title,
+    refGlyph: {
+      numberLabel: numberLabel(row),
+      state: row.state,
+      isPr: row.isPr,
+    },
+  }));
+}
+
+const issueRows = (list: IssueInfo[] | undefined): RefRow[] =>
+  (list ?? []).map((i) => ({
+    number: i.number,
+    title: i.title,
+    state: i.state,
+    isPr: false,
+    sortAt: i.updatedAt,
+  }));
+
+const prRows = (list: PrInfo[] | undefined): RefRow[] =>
+  // `PrInfo` carries no `updatedAt`, so PR rows order by their open date.
+  (list ?? []).map((p) => ({
+    number: p.number,
+    title: p.title,
+    state: p.state,
+    isPr: true,
+    sortAt: p.createdAt,
+  }));
+
+/**
+ * The per-surface data behind the comment composers' `@`/`#`/`!` autocomplete:
+ * which triggers this forge autolinks, and a pure filter over the cached
+ * candidates each one offers. Strictly lazy — the three underlying queries stay
+ * disabled until the first trigger token opens, so mounting a PR view costs
+ * nothing until someone actually types one.
+ */
+export function useMentionCandidates({
+  repoPath,
+  lens,
+  provider,
+}: {
+  repoPath: string;
+  lens: RemoteLens;
+  /** Absent until forge status resolves, and null on a repo with no hosted remote —
+   *  the source stays inert (no triggers, no queries) in both cases. */
+  provider: ForgeProvider | null | undefined;
+}): MentionSource {
+  const [active, setActive] = useState(false);
+  const triggers = provider ? TRIGGERS[provider] : NO_TRIGGERS;
+  const wantsUsers = active && triggers.includes("@");
+  const wantsIssues = active && triggers.includes("#");
+  // GitHub's `#` covers PRs too; GitLab reaches merge requests through `!` instead.
+  const wantsPrs =
+    active && (provider === "github" ? wantsIssues : triggers.includes("!"));
+
+  const users = useAssignableUsers(repoPath, wantsUsers, lens);
+  const issues = useIssueList(repoPath, wantsIssues, "open", 50, lens);
+  const prs = usePrList(repoPath, wantsPrs, "open", 50, lens);
+  const ghHost = useForgeGhHost(repoPath);
+
+  const onActive = useCallback(() => setActive(true), []);
+
+  // Both list queries leave state and limit free in their placeholder comparators,
+  // so a panel's closed-tab rows can be served here until this key's own fetch
+  // lands. Read placeholder rows as "still loading" rather than suggesting a
+  // closed issue the completion promised would be open.
+  const issueData = issues.isPlaceholderData ? undefined : issues.data;
+  const prData = prs.isPlaceholderData ? undefined : prs.data;
+  const issuesLoading = issues.isLoading || issues.isPlaceholderData;
+  const prsLoading = prs.isLoading || prs.isPlaceholderData;
+  // `query` closes over these rather than the query results themselves, which
+  // re-identify every render and would churn this source's identity downstream.
+  const userData = users.data;
+  const usersLoading = users.isLoading;
+
+  const query = (trigger: MentionTrigger, text: string) => {
+    if (!provider) return { items: [], loading: false };
+    if (trigger === "@") {
+      return {
+        items: rankUsers(userData ?? [], text, provider),
+        loading: usersLoading,
+      };
+    }
+    if (trigger === "!") {
+      return {
+        items: rankRefs(prRows(prData), text, (r) => `!${r.number}`),
+        loading: prsLoading,
+      };
+    }
+    // `#`: GitHub merges both lists into its shared number space; GitLab's `#`
+    // addresses issues alone.
+    const rows =
+      provider === "github"
+        ? [...issueRows(issueData), ...prRows(prData)]
+        : issueRows(issueData);
+    return {
+      items: rankRefs(rows, text, (r) => `#${r.number}`),
+      loading: issuesLoading || (provider === "github" && prsLoading),
+    };
+  };
+
+  return { triggers, ghHost, onActive, query };
+}

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -33,11 +33,13 @@ export interface MentionSource {
   ghHost: string | null;
   /** First time a trigger token opens — flips the lazy queries on. Idempotent. */
   onActive: () => void;
-  /** Pure filter over cached data; called during render. */
+  /** Pure filter over cached data; called during render. `isError` reports that a
+   *  backing list failed, which an empty result would otherwise present as a
+   *  confident "nothing matches". */
   query: (
     trigger: MentionTrigger,
     query: string,
-  ) => { items: MentionCandidate[]; loading: boolean };
+  ) => { items: MentionCandidate[]; loading: boolean; isError: boolean };
 }
 
 /**
@@ -214,17 +216,19 @@ export function useMentionCandidates({
   const usersLoading = users.isLoading;
 
   const query = (trigger: MentionTrigger, text: string) => {
-    if (!provider) return { items: [], loading: false };
+    if (!provider) return { items: [], loading: false, isError: false };
     if (trigger === "@") {
       return {
         items: rankUsers(userData ?? [], text, provider),
         loading: usersLoading,
+        isError: users.isError,
       };
     }
     if (trigger === "!") {
       return {
         items: rankRefs(prRows(prData), text, (r) => `!${r.number}`),
         loading: prsLoading,
+        isError: prs.isError,
       };
     }
     // `#`: GitHub merges both lists into its shared number space; GitLab's `#`
@@ -236,6 +240,7 @@ export function useMentionCandidates({
     return {
       items: rankRefs(rows, text, (r) => `#${r.number}`),
       loading: issuesLoading || (provider === "github" && prsLoading),
+      isError: issues.isError || (provider === "github" && prs.isError),
     };
   };
 

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -202,9 +202,9 @@ export function useMentionCandidates({
 
   const onActive = useCallback(() => setActive(true), []);
 
-  // The data/loading/error triples below are the whole of what `query` closes
-  // over — never the query result objects, which re-identify every render and
-  // would churn this source's identity downstream. Both list queries also leave
+  // The data/loading/error triples below are the only query state `query`
+  // closes over — never the query result objects, which re-identify every
+  // render and would churn this source's identity downstream. Both list queries also leave
   // state and limit free in their placeholder comparators, so a panel's closed-tab
   // rows can be served here until this key's own fetch lands: placeholder rows
   // read as "still loading" rather than suggesting a closed issue the completion

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -46,6 +46,7 @@ import {
   hasVisibleBody,
   Thread,
 } from "@/features/conversations/Thread";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { copyText } from "@/lib/clipboard";
 import type {
@@ -200,6 +201,13 @@ export function DiscussionView({
   number: number;
 }) {
   const details = useDiscussionDetails(repoPath, number);
+  // Discussions are a GitHub-only surface, and one that never carries the
+  // origin/upstream lens — the parent's discussions aren't reachable from here.
+  const mentions = useMentionCandidates({
+    repoPath,
+    lens: "origin",
+    provider: "github",
+  });
   const reactions = useDiscussionReactions(repoPath, number);
   const addComment = useAddDiscussionComment(repoPath);
   const markAnswer = useMarkDiscussionAnswer(repoPath);
@@ -813,6 +821,7 @@ export function DiscussionView({
                   }
                   reactionsHeld={detailsStale}
                   reactionsReason={staleReason}
+                  mentions={mentions}
                 />
               </div>
               {/* Every control in the row carries its own reason. */}
@@ -886,6 +895,7 @@ export function DiscussionView({
                       }
                       reactionsHeld={detailsStale}
                       reactionsReason={staleReason}
+                      mentions={mentions}
                     />
                   ))}
                   {reply.value.targetId === c.id && (
@@ -911,6 +921,7 @@ export function DiscussionView({
                         }}
                         rows={2}
                         textareaClassName="max-h-32 min-h-12 resize-y"
+                        mentions={mentions}
                       />
                       <div className="flex items-center gap-2">
                         <DisabledReasonButton
@@ -953,6 +964,7 @@ export function DiscussionView({
         submitLabel="Comment"
         ariaLabel="Add to the discussion"
         placeholder="Add to the discussion…"
+        mentions={mentions}
         busy={busy}
         reason={busyReason}
       />

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -818,7 +818,19 @@ Comments, replies, edits, and descriptions use a Markdown editor with **Write / 
 tabs and a formatting toolbar (bold, italic, headings, quote, code, links, and bulleted
 / numbered / task lists, with {{key:mod+b}} / {{key:mod+i}} / {{key:mod+k}}); press
 {{key:mod+enter}} to submit a comment or save an edit. The same editor is everywhere
-you write Markdown — issues, discussions, and release notes.
+you write Markdown — issues, discussions, and release notes. On **GitHub** and
+**GitLab** repos, typing **@** suggests people and **#** suggests issues and pull
+requests (on GitLab, **#** covers issues and **!** covers merge requests). That works
+in the comment box at the bottom of a pull request, issue, discussion, or commit, and
+in replies, edits, line comments on a diff, and release notes; arrow keys move through
+the list, Enter or Tab accepts, and Esc dismisses it. The comment box itself folds to a
+one-line strip when you want more of the thread on screen: the caret at the left of its
+button row collapses it, and clicking the strip (or starting a quote reply) opens it
+again with the cursor in the editor. The caret keeps that slot in both states, so
+collapsing leaves the pointer on the control that opens the box back up. Folded, the
+surface's own actions stay on the strip and a saved draft shows its first line there;
+the choice is remembered across every conversation surface and across restarts, and the
+command palette's **Collapse or expand the comment box** toggles it too.
 
 ## Conflicts with the base branch
 
@@ -1317,7 +1329,9 @@ add labels, **close / reopen** (closing asks first; either way your drafted comm
 alongside), **lock**, and **transfer** an issue to another repo.
 The comment box sits at the bottom of the issue,
 past the side rail, and the command palette's **Focus the comment box** jumps straight
-to it — no default shortcut, so give it one in **Settings → Keyboard**.
+to it — no default shortcut, so give it one in **Settings → Keyboard**. It folds to a
+one-line strip and completes **@** mentions and **#** references the same way it does on
+the Pull Requests tab.
 
 - **Sub-issues** — break an issue into a parent/child checklist with completion tracking.
 - **Dependencies** — link issues as blocked-by / blocking.
@@ -1453,7 +1467,9 @@ The **Discussions** tab ({{kbd:tab-discussions}}, in the More ▾ menu) browses 
 part in GitHub Discussions for the repo. (Discussions must be enabled on the repo.)
 
 - Read **threaded conversations** — top-level comments with nested replies — and post,
-  edit, delete, or hide comments with the Markdown editor.
+  edit, delete, or hide comments with the Markdown editor. The comment box folds to a
+  one-line strip and completes **@** mentions and **#** references the same way it does
+  on the Pull Requests tab.
 - In a Q&A discussion, **mark a reply as the answer**.
 - Add **reactions** and upvotes. The upvote chip stays keyboard-reachable while a vote is
   being recorded, or while the discussion you picked is still loading, and says what it's

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -819,8 +819,9 @@ tabs and a formatting toolbar (bold, italic, headings, quote, code, links, and b
 / numbered / task lists, with {{key:mod+b}} / {{key:mod+i}} / {{key:mod+k}}); press
 {{key:mod+enter}} to submit a comment or save an edit. The same editor is everywhere
 you write Markdown — issues, discussions, and release notes. On **GitHub** and
-**GitLab** repos, typing **@** suggests people and **#** suggests issues and pull
-requests (on GitLab, **#** covers issues and **!** covers merge requests). That works
+**GitLab** repos, typing **@** suggests people and **#** suggests the recently updated
+**open** issues and pull requests (on GitLab, **#** covers issues and **!** covers
+merge requests). That works
 in the comment box at the bottom of a pull request, issue, discussion, or commit, and
 in replies, edits, line comments on a diff, and release notes; arrow keys move through
 the list, Enter or Tab accepts, and Esc dismisses it. The comment box itself folds to a

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -1116,6 +1116,7 @@ export function RemoteIssueView({
         description={`Updates the title and description of #${number} on ${remoteLabel}.`}
         contentClassName="sm:max-w-lg"
         bodyTextareaClassName="max-h-72 min-h-24 resize-y font-mono"
+        mentions={mentions}
       />
 
       <DeleteCommentDialog

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -39,6 +39,7 @@ import {
   hasVisibleBody,
   Thread,
 } from "@/features/conversations/Thread";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
@@ -187,6 +188,7 @@ export function RemoteIssueView({
   const canTrackTime = forgeFeatureReady(forge.data, "timeTracking");
   const canLinkIssues = forgeFeatureReady(forge.data, "issueLinks");
   const details = useIssueDetails(repoPath, number, lens);
+  const mentions = useMentionCandidates({ repoPath, lens, provider });
   const comment = useCommentIssue(repoPath, lens);
   const closeIssue = useCloseIssue(repoPath, lens);
   const reopenIssue = useReopenIssue(repoPath, lens);
@@ -1023,6 +1025,7 @@ export function RemoteIssueView({
                   }
                   reactionsHeld={detailsStale}
                   reactionsReason={staleReason}
+                  mentions={mentions}
                 />
               ))}
               {comments.length === 0 && (
@@ -1072,6 +1075,7 @@ export function RemoteIssueView({
           value={compose.value}
           onChange={compose.set}
           onSubmit={submitComment}
+          mentions={mentions}
           submitLabel="Comment"
           busy={busy}
           reason={composerReason}

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -7,6 +7,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { CommentComposer } from "@/features/conversations/CommentComposer";
 import { DeleteCommentDialog } from "@/features/conversations/DeleteCommentDialog";
 import { Thread } from "@/features/conversations/Thread";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import type { DiffLineAnchor } from "@/features/diff/DiffSurface";
 import type { splitUnifiedDiff } from "@/lib/git/diff-split";
 import {
@@ -14,6 +15,7 @@ import {
   useCreateCommitComment,
   useDeleteCommitComment,
   useEditCommitComment,
+  useForgeStatus,
 } from "@/lib/git/queries";
 import type {
   CommitCommentOut,
@@ -255,6 +257,14 @@ export function CommitComments({
   const createComment = useCreateCommitComment(repoPath, lens);
   const editComment = useEditCommitComment(repoPath, lens);
   const deleteComment = useDeleteCommitComment(repoPath, lens);
+  // The pane takes `remoteLabel`, not the provider, and which triggers autolink
+  // is a per-forge fact — read it from the shared forge status.
+  const forge = useForgeStatus(repoPath);
+  const mentions = useMentionCandidates({
+    repoPath,
+    lens,
+    provider: forge.data?.provider,
+  });
 
   const [deletingId, setDeletingId] = useState<string | null>(null);
   // Identity is the same triple the comments are read and written under.
@@ -374,6 +384,7 @@ export function CommitComments({
                     ? () => setDeletingId(c.id)
                     : undefined
                 }
+                mentions={mentions}
               />
             ))}
 
@@ -418,6 +429,7 @@ export function CommitComments({
                             ? () => setDeletingId(c.id)
                             : undefined
                         }
+                        mentions={mentions}
                       />
                     </div>
                   );
@@ -442,6 +454,7 @@ export function CommitComments({
           onChange={draft.set}
           onSubmit={submit}
           submitLabel="Comment"
+          mentions={mentions}
           busy={busy}
           reason={composerReason}
         />
@@ -521,6 +534,7 @@ export function CommitLineComposer({
   lens: RemoteLens;
 }) {
   const createComment = useCreateCommitComment(repoPath, lens);
+  const mentions = useMentionCandidates({ repoPath, lens, provider });
   const [body, setBody] = useState("");
 
   // The multi-line range, normalized: [from, line] with from <= line.
@@ -599,6 +613,7 @@ export function CommitLineComposer({
         autoFocus
         rows={3}
         textareaClassName="max-h-48 min-h-16 resize-y"
+        mentions={mentions}
       />
       <div className="flex items-center gap-2">
         <DisabledReasonButton

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -5,6 +5,7 @@ import {
   hasVisibleBody,
   Thread,
 } from "@/features/conversations/Thread";
+import type { MentionSource } from "@/features/conversations/useMentionCandidates";
 import type { MinimizeReason } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
 import type {
@@ -200,6 +201,7 @@ export function PrActivityFeed({
   onToggleReaction,
   reactionsHeld = false,
   reactionsReason,
+  mentions,
 }: {
   pr: PrDetails;
   timeline: PrTimelineEvent[] | undefined;
@@ -257,6 +259,10 @@ export function PrActivityFeed({
   /** Why `reactionsHeld` holds — shown and announced on every control it
    *  disables. Absent leaves a plain disable no viewer can interrogate. */
   reactionsReason?: string | null;
+  /** Opt in to `@`/`#`/`!` autocomplete in every editor this feed opens (comment
+   *  edits, review-thread replies) — only surfaces whose forge autolinks the
+   *  completed reference pass one. */
+  mentions?: MentionSource;
 }) {
   const {
     renderedReviews,
@@ -374,6 +380,7 @@ export function PrActivityFeed({
                 : undefined
             }
             copyMarkdown={copyMarkdown}
+            mentions={mentions}
           />
           {stale && <StaleReviewMarker commitsSince={commitsSince(r.date)} />}
           {ownThreads.length > 0 && (
@@ -397,6 +404,7 @@ export function PrActivityFeed({
                 provider={providerKey}
                 apply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}
+                mentions={mentions}
                 revealThreadId={revealThreadId}
                 onRevealed={() => setRevealThreadId(null)}
               />
@@ -449,6 +457,7 @@ export function PrActivityFeed({
                 ? (content, active) => onToggleReaction(c.id, content, active)
                 : undefined
             }
+            mentions={mentions}
           />
         </div>
       ),

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -3366,6 +3366,7 @@ export function RemotePrView({
         description={`Updates the title, description, and base branch of #${number} on ${remoteLabel}.`}
         contentClassName="sm:max-w-lg"
         bodyTextareaClassName="max-h-72 min-h-24 resize-y font-mono"
+        mentions={mentions}
         onGenerate={aiEnabled ? runGenerate : undefined}
         generating={prGen.generating}
         belowBody={

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -56,6 +56,7 @@ import { LabelsPopover } from "@/features/conversations/LabelsPopover";
 import { makeQuoteReply } from "@/features/conversations/quoteReply";
 import { ReactionBar } from "@/features/conversations/ReactionBar";
 import { AuthorAvatar, LabelChip } from "@/features/conversations/Thread";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
@@ -369,6 +370,7 @@ export function RemotePrView({
   // For the read-only assignee/reviewer chips (closed/merged PRs): GitHub avatars
   // are login-derived, GitLab/Bitbucket carry a real avatarUrl on the ref.
   const ghHost = useForgeGhHost(repoPath);
+  const mentions = useMentionCandidates({ repoPath, lens, provider });
   const comment = useCommentPr(repoPath, lens);
   const checkout = useCheckoutPr(repoPath, lens);
   const repoStatus = useRepoStatus(repoPath);
@@ -2764,6 +2766,7 @@ export function RemotePrView({
                 providerKey={providerKey}
                 suggestionApply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}
+                mentions={mentions}
                 // Hide/Unhide stay visible but disabled through the switch. The
                 // permission reason ranks first — it's the one still true once the
                 // selected pull request is on screen.
@@ -2851,6 +2854,7 @@ export function RemotePrView({
                 provider={providerKey}
                 apply={suggestionApply}
                 fileDiffLookup={fileDiffLookup}
+                mentions={mentions}
                 revealThreadId={revealThreadId}
                 onRevealed={() => setRevealThreadId(null)}
               />
@@ -2879,6 +2883,7 @@ export function RemotePrView({
               submitLabel="Comment"
               ariaLabel="Leave a comment"
               placeholder="Leave a comment…"
+              mentions={mentions}
               busy={busy}
               // Every term of `busy` gets words, so a held Submit is never mute —
               // including the switch, where the comment would post against the
@@ -3090,6 +3095,7 @@ export function RemotePrView({
             provider={providerKey}
             apply={suggestionApply}
             fileDiffLookup={fileDiffLookup}
+            mentions={mentions}
             // gh GraphQL returns commits oldest-first, so the head is the last —
             // pin the file-row Blame at the PR's tip.
             blameRev={pr.commits.at(-1)?.oid}

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
+import type { MentionSource } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import {
   DiffContent,
@@ -59,6 +60,9 @@ interface DiffThreadWiring {
   /** File-section lookup for synthesizing a hunk on hunk-less providers, so the
    *  in-diff thread cards get the same Apply affordance. Absent = no synthesis. */
   fileDiffLookup?: (path: string) => string | undefined;
+  /** Opt in to `@`/`#`/`!` autocomplete in each card's editors. Absent = no
+   *  autocomplete. */
+  mentions?: MentionSource;
 }
 
 /**
@@ -75,6 +79,7 @@ function DiffThreadAnchor({
   provider,
   apply,
   fileDiffLookup,
+  mentions,
 }: { threads: ReviewThreadOut[] } & DiffThreadWiring) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const isExpanded = (t: ReviewThreadOut) => expanded[t.id] ?? !t.isResolved;
@@ -98,6 +103,7 @@ function DiffThreadAnchor({
           provider={provider}
           apply={apply}
           fileDiffLookup={fileDiffLookup}
+          mentions={mentions}
         />
       ))}
     </div>
@@ -126,6 +132,7 @@ export function PrFilesPane({
   provider,
   apply,
   fileDiffLookup,
+  mentions,
   blameRev,
 }: {
   files: PrFile[];
@@ -207,6 +214,7 @@ export function PrFilesPane({
                 provider={provider}
                 apply={apply}
                 fileDiffLookup={fileDiffLookup}
+                mentions={mentions}
               />
             )}
             {repoPath !== undefined &&
@@ -238,6 +246,7 @@ export function PrFilesPane({
     provider,
     apply,
     fileDiffLookup,
+    mentions,
   ]);
 
   const fileRows = files.map((file) => (

--- a/src/features/pulls/ReviewComposer.tsx
+++ b/src/features/pulls/ReviewComposer.tsx
@@ -2,6 +2,7 @@ import { type KeyboardEvent, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { useCreateReviewThread } from "@/lib/git/queries";
 import type { RemoteLens } from "@/lib/git/types";
 import { SUBMIT_HINT } from "@/lib/hotkeys/binding";
@@ -55,6 +56,7 @@ export function ReviewComposer({
   const [pending, setPending] = useState(false);
   const createThread = useCreateReviewThread(repoPath, lens);
   const addDraft = useAddReviewDraft(repoPath, lens, number);
+  const mentions = useMentionCandidates({ repoPath, lens, provider });
 
   // The multi-line range, normalized: [from, line] with from <= line.
   const rangeFrom = fromLine !== undefined && fromLine < line ? fromLine : line;
@@ -183,6 +185,7 @@ export function ReviewComposer({
         autoFocus
         rows={3}
         textareaClassName="max-h-48 min-h-16 resize-y"
+        mentions={mentions}
       />
       <div className="flex items-center gap-2">
         {canCreateThread && (

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Spinner } from "@/components/ui/spinner";
 import { Thread } from "@/features/conversations/Thread";
+import type { MentionSource } from "@/features/conversations/useMentionCandidates";
 import { copyText } from "@/lib/clipboard";
 import type {
   ApplyLinesResult,
@@ -517,6 +518,7 @@ export function ReviewThreadCard({
   provider = "github",
   apply,
   fileDiffLookup,
+  mentions,
   revealTarget = false,
   onRevealed,
 }: {
@@ -543,6 +545,9 @@ export function ReviewThreadCard({
    *  (GitLab/Bitbucket) and isn't outdated, a hunk is synthesized from it so the
    *  excerpt + Apply gating work as they do for GitHub. Absent = no synthesis. */
   fileDiffLookup?: (path: string) => string | undefined;
+  /** Opt in to `@`/`#`/`!` autocomplete in the reply and edit-in-place editors —
+   *  only surfaces whose forge autolinks the completed reference pass one. */
+  mentions?: MentionSource;
 } & ThreadCallbacks) {
   const [replying, setReplying] = useState(false);
   const [replyBody, setReplyBody] = useState("");
@@ -713,6 +718,7 @@ export function ReviewThreadCard({
                     ? () => onDeleteComment(c.id)
                     : undefined
                 }
+                mentions={mentions}
                 // Splice SuggestionBlocks between markdown segments — quote and copy
                 // still act on the RAW body, so only the render changes.
                 renderBody={(body) => (
@@ -762,6 +768,7 @@ export function ReviewThreadCard({
                   }}
                   rows={2}
                   textareaClassName="max-h-32 min-h-12 resize-y"
+                  mentions={mentions}
                 />
                 <div className="flex items-center gap-2">
                   <DisabledReasonButton
@@ -861,6 +868,7 @@ export function ReviewThreadList({
   provider = "github",
   apply,
   fileDiffLookup,
+  mentions,
   revealThreadId,
   onRevealed,
 }: {
@@ -874,6 +882,9 @@ export function ReviewThreadList({
   /** File-section lookup for synthesizing a hunk on hunk-less providers, threaded
    *  to every card. Absent = no synthesis. */
   fileDiffLookup?: (path: string) => string | undefined;
+  /** Opt in to `@`/`#`/`!` autocomplete in every card's editors. Absent = no
+   *  autocomplete (any unwired surface). */
+  mentions?: MentionSource;
   /** A thread id the parent wants revealed (e.g. a timeline "View thread" jump). When
    *  it matches one of THIS list's threads, the list opens that thread's
    *  resolved-group expander + expands the card so a resolved/collapsed target isn't
@@ -1031,6 +1042,7 @@ export function ReviewThreadList({
                   provider={provider}
                   apply={apply}
                   fileDiffLookup={fileDiffLookup}
+                  mentions={mentions}
                   revealTarget={t.id === revealThreadId}
                   onRevealed={onRevealed}
                 />
@@ -1063,6 +1075,7 @@ export function ReviewThreadList({
                         provider={provider}
                         apply={apply}
                         fileDiffLookup={fileDiffLookup}
+                        mentions={mentions}
                         revealTarget={t.id === revealThreadId}
                         onRevealed={onRevealed}
                       />
@@ -1098,6 +1111,7 @@ export function ReviewThreadsBlock({
   provider = "github",
   apply,
   fileDiffLookup,
+  mentions,
   revealThreadId,
   onRevealed,
 }: {
@@ -1115,6 +1129,9 @@ export function ReviewThreadsBlock({
   /** File-section lookup for synthesizing a hunk on hunk-less providers. Absent =
    *  no synthesis. */
   fileDiffLookup?: (path: string) => string | undefined;
+  /** Opt in to `@`/`#`/`!` autocomplete in every card's editors. Absent = no
+   *  autocomplete. */
+  mentions?: MentionSource;
   /** A thread id to reveal (timeline "View thread" jump) — passed straight to the
    *  inner list, which acts only if the id is one of these residual threads. */
   revealThreadId?: string | null;
@@ -1149,6 +1166,7 @@ export function ReviewThreadsBlock({
         provider={provider}
         apply={apply}
         fileDiffLookup={fileDiffLookup}
+        mentions={mentions}
         revealThreadId={revealThreadId}
         onRevealed={onRevealed}
       />

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { useAppForm } from "@/lib/form";
 import {
   useBranches,
@@ -111,6 +112,13 @@ export function CreateReleaseDialog({
   // provider with an auto-changelog API — gates the `gh` call in the AI hook.
   const isGitHub =
     releaseProvider !== "gitlab" && releaseProvider !== "bitbucket";
+  // Release notes autolink the same `@`/`#`/`!` references a comment does.
+  // Releases are repo-wide, so the candidate lists come off origin.
+  const mentions = useMentionCandidates({
+    repoPath,
+    lens: "origin",
+    provider: releaseProvider,
+  });
   const status = useRepoStatus(repoPath);
   const tagList = useTagList(repoPath);
   const branches = useBranches(repoPath);
@@ -426,6 +434,7 @@ export function CreateReleaseDialog({
                 // No `rows`/`resize-y` in fill mode: the explicit floor plus
                 // `flex-1` set the height, and a manual drag fights the flex sizing.
                 textareaClassName="min-h-32 font-mono"
+                mentions={mentions}
                 actions={
                   // GitLab's only generator is the AI one — with AI hidden the
                   // menu would hold a single disabled item, so hide it entirely.

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -28,6 +28,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { checkoutDetachedConfirm } from "@/features/history/commit-confirms";
 import { formatBytes } from "@/features/repository/insights/primitives";
 import { presentError } from "@/lib/error-summary";
@@ -83,6 +84,9 @@ export function TagDetailView({
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
   const remoteLabel = providerLabel(provider);
+  // Release notes autolink the same `@`/`#`/`!` references a comment does.
+  // Releases are repo-wide, so the candidate lists come off origin.
+  const mentions = useMentionCandidates({ repoPath, lens: "origin", provider });
   // Ask the provider for a release only when connected; otherwise it's just a tag.
   const release = useReleaseDetails(repoPath, ghReady ? tag : null);
   const tagList = useTagList(repoPath);
@@ -561,6 +565,7 @@ export function TagDetailView({
                     // `flex-1` set the height, and a manual drag fights the flex
                     // sizing.
                     textareaClassName="min-h-24 font-mono"
+                    mentions={mentions}
                   />
                 </div>
                 {/* GitLab has neither pre-release nor a per-release latest flag. */}

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -199,6 +199,12 @@ export const ACTIONS = [
     // it ships without spending a chord. Users can bind a key.
     defaultBinding: null,
   },
+  {
+    id: "toggle-comment-composer",
+    label: "Collapse or expand the comment box",
+    category: "Navigation",
+    defaultBinding: null,
+  },
 
   // Repository
   {

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -286,6 +286,10 @@ export interface AppSettings {
    *  (`pulls:local`, `issues:remote`, …); a missing key = expanded. Global and
    *  feature-scoped, so the remote key collapses that section across every repo. */
   collapsedConversationSections: string[];
+  /** Collapse the docked comment composer on every conversation surface down to a
+   *  one-line peek strip. Global, so the reading space is reclaimed everywhere at
+   *  once; the surface's own actions stay docked either way. */
+  commentComposerCollapsed: boolean;
   /** ISO-8601 expiry the user optionally entered for a Bitbucket (Atlassian) API token —
    *  Bitbucket never reports one, so it's user-supplied. null = not provided; cleared on
    *  disconnect. */
@@ -353,6 +357,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   theme: "system",
   diffViewMode: "unified",
   collapsedConversationSections: [],
+  commentComposerCollapsed: false,
   bitbucketTokenExpiresAt: null,
 };
 

--- a/src/lib/textarea-caret.ts
+++ b/src/lib/textarea-caret.ts
@@ -1,0 +1,92 @@
+// Ported from Component/textarea-caret-position (MIT licensed, © 2015 Jonathan Ong
+// et al.), trimmed to the textarea case we need. The technique: mirror the textarea
+// into a hidden div carrying its exact typography and box metrics, then measure where
+// a span placed after `position` characters lands.
+
+/** Style properties the mirror must copy for its wrapping to match the textarea's. */
+const MIRRORED_PROPERTIES = [
+  "direction",
+  "box-sizing",
+  "width",
+  "height",
+  "overflow-x",
+  "overflow-y",
+  "border-top-width",
+  "border-right-width",
+  "border-bottom-width",
+  "border-left-width",
+  "border-style",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "font-style",
+  "font-variant",
+  "font-weight",
+  "font-stretch",
+  "font-size",
+  "font-size-adjust",
+  "line-height",
+  "font-family",
+  "text-align",
+  "text-transform",
+  "text-indent",
+  "text-decoration",
+  "letter-spacing",
+  "word-spacing",
+  "tab-size",
+] as const;
+
+export interface CaretCoordinates {
+  top: number;
+  left: number;
+  height: number;
+}
+
+/**
+ * Where the caret sits when it is at `position`, in pixels **relative to the
+ * textarea's unscrolled content origin**. Callers subtract the element's
+ * `scrollTop`/`scrollLeft` and add its `getBoundingClientRect()` origin to reach
+ * viewport coordinates.
+ */
+export function getCaretCoordinates(
+  element: HTMLTextAreaElement,
+  position: number,
+): CaretCoordinates {
+  const computed = getComputedStyle(element);
+  const mirror = document.createElement("div");
+  const style = mirror.style;
+  style.position = "absolute";
+  style.top = "0";
+  style.left = "-9999px";
+  style.visibility = "hidden";
+  style.whiteSpace = "pre-wrap";
+  style.wordWrap = "break-word";
+  // `overflow-x`/`overflow-y` ride the copy loop below: reproducing the textarea's
+  // own scrollbar gutter is what keeps the mirror's wrapping faithful.
+  for (const prop of MIRRORED_PROPERTIES) {
+    style.setProperty(prop, computed.getPropertyValue(prop));
+  }
+
+  mirror.textContent = element.value.slice(0, position);
+  const marker = document.createElement("span");
+  // A non-empty span: a caret at the very end of the value would otherwise have no
+  // box to measure. The remaining text also keeps the last line's wrapping honest.
+  marker.textContent = element.value.slice(position) || ".";
+  mirror.appendChild(marker);
+  document.body.appendChild(mirror);
+
+  // `line-height: normal` resolves to the keyword, not a length — fall back to the
+  // usual ~1.2× font-size so a themed textarea can't yield NaN coordinates.
+  const fontSize = Number.parseFloat(computed.fontSize) || 0;
+  const lineHeight =
+    Number.parseFloat(computed.lineHeight) || Math.round(fontSize * 1.2);
+  const coordinates = {
+    top: marker.offsetTop + (Number.parseFloat(computed.borderTopWidth) || 0),
+    left:
+      marker.offsetLeft + (Number.parseFloat(computed.borderLeftWidth) || 0),
+    height: lineHeight,
+  };
+  document.body.removeChild(mirror);
+  return coordinates;
+}


### PR DESCRIPTION
Brings GitHub-style `@`/`#`/`!` completion to every Markdown box the app writes comments from, and lets the docked comment composer fold down to a one-line strip so more of a long thread stays on screen. Both are opt-in at the call site: a surface whose forge wouldn't autolink the completed reference passes no `mentions` source and gets no listener, query, or node for it.

### Mention & reference autocomplete

- Adds `src/features/conversations/useMentionCandidates.ts`, the per-surface data layer: a `TRIGGERS` table of what each forge actually autolinks (GitHub `@`/`#`, GitLab `@`/`#`/`!`, Bitbucket none, since its mentions need `@{accountId}`), plus a pure ranking filter over the cached assignable-user, issue, and PR lists (prefix beats substring, provider order as tiebreak, `MAX_ROWS` cap) and an idempotent `onActive` that flips the lazy queries on only once a token opens.
- Adds `src/components/mention-autocomplete.tsx` with `useMentionAutocomplete`: word-boundary token detection (a query never spans a trigger char), a caret-anchored portal listbox that flips above the caret only when the space there is genuinely better, arrow/Enter/Tab/Esc key ownership while a token is open, `RESYNC_KEYS` handling so a caret move can't outlive its token, `mousedown` + `preventDefault` commits so the textarea never blurs mid-splice, and `document.execCommand` insertion so one undo reverts the whole completion.
- Adds `src/lib/textarea-caret.ts` — a trimmed port of `textarea-caret-position` (MIT) that mirrors the textarea into a hidden div with its exact typography and box metrics to measure caret coordinates, with a `line-height: normal` fallback so a themed textarea can't yield NaN.
- Wires the optional `mentions` prop through `src/components/markdown-editor.tsx`: the popover is suspended in preview mode and while disabled, its keydown handler sits between the formatting chords and the consumer's own handler, and `onChange` syncs the token against the live selection.
- Threads the source through every conversation surface: `CommentEditor.tsx` and `Thread.tsx` (edit-in-place), `DiscussionView.tsx`, `RemoteIssueView.tsx`, `CommitComments.tsx` (including `CommitLineComposer`, which reads the provider off `useForgeStatus` since the pane only takes `remoteLabel`), `ReviewComposer.tsx`, `ReviewThreads.tsx`, `PrActivityFeed.tsx`, `RemotePrView.tsx`, `RemotePrViewParts.tsx`, and the release-notes editors in `CreateReleaseDialog.tsx` and `TagDetailView.tsx`.

### Collapsible comment composer

- Reworks `src/features/conversations/CommentComposer.tsx` into a two-state box: a peek strip that keeps the surface's own `actions`/`leadingActions` (Approve, Review, Close) docked and shows a saved draft's first line, with the caret button holding the same slot in both states. `expand()` measures the sibling scroll region via `findScrollRegion` and re-pins a reader who was at the bottom; `collapse()` re-homes focus onto the strip, since both collapse routes destroy the control that fired them. The imperative handle's `focus()`/`showPreview()` expand first.
- Keys every post-flip DOM follow-up on the render that actually committed the state change, via `pendingRef`/`pendingPeekRef` consumed in `useLayoutEffect` — a react-query notify can batch the re-render past any frame scheduled from the handler.
- Adds `src/features/conversations/useComposerCollapsed.ts`: one global, persisted preference shared by all conversation surfaces, patched into the query cache before persisting (with an invalidate-on-error rollback) so the expand can focus the editor a frame later, and returning whether the write was a real transition so callers can gate follow-ups.
- Registers `toggle-comment-composer` ("Collapse or expand the comment box", Navigation, no default binding) in `src/lib/hotkeys/registry.ts`, bound while a composer is mounted.
- Adds `commentComposerCollapsed` to `AppSettings` and `DEFAULT_SETTINGS` in `src/lib/settings/api.ts`.

### Documentation

- Adds two *Features* bullets to `README.md` covering mention/reference autocomplete and the collapsible comment box.
- Adds two "Keyboard & Markdown" entries to `site/src/data/capabilities.ts`.
- Extends the Markdown editor, Issues, and Discussions sections of `src/features/help/content.ts` with the trigger characters, the surfaces they work on, the accept/dismiss keys, and the fold behavior including the palette action.
- Adds `changelog.d/added-mention-autocomplete.md` and `changelog.d/added-collapsible-comment-composer.md`.
- Records the rAF-versus-`useLayoutEffect` rule for DOM follow-ups after a react-query-backed state flip in `.claude/skills/gd-conventions/SKILL.md`, citing `CommentComposer` as the reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added autocomplete for `@` mentions and `#`/`!` issue, pull request, and merge request references in GitHub and GitLab comments, replies, review threads, and release notes.
  * Added keyboard navigation, accessible suggestion menus, avatars, loading states, and forge-specific reference links.
  * Added collapsible comment composers with persistent state, draft previews, docked actions, focus restoration, and command-palette controls.

* **Documentation**
  * Updated user documentation, capabilities, and changelog entries for autocomplete and collapsible comment composers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->