### PR TITLE
feat(issues,pulls,forge): add issue activity timeline with avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ issues (creating one under the Upstream lens opens it **on the parent**),
 and a fork with issues turned off offers a one-click switch to Upstream
 instead of a dead end.
 
+**Activity feed**: an issue's timeline events interleave with its comments,
+date-sorted oldest-to-newest — labels, assignees, milestones, **mentioned
+this in** cross-references, linked pull requests, marked-as-duplicate,
+pin/lock/transfer, and close (with its reason) or reopen. Each event row
+carries the actor's **avatar** and a relative timestamp, and a
+cross-reference, link, or duplicate row pointing inside the repository jumps
+to the pull request or issue it names. GitLab issues report labels, state
+changes, milestones, assignment, and same-project mentions.
+
 ![An issue open in GitDesktop with its description, labels, assignees, milestone, sub-issues, and a linked development branch and pull request; local and GitHub issues appear together in the sidebar.](site/src/assets/app-issues.png)
 
 ### Code TODOs

--- a/README.md
+++ b/README.md
@@ -455,13 +455,15 @@ and a fork with issues turned off offers a one-click switch to Upstream
 instead of a dead end.
 
 **Activity feed**: an issue's timeline events interleave with its comments,
-date-sorted oldest-to-newest — labels, assignees, milestones, **mentioned
-this in** cross-references, linked pull requests, marked-as-duplicate,
-pin/lock/transfer, and close (with its reason) or reopen. Each event row
-carries the actor's **avatar** and a relative timestamp, and a
-cross-reference, link, or duplicate row pointing inside the repository jumps
-to the pull request or issue it names. GitLab issues report labels, state
-changes, milestones, assignment, and same-project mentions.
+date-sorted oldest-to-newest — labels, assignees, milestones, title renames,
+**mentioned this in** cross-references, linked pull requests,
+marked-as-duplicate, pin/lock/transfer, and close (with its reason) or
+reopen. Each event row carries the actor's **avatar** and a relative
+timestamp, and a cross-reference, link, or duplicate row pointing inside the
+repository jumps to the pull request or issue it names (under a fork's
+**Upstream** lens those rows stay plain text). GitLab issues report labels,
+state changes, milestones, assignment, locks, duplicates, and same-project
+mentions.
 
 ![An issue open in GitDesktop with its description, labels, assignees, milestone, sub-issues, and a linked development branch and pull request; local and GitHub issues appear together in the sidebar.](site/src/assets/app-issues.png)
 

--- a/changelog.d/added-issue-timeline.md
+++ b/changelog.d/added-issue-timeline.md
@@ -1,5 +1,6 @@
 - **Issue activity timeline.** Issues now show their full activity alongside the
-  comments, date-sorted oldest to newest: labels, assignees, milestones,
-  "mentioned this in" cross-references, linked pull requests, and state changes.
-  A cross-reference row in the same repository jumps straight to the pull request
-  or issue it names. Works on GitHub and GitLab.
+  comments, date-sorted oldest to newest: labels, assignees, milestones, title
+  renames, "mentioned this in" cross-references, linked pull requests, and state
+  changes. A cross-reference row pointing inside the repository jumps straight to
+  the pull request or issue it names (browsing a fork's parent under the Upstream
+  lens keeps those rows as plain text). Works on GitHub and GitLab.

--- a/changelog.d/added-issue-timeline.md
+++ b/changelog.d/added-issue-timeline.md
@@ -1,0 +1,5 @@
+- **Issue activity timeline.** Issues now show their full activity alongside the
+  comments, date-sorted oldest to newest: labels, assignees, milestones,
+  "mentioned this in" cross-references, linked pull requests, and state changes.
+  A cross-reference row in the same repository jumps straight to the pull request
+  or issue it names. Works on GitHub and GitLab.

--- a/changelog.d/changed-timeline-avatars.md
+++ b/changelog.d/changed-timeline-avatars.md
@@ -1,0 +1,2 @@
+- Timeline event rows on pull requests and issues now show the actor's avatar
+  beside their name.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -281,6 +281,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Issues & discussions",
+    label:
+      "Issue activity timeline — labels, assignees, milestones, linked PRs & mentions, with actor avatars",
+  },
+  {
+    group: "Issues & discussions",
     label: "GitHub Discussions — read, post & react",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -282,7 +282,7 @@ export const capabilities: Capability[] = [
   {
     group: "Issues & discussions",
     label:
-      "Issue activity timeline — labels, assignees, milestones, linked PRs & mentions, with actor avatars",
+      "Issue activity timeline — labels, assignees, milestones, renames, linked PRs, mentions & state changes, with actor avatars",
   },
   {
     group: "Issues & discussions",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -550,7 +550,9 @@ const forges = [
     <p>
       Browse, open, and edit GitHub and GitLab issues without the tab-switch. Labels,
       assignees, milestones, issue type, sub-issues, dependencies, and the pull requests
-      and branches that close them all sit in one panel.
+      and branches that close them all sit in one panel. The conversation reads as one
+      date-sorted activity feed, with label, assignment, milestone, mention, and
+      state-change events interleaved between the comments.
     </p>
     <p class="text-muted">
       A <span class="text-ink">Code TODOs</span> tab scans your working tree for

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -1441,7 +1441,7 @@ pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTim
     // Sort ascending by INSTANT, stably. Bitbucket stamps activity in the actor's
     // local offset ("…-04:00"), so a lexicographic compare of the raw strings puts
     // mixed offsets out of chronological order. Undated/unparseable events sort first.
-    events.sort_by_key(bb_timeline_instant);
+    events.sort_by_cached_key(bb_timeline_instant);
     Ok(events)
 }
 
@@ -1504,8 +1504,8 @@ fn bb_actor(u: Option<&BbUser>) -> ForgeUserRef {
     }
 }
 
-/// The date field of a `ForgeTimelineEventOut` produced by [`pr_activity`] — the sort
-/// key. Exhaustive over the union so a new variant can't silently sort as "".
+/// The date field of a `ForgeTimelineEventOut` produced by [`pr_activity`], verbatim.
+/// Exhaustive over the union so a new variant can't silently read as "".
 fn bb_timeline_date(e: &ForgeTimelineEventOut) -> &str {
     match e {
         ForgeTimelineEventOut::Merged { date, .. }
@@ -5623,7 +5623,7 @@ mod tests {
             date: date.to_string(),
         };
         let mut events = [ev(local_evening), ev(utc_late), ev("")];
-        events.sort_by_key(bb_timeline_instant);
+        events.sort_by_cached_key(bb_timeline_instant);
         let dates: Vec<&str> = events.iter().map(bb_timeline_date).collect();
         // Undated first, then the true chronological order — the reverse of the
         // strings for the dated pair.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -31,7 +31,8 @@ use crate::forge::http::{
 };
 use crate::forge::model::{
     namespace_set, Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList,
-    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeTimelineEventOut, ForgeUserRef, Implemented,
+    Provider,
 };
 use crate::forge::{
     cap_readme, validate_owner, validate_repo_name, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
@@ -42,7 +43,7 @@ use crate::github::actions::{RunDetail, RunJob, WorkflowRun};
 use crate::github::pr::{
     ApprovalState, CommitCommentOut, DraftCommentIn, PrAuthor, PrCiRefIn, PrCiStatus, PrCommitOut,
     PrDetails, PrFileOut, PrInfo, PrListLabel, PrMergeability, PrPollInfo, PrRef, PrThreadOut,
-    PrTimelineEventOut, ReviewSubmitOut, ReviewThreadOut,
+    ReviewSubmitOut, ReviewThreadOut,
 };
 
 /// Whether this process has SUCCESSFULLY seeded git's credential store this session
@@ -1412,12 +1413,12 @@ struct BbActivityApproval {
 }
 
 /// The PR's activity timeline — state changes (merge/decline) and review verdicts
-/// (approve / request-changes) — mapped onto the neutral `PrTimelineEventOut` union,
+/// (approve / request-changes) — mapped onto the neutral `ForgeTimelineEventOut` union,
 /// oldest→newest. Bitbucket's arm of `forge_pr_timeline`. Deliberately omits
 /// `update`-commit events and `comment` activity (commits + comments come from
 /// `pr.commits`/`pr.comments` on the frontend); Bitbucket has no label/reopen/draft/
 /// review-request events. Best-effort: a failed fetch yields an empty timeline.
-pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<PrTimelineEventOut>> {
+pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTimelineEventOut>> {
     let creds = http::load_credentials().await?;
     let (ws, slug) = workspace_slug(repo_path).await?;
     // Bitbucket rejects pagelen > 50 on the activity endpoint ("Invalid pagelen").
@@ -1430,7 +1431,7 @@ pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
         .await
         .unwrap_or_default();
 
-    let mut events: Vec<PrTimelineEventOut> = page
+    let mut events: Vec<ForgeTimelineEventOut> = page
         .values
         .into_iter()
         .filter_map(map_activity_entry)
@@ -1446,31 +1447,36 @@ pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
 /// Pure (unit-tested). An `update` is only an event when it carries a `changes.status`
 /// transition AND landed on a terminal state — an OPEN update editing draft/title is
 /// skipped; the `update.state` string (not the internal `status.new`) drives the kind.
-fn map_activity_entry(entry: BbActivity) -> Option<PrTimelineEventOut> {
+fn map_activity_entry(entry: BbActivity) -> Option<ForgeTimelineEventOut> {
     if let Some(u) = entry.update {
         let changed = u.changes.and_then(|c| c.status).is_some();
         if !changed {
             return None;
         }
-        let actor = u.author.as_ref().map(user_login).unwrap_or_default();
+        let actor = bb_actor(u.author.as_ref());
         let date = u.date;
         match u.state.as_str() {
-            "MERGED" => Some(PrTimelineEventOut::Merged {
+            "MERGED" => Some(ForgeTimelineEventOut::Merged {
                 actor,
                 commit_oid: None,
                 date,
             }),
-            "DECLINED" | "SUPERSEDED" => Some(PrTimelineEventOut::Closed { actor, date }),
+            // Bitbucket reports no close reason, so `state_reason` stays empty.
+            "DECLINED" | "SUPERSEDED" => Some(ForgeTimelineEventOut::Closed {
+                actor,
+                state_reason: String::new(),
+                date,
+            }),
             _ => None,
         }
     } else if let Some(a) = entry.approval {
-        Some(PrTimelineEventOut::Approved {
-            actor: a.user.as_ref().map(user_login).unwrap_or_default(),
+        Some(ForgeTimelineEventOut::Approved {
+            actor: bb_actor(a.user.as_ref()),
             date: a.date,
         })
     } else if let Some(a) = entry.changes_requested {
-        Some(PrTimelineEventOut::ChangesRequested {
-            actor: a.user.as_ref().map(user_login).unwrap_or_default(),
+        Some(ForgeTimelineEventOut::ChangesRequested {
+            actor: bb_actor(a.user.as_ref()),
             date: a.date,
         })
     } else {
@@ -1478,22 +1484,43 @@ fn map_activity_entry(entry: BbActivity) -> Option<PrTimelineEventOut> {
     }
 }
 
-/// The date field of a `PrTimelineEventOut` produced by [`pr_activity`] — the sort
+/// A Bitbucket timeline actor as a neutral user ref. Participant objects carry no
+/// `username`, so the display name fills both `id` and `label` (see [`user_login`]);
+/// a missing user yields an all-empty ref, which the frontend renders as no actor.
+fn bb_actor(u: Option<&BbUser>) -> ForgeUserRef {
+    let login = u.map(user_login).unwrap_or_default();
+    ForgeUserRef {
+        id: login.clone(),
+        label: login,
+        avatar_url: u.map(user_avatar).unwrap_or_default(),
+        is_bot: false,
+    }
+}
+
+/// The date field of a `ForgeTimelineEventOut` produced by [`pr_activity`] — the sort
 /// key. Exhaustive over the union so a new variant can't silently sort as "".
-fn bb_timeline_date(e: &PrTimelineEventOut) -> &str {
+fn bb_timeline_date(e: &ForgeTimelineEventOut) -> &str {
     match e {
-        PrTimelineEventOut::Merged { date, .. }
-        | PrTimelineEventOut::Closed { date, .. }
-        | PrTimelineEventOut::Approved { date, .. }
-        | PrTimelineEventOut::ChangesRequested { date, .. }
-        | PrTimelineEventOut::Unapproved { date, .. }
-        | PrTimelineEventOut::Labeled { date, .. }
-        | PrTimelineEventOut::Reopened { date, .. }
-        | PrTimelineEventOut::ForcePushed { date, .. }
-        | PrTimelineEventOut::ReviewRequested { date, .. }
-        | PrTimelineEventOut::ReadyForReview { date, .. }
-        | PrTimelineEventOut::ConvertToDraft { date, .. }
-        | PrTimelineEventOut::Renamed { date, .. } => date,
+        ForgeTimelineEventOut::Merged { date, .. }
+        | ForgeTimelineEventOut::Closed { date, .. }
+        | ForgeTimelineEventOut::Approved { date, .. }
+        | ForgeTimelineEventOut::ChangesRequested { date, .. }
+        | ForgeTimelineEventOut::Unapproved { date, .. }
+        | ForgeTimelineEventOut::Labeled { date, .. }
+        | ForgeTimelineEventOut::Reopened { date, .. }
+        | ForgeTimelineEventOut::ForcePushed { date, .. }
+        | ForgeTimelineEventOut::ReviewRequested { date, .. }
+        | ForgeTimelineEventOut::ReadyForReview { date, .. }
+        | ForgeTimelineEventOut::ConvertToDraft { date, .. }
+        | ForgeTimelineEventOut::Renamed { date, .. }
+        | ForgeTimelineEventOut::Assigned { date, .. }
+        | ForgeTimelineEventOut::Milestoned { date, .. }
+        | ForgeTimelineEventOut::CrossReferenced { date, .. }
+        | ForgeTimelineEventOut::Connected { date, .. }
+        | ForgeTimelineEventOut::Pinned { date, .. }
+        | ForgeTimelineEventOut::Locked { date, .. }
+        | ForgeTimelineEventOut::Transferred { date, .. }
+        | ForgeTimelineEventOut::MarkedAsDuplicate { date, .. } => date,
     }
 }
 
@@ -5483,7 +5510,7 @@ mod tests {
         from_bb_pr(serde_json::from_str(json).expect("PR should parse"))
     }
 
-    fn activity(json: &str) -> Option<PrTimelineEventOut> {
+    fn activity(json: &str) -> Option<ForgeTimelineEventOut> {
         map_activity_entry(serde_json::from_str(json).expect("activity should parse"))
     }
 
@@ -5492,12 +5519,14 @@ mod tests {
         // Shape from the live `approval` activity entry.
         let ev = activity(
             r#"{"approval":{"date":"2026-07-03T21:12:55.697902-04:00",
-                "user":{"display_name":"Casey Approver","uuid":"{0f39}"}}}"#,
+                "user":{"display_name":"Casey Approver","uuid":"{0f39}",
+                        "links":{"avatar":{"href":"https://bb/casey.png"}}}}}"#,
         )
         .expect("approval is a timeline event");
         match ev {
-            PrTimelineEventOut::Approved { actor, date } => {
-                assert_eq!(actor, "Casey Approver");
+            ForgeTimelineEventOut::Approved { actor, date } => {
+                assert_eq!(actor.label, "Casey Approver");
+                assert_eq!(actor.avatar_url, "https://bb/casey.png");
                 assert_eq!(date, "2026-07-03T21:12:55.697902-04:00");
             }
             _ => panic!("expected Approved"),
@@ -5511,7 +5540,12 @@ mod tests {
                 "user":{"display_name":"Ada"}}}"#,
         )
         .expect("changes_requested is a timeline event");
-        assert!(matches!(ev, PrTimelineEventOut::ChangesRequested { .. }));
+        // No `links.avatar` on this entry → an empty URL, never a guessed one.
+        assert!(matches!(
+            ev,
+            ForgeTimelineEventOut::ChangesRequested { actor, .. }
+                if actor.label == "Ada" && actor.avatar_url.is_empty()
+        ));
     }
 
     #[test]
@@ -5523,7 +5557,7 @@ mod tests {
                 "changes":{"status":{"old":"open","new":"fulfilled"}}}}"#,
         )
         .expect("a status-changing MERGED update is an event");
-        assert!(matches!(ev, PrTimelineEventOut::Merged { .. }));
+        assert!(matches!(ev, ForgeTimelineEventOut::Merged { .. }));
     }
 
     #[test]
@@ -5534,7 +5568,11 @@ mod tests {
                 "changes":{"status":{"old":"open","new":"rejected"}}}}"#,
         )
         .expect("a status-changing DECLINED update is an event");
-        assert!(matches!(ev, PrTimelineEventOut::Closed { .. }));
+        // Bitbucket reports no close reason.
+        assert!(matches!(
+            ev,
+            ForgeTimelineEventOut::Closed { state_reason, .. } if state_reason.is_empty()
+        ));
     }
 
     #[test]

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -1484,13 +1484,17 @@ fn map_activity_entry(entry: BbActivity) -> Option<ForgeTimelineEventOut> {
     }
 }
 
-/// A Bitbucket timeline actor as a neutral user ref. Participant objects carry no
-/// `username`, so the display name fills both `id` and `label` (see [`user_login`]);
-/// a missing user yields an all-empty ref, which the frontend renders as no actor.
+/// A Bitbucket timeline actor as a neutral user ref: the braced account `uuid` as
+/// `id`, [`user_login`]'s display name as `label`. A uuid-less payload falls back
+/// to the display name — a deliberate deviation from the pickers, which drop such
+/// users: a timeline row still names whoever acted. A missing user yields an
+/// all-empty ref, rendered as no actor.
 fn bb_actor(u: Option<&BbUser>) -> ForgeUserRef {
     let login = u.map(user_login).unwrap_or_default();
     ForgeUserRef {
-        id: login.clone(),
+        id: u
+            .and_then(|x| x.uuid.clone())
+            .unwrap_or_else(|| login.clone()),
         label: login,
         avatar_url: u.map(user_avatar).unwrap_or_default(),
         is_bot: false,
@@ -5525,6 +5529,7 @@ mod tests {
         .expect("approval is a timeline event");
         match ev {
             ForgeTimelineEventOut::Approved { actor, date } => {
+                assert_eq!(actor.id, "{0f39}");
                 assert_eq!(actor.label, "Casey Approver");
                 assert_eq!(actor.avatar_url, "https://bb/casey.png");
                 assert_eq!(date, "2026-07-03T21:12:55.697902-04:00");
@@ -5540,11 +5545,12 @@ mod tests {
                 "user":{"display_name":"Ada"}}}"#,
         )
         .expect("changes_requested is a timeline event");
-        // No `links.avatar` on this entry → an empty URL, never a guessed one.
+        // No `links.avatar` → empty URL, never guessed; no `uuid` → id falls back
+        // to the display name rather than shipping empty.
         assert!(matches!(
             ev,
             ForgeTimelineEventOut::ChangesRequested { actor, .. }
-                if actor.label == "Ada" && actor.avatar_url.is_empty()
+                if actor.id == "Ada" && actor.label == "Ada" && actor.avatar_url.is_empty()
         ));
     }
 

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -19,6 +19,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 use tauri_plugin_http::reqwest;
 
@@ -1437,8 +1438,10 @@ pub async fn pr_activity(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTim
         .filter_map(map_activity_entry)
         .collect();
 
-    // Sort ascending by date (empty dates sort first, stably).
-    events.sort_by(|a, b| bb_timeline_date(a).cmp(bb_timeline_date(b)));
+    // Sort ascending by INSTANT, stably. Bitbucket stamps activity in the actor's
+    // local offset ("…-04:00"), so a lexicographic compare of the raw strings puts
+    // mixed offsets out of chronological order. Undated/unparseable events sort first.
+    events.sort_by_key(bb_timeline_instant);
     Ok(events)
 }
 
@@ -1526,6 +1529,14 @@ fn bb_timeline_date(e: &ForgeTimelineEventOut) -> &str {
         | ForgeTimelineEventOut::Transferred { date, .. }
         | ForgeTimelineEventOut::MarkedAsDuplicate { date, .. } => date,
     }
+}
+
+/// The sort key behind [`pr_activity`]'s ordering: the event's date as an INSTANT.
+/// `None` for an empty or unparseable stamp, which `Option`'s ordering places before
+/// every dated event. Comparing parsed instants is what makes the order correct across
+/// Bitbucket's mixed local offsets — the raw strings don't sort chronologically.
+fn bb_timeline_instant(e: &ForgeTimelineEventOut) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(bb_timeline_date(e)).ok()
 }
 
 /// Map one non-deleted/non-pending comment onto a neutral thread. The body is the raw
@@ -5596,6 +5607,27 @@ mod tests {
         .is_none());
         // A comment activity carries neither update/approval/changes_requested.
         assert!(activity(r#"{"comment":{"id":1}}"#).is_none());
+    }
+
+    #[test]
+    fn activity_sort_orders_by_instant_across_mixed_offsets() {
+        // Bitbucket stamps in the actor's local offset, so string order and instant
+        // order disagree: "…T21:00:00-04:00" is 01:00Z the NEXT day, later than
+        // "…T23:00:00Z", yet it sorts first lexicographically.
+        let local_evening = "2026-07-03T21:00:00-04:00";
+        let utc_late = "2026-07-03T23:00:00Z";
+        assert!(local_evening < utc_late, "the string order is the trap");
+
+        let ev = |date: &str| ForgeTimelineEventOut::Approved {
+            actor: bb_actor(None),
+            date: date.to_string(),
+        };
+        let mut events = [ev(local_evening), ev(utc_late), ev("")];
+        events.sort_by_key(bb_timeline_instant);
+        let dates: Vec<&str> = events.iter().map(bb_timeline_date).collect();
+        // Undated first, then the true chronological order — the reverse of the
+        // strings for the dated pair.
+        assert_eq!(dates, vec!["", utc_late, local_evening]);
     }
 
     #[test]

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -131,7 +131,7 @@ pub async fn pr_timeline(
     repo_path: &str,
     number: u64,
     lens: Option<&str>,
-) -> AppResult<Vec<crate::github::pr::PrTimelineEventOut>> {
+) -> AppResult<Vec<crate::forge::model::ForgeTimelineEventOut>> {
     crate::github::pr::pr_timeline(repo_path, number, lens).await
 }
 
@@ -335,6 +335,14 @@ pub async fn view_issue(
     lens: Option<String>,
 ) -> AppResult<crate::github::issue::IssueDetails> {
     crate::github::issue::gh_issue_view(repo_path.to_string(), number, lens).await
+}
+
+pub async fn issue_timeline(
+    repo_path: &str,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<Vec<crate::forge::model::ForgeTimelineEventOut>> {
+    crate::github::issue::gh_issue_timeline(repo_path.to_string(), number, lens).await
 }
 
 // ── CI / Actions ─────────────────────────────────────────────────────────────

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -1577,7 +1577,7 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTim
     }
 
     // Combine all classes and sort ascending by instant (undated events sort first).
-    events.sort_by_key(timeline_event_instant);
+    events.sort_by_cached_key(timeline_event_instant);
     Ok(events)
 }
 
@@ -1822,7 +1822,7 @@ pub async fn issue_timeline(repo_path: &str, number: u64) -> AppResult<Vec<Forge
     }
 
     // Combine all classes and sort ascending by instant (undated events sort first).
-    events.sort_by_key(timeline_event_instant);
+    events.sort_by_cached_key(timeline_event_instant);
     Ok(events)
 }
 
@@ -9079,7 +9079,7 @@ mod tests {
                 date: "2026-07-01T00:00:00Z".into(),
             },
         ];
-        events.sort_by_key(timeline_event_instant);
+        events.sort_by_cached_key(timeline_event_instant);
         let dates: Vec<&str> = events.iter().map(timeline_event_date).collect();
         assert_eq!(
             dates,
@@ -9101,7 +9101,7 @@ mod tests {
             date: date.to_string(),
         };
         let mut events = [ev(with_millis), ev(bare), ev("")];
-        events.sort_by_key(timeline_event_instant);
+        events.sort_by_cached_key(timeline_event_instant);
         let dates: Vec<&str> = events.iter().map(timeline_event_date).collect();
         // Undated first, then true chronological order — the reverse of the strings
         // for the dated pair.

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -7,6 +7,8 @@
 
 use std::collections::HashMap;
 
+use chrono::{DateTime, FixedOffset};
+
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
@@ -1435,8 +1437,8 @@ struct GlabStateEvent {
     created_at: String,
 }
 
-/// The date field of a `ForgeTimelineEventOut` — the sort key. Empty dates sort first
-/// (stable), which keeps undated events at the top rather than dropping them.
+/// The date field of a `ForgeTimelineEventOut`, verbatim. Exhaustive over the union so
+/// a new variant can't silently read as "".
 fn timeline_event_date(e: &ForgeTimelineEventOut) -> &str {
     match e {
         ForgeTimelineEventOut::Labeled { date, .. }
@@ -1462,6 +1464,16 @@ fn timeline_event_date(e: &ForgeTimelineEventOut) -> &str {
         | ForgeTimelineEventOut::Transferred { date, .. }
         | ForgeTimelineEventOut::MarkedAsDuplicate { date, .. } => date,
     }
+}
+
+/// The sort key for both GitLab timelines: the event's date as an INSTANT. `None` for
+/// an empty or unparseable stamp, which `Option`'s ordering places before every dated
+/// event, keeping undated events at the top rather than dropping them. Parsing rather
+/// than comparing the raw strings is what keeps the order correct regardless of offset
+/// or fractional-second width — `…:03.613Z` string-sorts BEFORE `…:03Z` ('.' < 'Z')
+/// while being the later instant.
+fn timeline_event_instant(e: &ForgeTimelineEventOut) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(timeline_event_date(e)).ok()
 }
 
 /// A GitLab timeline actor as a neutral user ref. GitLab identifies users by
@@ -1564,8 +1576,8 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTim
         }
     }
 
-    // Combine all classes and sort ascending by date (empty dates sort first).
-    events.sort_by(|a, b| timeline_event_date(a).cmp(timeline_event_date(b)));
+    // Combine all classes and sort ascending by instant (undated events sort first).
+    events.sort_by_key(timeline_event_instant);
     Ok(events)
 }
 
@@ -1809,8 +1821,8 @@ pub async fn issue_timeline(repo_path: &str, number: u64) -> AppResult<Vec<Forge
         }
     }
 
-    // Combine all classes and sort ascending by date (empty dates sort first).
-    events.sort_by(|a, b| timeline_event_date(a).cmp(timeline_event_date(b)));
+    // Combine all classes and sort ascending by instant (undated events sort first).
+    events.sort_by_key(timeline_event_instant);
     Ok(events)
 }
 
@@ -9067,12 +9079,33 @@ mod tests {
                 date: "2026-07-01T00:00:00Z".into(),
             },
         ];
-        events.sort_by(|a, b| timeline_event_date(a).cmp(timeline_event_date(b)));
+        events.sort_by_key(timeline_event_instant);
         let dates: Vec<&str> = events.iter().map(timeline_event_date).collect();
         assert_eq!(
             dates,
             vec!["", "2026-07-01T00:00:00Z", "2026-07-02T00:00:00Z"]
         );
+    }
+
+    #[test]
+    fn timeline_sorts_by_instant_across_mixed_fractional_precision() {
+        // GitLab stamps most timestamps with millis but not all endpoints agree, and
+        // a string compare gets mixed widths backwards: '.' (0x2E) < 'Z' (0x5A), so
+        // "…:03.613Z" sorts BEFORE "…:03Z" while being the LATER instant.
+        let with_millis = "2026-07-01T00:00:03.613Z";
+        let bare = "2026-07-01T00:00:03Z";
+        assert!(with_millis < bare, "the string order is the trap");
+
+        let ev = |date: &str| ForgeTimelineEventOut::Approved {
+            actor: gl_actor(None),
+            date: date.to_string(),
+        };
+        let mut events = [ev(with_millis), ev(bare), ev("")];
+        events.sort_by_key(timeline_event_instant);
+        let dates: Vec<&str> = events.iter().map(timeline_event_date).collect();
+        // Undated first, then true chronological order — the reverse of the strings
+        // for the dated pair.
+        assert_eq!(dates, vec!["", bare, with_millis]);
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -1410,16 +1410,24 @@ struct GlabEventLabel {
 }
 
 /// Map one `resource_label_events` entry (MR or issue — the endpoints share a shape),
-/// or `None` once the label itself has been deleted. The endpoint returns `color` WITH
-/// a leading `#` while the `Labeled.color` contract is bare hex (the frontend renders
+/// or `None` once the label itself has been deleted, or for an action we don't model,
+/// which is skipped rather than guessed. The endpoint returns `color` WITH a leading
+/// `#` while the `Labeled.color` contract is bare hex (the frontend renders
 /// `#${color}`), so the strip is part of the mapping, not a caller's job. Pure
 /// (unit-tested).
 fn map_label_event(e: GlabLabelEvent) -> Option<ForgeTimelineEventOut> {
     let label = e.label?;
+    // Only the two known actions map; anything else (including the serde default on a
+    // malformed payload) would otherwise render as a removal that never happened.
+    let added = match e.action.as_str() {
+        "add" => true,
+        "remove" => false,
+        _ => return None,
+    };
     Some(ForgeTimelineEventOut::Labeled {
         label: label.name,
         color: label.color.trim_start_matches('#').to_string(),
-        added: e.action == "add",
+        added,
         actor: gl_actor(e.user),
         date: e.created_at,
     })
@@ -1449,7 +1457,7 @@ fn timeline_event_date(e: &ForgeTimelineEventOut) -> &str {
         | ForgeTimelineEventOut::ChangesRequested { date, .. }
         | ForgeTimelineEventOut::Unapproved { date, .. } => date,
         // The GitLab arm never produces these, but the union is shared — match
-        // exhaustively so a new variant can't silently sort as "".
+        // exhaustively so a new variant can't silently read as "".
         ForgeTimelineEventOut::ForcePushed { date, .. }
         | ForgeTimelineEventOut::ReviewRequested { date, .. }
         | ForgeTimelineEventOut::ReadyForReview { date, .. }
@@ -1602,13 +1610,21 @@ struct GlabEventMilestone {
 }
 
 /// Map one issue `resource_milestone_events` entry, or `None` when the milestone it
-/// pointed at has since been deleted (GitLab keeps the event, nulls the milestone).
-/// Pure (unit-tested).
+/// pointed at has since been deleted (GitLab keeps the event, nulls the milestone), or
+/// for an action we don't model, which is skipped rather than guessed. Pure
+/// (unit-tested).
 fn map_issue_milestone_event(e: GlabMilestoneEvent) -> Option<ForgeTimelineEventOut> {
     let milestone = e.milestone?;
+    // Only the two known actions map; anything else (including the serde default on a
+    // malformed payload) would otherwise render as a removal that never happened.
+    let added = match e.action.as_str() {
+        "add" => true,
+        "remove" => false,
+        _ => return None,
+    };
     Some(ForgeTimelineEventOut::Milestoned {
         milestone: milestone.title,
-        added: e.action == "add",
+        added,
         actor: gl_actor(e.user),
         date: e.created_at,
     })
@@ -8889,6 +8905,23 @@ mod tests {
             r#"{"action":"add","created_at":"2026-06-30T00:35:46.215Z","label":null}"#
         ))
         .is_none());
+        // An unknown or missing action is skipped, never rendered as a removal.
+        for action in [r#""relabel""#, r#""""#] {
+            assert!(
+                map_label_event(ev(&format!(
+                    r##"{{"action":{action},"created_at":"2026-06-30T00:35:46.215Z",
+                        "label":{{"name":"enhancement","color":"#5cb85c"}}}}"##
+                )))
+                .is_none(),
+                "action {action}"
+            );
+        }
+        // `action` absent entirely (serde default) is the same skip.
+        assert!(map_label_event(ev(
+            r##"{"created_at":"2026-06-30T00:35:46.215Z",
+                "label":{"name":"enhancement","color":"#5cb85c"}}"##
+        ))
+        .is_none());
     }
 
     #[test]
@@ -9018,6 +9051,22 @@ mod tests {
         assert!(map_issue_milestone_event(ev(r#"{"action":"add",
             "created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"},
             "milestone":null}"#))
+        .is_none());
+        // An unknown or missing action is skipped, never rendered as a removal.
+        for action in [r#""retitle""#, r#""""#] {
+            assert!(
+                map_issue_milestone_event(ev(&format!(
+                    r#"{{"action":{action},"created_at":"2026-08-23T00:00:00Z",
+                        "milestone":{{"title":"v1.0"}}}}"#
+                )))
+                .is_none(),
+                "action {action}"
+            );
+        }
+        // `action` absent entirely (serde default) is the same skip.
+        assert!(map_issue_milestone_event(ev(
+            r#"{"created_at":"2026-08-23T00:00:00Z","milestone":{"title":"v1.0"}}"#
+        ))
         .is_none());
     }
 

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -1407,6 +1407,22 @@ struct GlabEventLabel {
     color: String,
 }
 
+/// Map one `resource_label_events` entry (MR or issue — the endpoints share a shape),
+/// or `None` once the label itself has been deleted. The endpoint returns `color` WITH
+/// a leading `#` while the `Labeled.color` contract is bare hex (the frontend renders
+/// `#${color}`), so the strip is part of the mapping, not a caller's job. Pure
+/// (unit-tested).
+fn map_label_event(e: GlabLabelEvent) -> Option<ForgeTimelineEventOut> {
+    let label = e.label?;
+    Some(ForgeTimelineEventOut::Labeled {
+        label: label.name,
+        color: label.color.trim_start_matches('#').to_string(),
+        added: e.action == "add",
+        actor: gl_actor(e.user),
+        date: e.created_at,
+    })
+}
+
 /// One `resource_state_events` entry: `{state:"closed"|"reopened"|"merged", user,
 /// created_at}`.
 #[derive(Deserialize)]
@@ -1482,89 +1498,63 @@ fn map_approval_note(
 /// The MR's activity timeline — label add/remove, state changes, and approval-flow
 /// events — mapped onto the neutral `ForgeTimelineEventOut` union, oldest→newest.
 /// Deliberately omits commits (the frontend interleaves `pr.commits`), force-pushes
-/// (no GitLab API), and draft/ready + review-request events. Every sub-fetch is
-/// best-effort and a single `per_page=100` page, so a very busy MR truncates the
-/// oldest events of that class.
+/// (no GitLab API), and draft/ready + review-request events.
+///
+/// Every sub-fetch is best-effort and a single `per_page=100` page, and which end a
+/// busy MR truncates differs by class: `notes` defaults to newest-first, so approvals
+/// keep the NEWEST page; the `resource_*` endpoints ignore `sort` and always answer
+/// oldest-first, so those classes keep the OLDEST page. The same feed's conversation
+/// half (`view_pr`'s comment read) keeps the oldest page, so past 100 notes the merged
+/// feed pairs the oldest comments with the newest events; unifying the windows is
+/// deferred.
 pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTimelineEventOut>> {
     let enc = encode_project(&project_path(repo_path).await?);
+    let base = format!("projects/{enc}/merge_requests/{number}");
     let mut events: Vec<ForgeTimelineEventOut> = Vec::new();
 
-    // Label add/remove events.
-    let label_events: Vec<GlabLabelEvent> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/merge_requests/{number}/resource_label_events?per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
-    for e in label_events {
-        let Some(label) = e.label else { continue };
-        events.push(ForgeTimelineEventOut::Labeled {
-            label: label.name,
-            // `resource_label_events` returns `color` WITH a leading `#`, but the
-            // `Labeled.color` contract is bare hex (the frontend renders `#${color}`)
-            // — strip it, like the file's other GitLab label producers.
-            color: label.color.trim_start_matches('#').to_string(),
-            added: e.action == "add",
-            actor: gl_actor(e.user),
-            date: e.created_at,
-        });
-    }
+    // Three independent reads on the MR-open foreground path; the terminal sort makes
+    // arrival order irrelevant, so run them concurrently.
+    let (label_events, state_events, notes) = tokio::join!(
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/resource_label_events?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabLabelEvent>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/resource_state_events?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabStateEvent>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+        // Approval-flow events — system notes carry the timestamped history
+        // (see `map_approval_note`).
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/notes?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabNote>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+    );
 
-    // State-change events (closed / reopened / merged).
-    let state_events: Vec<GlabStateEvent> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/merge_requests/{number}/resource_state_events?per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
-    for e in state_events {
-        let actor = gl_actor(e.user);
-        let date = e.created_at;
-        let mapped = match e.state.as_str() {
-            // GitLab reports no close reason, so `state_reason` stays empty.
-            "closed" => ForgeTimelineEventOut::Closed {
-                actor,
-                state_reason: String::new(),
-                date,
-            },
-            "reopened" => ForgeTimelineEventOut::Reopened { actor, date },
-            "merged" => ForgeTimelineEventOut::Merged {
-                actor,
-                commit_oid: None,
-                date,
-            },
-            // Unknown/new state (e.g. "locked") — skip rather than guess.
-            _ => continue,
-        };
-        events.push(mapped);
-    }
+    events.extend(label_events.into_iter().filter_map(map_label_event));
+    events.extend(state_events.into_iter().filter_map(map_state_event));
 
-    // Approval-flow events — system notes carry the timestamped history
-    // (see `map_approval_note`).
-    let notes: Vec<GlabNote> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/merge_requests/{number}/notes?sort=asc&per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
     for n in notes {
         if !n.system {
             continue;
@@ -1612,10 +1602,11 @@ fn map_issue_milestone_event(e: GlabMilestoneEvent) -> Option<ForgeTimelineEvent
     })
 }
 
-/// Map one issue `resource_state_events` entry. An issue only closes and reopens —
-/// any other state (including `merged`, which the MR arm handles) is skipped rather
-/// than guessed. Pure (unit-tested).
-fn map_issue_state_event(e: GlabStateEvent) -> Option<ForgeTimelineEventOut> {
+/// Map one `resource_state_events` entry (MR or issue — the endpoints share a shape),
+/// or `None` for a state we don't model, which is skipped rather than guessed. The
+/// `merged` arm is unreachable from the issue caller: GitLab only ever reports it on
+/// merge requests. Pure (unit-tested).
+fn map_state_event(e: GlabStateEvent) -> Option<ForgeTimelineEventOut> {
     let actor = gl_actor(e.user);
     let date = e.created_at;
     match e.state.as_str() {
@@ -1626,6 +1617,11 @@ fn map_issue_state_event(e: GlabStateEvent) -> Option<ForgeTimelineEventOut> {
             date,
         }),
         "reopened" => Some(ForgeTimelineEventOut::Reopened { actor, date }),
+        "merged" => Some(ForgeTimelineEventOut::Merged {
+            actor,
+            commit_oid: None,
+            date,
+        }),
         _ => None,
     }
 }
@@ -1728,87 +1724,82 @@ fn map_issue_system_note(
 
 /// The issue's activity timeline — label add/remove, state changes, milestone
 /// changes, and the assignment/cross-reference/duplicate/lock system notes — mapped
-/// onto the neutral `ForgeTimelineEventOut` union, oldest→newest. Every sub-fetch is
-/// best-effort and a single `per_page=100` page, so a very busy issue truncates the
-/// oldest events of that class.
+/// onto the neutral `ForgeTimelineEventOut` union, oldest→newest.
+///
+/// Every sub-fetch is best-effort and a single `per_page=100` page, and which end a
+/// busy issue truncates differs by class: `notes` defaults to newest-first, so the
+/// system-note events keep the NEWEST page; the `resource_*` endpoints ignore `sort`
+/// and always answer oldest-first, so those classes keep the OLDEST page. The same
+/// feed's conversation half (`view_issue`'s comment read) keeps the oldest page, so
+/// past 100 notes the merged feed pairs the oldest comments with the newest events;
+/// unifying the windows is deferred.
 pub async fn issue_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTimelineEventOut>> {
     let enc = encode_project(&project_path(repo_path).await?);
+    let base = format!("projects/{enc}/issues/{number}");
     let mut events: Vec<ForgeTimelineEventOut> = Vec::new();
 
-    // Label add/remove events.
-    let label_events: Vec<GlabLabelEvent> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/issues/{number}/resource_label_events?per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
-    for e in label_events {
-        let Some(label) = e.label else { continue };
-        events.push(ForgeTimelineEventOut::Labeled {
-            label: label.name,
-            // `resource_label_events` returns `color` WITH a leading `#`, but the
-            // `Labeled.color` contract is bare hex (the frontend renders `#${color}`).
-            color: label.color.trim_start_matches('#').to_string(),
-            added: e.action == "add",
-            actor: gl_actor(e.user),
-            date: e.created_at,
-        });
-    }
+    // Four independent reads on the issue-open foreground path; the terminal sort
+    // makes arrival order irrelevant, so run them concurrently.
+    let (label_events, state_events, milestone_events, notes) = tokio::join!(
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/resource_label_events?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabLabelEvent>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/resource_state_events?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabStateEvent>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+        async {
+            run_glab(
+                Some(repo_path),
+                &[
+                    "api",
+                    &format!("{base}/resource_milestone_events?per_page=100"),
+                ],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabMilestoneEvent>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+        // Assignment / cross-reference / duplicate / lock events (see
+        // `map_issue_system_note`).
+        async {
+            run_glab(
+                Some(repo_path),
+                &["api", &format!("{base}/notes?per_page=100")],
+                GLAB_NETWORK_TIMEOUT,
+            )
+            .await
+            .ok()
+            .and_then(|o| serde_json::from_str::<Vec<GlabNote>>(&o.stdout_lossy()).ok())
+            .unwrap_or_default()
+        },
+    );
 
-    // State-change events. An issue never merges, so only close/reopen appear.
-    let state_events: Vec<GlabStateEvent> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/issues/{number}/resource_state_events?per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
-    events.extend(state_events.into_iter().filter_map(map_issue_state_event));
-
-    // Milestone add/remove events.
-    let milestone_events: Vec<GlabMilestoneEvent> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/issues/{number}/resource_milestone_events?per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
+    events.extend(label_events.into_iter().filter_map(map_label_event));
+    events.extend(state_events.into_iter().filter_map(map_state_event));
     events.extend(
         milestone_events
             .into_iter()
             .filter_map(map_issue_milestone_event),
     );
 
-    // Assignment / cross-reference / duplicate / lock events (see
-    // `map_issue_system_note`).
-    let notes: Vec<GlabNote> = run_glab(
-        Some(repo_path),
-        &[
-            "api",
-            &format!("projects/{enc}/issues/{number}/notes?sort=asc&per_page=100"),
-        ],
-        GLAB_NETWORK_TIMEOUT,
-    )
-    .await
-    .ok()
-    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
-    .unwrap_or_default();
     for n in notes {
         if !n.system {
             continue;
@@ -8853,18 +8844,39 @@ mod tests {
 
     #[test]
     fn label_event_color_is_stripped_to_bare_hex() {
+        let ev = |json: &str| -> GlabLabelEvent {
+            serde_json::from_str(json).expect("label event should parse")
+        };
         // `resource_label_events` returns `color` with a leading `#`; the
-        // `Labeled.color` contract is bare hex — run the same strip the mapper does.
-        let e: GlabLabelEvent = serde_json::from_str(
-            r##"{"action":"add","created_at":"2026-06-30T00:35:46.215Z",
+        // `Labeled.color` contract is bare hex.
+        match map_label_event(ev(r##"{"action":"add","created_at":"2026-06-30T00:35:46.215Z",
+            "user":{"username":"theBGuy"},
+            "label":{"name":"enhancement","color":"#5cb85c"}}"##)) {
+            Some(ForgeTimelineEventOut::Labeled {
+                label,
+                color,
+                added,
+                actor,
+                ..
+            }) => {
+                assert_eq!((label.as_str(), color.as_str()), ("enhancement", "5cb85c"));
+                assert!(added);
+                assert_eq!(actor.id, "theBGuy");
+            }
+            _ => panic!("expected Labeled"),
+        }
+        // An already-bare color is unchanged (idempotent), and `remove` is a removal.
+        assert!(matches!(
+            map_label_event(ev(r##"{"action":"remove","created_at":"2026-06-30T00:35:46.215Z",
                 "user":{"username":"theBGuy"},
-                "label":{"name":"enhancement","color":"#5cb85c"}}"##,
-        )
-        .expect("label event should parse");
-        let label = e.label.expect("label present");
-        assert_eq!(label.color.trim_start_matches('#'), "5cb85c");
-        // An already-bare color is unchanged (idempotent).
-        assert_eq!("5cb85c".trim_start_matches('#'), "5cb85c");
+                "label":{"name":"enhancement","color":"5cb85c"}}"##)),
+            Some(ForgeTimelineEventOut::Labeled { color, added: false, .. }) if color == "5cb85c"
+        ));
+        // A deleted label leaves `label: null` — the entry is skipped.
+        assert!(map_label_event(ev(
+            r#"{"action":"add","created_at":"2026-06-30T00:35:46.215Z","label":null}"#
+        ))
+        .is_none());
     }
 
     #[test]
@@ -8998,28 +9010,43 @@ mod tests {
     }
 
     #[test]
-    fn issue_state_events_map_close_reopen_only() {
-        let ev = |json: &str| -> GlabStateEvent {
-            serde_json::from_str(json).expect("state event should parse")
+    fn state_events_map_close_reopen_and_merge() {
+        let ev = |state: &str| -> GlabStateEvent {
+            serde_json::from_str(&format!(
+                r#"{{"state":"{state}","created_at":"2026-08-23T00:00:00Z",
+                    "user":{{"username":"theBGuy"}}}}"#
+            ))
+            .expect("state event should parse")
         };
+        match map_state_event(ev("closed")) {
+            Some(ForgeTimelineEventOut::Closed {
+                state_reason,
+                actor,
+                date,
+            }) => {
+                // GitLab reports no close reason.
+                assert!(state_reason.is_empty());
+                assert_eq!(actor.id, "theBGuy");
+                assert_eq!(date, "2026-08-23T00:00:00Z");
+            }
+            _ => panic!("expected Closed"),
+        }
         assert!(matches!(
-            map_issue_state_event(ev(
-                r#"{"state":"closed","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
-            )),
-            Some(ForgeTimelineEventOut::Closed { .. })
-        ));
-        assert!(matches!(
-            map_issue_state_event(ev(
-                r#"{"state":"reopened","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
-            )),
+            map_state_event(ev("reopened")),
             Some(ForgeTimelineEventOut::Reopened { .. })
         ));
-        // Issues never merge, and an unknown/new state is skipped rather than guessed.
-        assert!(map_issue_state_event(ev(
-            r#"{"state":"merged","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
-        ))
-        .is_none());
-        assert!(map_issue_state_event(ev(r#"{"state":"weird_new_state"}"#)).is_none());
+        // `merged` reaches this mapper only from the MR arm; GitLab never reports it
+        // on an issue.
+        assert!(matches!(
+            map_state_event(ev("merged")),
+            Some(ForgeTimelineEventOut::Merged {
+                commit_oid: None,
+                ..
+            })
+        ));
+        // An unknown/new state is skipped rather than guessed.
+        assert!(map_state_event(ev("weird_new_state")).is_none());
+        assert!(map_state_event(ev("")).is_none());
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -13,7 +13,8 @@ use crate::error::{AppError, AppResult};
 use crate::forge::glab::{run_glab, run_glab_ex, run_glab_raw, GLAB_NETWORK_TIMEOUT, GLAB_TIMEOUT};
 use crate::forge::model::{
     namespace_set, Capabilities, CompletedReviewerOut, ForgeForkResult, ForgeRepo, ForgeRepoList,
-    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeUserRef, Implemented, Provider,
+    ForgeSearchList, ForgeSearchRepo, ForgeStatus, ForgeTimelineEventOut, ForgeUserRef, Implemented,
+    Provider,
 };
 use crate::forge::{
     cap_readme, validate_owner, validate_repo_name, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
@@ -25,8 +26,8 @@ use crate::github::issue::{IssueDetails, IssueInfo, IssueReactions, Milestone, R
 use crate::github::pr::{
     ApprovalState, CommitCommentOut, DraftCommentIn, ExternalReviewItem, PrAuthor, PrCheckOut,
     PrCiStatus, PrCommitOut, PrDetails, PrFileOut, PrInfo, PrListLabel, PrMergeability, PrPollInfo,
-    PrRef, PrStackInfo, PrStackMember, PrThreadOut, PrTimelineEventOut, RepoLabel, ReviewSubmitOut,
-    ReviewThreadOut, STACKS_TIMEOUT,
+    PrRef, PrStackInfo, PrStackMember, PrThreadOut, RepoLabel, ReviewSubmitOut, ReviewThreadOut,
+    STACKS_TIMEOUT,
 };
 use crate::github::release::{ReleaseAsset, ReleaseDetails, ReleaseInfo};
 use crate::state::AppState;
@@ -1418,24 +1419,45 @@ struct GlabStateEvent {
     created_at: String,
 }
 
-/// The date field of a `PrTimelineEventOut` — the sort key. Empty dates sort first
+/// The date field of a `ForgeTimelineEventOut` — the sort key. Empty dates sort first
 /// (stable), which keeps undated events at the top rather than dropping them.
-fn timeline_event_date(e: &PrTimelineEventOut) -> &str {
+fn timeline_event_date(e: &ForgeTimelineEventOut) -> &str {
     match e {
-        PrTimelineEventOut::Labeled { date, .. }
-        | PrTimelineEventOut::Closed { date, .. }
-        | PrTimelineEventOut::Reopened { date, .. }
-        | PrTimelineEventOut::Merged { date, .. }
-        | PrTimelineEventOut::Approved { date, .. }
-        | PrTimelineEventOut::ChangesRequested { date, .. }
-        | PrTimelineEventOut::Unapproved { date, .. } => date,
+        ForgeTimelineEventOut::Labeled { date, .. }
+        | ForgeTimelineEventOut::Closed { date, .. }
+        | ForgeTimelineEventOut::Reopened { date, .. }
+        | ForgeTimelineEventOut::Merged { date, .. }
+        | ForgeTimelineEventOut::Approved { date, .. }
+        | ForgeTimelineEventOut::ChangesRequested { date, .. }
+        | ForgeTimelineEventOut::Unapproved { date, .. } => date,
         // The GitLab arm never produces these, but the union is shared — match
         // exhaustively so a new variant can't silently sort as "".
-        PrTimelineEventOut::ForcePushed { date, .. }
-        | PrTimelineEventOut::ReviewRequested { date, .. }
-        | PrTimelineEventOut::ReadyForReview { date, .. }
-        | PrTimelineEventOut::ConvertToDraft { date, .. }
-        | PrTimelineEventOut::Renamed { date, .. } => date,
+        ForgeTimelineEventOut::ForcePushed { date, .. }
+        | ForgeTimelineEventOut::ReviewRequested { date, .. }
+        | ForgeTimelineEventOut::ReadyForReview { date, .. }
+        | ForgeTimelineEventOut::ConvertToDraft { date, .. }
+        | ForgeTimelineEventOut::Renamed { date, .. }
+        | ForgeTimelineEventOut::Assigned { date, .. }
+        | ForgeTimelineEventOut::Milestoned { date, .. }
+        | ForgeTimelineEventOut::CrossReferenced { date, .. }
+        | ForgeTimelineEventOut::Connected { date, .. }
+        | ForgeTimelineEventOut::Pinned { date, .. }
+        | ForgeTimelineEventOut::Locked { date, .. }
+        | ForgeTimelineEventOut::Transferred { date, .. }
+        | ForgeTimelineEventOut::MarkedAsDuplicate { date, .. } => date,
+    }
+}
+
+/// A GitLab timeline actor as a neutral user ref. GitLab identifies users by
+/// username, so it fills both `id` and `label`; a missing user (deleted account)
+/// yields an all-empty ref, which the frontend renders as no actor at all.
+fn gl_actor(u: Option<GlabMrUser>) -> ForgeUserRef {
+    let (username, avatar_url) = u.map(|u| (u.username, u.avatar_url)).unwrap_or_default();
+    ForgeUserRef {
+        id: username.clone(),
+        label: username,
+        avatar_url,
+        is_bot: false,
     }
 }
 
@@ -1444,24 +1466,28 @@ fn timeline_event_date(e: &PrTimelineEventOut) -> &str {
 /// bodies ("approved this merge request", "unapproved this merge request",
 /// "requested changes") — the only place these carry a per-event timestamp + actor
 /// (the `/approvals` endpoint reports only the current state). Pure (unit-tested).
-fn map_approval_note(body: &str, actor: String, date: String) -> Option<PrTimelineEventOut> {
+fn map_approval_note(
+    body: &str,
+    actor: ForgeUserRef,
+    date: String,
+) -> Option<ForgeTimelineEventOut> {
     match body.trim() {
-        "approved this merge request" => Some(PrTimelineEventOut::Approved { actor, date }),
-        "unapproved this merge request" => Some(PrTimelineEventOut::Unapproved { actor, date }),
-        "requested changes" => Some(PrTimelineEventOut::ChangesRequested { actor, date }),
+        "approved this merge request" => Some(ForgeTimelineEventOut::Approved { actor, date }),
+        "unapproved this merge request" => Some(ForgeTimelineEventOut::Unapproved { actor, date }),
+        "requested changes" => Some(ForgeTimelineEventOut::ChangesRequested { actor, date }),
         _ => None,
     }
 }
 
 /// The MR's activity timeline — label add/remove, state changes, and approval-flow
-/// events — mapped onto the neutral `PrTimelineEventOut` union, oldest→newest.
+/// events — mapped onto the neutral `ForgeTimelineEventOut` union, oldest→newest.
 /// Deliberately omits commits (the frontend interleaves `pr.commits`), force-pushes
 /// (no GitLab API), and draft/ready + review-request events. Every sub-fetch is
 /// best-effort and a single `per_page=100` page, so a very busy MR truncates the
 /// oldest events of that class.
-pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<PrTimelineEventOut>> {
+pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTimelineEventOut>> {
     let enc = encode_project(&project_path(repo_path).await?);
-    let mut events: Vec<PrTimelineEventOut> = Vec::new();
+    let mut events: Vec<ForgeTimelineEventOut> = Vec::new();
 
     // Label add/remove events.
     let label_events: Vec<GlabLabelEvent> = run_glab(
@@ -1478,14 +1504,14 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
     .unwrap_or_default();
     for e in label_events {
         let Some(label) = e.label else { continue };
-        events.push(PrTimelineEventOut::Labeled {
+        events.push(ForgeTimelineEventOut::Labeled {
             label: label.name,
             // `resource_label_events` returns `color` WITH a leading `#`, but the
             // `Labeled.color` contract is bare hex (the frontend renders `#${color}`)
             // — strip it, like the file's other GitLab label producers.
             color: label.color.trim_start_matches('#').to_string(),
             added: e.action == "add",
-            actor: e.user.map(|u| u.username).unwrap_or_default(),
+            actor: gl_actor(e.user),
             date: e.created_at,
         });
     }
@@ -1504,12 +1530,17 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
     .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
     .unwrap_or_default();
     for e in state_events {
-        let actor = e.user.map(|u| u.username).unwrap_or_default();
+        let actor = gl_actor(e.user);
         let date = e.created_at;
         let mapped = match e.state.as_str() {
-            "closed" => PrTimelineEventOut::Closed { actor, date },
-            "reopened" => PrTimelineEventOut::Reopened { actor, date },
-            "merged" => PrTimelineEventOut::Merged {
+            // GitLab reports no close reason, so `state_reason` stays empty.
+            "closed" => ForgeTimelineEventOut::Closed {
+                actor,
+                state_reason: String::new(),
+                date,
+            },
+            "reopened" => ForgeTimelineEventOut::Reopened { actor, date },
+            "merged" => ForgeTimelineEventOut::Merged {
                 actor,
                 commit_oid: None,
                 date,
@@ -1538,8 +1569,251 @@ pub async fn mr_timeline(repo_path: &str, number: u64) -> AppResult<Vec<PrTimeli
         if !n.system {
             continue;
         }
-        let actor = n.author.map(|a| a.username).unwrap_or_default();
-        if let Some(ev) = map_approval_note(&n.body, actor, n.created_at) {
+        if let Some(ev) = map_approval_note(&n.body, gl_actor(n.author), n.created_at) {
+            events.push(ev);
+        }
+    }
+
+    // Combine all classes and sort ascending by date (empty dates sort first).
+    events.sort_by(|a, b| timeline_event_date(a).cmp(timeline_event_date(b)));
+    Ok(events)
+}
+
+/// One `resource_milestone_events` entry: `{action:"add"|"remove", milestone{title},
+/// user, created_at}`. `milestone` is null once the milestone itself is deleted.
+#[derive(Deserialize)]
+struct GlabMilestoneEvent {
+    #[serde(default)]
+    action: String,
+    #[serde(default)]
+    milestone: Option<GlabEventMilestone>,
+    #[serde(default)]
+    user: Option<GlabMrUser>,
+    #[serde(default)]
+    created_at: String,
+}
+
+#[derive(Deserialize)]
+struct GlabEventMilestone {
+    #[serde(default)]
+    title: String,
+}
+
+/// Map one issue `resource_milestone_events` entry, or `None` when the milestone it
+/// pointed at has since been deleted (GitLab keeps the event, nulls the milestone).
+/// Pure (unit-tested).
+fn map_issue_milestone_event(e: GlabMilestoneEvent) -> Option<ForgeTimelineEventOut> {
+    let milestone = e.milestone?;
+    Some(ForgeTimelineEventOut::Milestoned {
+        milestone: milestone.title,
+        added: e.action == "add",
+        actor: gl_actor(e.user),
+        date: e.created_at,
+    })
+}
+
+/// Map one issue `resource_state_events` entry. An issue only closes and reopens —
+/// any other state (including `merged`, which the MR arm handles) is skipped rather
+/// than guessed. Pure (unit-tested).
+fn map_issue_state_event(e: GlabStateEvent) -> Option<ForgeTimelineEventOut> {
+    let actor = gl_actor(e.user);
+    let date = e.created_at;
+    match e.state.as_str() {
+        // GitLab reports no close reason, so `state_reason` stays empty.
+        "closed" => Some(ForgeTimelineEventOut::Closed {
+            actor,
+            state_reason: String::new(),
+            date,
+        }),
+        "reopened" => Some(ForgeTimelineEventOut::Reopened { actor, date }),
+        _ => None,
+    }
+}
+
+/// Map a GitLab issue system-note body onto a timeline event, or `None` when it isn't
+/// one we model. GitLab records assignment, cross-references, duplicates and lock
+/// changes only as system notes — there is no structured endpoint for them. The
+/// matcher is anchored and exact-form only: an unrecognized body is skipped rather
+/// than half-parsed, because these bodies are free-form English that GitLab extends.
+/// Cross-PROJECT mentions (`mentioned in merge request group/proj!7`) deliberately
+/// don't match — the neutral `source_repo` means an `owner/name` slug, and GitLab's
+/// note gives no reliable way to split one out. Pure (unit-tested).
+fn map_issue_system_note(
+    body: &str,
+    actor: ForgeUserRef,
+    date: String,
+) -> Option<ForgeTimelineEventOut> {
+    let body = body.trim();
+    // The reference number runs to end-of-string; a cross-project form
+    // (`…!7` prefixed by `group/proj`) never reaches here, so no digits, no match.
+    let number = |rest: &str| {
+        (!rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+            .then(|| rest.parse::<u64>().ok())
+            .flatten()
+    };
+    // gitlab.com writes the lock notes as "…the discussion in this issue" (measured
+    // against project 83906586, 2026-08-23); the short forms are accepted too so an
+    // older self-managed wording can't drop the event.
+    match body {
+        "locked the discussion in this issue" | "locked this issue" => {
+            return Some(ForgeTimelineEventOut::Locked {
+                locked: true,
+                // GitLab records no lock reason.
+                reason: String::new(),
+                actor,
+                date,
+            })
+        }
+        "unlocked the discussion in this issue" | "unlocked this issue" => {
+            return Some(ForgeTimelineEventOut::Locked {
+                locked: false,
+                reason: String::new(),
+                actor,
+                date,
+            })
+        }
+        _ => {}
+    }
+    if let Some((name, added)) = body
+        .strip_prefix("assigned to @")
+        .map(|rest| (rest, true))
+        .or_else(|| body.strip_prefix("unassigned @").map(|rest| (rest, false)))
+    {
+        // One `@username` only: a multi-assignee body ("assigned to @a and @b")
+        // carries whitespace and is skipped rather than credited to the first name.
+        return (!name.is_empty() && !name.contains(char::is_whitespace)).then(|| {
+            ForgeTimelineEventOut::Assigned {
+                assignee: name.to_string(),
+                added,
+                actor,
+                date,
+            }
+        });
+    }
+    if let Some((n, kind)) = body
+        .strip_prefix("mentioned in merge request !")
+        .and_then(number)
+        .map(|n| (n, "pr"))
+        .or_else(|| {
+            body.strip_prefix("mentioned in issue #")
+                .and_then(number)
+                .map(|n| (n, "issue"))
+        })
+    {
+        return Some(ForgeTimelineEventOut::CrossReferenced {
+            source_kind: kind.to_string(),
+            source_number: n,
+            // The note carries neither the referrer's title nor its project.
+            source_title: String::new(),
+            source_repo: String::new(),
+            will_close: false,
+            actor,
+            date,
+        });
+    }
+    if let Some(n) = body
+        .strip_prefix("marked this issue as a duplicate of #")
+        .and_then(number)
+    {
+        return Some(ForgeTimelineEventOut::MarkedAsDuplicate {
+            canonical_kind: "issue".to_string(),
+            canonical_number: n,
+            canonical_repo: String::new(),
+            actor,
+            date,
+        });
+    }
+    None
+}
+
+/// The issue's activity timeline — label add/remove, state changes, milestone
+/// changes, and the assignment/cross-reference/duplicate/lock system notes — mapped
+/// onto the neutral `ForgeTimelineEventOut` union, oldest→newest. Every sub-fetch is
+/// best-effort and a single `per_page=100` page, so a very busy issue truncates the
+/// oldest events of that class.
+pub async fn issue_timeline(repo_path: &str, number: u64) -> AppResult<Vec<ForgeTimelineEventOut>> {
+    let enc = encode_project(&project_path(repo_path).await?);
+    let mut events: Vec<ForgeTimelineEventOut> = Vec::new();
+
+    // Label add/remove events.
+    let label_events: Vec<GlabLabelEvent> = run_glab(
+        Some(repo_path),
+        &[
+            "api",
+            &format!("projects/{enc}/issues/{number}/resource_label_events?per_page=100"),
+        ],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await
+    .ok()
+    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
+    .unwrap_or_default();
+    for e in label_events {
+        let Some(label) = e.label else { continue };
+        events.push(ForgeTimelineEventOut::Labeled {
+            label: label.name,
+            // `resource_label_events` returns `color` WITH a leading `#`, but the
+            // `Labeled.color` contract is bare hex (the frontend renders `#${color}`).
+            color: label.color.trim_start_matches('#').to_string(),
+            added: e.action == "add",
+            actor: gl_actor(e.user),
+            date: e.created_at,
+        });
+    }
+
+    // State-change events. An issue never merges, so only close/reopen appear.
+    let state_events: Vec<GlabStateEvent> = run_glab(
+        Some(repo_path),
+        &[
+            "api",
+            &format!("projects/{enc}/issues/{number}/resource_state_events?per_page=100"),
+        ],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await
+    .ok()
+    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
+    .unwrap_or_default();
+    events.extend(state_events.into_iter().filter_map(map_issue_state_event));
+
+    // Milestone add/remove events.
+    let milestone_events: Vec<GlabMilestoneEvent> = run_glab(
+        Some(repo_path),
+        &[
+            "api",
+            &format!("projects/{enc}/issues/{number}/resource_milestone_events?per_page=100"),
+        ],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await
+    .ok()
+    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
+    .unwrap_or_default();
+    events.extend(
+        milestone_events
+            .into_iter()
+            .filter_map(map_issue_milestone_event),
+    );
+
+    // Assignment / cross-reference / duplicate / lock events (see
+    // `map_issue_system_note`).
+    let notes: Vec<GlabNote> = run_glab(
+        Some(repo_path),
+        &[
+            "api",
+            &format!("projects/{enc}/issues/{number}/notes?sort=asc&per_page=100"),
+        ],
+        GLAB_NETWORK_TIMEOUT,
+    )
+    .await
+    .ok()
+    .and_then(|o| serde_json::from_str(&o.stdout_lossy()).ok())
+    .unwrap_or_default();
+    for n in notes {
+        if !n.system {
+            continue;
+        }
+        if let Some(ev) = map_issue_system_note(&n.body, gl_actor(n.author), n.created_at) {
             events.push(ev);
         }
     }
@@ -8536,26 +8810,44 @@ mod tests {
 
     #[test]
     fn approval_notes_map_to_the_right_variant() {
-        let a = || "theBGuy".to_string();
+        let a = || {
+            gl_actor(Some(
+                serde_json::from_str(
+                    r#"{"username":"theBGuy","avatar_url":"https://gl/u/theBGuy.png"}"#,
+                )
+                .expect("user should parse"),
+            ))
+        };
         let d = || "2026-07-02T05:45:40.961Z".to_string();
-        assert!(matches!(
-            map_approval_note("approved this merge request", a(), d()),
-            Some(PrTimelineEventOut::Approved { .. })
-        ));
+        match map_approval_note("approved this merge request", a(), d()) {
+            Some(ForgeTimelineEventOut::Approved { actor, .. }) => {
+                // The username fills both id and label; the avatar rides along.
+                assert_eq!((actor.id.as_str(), actor.label.as_str()), ("theBGuy", "theBGuy"));
+                assert_eq!(actor.avatar_url, "https://gl/u/theBGuy.png");
+            }
+            _ => panic!("expected Approved"),
+        }
         assert!(matches!(
             map_approval_note("unapproved this merge request", a(), d()),
-            Some(PrTimelineEventOut::Unapproved { .. })
+            Some(ForgeTimelineEventOut::Unapproved { .. })
         ));
         assert!(matches!(
             map_approval_note("requested changes", a(), d()),
-            Some(PrTimelineEventOut::ChangesRequested { .. })
+            Some(ForgeTimelineEventOut::ChangesRequested { .. })
         ));
         // A non-approval system note (e.g. a time-tracking note) is not a timeline event.
         assert!(map_approval_note("added 3h of time spent", a(), d()).is_none());
         // Leading/trailing whitespace is tolerated.
         assert!(matches!(
             map_approval_note("  approved this merge request  ", a(), d()),
-            Some(PrTimelineEventOut::Approved { .. })
+            Some(ForgeTimelineEventOut::Approved { .. })
+        ));
+        // A deleted-account note keeps its event with an all-empty actor.
+        let ghost = gl_actor(None);
+        assert!(ghost.label.is_empty() && ghost.avatar_url.is_empty());
+        assert!(matches!(
+            map_approval_note("approved this merge request", ghost, d()),
+            Some(ForgeTimelineEventOut::Approved { .. })
         ));
     }
 
@@ -8576,19 +8868,175 @@ mod tests {
     }
 
     #[test]
+    fn issue_system_notes_map_to_the_right_variant() {
+        let a = || {
+            gl_actor(Some(
+                serde_json::from_str(
+                    r#"{"username":"theBGuy","avatar_url":"https://gl/u/theBGuy.png"}"#,
+                )
+                .expect("user should parse"),
+            ))
+        };
+        let d = || "2026-08-23T05:45:40.961Z".to_string();
+
+        match map_issue_system_note("assigned to @theBGuy", a(), d()) {
+            Some(ForgeTimelineEventOut::Assigned {
+                assignee,
+                added,
+                actor,
+                ..
+            }) => {
+                assert_eq!(assignee, "theBGuy");
+                assert!(added);
+                assert_eq!(actor.id, "theBGuy");
+            }
+            _ => panic!("expected Assigned"),
+        }
+        assert!(matches!(
+            map_issue_system_note("unassigned @theBGuy", a(), d()),
+            Some(ForgeTimelineEventOut::Assigned { added: false, .. })
+        ));
+        // Multi-assignee bodies are skipped rather than half-parsed.
+        assert!(map_issue_system_note("assigned to @a and @b", a(), d()).is_none());
+        // A bare prefix with no username is not an event either.
+        assert!(map_issue_system_note("assigned to @", a(), d()).is_none());
+
+        match map_issue_system_note("mentioned in merge request !151", a(), d()) {
+            Some(ForgeTimelineEventOut::CrossReferenced {
+                source_kind,
+                source_number,
+                source_repo,
+                will_close,
+                ..
+            }) => {
+                assert_eq!((source_kind.as_str(), source_number), ("pr", 151));
+                assert!(source_repo.is_empty() && !will_close);
+            }
+            _ => panic!("expected CrossReferenced"),
+        }
+        assert!(matches!(
+            map_issue_system_note("mentioned in issue #150", a(), d()),
+            Some(ForgeTimelineEventOut::CrossReferenced { source_number: 150, .. })
+        ));
+        // Cross-PROJECT mentions carry a project path the neutral shape can't
+        // express — they must NOT match as a same-project reference.
+        assert!(map_issue_system_note("mentioned in merge request group/proj!7", a(), d()).is_none());
+        assert!(map_issue_system_note("mentioned in issue group/proj#7", a(), d()).is_none());
+        // A non-numeric tail is not a reference.
+        assert!(map_issue_system_note("mentioned in issue #abc", a(), d()).is_none());
+
+        match map_issue_system_note("marked this issue as a duplicate of #12", a(), d()) {
+            Some(ForgeTimelineEventOut::MarkedAsDuplicate {
+                canonical_kind,
+                canonical_number,
+                ..
+            }) => assert_eq!((canonical_kind.as_str(), canonical_number), ("issue", 12)),
+            _ => panic!("expected MarkedAsDuplicate"),
+        }
+
+        // gitlab.com's live wording, plus the short form kept for older instances.
+        for body in ["locked the discussion in this issue", "locked this issue"] {
+            assert!(
+                matches!(
+                    map_issue_system_note(body, a(), d()),
+                    Some(ForgeTimelineEventOut::Locked { locked: true, .. })
+                ),
+                "body {body}"
+            );
+        }
+        for body in ["unlocked the discussion in this issue", "unlocked this issue"] {
+            assert!(
+                matches!(
+                    map_issue_system_note(body, a(), d()),
+                    Some(ForgeTimelineEventOut::Locked { locked: false, .. })
+                ),
+                "body {body}"
+            );
+        }
+        // Leading/trailing whitespace is tolerated, like the approval matcher.
+        assert!(matches!(
+            map_issue_system_note("  locked the discussion in this issue  ", a(), d()),
+            Some(ForgeTimelineEventOut::Locked { locked: true, .. })
+        ));
+        // Anything else GitLab writes as a system note is skipped, never guessed.
+        assert!(map_issue_system_note("changed the description", a(), d()).is_none());
+        assert!(map_issue_system_note("added 3h of time spent", a(), d()).is_none());
+    }
+
+    #[test]
+    fn issue_milestone_events_map_or_skip() {
+        let ev = |json: &str| -> GlabMilestoneEvent {
+            serde_json::from_str(json).expect("milestone event should parse")
+        };
+        match map_issue_milestone_event(ev(r#"{"action":"add",
+            "created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"},
+            "milestone":{"title":"v1.0"}}"#)) {
+            Some(ForgeTimelineEventOut::Milestoned {
+                milestone,
+                added,
+                actor,
+                date,
+            }) => {
+                assert_eq!(milestone, "v1.0");
+                assert!(added);
+                assert_eq!(actor.id, "theBGuy");
+                assert_eq!(date, "2026-08-23T00:00:00Z");
+            }
+            _ => panic!("expected Milestoned"),
+        }
+        assert!(matches!(
+            map_issue_milestone_event(ev(r#"{"action":"remove",
+                "created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"},
+                "milestone":{"title":"v1.0"}}"#)),
+            Some(ForgeTimelineEventOut::Milestoned { added: false, .. })
+        ));
+        // A deleted milestone leaves `milestone: null` — the entry is skipped.
+        assert!(map_issue_milestone_event(ev(r#"{"action":"add",
+            "created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"},
+            "milestone":null}"#))
+        .is_none());
+    }
+
+    #[test]
+    fn issue_state_events_map_close_reopen_only() {
+        let ev = |json: &str| -> GlabStateEvent {
+            serde_json::from_str(json).expect("state event should parse")
+        };
+        assert!(matches!(
+            map_issue_state_event(ev(
+                r#"{"state":"closed","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
+            )),
+            Some(ForgeTimelineEventOut::Closed { .. })
+        ));
+        assert!(matches!(
+            map_issue_state_event(ev(
+                r#"{"state":"reopened","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
+            )),
+            Some(ForgeTimelineEventOut::Reopened { .. })
+        ));
+        // Issues never merge, and an unknown/new state is skipped rather than guessed.
+        assert!(map_issue_state_event(ev(
+            r#"{"state":"merged","created_at":"2026-08-23T00:00:00Z","user":{"username":"theBGuy"}}"#
+        ))
+        .is_none());
+        assert!(map_issue_state_event(ev(r#"{"state":"weird_new_state"}"#)).is_none());
+    }
+
+    #[test]
     fn timeline_sorts_ascending_by_date_empties_first() {
         let mut events = [
-            PrTimelineEventOut::Merged {
-                actor: String::new(),
+            ForgeTimelineEventOut::Merged {
+                actor: gl_actor(None),
                 commit_oid: None,
                 date: "2026-07-02T00:00:00Z".into(),
             },
-            PrTimelineEventOut::Approved {
-                actor: String::new(),
+            ForgeTimelineEventOut::Approved {
+                actor: gl_actor(None),
                 date: String::new(),
             },
-            PrTimelineEventOut::Closed {
-                actor: String::new(),
+            ForgeTimelineEventOut::Closed {
+                actor: gl_actor(None),
+                state_reason: String::new(),
                 date: "2026-07-01T00:00:00Z".into(),
             },
         ];

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -1207,7 +1207,7 @@ pub async fn forge_pr_list_mergeability(
 
 /// The PR/MR activity timeline — state changes, label edits, approvals — behind the
 /// abstraction. Each provider maps its own event source onto the neutral
-/// `PrTimelineEventOut` union: GitHub `timelineItems`, GitLab resource/state/label
+/// `ForgeTimelineEventOut` union: GitHub `timelineItems`, GitLab resource/state/label
 /// events + approval system-notes, Bitbucket PR `activity`. Events sort oldest→newest;
 /// the frontend interleaves `pr.commits` itself, so no arm emits commit events.
 #[tauri::command]
@@ -1215,7 +1215,7 @@ pub async fn forge_pr_timeline(
     repo_path: String,
     number: u64,
     lens: Option<String>,
-) -> AppResult<Vec<crate::github::pr::PrTimelineEventOut>> {
+) -> AppResult<Vec<crate::forge::model::ForgeTimelineEventOut>> {
     match detect_non_github(&repo_path).await {
         Some((Provider::GitLab, _)) => gitlab::mr_timeline(&repo_path, number).await,
         Some((Provider::Bitbucket, _)) => bitbucket::pr_activity(&repo_path, number).await,
@@ -2003,6 +2003,26 @@ pub async fn forge_issue_view(
             "Bitbucket issues aren't supported yet.".into(),
         )),
         _ => github::view_issue(&repo_path, number, lens).await,
+    }
+}
+
+/// The issue's activity timeline — label, assignee and milestone changes,
+/// cross-references and links, state changes — behind the abstraction, on the same
+/// neutral `ForgeTimelineEventOut` union as the PR read. GitHub maps
+/// `timelineItems`; GitLab maps its resource label/state/milestone events plus the
+/// assignment/reference/lock system notes. Events sort oldest→newest.
+#[tauri::command]
+pub async fn forge_issue_timeline(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<Vec<crate::forge::model::ForgeTimelineEventOut>> {
+    match detect_non_github(&repo_path).await {
+        Some((Provider::GitLab, _)) => gitlab::issue_timeline(&repo_path, number).await,
+        Some((Provider::Bitbucket, _)) => Err(AppError::InvalidArgument(
+            "Bitbucket issues aren't supported yet.".into(),
+        )),
+        _ => github::issue_timeline(&repo_path, number, lens).await,
     }
 }
 

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -629,9 +629,10 @@ pub struct ForgeUserRef {
 /// One activity-timeline event on a merge/pull request or an issue, a tagged union
 /// keyed on `kind` (camelCase). The backend maps a GitHub `timelineItems`
 /// `__typename` (or a GitLab/Bitbucket event) onto a variant; an unclassifiable node
-/// is skipped, never a panic. Every `date`/string defaults to `""` for provider
-/// nulls, so a field is absent-as-empty rather than missing — `Merged.commit_oid` is
-/// the one exception, an `Option` that is genuinely absent from the wire when unset.
+/// is skipped, never a panic. Every `date`/string defaults to `""` (and every
+/// number to `0`, every flag to `false`) for provider nulls, so a field is
+/// absent-as-empty rather than missing — `Merged.commit_oid` is the one exception,
+/// an `Option` that is genuinely absent from the wire when unset.
 ///
 /// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
 /// for the TS mirror (`src/lib/git/types.ts`): without it `Merged.commit_oid` reaches
@@ -717,7 +718,11 @@ pub enum ForgeTimelineEventOut {
     /// `CrossReferencedEvent` — another PR/issue mentioned this one. `source_kind` is
     /// `"pr"` / `"issue"` (`""` when unrecognized) and `source_repo` is the referring
     /// entity's `owner/name`: a cross-reference can live in ANOTHER repository, so the
-    /// number alone can't address it.
+    /// number alone can't address it. An EMPTY `source_repo` is a same-repo guarantee,
+    /// not an unknown — GitHub always names the repo (schema-non-null), and GitLab's
+    /// note matcher only accepts same-project reference forms. `will_close` is carried
+    /// so a future closing-reference treatment needs no wire change; no renderer
+    /// reads it yet.
     CrossReferenced {
         source_kind: String,
         source_number: u64,
@@ -728,8 +733,8 @@ pub enum ForgeTimelineEventOut {
         date: String,
     },
     /// `ConnectedEvent` (`added = true`) / `DisconnectedEvent` (`added = false`) — a
-    /// PR/issue link was made or broken. Same `source_*` shape (and cross-repo caveat)
-    /// as [`ForgeTimelineEventOut::CrossReferenced`].
+    /// PR/issue link was made or broken. Same `source_*` shape and contract (including
+    /// the empty-means-same-repo guarantee) as [`ForgeTimelineEventOut::CrossReferenced`].
     Connected {
         source_kind: String,
         source_number: u64,
@@ -760,7 +765,8 @@ pub enum ForgeTimelineEventOut {
         date: String,
     },
     /// `MarkedAsDuplicateEvent` — closed as a duplicate of the canonical entity.
-    /// `canonical_repo` carries its `owner/name` for the same cross-repo reason as
+    /// `canonical_repo` carries its `owner/name` for the same cross-repo reason — and
+    /// the same empty-means-same-repo contract — as
     /// [`ForgeTimelineEventOut::CrossReferenced`].
     MarkedAsDuplicate {
         canonical_kind: String,

--- a/src-tauri/src/forge/model.rs
+++ b/src-tauri/src/forge/model.rs
@@ -602,24 +602,173 @@ pub struct ForgeStatus {
     pub implemented: Implemented,
 }
 
-/// A provider user reference for pickers — a stable id plus a human label.
-/// Bitbucket's reviewer picker is the emitter today (id = the braced account
-/// uuid, label = display name / nickname): Bitbucket identity must travel as the
-/// uuid because participant objects never carry `username`, and nicknames aren't
-/// unique — the display string alone can't round-trip a mutation safely.
+/// A provider user reference — a stable id plus a human label — for pickers,
+/// read-only chips, and timeline actors. Bitbucket identity must travel as the
+/// braced account uuid (id) with the display name / nickname as the label:
+/// participant objects never carry `username`, and nicknames aren't unique, so
+/// the display string alone can't round-trip a mutation safely. GitHub and GitLab
+/// put the login/username in both fields.
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ForgeUserRef {
     pub id: String,
     pub label: String,
-    /// The user's avatar URL when the provider supplies one (GitLab/Bitbucket
-    /// return it directly). Empty for GitHub, where the picker derives the avatar
-    /// from the login (`<host>/<login>.png`), so we don't spend a field on it.
+    /// The user's avatar URL whenever the source supplies one — GitLab/Bitbucket
+    /// return it on every user, and the GitHub timeline reads `actor.avatarUrl`.
+    /// Empty means the frontend derives it from the login on GitHub
+    /// (`<host>/<login>.png`) and falls back to initials elsewhere, so an emitter
+    /// with no URL to hand leaves it empty rather than guessing one.
     pub avatar_url: String,
-    /// True for a bot requested reviewer (e.g. GitHub Copilot). Bot reviewers are
+    /// True for a bot account — a bot requested reviewer (e.g. GitHub Copilot), or
+    /// a timeline actor whose GraphQL `__typename` is `Bot`. Bot reviewers are
     /// display-only: they are never part of the editable picker's managed set and
     /// the reviewer setters never add or remove them.
     pub is_bot: bool,
+}
+
+/// One activity-timeline event on a merge/pull request or an issue, a tagged union
+/// keyed on `kind` (camelCase). The backend maps a GitHub `timelineItems`
+/// `__typename` (or a GitLab/Bitbucket event) onto a variant; an unclassifiable node
+/// is skipped, never a panic. Every `date`/string defaults to `""` for provider
+/// nulls, so a field is absent-as-empty rather than missing — `Merged.commit_oid` is
+/// the one exception, an `Option` that is genuinely absent from the wire when unset.
+///
+/// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
+/// for the TS mirror (`src/lib/git/types.ts`): without it `Merged.commit_oid` reaches
+/// TS as `undefined` and a merged PR silently loses its merge commit.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum ForgeTimelineEventOut {
+    /// `HeadRefForcePushedEvent` — the head branch was force-pushed.
+    ForcePushed {
+        before: String,
+        after: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `LabeledEvent` (`added = true`) / `UnlabeledEvent` (`added = false`).
+    Labeled {
+        label: String,
+        color: String,
+        added: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `ReviewRequestedEvent` — `reviewer` is a user login OR a team slug.
+    ReviewRequested {
+        reviewer: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `ReadyForReviewEvent` — a draft was marked ready.
+    ReadyForReview { actor: ForgeUserRef, date: String },
+    /// `ConvertToDraftEvent` — the PR was converted back to a draft.
+    ConvertToDraft { actor: ForgeUserRef, date: String },
+    /// `ClosedEvent` — the PR/issue was closed (without merging). `state_reason` is
+    /// GitHub's issue close reason lowercased ("completed" / "not_planned" /
+    /// "duplicate"); `""` for PRs and for the other providers, which report none.
+    Closed {
+        actor: ForgeUserRef,
+        state_reason: String,
+        date: String,
+    },
+    /// `ReopenedEvent` — a closed PR/issue was reopened.
+    Reopened { actor: ForgeUserRef, date: String },
+    /// `MergedEvent` — `commit_oid` is the merge commit (may be `None`).
+    Merged {
+        actor: ForgeUserRef,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        commit_oid: Option<String>,
+        date: String,
+    },
+    /// `RenamedTitleEvent` — the title changed.
+    Renamed {
+        previous: String,
+        current: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// An approval was given. GitHub surfaces approvals through the review flow
+    /// (they render as review cards), so its own timeline never emits this — it's
+    /// produced by the GitLab (system-note "approved") and Bitbucket (`approval`
+    /// activity) arms, whose approvals carry no reviewable body.
+    Approved { actor: ForgeUserRef, date: String },
+    /// A "request changes" verdict without an accompanying review card. Emitted by
+    /// the GitLab (system-note "requested changes") and Bitbucket (`changes_requested`
+    /// activity) arms; GitHub renders its request-changes reviews as cards instead.
+    ChangesRequested { actor: ForgeUserRef, date: String },
+    /// A previously-given approval was withdrawn (GitLab system-note "unapproved";
+    /// Bitbucket has no explicit unapproval activity). GitHub never emits it.
+    Unapproved { actor: ForgeUserRef, date: String },
+    /// `AssignedEvent` (`added = true`) / `UnassignedEvent` (`added = false`).
+    Assigned {
+        assignee: String,
+        added: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `MilestonedEvent` (`added = true`) / `DemilestonedEvent` (`added = false`).
+    Milestoned {
+        milestone: String,
+        added: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `CrossReferencedEvent` — another PR/issue mentioned this one. `source_kind` is
+    /// `"pr"` / `"issue"` (`""` when unrecognized) and `source_repo` is the referring
+    /// entity's `owner/name`: a cross-reference can live in ANOTHER repository, so the
+    /// number alone can't address it.
+    CrossReferenced {
+        source_kind: String,
+        source_number: u64,
+        source_title: String,
+        source_repo: String,
+        will_close: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `ConnectedEvent` (`added = true`) / `DisconnectedEvent` (`added = false`) — a
+    /// PR/issue link was made or broken. Same `source_*` shape (and cross-repo caveat)
+    /// as [`ForgeTimelineEventOut::CrossReferenced`].
+    Connected {
+        source_kind: String,
+        source_number: u64,
+        source_title: String,
+        source_repo: String,
+        added: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `PinnedEvent` (`added = true`) / `UnpinnedEvent` (`added = false`).
+    Pinned {
+        added: bool,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `LockedEvent` (`locked = true`) / `UnlockedEvent` (`locked = false`). `reason`
+    /// is GitHub's lock reason lowercased, `""` when none was given or on unlock.
+    Locked {
+        locked: bool,
+        reason: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `TransferredEvent` — the issue moved here from `from_repo` (`owner/name`).
+    Transferred {
+        from_repo: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
+    /// `MarkedAsDuplicateEvent` — closed as a duplicate of the canonical entity.
+    /// `canonical_repo` carries its `owner/name` for the same cross-repo reason as
+    /// [`ForgeTimelineEventOut::CrossReferenced`].
+    MarkedAsDuplicate {
+        canonical_kind: String,
+        canonical_number: u64,
+        canonical_repo: String,
+        actor: ForgeUserRef,
+        date: String,
+    },
 }
 
 /// A reviewer who has submitted a verdict (GitLab approval/requested-changes,
@@ -776,6 +925,105 @@ mod tests {
             namespace_set(["".to_string(), "octocat".to_string()]),
             vec!["octocat".to_string()]
         );
+    }
+
+    fn actor(login: &str) -> ForgeUserRef {
+        ForgeUserRef {
+            id: login.to_string(),
+            label: login.to_string(),
+            avatar_url: format!("https://avatars/{login}.png"),
+            is_bot: false,
+        }
+    }
+
+    /// Pins the IPC contract with the TS mirror (src/lib/git/types.ts): `commit_oid` is
+    /// the variant's multi-word field (read as `commitOid`), and `actor` is a nested
+    /// object whose own keys are camelCase too.
+    #[test]
+    fn merged_timeline_event_wire_shape_is_camel_case() {
+        let merged = serde_json::to_value(ForgeTimelineEventOut::Merged {
+            actor: actor("alice"),
+            commit_oid: Some("deadbeef".to_string()),
+            date: "2026-05-12T12:01:23Z".to_string(),
+        })
+        .expect("Merged serializes");
+        let obj = merged.as_object().expect("Merged is a JSON object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["actor", "commitOid", "date", "kind"]);
+        assert_eq!(obj["kind"], "merged");
+        assert_eq!(obj["commitOid"], "deadbeef");
+        assert!(
+            obj.get("commit_oid").is_none(),
+            "snake_case field must not ship"
+        );
+        let mut actor_keys: Vec<&str> = obj["actor"]
+            .as_object()
+            .expect("actor is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        actor_keys.sort_unstable();
+        assert_eq!(actor_keys, ["avatarUrl", "id", "isBot", "label"]);
+    }
+
+    /// The ref-carrying variants have the most multi-word fields, so they're the
+    /// tightest check that `rename_all_fields` still covers a NEW variant.
+    #[test]
+    fn cross_referenced_wire_shape_is_camel_case() {
+        let value = serde_json::to_value(ForgeTimelineEventOut::CrossReferenced {
+            source_kind: "pr".to_string(),
+            source_number: 42,
+            source_title: "Fix the thing".to_string(),
+            source_repo: "octocat/hello".to_string(),
+            will_close: true,
+            actor: actor("alice"),
+            date: "2026-05-12T12:01:23Z".to_string(),
+        })
+        .expect("CrossReferenced serializes");
+        let obj = value.as_object().expect("CrossReferenced is a JSON object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "actor",
+                "date",
+                "kind",
+                "sourceKind",
+                "sourceNumber",
+                "sourceRepo",
+                "sourceTitle",
+                "willClose",
+            ]
+        );
+        assert_eq!(obj["kind"], "crossReferenced");
+    }
+
+    /// `state_reason` always ships (no skip), so the issue view can distinguish a
+    /// "closed as not planned" from a plain close without a second read.
+    #[test]
+    fn closed_timeline_event_serializes_state_reason() {
+        let value = serde_json::to_value(ForgeTimelineEventOut::Closed {
+            actor: actor("alice"),
+            state_reason: "not_planned".to_string(),
+            date: "2026-05-12T12:01:23Z".to_string(),
+        })
+        .expect("Closed serializes");
+        let obj = value.as_object().expect("Closed is a JSON object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["actor", "date", "kind", "stateReason"]);
+        assert_eq!(obj["kind"], "closed");
+        assert_eq!(obj["stateReason"], "not_planned");
+        // The empty (PR / non-GitHub) case still ships the key.
+        let empty = serde_json::to_value(ForgeTimelineEventOut::Closed {
+            actor: actor("alice"),
+            state_reason: String::new(),
+            date: String::new(),
+        })
+        .expect("Closed serializes");
+        assert_eq!(empty["stateReason"], "");
     }
 
     #[test]

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -1177,6 +1177,54 @@ pub struct LinkedPr {
     pub url: String,
 }
 
+const ISSUE_TIMELINE_QUERY: &str = r#"query($owner:String!,$name:String!,$number:Int!){ repository(owner:$owner,name:$name){ issue(number:$number){ timelineItems(last:100, itemTypes:[LABELED_EVENT, UNLABELED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT, CROSS_REFERENCED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT, MILESTONED_EVENT, DEMILESTONED_EVENT, CLOSED_EVENT, REOPENED_EVENT, RENAMED_TITLE_EVENT, PINNED_EVENT, UNPINNED_EVENT, LOCKED_EVENT, UNLOCKED_EVENT, MARKED_AS_DUPLICATE_EVENT, TRANSFERRED_EVENT]){ nodes{ __typename ... on LabeledEvent{ actor{login avatarUrl(size: 48) __typename} createdAt label{name color} } ... on UnlabeledEvent{ actor{login avatarUrl(size: 48) __typename} createdAt label{name color} } ... on AssignedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt assignee{ __typename ... on User{login} ... on Bot{login} ... on Mannequin{login} ... on Organization{login} } } ... on UnassignedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt assignee{ __typename ... on User{login} ... on Bot{login} ... on Mannequin{login} ... on Organization{login} } } ... on CrossReferencedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt willCloseTarget source{ __typename ... on Issue{number title repository{nameWithOwner}} ... on PullRequest{number title repository{nameWithOwner}} } } ... on ConnectedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt source{ __typename ... on Issue{number title repository{nameWithOwner}} ... on PullRequest{number title repository{nameWithOwner}} } subject{ __typename ... on Issue{number title repository{nameWithOwner}} ... on PullRequest{number title repository{nameWithOwner}} } } ... on DisconnectedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt source{ __typename ... on Issue{number title repository{nameWithOwner}} ... on PullRequest{number title repository{nameWithOwner}} } subject{ __typename ... on Issue{number title repository{nameWithOwner}} ... on PullRequest{number title repository{nameWithOwner}} } } ... on MilestonedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt milestoneTitle } ... on DemilestonedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt milestoneTitle } ... on ClosedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt stateReason } ... on ReopenedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on RenamedTitleEvent{ actor{login avatarUrl(size: 48) __typename} createdAt previousTitle currentTitle } ... on PinnedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on UnpinnedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on LockedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt lockReason } ... on UnlockedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on MarkedAsDuplicateEvent{ actor{login avatarUrl(size: 48) __typename} createdAt canonical{ __typename ... on Issue{number repository{nameWithOwner}} ... on PullRequest{number repository{nameWithOwner}} } } ... on TransferredEvent{ actor{login avatarUrl(size: 48) __typename} createdAt fromRepository{nameWithOwner} } } } } } }"#;
+
+/// The issue's activity timeline — label/assignee/milestone changes, cross-references
+/// and links, state changes — for the conversation view; GitHub's arm of
+/// `forge_issue_timeline`. Nodes arrive oldest→newest and that order is preserved.
+/// One `last:100` window with no pagination, like the PR read: a very busy issue
+/// truncates its oldest events.
+///
+/// Every fragment's selection set is dictated by `map_timeline_node`'s documented
+/// contract — a missing `repository{nameWithOwner}` arrives as an empty string
+/// rather than an error.
+pub async fn gh_issue_timeline(
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<Vec<crate::forge::model::ForgeTimelineEventOut>> {
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
+    let out = run_gh(
+        Some(&repo_path),
+        &[
+            "api",
+            "graphql",
+            "-F",
+            &format!("owner={owner}"),
+            "-F",
+            &format!("name={name}"),
+            "-F",
+            &format!("number={number}"),
+            "-f",
+            &format!("query={ISSUE_TIMELINE_QUERY}"),
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let value: serde_json::Value = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse issue timeline: {e}")))?;
+    let nodes = value
+        .pointer("/data/repository/issue/timelineItems/nodes")
+        .and_then(serde_json::Value::as_array);
+    Ok(nodes
+        .map(|ns| {
+            ns.iter()
+                .filter_map(crate::github::pr::map_timeline_node)
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
 /// An issue's "Development" links: the PRs that close it + branches linked to it.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1369,7 +1417,7 @@ pub fn read_issue_templates(repo_path: String) -> AppResult<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_issues_disabled, map_gh_too_old};
+    use super::{is_issues_disabled, map_gh_too_old, ISSUE_TIMELINE_QUERY};
     use crate::error::AppError;
 
     #[test]
@@ -1426,5 +1474,41 @@ mod tests {
             map_gh_too_old(AppError::IssuesDisabled),
             AppError::IssuesDisabled
         ));
+    }
+
+    #[test]
+    fn issue_timeline_query_selects_every_mapped_field() {
+        // A dropped selection is a SILENT failure — GraphQL simply omits the field
+        // and `map_timeline_node` reads it as "", so pin the contract here.
+        assert!(ISSUE_TIMELINE_QUERY.contains("actor{login avatarUrl(size: 48) __typename}"));
+        // source/subject/canonical, each on its Issue AND PullRequest fragment.
+        assert!(ISSUE_TIMELINE_QUERY.matches("repository{nameWithOwner}").count() >= 4);
+        assert!(ISSUE_TIMELINE_QUERY.contains("willCloseTarget"));
+        assert!(ISSUE_TIMELINE_QUERY.contains("stateReason"));
+        for item_type in [
+            "LABELED_EVENT",
+            "UNLABELED_EVENT",
+            "ASSIGNED_EVENT",
+            "UNASSIGNED_EVENT",
+            "CROSS_REFERENCED_EVENT",
+            "CONNECTED_EVENT",
+            "DISCONNECTED_EVENT",
+            "MILESTONED_EVENT",
+            "DEMILESTONED_EVENT",
+            "CLOSED_EVENT",
+            "REOPENED_EVENT",
+            "RENAMED_TITLE_EVENT",
+            "PINNED_EVENT",
+            "UNPINNED_EVENT",
+            "LOCKED_EVENT",
+            "UNLOCKED_EVENT",
+            "MARKED_AS_DUPLICATE_EVENT",
+            "TRANSFERRED_EVENT",
+        ] {
+            assert!(
+                ISSUE_TIMELINE_QUERY.contains(item_type),
+                "itemTypes missing {item_type}"
+            );
+        }
     }
 }

--- a/src-tauri/src/github/issue.rs
+++ b/src-tauri/src/github/issue.rs
@@ -1481,8 +1481,20 @@ mod tests {
         // A dropped selection is a SILENT failure — GraphQL simply omits the field
         // and `map_timeline_node` reads it as "", so pin the contract here.
         assert!(ISSUE_TIMELINE_QUERY.contains("actor{login avatarUrl(size: 48) __typename}"));
-        // source/subject/canonical, each on its Issue AND PullRequest fragment.
-        assert!(ISSUE_TIMELINE_QUERY.matches("repository{nameWithOwner}").count() >= 4);
+        // 12 = CrossReferenced `source` + Connected/Disconnected `source` and
+        // `subject` + MarkedAsDuplicate `canonical`, each on its Issue AND
+        // PullRequest fragment. TransferredEvent's `fromRepository{nameWithOwner}`
+        // is a different (capitalized) token and doesn't count here. Exact, so
+        // dropping a whole fragment fails instead of sliding under a floor.
+        assert_eq!(
+            ISSUE_TIMELINE_QUERY
+                .matches("repository{nameWithOwner}")
+                .count(),
+            12
+        );
+        // Connected/Disconnected map from `subject`; drop it and the event silently
+        // self-references, because `source` is the issue the event sits on.
+        assert_eq!(ISSUE_TIMELINE_QUERY.matches("subject{").count(), 2);
         assert!(ISSUE_TIMELINE_QUERY.contains("willCloseTarget"));
         assert!(ISSUE_TIMELINE_QUERY.contains("stateReason"));
         for item_type in [

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
 use crate::forge::gitlab::null_to_default;
+use crate::forge::model::{ForgeTimelineEventOut, ForgeUserRef};
 use crate::git::runner::{run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
 use crate::github::issue::{map_reaction_groups, repo_owner_name, IssueReactions};
 use crate::github::runner::{run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
@@ -3919,100 +3920,66 @@ pub async fn gh_pr_reactions(
     Ok(IssueReactions { body, comments })
 }
 
-/// One activity-timeline event on a PR, a tagged union keyed on `kind` (camelCase)
-/// feeding the Conversation tab. The backend maps a GitHub `timelineItems`
-/// `__typename` onto a variant; an unclassifiable node is skipped, never a panic.
-/// Every `actor`/`date`/oid defaults to `""` for GitHub nulls.
-///
-/// `rename_all` renames VARIANT tags only, so `rename_all_fields` is load-bearing
-/// for the TS mirror (`src/lib/git/types.ts`): without it `Merged.commit_oid` reaches
-/// TS as `undefined` and a merged PR silently loses its merge commit.
-#[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
-pub enum PrTimelineEventOut {
-    /// `HeadRefForcePushedEvent` — the head branch was force-pushed.
-    ForcePushed {
-        before: String,
-        after: String,
-        actor: String,
-        date: String,
-    },
-    /// `LabeledEvent` (`added = true`) / `UnlabeledEvent` (`added = false`).
-    Labeled {
-        label: String,
-        color: String,
-        added: bool,
-        actor: String,
-        date: String,
-    },
-    /// `ReviewRequestedEvent` — `reviewer` is a user login OR a team slug.
-    ReviewRequested {
-        reviewer: String,
-        actor: String,
-        date: String,
-    },
-    /// `ReadyForReviewEvent` — a draft was marked ready.
-    ReadyForReview { actor: String, date: String },
-    /// `ConvertToDraftEvent` — the PR was converted back to a draft.
-    ConvertToDraft { actor: String, date: String },
-    /// `ClosedEvent` — the PR was closed (without merging).
-    Closed { actor: String, date: String },
-    /// `ReopenedEvent` — a closed PR was reopened.
-    Reopened { actor: String, date: String },
-    /// `MergedEvent` — `commit_oid` is the merge commit (may be `None`).
-    Merged {
-        actor: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        commit_oid: Option<String>,
-        date: String,
-    },
-    /// `RenamedTitleEvent` — the PR title changed.
-    Renamed {
-        previous: String,
-        current: String,
-        actor: String,
-        date: String,
-    },
-    /// An approval was given. GitHub surfaces approvals through the review flow
-    /// (they render as review cards), so its own timeline never emits this — it's
-    /// produced by the GitLab (system-note "approved") and Bitbucket (`approval`
-    /// activity) arms, whose approvals carry no reviewable body.
-    Approved { actor: String, date: String },
-    /// A "request changes" verdict without an accompanying review card. Emitted by
-    /// the GitLab (system-note "requested changes") and Bitbucket (`changes_requested`
-    /// activity) arms; GitHub renders its request-changes reviews as cards instead.
-    ChangesRequested { actor: String, date: String },
-    /// A previously-given approval was withdrawn (GitLab system-note "unapproved";
-    /// Bitbucket has no explicit unapproval activity). GitHub never emits it.
-    Unapproved { actor: String, date: String },
-}
+const PR_TIMELINE_QUERY: &str = r#"query($owner:String!,$name:String!,$number:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ timelineItems(last:100, itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT, LABELED_EVENT, UNLABELED_EVENT, REVIEW_REQUESTED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, CLOSED_EVENT, REOPENED_EVENT, MERGED_EVENT, RENAMED_TITLE_EVENT]){ nodes{ __typename ... on HeadRefForcePushedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt beforeCommit{oid} afterCommit{oid} } ... on LabeledEvent{ actor{login avatarUrl(size: 48) __typename} createdAt label{name color} } ... on UnlabeledEvent{ actor{login avatarUrl(size: 48) __typename} createdAt label{name color} } ... on ReviewRequestedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt requestedReviewer{ __typename ... on User{login} ... on Team{slug} } } ... on ReadyForReviewEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on ConvertToDraftEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on ClosedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on ReopenedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt } ... on MergedEvent{ actor{login avatarUrl(size: 48) __typename} createdAt commit{oid} } ... on RenamedTitleEvent{ actor{login avatarUrl(size: 48) __typename} createdAt previousTitle currentTitle } } } } } }"#;
 
-const PR_TIMELINE_QUERY: &str = r#"query($owner:String!,$name:String!,$number:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ timelineItems(last:100, itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT, LABELED_EVENT, UNLABELED_EVENT, REVIEW_REQUESTED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, CLOSED_EVENT, REOPENED_EVENT, MERGED_EVENT, RENAMED_TITLE_EVENT]){ nodes{ __typename ... on HeadRefForcePushedEvent{ actor{login} createdAt beforeCommit{oid} afterCommit{oid} } ... on LabeledEvent{ actor{login} createdAt label{name color} } ... on UnlabeledEvent{ actor{login} createdAt label{name color} } ... on ReviewRequestedEvent{ actor{login} createdAt requestedReviewer{ __typename ... on User{login} ... on Team{slug} } } ... on ReadyForReviewEvent{ actor{login} createdAt } ... on ConvertToDraftEvent{ actor{login} createdAt } ... on ClosedEvent{ actor{login} createdAt } ... on ReopenedEvent{ actor{login} createdAt } ... on MergedEvent{ actor{login} createdAt commit{oid} } ... on RenamedTitleEvent{ actor{login} createdAt previousTitle currentTitle } } } } } }"#;
-
-/// Map one `timelineItems` node onto a `PrTimelineEventOut`, or `None` when the
+/// Map one `timelineItems` node onto a [`ForgeTimelineEventOut`], or `None` when the
 /// `__typename` is missing/unrecognized (so one odd node can't break the batch).
 /// Every string field defaults to `""` for nulls — ghost actor, gone commit, absent title.
-fn map_timeline_node(node: &serde_json::Value) -> Option<PrTimelineEventOut> {
+///
+/// Shared by the PR and issue timeline reads, so it classifies typenames the PR query
+/// never asks for. A caller's query must select, on each fragment it does request:
+/// `actor{login avatarUrl(size: 48) __typename}` (the unsized default is a 460px
+/// asset for a 16px slot), and on the `source`/`subject`/`canonical`
+/// entity fragments `number title repository{nameWithOwner}` — a reference can point
+/// into another repository, so the number alone can't address it.
+pub(crate) fn map_timeline_node(node: &serde_json::Value) -> Option<ForgeTimelineEventOut> {
     let s = |p: &str| {
         node.pointer(p)
             .and_then(serde_json::Value::as_str)
             .unwrap_or("")
             .to_string()
     };
-    let actor = s("/actor/login");
+    let typename = node.get("__typename").and_then(serde_json::Value::as_str)?;
+    let actor = ForgeUserRef {
+        id: s("/actor/login"),
+        label: s("/actor/login"),
+        avatar_url: s("/actor/avatarUrl"),
+        is_bot: node
+            .pointer("/actor/__typename")
+            .and_then(serde_json::Value::as_str)
+            == Some("Bot"),
+    };
     let date = s("/createdAt");
-    match node.get("__typename").and_then(serde_json::Value::as_str)? {
-        "HeadRefForcePushedEvent" => Some(PrTimelineEventOut::ForcePushed {
+    // A referenced PR/issue under `base` → (kind, number, title, owner/name).
+    let entity = |base: &str| {
+        let kind = match node
+            .pointer(&format!("{base}/__typename"))
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("PullRequest") => "pr",
+            Some("Issue") => "issue",
+            _ => "",
+        };
+        (
+            kind.to_string(),
+            node.pointer(&format!("{base}/number"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            s(&format!("{base}/title")),
+            s(&format!("{base}/repository/nameWithOwner")),
+        )
+    };
+    match typename {
+        "HeadRefForcePushedEvent" => Some(ForgeTimelineEventOut::ForcePushed {
             before: s("/beforeCommit/oid"),
             after: s("/afterCommit/oid"),
             actor,
             date,
         }),
-        "LabeledEvent" | "UnlabeledEvent" => Some(PrTimelineEventOut::Labeled {
+        "LabeledEvent" | "UnlabeledEvent" => Some(ForgeTimelineEventOut::Labeled {
             label: s("/label/name"),
             color: s("/label/color"),
-            added: node.get("__typename").and_then(serde_json::Value::as_str)
-                == Some("LabeledEvent"),
+            added: typename == "LabeledEvent",
             actor,
             date,
         }),
@@ -4027,34 +3994,121 @@ fn map_timeline_node(node: &serde_json::Value) -> Option<PrTimelineEventOut> {
                     user
                 }
             };
-            Some(PrTimelineEventOut::ReviewRequested {
+            Some(ForgeTimelineEventOut::ReviewRequested {
                 reviewer,
                 actor,
                 date,
             })
         }
-        "ReadyForReviewEvent" => Some(PrTimelineEventOut::ReadyForReview { actor, date }),
-        "ConvertToDraftEvent" => Some(PrTimelineEventOut::ConvertToDraft { actor, date }),
-        "ClosedEvent" => Some(PrTimelineEventOut::Closed { actor, date }),
-        "ReopenedEvent" => Some(PrTimelineEventOut::Reopened { actor, date }),
+        "ReadyForReviewEvent" => Some(ForgeTimelineEventOut::ReadyForReview { actor, date }),
+        "ConvertToDraftEvent" => Some(ForgeTimelineEventOut::ConvertToDraft { actor, date }),
+        "ClosedEvent" => Some(ForgeTimelineEventOut::Closed {
+            actor,
+            // GraphQL sends COMPLETED / NOT_PLANNED / DUPLICATE on issues and nothing
+            // on PRs; the wire contract is lowercase.
+            state_reason: s("/stateReason").to_lowercase(),
+            date,
+        }),
+        "ReopenedEvent" => Some(ForgeTimelineEventOut::Reopened { actor, date }),
         "MergedEvent" => {
             let commit_oid = node
                 .pointer("/commit/oid")
                 .and_then(serde_json::Value::as_str)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string);
-            Some(PrTimelineEventOut::Merged {
+            Some(ForgeTimelineEventOut::Merged {
                 actor,
                 commit_oid,
                 date,
             })
         }
-        "RenamedTitleEvent" => Some(PrTimelineEventOut::Renamed {
+        "RenamedTitleEvent" => Some(ForgeTimelineEventOut::Renamed {
             previous: s("/previousTitle"),
             current: s("/currentTitle"),
             actor,
             date,
         }),
+        "AssignedEvent" | "UnassignedEvent" => Some(ForgeTimelineEventOut::Assigned {
+            assignee: s("/assignee/login"),
+            added: typename == "AssignedEvent",
+            actor,
+            date,
+        }),
+        "MilestonedEvent" | "DemilestonedEvent" => Some(ForgeTimelineEventOut::Milestoned {
+            milestone: s("/milestoneTitle"),
+            added: typename == "MilestonedEvent",
+            actor,
+            date,
+        }),
+        "CrossReferencedEvent" => {
+            let (source_kind, source_number, source_title, source_repo) = entity("/source");
+            Some(ForgeTimelineEventOut::CrossReferenced {
+                source_kind,
+                source_number,
+                source_title,
+                source_repo,
+                will_close: node
+                    .pointer("/willCloseTarget")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+                actor,
+                date,
+            })
+        }
+        "ConnectedEvent" | "DisconnectedEvent" => {
+            // Probed live: on a ConnectedEvent `source` is the issue the event sits on
+            // and `subject` is the linked PR — so prefer `subject`, falling back to
+            // `source` only when it carries no number.
+            let subject = entity("/subject");
+            let (source_kind, source_number, source_title, source_repo) = if subject.1 != 0 {
+                subject
+            } else {
+                entity("/source")
+            };
+            Some(ForgeTimelineEventOut::Connected {
+                source_kind,
+                source_number,
+                source_title,
+                source_repo,
+                added: typename == "ConnectedEvent",
+                actor,
+                date,
+            })
+        }
+        "PinnedEvent" | "UnpinnedEvent" => Some(ForgeTimelineEventOut::Pinned {
+            added: typename == "PinnedEvent",
+            actor,
+            date,
+        }),
+        "LockedEvent" => Some(ForgeTimelineEventOut::Locked {
+            locked: true,
+            // GraphQL's LockReason is an uppercase enum (OFF_TOPIC, TOO_HEATED,
+            // RESOLVED, SPAM); the wire contract is lowercase, like `state_reason`.
+            reason: s("/lockReason").to_lowercase(),
+            actor,
+            date,
+        }),
+        "UnlockedEvent" => Some(ForgeTimelineEventOut::Locked {
+            locked: false,
+            reason: String::new(),
+            actor,
+            date,
+        }),
+        "TransferredEvent" => Some(ForgeTimelineEventOut::Transferred {
+            from_repo: s("/fromRepository/nameWithOwner"),
+            actor,
+            date,
+        }),
+        "MarkedAsDuplicateEvent" => {
+            let (canonical_kind, canonical_number, _, canonical_repo) = entity("/canonical");
+            Some(ForgeTimelineEventOut::MarkedAsDuplicate {
+                canonical_kind,
+                canonical_number,
+                canonical_repo,
+                actor,
+                date,
+            })
+        }
         _ => None,
     }
 }
@@ -4068,7 +4122,7 @@ pub async fn pr_timeline(
     repo_path: &str,
     number: u64,
     lens: Option<&str>,
-) -> AppResult<Vec<PrTimelineEventOut>> {
+) -> AppResult<Vec<ForgeTimelineEventOut>> {
     let (owner, name) = repo_owner_name(repo_path, lens).await?;
     let out = run_gh(
         Some(repo_path),
@@ -5715,7 +5769,7 @@ mod tests {
         GhPrRestCommit, GhPrRestCommitGitAuthor, GhPrRestCommitInner, GhPrRestPull, GhPrRestReview,
         GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome,
         GhMergeabilityRow, PrMergeability, PrPollInfo, PrStackInfo, PrStackMember,
-        PrTimelineEventOut,
+        ForgeTimelineEventOut,
         batch_check_present, oid_outside_origin_graph, select_fork_pr_match, validate_branch,
         ForkPrMatch, RawForkPr, RawLogin, RawPr,
     };
@@ -7316,22 +7370,36 @@ github.acme.com
         // Force-push → before/after oids + actor + date.
         match node(serde_json::json!({
             "__typename": "HeadRefForcePushedEvent",
-            "actor": {"login": "alice"},
+            "actor": {"login": "alice", "avatarUrl": "https://a/alice.png", "__typename": "User"},
             "createdAt": "2026-05-12T12:01:23Z",
             "beforeCommit": {"oid": "aaa"},
             "afterCommit": {"oid": "bbb"},
         })) {
-            Some(PrTimelineEventOut::ForcePushed {
+            Some(ForgeTimelineEventOut::ForcePushed {
                 before,
                 after,
                 actor,
                 date,
             }) => {
-                assert_eq!((before, after, actor), ("aaa".into(), "bbb".into(), "alice".into()));
+                assert_eq!((before, after), ("aaa".into(), "bbb".into()));
+                // The login fills BOTH id and label (GitHub identifies users by login).
+                assert_eq!((actor.id, actor.label), ("alice".into(), "alice".into()));
+                assert_eq!(actor.avatar_url, "https://a/alice.png");
+                assert!(!actor.is_bot);
                 assert_eq!(date, "2026-05-12T12:01:23Z");
             }
             other => panic!("expected ForcePushed, got {:?}", other.is_some()),
         }
+
+        // A GitHub App actor (`__typename: "Bot"`) is flagged as a bot.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "LabeledEvent",
+                "actor": {"login": "dependabot", "avatarUrl": "u", "__typename": "Bot"},
+                "createdAt": "d", "label": {"name": "deps", "color": "ededed"},
+            })),
+            Some(ForgeTimelineEventOut::Labeled { actor, .. }) if actor.is_bot
+        ));
 
         // LABELED_EVENT → added = true; UNLABELED_EVENT → added = false.
         match node(serde_json::json!({
@@ -7340,7 +7408,7 @@ github.acme.com
             "createdAt": "d",
             "label": {"name": "bug", "color": "d73a4a"},
         })) {
-            Some(PrTimelineEventOut::Labeled { label, color, added, .. }) => {
+            Some(ForgeTimelineEventOut::Labeled { label, color, added, .. }) => {
                 assert_eq!((label, color, added), ("bug".into(), "d73a4a".into(), true));
             }
             _ => panic!("expected Labeled"),
@@ -7351,7 +7419,7 @@ github.acme.com
                 "actor": {"login": "bot"}, "createdAt": "d",
                 "label": {"name": "bug", "color": "d73a4a"},
             })),
-            Some(PrTimelineEventOut::Labeled { added: false, .. })
+            Some(ForgeTimelineEventOut::Labeled { added: false, .. })
         ));
 
         // Review request: User login and Team slug both land in `reviewer`.
@@ -7360,14 +7428,14 @@ github.acme.com
                 "__typename": "ReviewRequestedEvent", "actor": {"login": "a"}, "createdAt": "d",
                 "requestedReviewer": {"__typename": "User", "login": "carol"},
             })),
-            Some(PrTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer == "carol"
+            Some(ForgeTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer == "carol"
         ));
         assert!(matches!(
             node(serde_json::json!({
                 "__typename": "ReviewRequestedEvent", "actor": {"login": "a"}, "createdAt": "d",
                 "requestedReviewer": {"__typename": "Team", "slug": "reviewers"},
             })),
-            Some(PrTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer == "reviewers"
+            Some(ForgeTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer == "reviewers"
         ));
         // A null requestedReviewer (deleted entity) → empty reviewer, still classified.
         assert!(matches!(
@@ -7375,17 +7443,17 @@ github.acme.com
                 "__typename": "ReviewRequestedEvent", "actor": {"login": "a"}, "createdAt": "d",
                 "requestedReviewer": serde_json::Value::Null,
             })),
-            Some(PrTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer.is_empty()
+            Some(ForgeTimelineEventOut::ReviewRequested { reviewer, .. }) if reviewer.is_empty()
         ));
 
-        // Merged with a commit oid; a ghost/null actor defaults to "".
+        // Merged with a commit oid; a ghost/null actor defaults to an empty ref.
         assert!(matches!(
             node(serde_json::json!({
                 "__typename": "MergedEvent", "actor": serde_json::Value::Null, "createdAt": "d",
                 "commit": {"oid": "deadbeef"},
             })),
-            Some(PrTimelineEventOut::Merged { actor, commit_oid: Some(oid), .. })
-                if actor.is_empty() && oid == "deadbeef"
+            Some(ForgeTimelineEventOut::Merged { actor, commit_oid: Some(oid), .. })
+                if actor.label.is_empty() && actor.avatar_url.is_empty() && oid == "deadbeef"
         ));
 
         // Rename carries both titles.
@@ -7394,35 +7462,189 @@ github.acme.com
                 "__typename": "RenamedTitleEvent", "actor": {"login": "a"}, "createdAt": "d",
                 "previousTitle": "old", "currentTitle": "new",
             })),
-            Some(PrTimelineEventOut::Renamed { previous, current, .. })
+            Some(ForgeTimelineEventOut::Renamed { previous, current, .. })
                 if previous == "old" && current == "new"
+        ));
+
+        // Close: GraphQL's uppercase stateReason lands lowercased; a PR close (no
+        // stateReason at all) leaves it empty.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "ClosedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "stateReason": "NOT_PLANNED",
+            })),
+            Some(ForgeTimelineEventOut::Closed { state_reason, .. })
+                if state_reason == "not_planned"
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "ClosedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            })),
+            Some(ForgeTimelineEventOut::Closed { state_reason, .. }) if state_reason.is_empty()
+        ));
+
+        // Assign / unassign — the paired variant flips `added`.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "AssignedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "assignee": {"login": "carol"},
+            })),
+            Some(ForgeTimelineEventOut::Assigned { assignee, added: true, .. })
+                if assignee == "carol"
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "UnassignedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "assignee": {"login": "carol"},
+            })),
+            Some(ForgeTimelineEventOut::Assigned { added: false, .. })
+        ));
+
+        // Milestone / demilestone.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "MilestonedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "milestoneTitle": "v1.0",
+            })),
+            Some(ForgeTimelineEventOut::Milestoned { milestone, added: true, .. })
+                if milestone == "v1.0"
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "DemilestonedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "milestoneTitle": "v1.0",
+            })),
+            Some(ForgeTimelineEventOut::Milestoned { added: false, .. })
+        ));
+
+        // Cross-reference: the source's __typename maps to the neutral kind, and the
+        // referring repo travels with it.
+        match node(serde_json::json!({
+            "__typename": "CrossReferencedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            "willCloseTarget": true,
+            "source": {"__typename": "PullRequest", "number": 42, "title": "Fix it",
+                       "repository": {"nameWithOwner": "octocat/other"}},
+        })) {
+            Some(ForgeTimelineEventOut::CrossReferenced {
+                source_kind,
+                source_number,
+                source_title,
+                source_repo,
+                will_close,
+                ..
+            }) => {
+                assert_eq!((source_kind.as_str(), source_number), ("pr", 42));
+                assert_eq!(source_title, "Fix it");
+                assert_eq!(source_repo, "octocat/other");
+                assert!(will_close);
+            }
+            _ => panic!("expected CrossReferenced"),
+        }
+        // An Issue source, no willCloseTarget, and no repository selected → "issue",
+        // false, and an empty repo (never a guessed one).
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "CrossReferencedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "source": {"__typename": "Issue", "number": 7, "title": "t"},
+            })),
+            Some(ForgeTimelineEventOut::CrossReferenced {
+                source_kind, source_repo, will_close: false, ..
+            }) if source_kind == "issue" && source_repo.is_empty()
+        ));
+
+        // Connected: `subject` is the LINKED entity and wins; `source` is the issue
+        // the event sits on and is only the fallback.
+        match node(serde_json::json!({
+            "__typename": "ConnectedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            "source": {"__typename": "Issue", "number": 7, "title": "the issue",
+                       "repository": {"nameWithOwner": "octocat/self"}},
+            "subject": {"__typename": "PullRequest", "number": 9, "title": "the pr",
+                        "repository": {"nameWithOwner": "octocat/other"}},
+        })) {
+            Some(ForgeTimelineEventOut::Connected {
+                source_kind,
+                source_number,
+                source_repo,
+                added,
+                ..
+            }) => {
+                assert_eq!((source_kind.as_str(), source_number), ("pr", 9));
+                assert_eq!(source_repo, "octocat/other");
+                assert!(added);
+            }
+            _ => panic!("expected Connected"),
+        }
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "DisconnectedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "source": {"__typename": "Issue", "number": 7, "title": "the issue"},
+            })),
+            Some(ForgeTimelineEventOut::Connected { source_number: 7, added: false, .. })
+        ));
+
+        // Pin / unpin, lock / unlock.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "PinnedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            })),
+            Some(ForgeTimelineEventOut::Pinned { added: true, .. })
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "UnpinnedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            })),
+            Some(ForgeTimelineEventOut::Pinned { added: false, .. })
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "LockedEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "lockReason": "TOO_HEATED",
+            })),
+            Some(ForgeTimelineEventOut::Locked { locked: true, reason, .. })
+                if reason == "too_heated"
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "UnlockedEvent", "actor": {"login": "a"}, "createdAt": "d",
+            })),
+            Some(ForgeTimelineEventOut::Locked { locked: false, reason, .. })
+                if reason.is_empty()
+        ));
+
+        // Transfer + marked-as-duplicate carry the other repo / canonical entity.
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "TransferredEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "fromRepository": {"nameWithOwner": "octocat/old"},
+            })),
+            Some(ForgeTimelineEventOut::Transferred { from_repo, .. })
+                if from_repo == "octocat/old"
+        ));
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "MarkedAsDuplicateEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "canonical": {"__typename": "Issue", "number": 3,
+                              "repository": {"nameWithOwner": "octocat/other"}},
+            })),
+            Some(ForgeTimelineEventOut::MarkedAsDuplicate {
+                canonical_kind, canonical_number: 3, canonical_repo, ..
+            }) if canonical_kind == "issue" && canonical_repo == "octocat/other"
+        ));
+        // A null canonical (deleted entity) → zeroed number + empty kind/repo, still
+        // classified so the row can say "marked this as a duplicate".
+        assert!(matches!(
+            node(serde_json::json!({
+                "__typename": "MarkedAsDuplicateEvent", "actor": {"login": "a"}, "createdAt": "d",
+                "canonical": serde_json::Value::Null,
+            })),
+            Some(ForgeTimelineEventOut::MarkedAsDuplicate {
+                canonical_kind, canonical_number: 0, canonical_repo, ..
+            }) if canonical_kind.is_empty() && canonical_repo.is_empty()
         ));
 
         // An unrecognized/missing __typename is skipped (None), not a panic.
         assert!(node(serde_json::json!({ "__typename": "SomeOtherEvent" })).is_none());
         assert!(node(serde_json::json!({ "actor": {"login": "a"} })).is_none());
-    }
-
-    #[test]
-    fn merged_timeline_event_wire_shape_is_camel_case() {
-        // Pins the IPC contract with the TS mirror (src/lib/git/types.ts): `commit_oid`
-        // is the enum's only multi-word field, and the frontend reads it as `commitOid`.
-        let merged = serde_json::to_value(PrTimelineEventOut::Merged {
-            actor: "alice".to_string(),
-            commit_oid: Some("deadbeef".to_string()),
-            date: "2026-05-12T12:01:23Z".to_string(),
-        })
-        .expect("Merged serializes");
-        let obj = merged.as_object().expect("Merged is a JSON object");
-        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
-        keys.sort_unstable();
-        assert_eq!(keys, ["actor", "commitOid", "date", "kind"]);
-        assert_eq!(obj["kind"], "merged");
-        assert_eq!(obj["commitOid"], "deadbeef");
-        assert!(
-            obj.get("commit_oid").is_none(),
-            "snake_case field must not ship"
-        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -340,6 +340,7 @@ pub fn run() {
             forge::forge_pr_mergeability,
             forge::forge_pr_list_mergeability,
             forge::forge_pr_timeline,
+            forge::forge_issue_timeline,
             forge::forge_pr_diff,
             forge::forge_pr_commit_diff,
             forge::forge_commit_comments,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1319,6 +1319,15 @@ The comment box sits at the bottom of the issue,
 past the side rail, and the command palette's **Focus the comment box** jumps straight
 to it — no default shortcut, so give it one in **Settings → Keyboard**.
 
+Comments share the issue with a **date-sorted activity feed**: timeline events interleave
+with the conversation oldest-to-newest, each a calm one-line entry carrying the actor's
+avatar and a relative timestamp. Labels added and removed, assignment, milestones,
+**mentioned this in** cross-references, linked pull requests, marked-as-duplicate, pin,
+lock, transfer, and close (with GitHub's close reason) or reopen all land there. A
+cross-reference, link, or duplicate row pointing inside this repository is clickable and
+jumps to the pull request or issue it names. **GitLab** issues get the same feed for
+labels, state changes, milestones, assignment, and same-project mentions.
+
 - **Sub-issues** — break an issue into a parent/child checklist with completion tracking.
 - **Dependencies** — link issues as blocked-by / blocking.
 - **Development** — see linked PRs and branches, and **create a branch** wired to the

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1322,11 +1322,13 @@ to it — no default shortcut, so give it one in **Settings → Keyboard**.
 Comments share the issue with a **date-sorted activity feed**: timeline events interleave
 with the conversation oldest-to-newest, each a calm one-line entry carrying the actor's
 avatar and a relative timestamp. Labels added and removed, assignment, milestones,
-**mentioned this in** cross-references, linked pull requests, marked-as-duplicate, pin,
-lock, transfer, and close (with GitHub's close reason) or reopen all land there. A
-cross-reference, link, or duplicate row pointing inside this repository is clickable and
-jumps to the pull request or issue it names. **GitLab** issues get the same feed for
-labels, state changes, milestones, assignment, and same-project mentions.
+title renames, **mentioned this in** cross-references, linked pull requests,
+marked-as-duplicate, pin, lock, transfer, and close (with GitHub's close reason) or
+reopen all land there. A cross-reference, link, or duplicate row pointing inside this
+repository is clickable and jumps to the pull request or issue it names; browsing a
+fork's parent under the **Upstream** lens keeps those rows plain text. **GitLab**
+issues get the same feed for labels, state changes, milestones, assignment, locks,
+duplicates, and same-project mentions.
 
 - **Sub-issues** — break an issue into a parent/child checklist with completion tracking.
 - **Dependencies** — link issues as blocked-by / blocking.

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -40,6 +40,11 @@ import {
   Thread,
 } from "@/features/conversations/Thread";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
+import {
+  sortTimeline,
+  type TimelineEntry,
+  TimelineEventRow,
+} from "@/features/pulls/PrTimeline";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import type { LockReason, MinimizeReason } from "@/lib/git/api";
@@ -58,6 +63,7 @@ import {
   useGlMemberProjects,
   useIssueDetails,
   useIssueReactions,
+  useIssueTimeline,
   useLockIssue,
   useMinimizeComment,
   usePinIssue,
@@ -201,6 +207,8 @@ export function RemoteIssueView({
   const transferIssue = useTransferIssue(repoPath, lens);
   const deleteIssue = useDeleteIssue(repoPath, lens);
   const selectIssue = useUiStore((s) => s.selectIssue);
+  const selectPr = useUiStore((s) => s.selectPr);
+  const setRepoTab = useUiStore((s) => s.setRepoTab);
   const selectedIssue = useUiStore((s) => s.selectedIssue);
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
   // Whether this view owns the current selection: the mounted view lags the
@@ -217,6 +225,16 @@ export function RemoteIssueView({
   const canEditOwnComments =
     canWrite || forgeFeatureReady(forge.data, "issueCommentEdit");
   const reactions = useIssueReactions(repoPath, canReact ? number : null, lens);
+  // Activity-timeline events (labels, assignment, milestones, cross-references,
+  // state changes) interleaved into the feed below; provider-neutral via the
+  // backend's `forge_issue_timeline`. The composite gate is load-bearing: an
+  // unresolved provider must not fetch, and Bitbucket issues aren't wired.
+  const timeline = useIssueTimeline(
+    repoPath,
+    number,
+    !!provider && provider !== "bitbucket",
+    lens,
+  );
   const toggleReactionMutation = useToggleReaction(
     repoPath,
     ["repo", repoPath, "issue", lens, number, "reactions"] as const,
@@ -507,6 +525,19 @@ export function RemoteIssueView({
     });
   }
 
+  /** Drill into a PR/issue a timeline reference row points at. Same-repo only —
+   *  the row hands over a bare number, which addresses nothing elsewhere, and
+   *  TimelineEventRow already keeps cross-repo chips non-interactive. Each arm is
+   *  the navigation its own surface uses (Development panel / related issues). */
+  function openRef(kind: "pr" | "issue", refNumber: number) {
+    if (kind === "pr") {
+      selectPr({ kind: "remote", id: String(refNumber) });
+      setRepoTab("pulls");
+      return;
+    }
+    selectIssue({ kind: "remote", id: String(refNumber) });
+  }
+
   function submitTransfer() {
     const destination = transferDest.trim();
     if (!destination) return;
@@ -558,6 +589,77 @@ export function RemoteIssueView({
   )
     .filter((n) => !repoQuery || n.toLowerCase().includes(repoQuery))
     .slice(0, 6);
+
+  // The activity feed: comments interleaved with timeline events, oldest→newest,
+  // on the PR feed's slot convention (comments 2, events 3). Keys are slot-prefixed
+  // because a comment id and an event index share one child list.
+  const feedEntries: TimelineEntry[] = [];
+  for (const c of comments) {
+    feedEntries.push({
+      date: c.date,
+      sortKey: 2,
+      node: (
+        <Thread
+          key={`comment-${c.id}`}
+          thread={c}
+          onQuote={
+            canWrite && !detailsStale ? () => quoteReply(c.body) : undefined
+          }
+          onSaveEdit={
+            canEditOwnComments && c.viewerDidAuthor && !detailsStale
+              ? (body) => saveCommentEdit(c.id, body)
+              : undefined
+          }
+          // Withholding the handler only drops the menu entry; an editor
+          // already open when the switch began needs its Save held too.
+          editHeld={detailsStale}
+          onDelete={
+            canEditOwnComments && c.viewerDidAuthor && !detailsStale
+              ? () => setDeletingCommentId(c.id)
+              : undefined
+          }
+          onHide={
+            canWrite && !c.isMinimized
+              ? (classifier) => hideComment(c.id, classifier)
+              : undefined
+          }
+          onUnhide={
+            canWrite && c.isMinimized ? () => unhideComment(c.id) : undefined
+          }
+          // Hide/Unhide stay visible but disabled through the switch. The
+          // permission reason ranks first — it's the one still true once
+          // the selected issue is on screen.
+          disabledReason={triageItemReason ?? staleReason}
+          reactions={canReact ? reactions.data?.comments[c.id] : undefined}
+          onToggleReaction={
+            canReact
+              ? (content, active) => toggleReaction(c.id, content, active)
+              : undefined
+          }
+          reactionsHeld={detailsStale}
+          reactionsReason={staleReason}
+        />
+      ),
+    });
+  }
+  for (const [i, ev] of (timeline.data ?? []).entries()) {
+    feedEntries.push({
+      date: ev.date,
+      sortKey: 3,
+      node: (
+        <TimelineEventRow
+          key={`event-${i}`}
+          event={ev}
+          onOpenRef={openRef}
+          // ForgeStatus.repo is the ORIGIN slug, lens-unaware: under the Upstream
+          // lens an upstream-repo ref mismatches and its chip degrades to inert
+          // text — never a wrong drill-in, so the safe direction.
+          selfRepo={forge.data?.repo ?? undefined}
+        />
+      ),
+    });
+  }
+  const feed = sortTimeline(feedEntries);
 
   // The close/reopen arm LEADS the bottom bar in both permission states — inside
   // the composer's action row (Comment is the primary and stays last), or alone
@@ -976,56 +1078,8 @@ export function RemoteIssueView({
                   disabledReason={writeReason ?? staleReason}
                 />
               )}
-              {comments.map((c) => (
-                <Thread
-                  key={c.id}
-                  thread={c}
-                  onQuote={
-                    canWrite && !detailsStale
-                      ? () => quoteReply(c.body)
-                      : undefined
-                  }
-                  onSaveEdit={
-                    canEditOwnComments && c.viewerDidAuthor && !detailsStale
-                      ? (body) => saveCommentEdit(c.id, body)
-                      : undefined
-                  }
-                  // Withholding the handler only drops the menu entry; an editor
-                  // already open when the switch began needs its Save held too.
-                  editHeld={detailsStale}
-                  onDelete={
-                    canEditOwnComments && c.viewerDidAuthor && !detailsStale
-                      ? () => setDeletingCommentId(c.id)
-                      : undefined
-                  }
-                  onHide={
-                    canWrite && !c.isMinimized
-                      ? (classifier) => hideComment(c.id, classifier)
-                      : undefined
-                  }
-                  onUnhide={
-                    canWrite && c.isMinimized
-                      ? () => unhideComment(c.id)
-                      : undefined
-                  }
-                  // Hide/Unhide stay visible but disabled through the switch. The
-                  // permission reason ranks first — it's the one still true once
-                  // the selected issue is on screen.
-                  disabledReason={triageItemReason ?? staleReason}
-                  reactions={
-                    canReact ? reactions.data?.comments[c.id] : undefined
-                  }
-                  onToggleReaction={
-                    canReact
-                      ? (content, active) =>
-                          toggleReaction(c.id, content, active)
-                      : undefined
-                  }
-                  reactionsHeld={detailsStale}
-                  reactionsReason={staleReason}
-                />
-              ))}
-              {comments.length === 0 && (
+              {feed.map((e) => e.node)}
+              {feed.length === 0 && (
                 <p className="text-xs text-muted-foreground">
                   No comments yet.
                 </p>

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -48,6 +48,7 @@ import {
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import type { LockReason, MinimizeReason } from "@/lib/git/api";
+import { useActiveForgeGhHost } from "@/lib/git/host";
 import {
   forgeFeatureReady,
   TRIAGE_ACCESS_ITEM_REASON,
@@ -235,6 +236,8 @@ export function RemoteIssueView({
     !!provider && provider !== "bitbucket",
     lens,
   );
+  // Feed-constant, so it's read once here rather than per event row.
+  const ghHost = useActiveForgeGhHost();
   const toggleReactionMutation = useToggleReaction(
     repoPath,
     ["repo", repoPath, "issue", lens, number, "reactions"] as const,
@@ -525,10 +528,10 @@ export function RemoteIssueView({
     });
   }
 
-  /** Drill into a PR/issue a timeline reference row points at. Same-repo only —
-   *  the row hands over a bare number, which addresses nothing elsewhere, and
-   *  TimelineEventRow already keeps cross-repo chips non-interactive. Each arm is
-   *  the navigation its own surface uses (Development panel / related issues). */
+  /** Drill into a PR/issue a timeline reference row points at. The bare number it
+   *  hands over resolves under the CURRENT lens, so the call site wires this only
+   *  under the origin lens (see the lens note on `onOpenRef` there). Each arm is the
+   *  navigation its own surface uses (Development panel / related issues). */
   function openRef(kind: "pr" | "issue", refNumber: number) {
     if (kind === "pr") {
       selectPr({ kind: "remote", id: String(refNumber) });
@@ -650,10 +653,13 @@ export function RemoteIssueView({
         <TimelineEventRow
           key={`event-${i}`}
           event={ev}
-          onOpenRef={openRef}
-          // ForgeStatus.repo is the ORIGIN slug, lens-unaware: under the Upstream
-          // lens an upstream-repo ref mismatches and its chip degrades to inert
-          // text — never a wrong drill-in, so the safe direction.
+          ghHost={ghHost}
+          // `ForgeStatus.repo` is the ORIGIN slug, so a chip's same-repo verdict is
+          // only trustworthy under the origin lens: off it, a ref living in the fork
+          // matches the slug while the drill-in resolves against the upstream repo
+          // and lands on a different entity. Withholding the handler there renders
+          // every reference inert instead.
+          onOpenRef={lens === "origin" ? openRef : undefined}
           selfRepo={forge.data?.repo ?? undefined}
         />
       ),

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -1095,7 +1095,9 @@ export function RemoteIssueView({
                 />
               )}
               {feed.map((e) => e.node)}
-              {feed.length === 0 && (
+              {/* Wait for the timeline too: on an events-only issue the details
+                  can resolve first and flash this before the rows arrive. */}
+              {feed.length === 0 && !timeline.isPending && (
                 <p className="text-xs text-muted-foreground">
                   No comments yet.
                 </p>

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -48,7 +48,7 @@ import {
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import type { LockReason, MinimizeReason } from "@/lib/git/api";
-import { useActiveForgeGhHost } from "@/lib/git/host";
+import { useForgeGhHost } from "@/lib/git/host";
 import {
   forgeFeatureReady,
   TRIAGE_ACCESS_ITEM_REASON,
@@ -236,8 +236,9 @@ export function RemoteIssueView({
     !!provider && provider !== "bitbucket",
     lens,
   );
-  // Feed-constant, so it's read once here rather than per event row.
-  const ghHost = useActiveForgeGhHost();
+  // Feed-constant, so it's read once here rather than per event row; the
+  // repo-path variant avoids the active-repo hook's second store subscription.
+  const ghHost = useForgeGhHost(repoPath);
   const toggleReactionMutation = useToggleReaction(
     repoPath,
     ["repo", repoPath, "issue", lens, number, "reactions"] as const,
@@ -657,10 +658,13 @@ export function RemoteIssueView({
           // `ForgeStatus.repo` is the ORIGIN slug, so a chip's same-repo verdict is
           // only trustworthy under the origin lens: off it, a ref living in the fork
           // matches the slug while the drill-in resolves against the upstream repo
-          // and lands on a different entity. Withholding the handler there renders
-          // every reference inert instead.
+          // and lands on a different entity. BOTH props gate on the lens — the
+          // handler so off-lens refs are inert, and selfRepo so they keep their
+          // explicit owner/name prefix instead of reading as this repo's number.
           onOpenRef={lens === "origin" ? openRef : undefined}
-          selfRepo={forge.data?.repo ?? undefined}
+          selfRepo={
+            lens === "origin" ? (forge.data?.repo ?? undefined) : undefined
+          }
         />
       ),
     });

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -232,12 +232,8 @@ export function RemoteIssueView({
   // state changes) interleaved into the feed below; provider-neutral via the
   // backend's `forge_issue_timeline`. The composite gate is load-bearing: an
   // unresolved provider must not fetch, and Bitbucket issues aren't wired.
-  const timeline = useIssueTimeline(
-    repoPath,
-    number,
-    !!provider && provider !== "bitbucket",
-    lens,
-  );
+  const timelineEnabled = !!provider && provider !== "bitbucket";
+  const timeline = useIssueTimeline(repoPath, number, timelineEnabled, lens);
   // Feed-constant, so it's read once here rather than per event row; the
   // repo-path variant avoids the active-repo hook's second store subscription.
   const ghHost = useForgeGhHost(repoPath);
@@ -1096,12 +1092,17 @@ export function RemoteIssueView({
               )}
               {feed.map((e) => e.node)}
               {/* Wait for the timeline too: on an events-only issue the details
-                  can resolve first and flash this before the rows arrive. */}
-              {feed.length === 0 && !timeline.isPending && (
-                <p className="text-xs text-muted-foreground">
-                  No comments yet.
-                </p>
-              )}
+                  can resolve first and flash this before the rows arrive. A
+                  DISABLED timeline query never leaves pending, so it can't be
+                  the thing waited on — when the forge probe settles without
+                  enabling it, no events are coming and the line shows. */}
+              {feed.length === 0 &&
+                !forge.isPending &&
+                (!timelineEnabled || !timeline.isPending) && (
+                  <p className="text-xs text-muted-foreground">
+                    No comments yet.
+                  </p>
+                )}
             </div>
           </ScrollArea>
         </div>

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -9,10 +9,10 @@ import type { MinimizeReason } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
 import type {
   ForgeProvider,
+  ForgeTimelineEvent,
   IssueReactions,
   PrDetails,
   PrThreadOut,
-  PrTimelineEvent,
   ReviewThreadOut,
 } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
@@ -202,7 +202,7 @@ export function PrActivityFeed({
   reactionsReason,
 }: {
   pr: PrDetails;
-  timeline: PrTimelineEvent[] | undefined;
+  timeline: ForgeTimelineEvent[] | undefined;
   reactions: IssueReactions | undefined;
   claims: PrThreadClaims;
   providerKey: ForgeProvider;

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/conversations/Thread";
 import type { MinimizeReason } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
+import { useActiveForgeGhHost } from "@/lib/git/host";
 import type {
   ForgeProvider,
   ForgeTimelineEvent,
@@ -264,6 +265,8 @@ export function PrActivityFeed({
     wrapperReviewIds,
     wrappedThreadFor,
   } = claims;
+  // Feed-constant, so it's read once here rather than per event row.
+  const ghHost = useActiveForgeGhHost();
   // Newest commit date drives approval staleness. gh returns
   // oldest-first, but be defensive: max over all commit dates.
   const newestCommitMs = pr.commits.reduce((max, c) => {
@@ -477,7 +480,7 @@ export function PrActivityFeed({
     entries.push({
       date: ev.date,
       sortKey: 3,
-      node: <TimelineEventRow key={`event-${i}`} event={ev} />,
+      node: <TimelineEventRow key={`event-${i}`} event={ev} ghHost={ghHost} />,
     });
   }
 

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -34,7 +34,6 @@ import {
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { RelativeTime } from "@/components/relative-time";
 import type { CommitRow } from "@/features/conversations/CommitsList";
-import { useActiveForgeGhHost } from "@/lib/git/host";
 import type { ForgeTimelineEvent } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { parseableDate } from "@/lib/time";
@@ -359,7 +358,9 @@ function eventPresentation(event: ForgeTimelineEvent): EventPresentation {
 /** The compact `owner/name#N` + title reference a cross-reference / link / duplicate
  *  row points at. Interactive only when the caller can navigate there AND the ref is
  *  in the viewed repo: a cross-repo number would drill into the wrong entity, so it
- *  renders as text carrying its repo prefix instead. */
+ *  renders as text carrying its repo prefix instead. An empty `chip.repo` is the
+ *  wire's same-repo GUARANTEE, not an unknown (ForgeTimelineEventOut::CrossReferenced
+ *  pins that contract), which is why it passes the gate. */
 function ReferenceChip({
   chip,
   onOpenRef,
@@ -405,10 +406,15 @@ function ReferenceChip({
  *  beside it, and a metadata row must not add a tab stop per event. */
 export function TimelineEventRow({
   event,
+  ghHost,
   onOpenRef,
   selfRepo,
 }: {
   event: ForgeTimelineEvent;
+  /** GitHub host for the actor's login-derived avatar (`null` off GitHub). Resolved
+   *  once by the feed and passed down: it's feed-constant, and reading it per row
+   *  would be one store subscription per event. */
+  ghHost: string | null;
   /** Drill into a referenced PR/issue from a reference chip. Without it the chip
    *  stays plain text. */
   onOpenRef?: (kind: "pr" | "issue", number: number) => void;
@@ -417,7 +423,6 @@ export function TimelineEventRow({
   selfRepo?: string;
 }) {
   const { Icon, tone, label, colorDot, refChip } = eventPresentation(event);
-  const ghHost = useActiveForgeGhHost();
   return (
     <div className="flex items-start gap-2 text-xs">
       <RailIcon Icon={Icon} tone={tone} label={label} />

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -1,15 +1,27 @@
 import {
   ArrowCounterClockwiseIcon,
   ArrowsClockwiseIcon,
+  ArrowsLeftRightIcon,
   CaretDownIcon,
   CaretRightIcon,
   CheckCircleIcon,
+  FlagIcon,
   GitBranchIcon,
   GitCommitIcon,
   GitMergeIcon,
   GitPullRequestIcon,
+  LinkBreakIcon,
+  LinkIcon,
+  LockSimpleIcon,
+  LockSimpleOpenIcon,
   PencilSimpleIcon,
+  ProhibitIcon,
+  PushPinIcon,
+  PushPinSlashIcon,
+  StackIcon,
   TagIcon,
+  UserMinusIcon,
+  UserPlusIcon,
   WarningIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
@@ -19,9 +31,11 @@ import {
   type ReactNode,
   useState,
 } from "react";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { RelativeTime } from "@/components/relative-time";
 import type { CommitRow } from "@/features/conversations/CommitsList";
-import type { PrTimelineEvent } from "@/lib/git/types";
+import { useActiveForgeGhHost } from "@/lib/git/host";
+import type { ForgeTimelineEvent } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { parseableDate } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -124,16 +138,55 @@ function RailIcon({
   );
 }
 
-/** Presentation (icon, tone, verb phrase, actor) for one timeline event. Icon +
- *  word — never color-alone. Returns the pieces so the row can render actor +
- *  time consistently. `label` is the accessible verb; `extra` is optional
- *  trailing content (e.g. a label color dot). */
-function eventPresentation(event: PrTimelineEvent): {
+/** A referenced PR/issue a timeline row points at. `repo` is its `owner/name`, or
+ *  `""` when the provider didn't say — a reference can live in ANOTHER repository,
+ *  so the number alone can't address it. */
+interface ReferenceChipData {
+  /** `"pr"` / `"issue"`, or `""` when the entity's type is unknown. */
+  kind: string;
+  number: number;
+  title: string;
+  repo: string;
+}
+
+interface EventPresentation {
   Icon: typeof GitCommitIcon;
   tone?: string;
   label: string;
   colorDot?: string;
-} {
+  /** Rendered after the label as a compact `#N` + title reference. */
+  refChip?: ReferenceChipData;
+}
+
+/** Per-reason presentation for a `closed` event (GitHub issues only); the plain PR
+ *  close and every unknown reason fall back to the base close in `eventPresentation`. */
+const CLOSE_REASON_PRESENTATION: Partial<Record<string, EventPresentation>> = {
+  // Completed is a resolution, so it takes the terminal-success token rather than
+  // the destructive close.
+  completed: {
+    Icon: CheckCircleIcon,
+    tone: "text-merged",
+    label: "closed this as completed",
+  },
+  duplicate: {
+    Icon: XCircleIcon,
+    tone: "text-destructive",
+    label: "closed this as a duplicate",
+  },
+  // Not-planned is a dismissal rather than a resolution, so it reads muted — the
+  // prohibit glyph, not the destructive X.
+  not_planned: {
+    Icon: ProhibitIcon,
+    tone: "text-muted-foreground",
+    label: "closed this as not planned",
+  },
+};
+
+/** Presentation (icon, tone, verb phrase, actor) for one timeline event. Icon +
+ *  word — never color-alone. Returns the pieces so the row can render actor +
+ *  time consistently. `label` is the accessible verb; `extra` is optional
+ *  trailing content (e.g. a label color dot). */
+function eventPresentation(event: ForgeTimelineEvent): EventPresentation {
   switch (event.kind) {
     case "forcePushed":
       return {
@@ -178,11 +231,13 @@ function eventPresentation(event: PrTimelineEvent): {
         label: "withdrew their approval",
       };
     case "closed":
-      return {
-        Icon: XCircleIcon,
-        tone: "text-destructive",
-        label: "closed this",
-      };
+      return (
+        CLOSE_REASON_PRESENTATION[event.stateReason] ?? {
+          Icon: XCircleIcon,
+          tone: "text-destructive",
+          label: "closed this",
+        }
+      );
     case "reopened":
       return {
         Icon: CheckCircleIcon,
@@ -202,19 +257,184 @@ function eventPresentation(event: PrTimelineEvent): {
         Icon: GitBranchIcon,
         label: `renamed this from ${event.previous} to ${event.current}`,
       };
+    case "assigned": {
+      // An actor assigning themselves reads as "self-assigned", matching how every
+      // forge phrases it; `actor.label` and `assignee` are both the login.
+      const self = event.actor.label === event.assignee;
+      if (event.added) {
+        return {
+          Icon: UserPlusIcon,
+          label: self ? "self-assigned this" : `assigned ${event.assignee}`,
+        };
+      }
+      return {
+        Icon: UserMinusIcon,
+        label: self
+          ? "removed their assignment"
+          : `unassigned ${event.assignee}`,
+      };
+    }
+    case "milestoned":
+      return {
+        Icon: FlagIcon,
+        label: event.added
+          ? `added this to the ${event.milestone} milestone`
+          : `removed this from the ${event.milestone} milestone`,
+      };
+    case "crossReferenced":
+      // A deleted or inaccessible referent comes back as number 0 — say the plain
+      // thing rather than offer a chip that leads nowhere.
+      if (!event.sourceNumber) {
+        return { Icon: LinkIcon, label: "mentioned this" };
+      }
+      return {
+        Icon: LinkIcon,
+        label: "mentioned this in",
+        refChip: {
+          kind: event.sourceKind,
+          number: event.sourceNumber,
+          title: event.sourceTitle,
+          repo: event.sourceRepo,
+        },
+      };
+    case "connected":
+      if (!event.sourceNumber) {
+        return {
+          Icon: event.added ? LinkIcon : LinkBreakIcon,
+          label: event.added ? "linked this" : "unlinked this",
+        };
+      }
+      return {
+        Icon: event.added ? LinkIcon : LinkBreakIcon,
+        label: event.added ? "linked" : "unlinked",
+        refChip: {
+          kind: event.sourceKind,
+          number: event.sourceNumber,
+          title: event.sourceTitle,
+          repo: event.sourceRepo,
+        },
+      };
+    case "pinned":
+      return {
+        Icon: event.added ? PushPinIcon : PushPinSlashIcon,
+        label: event.added ? "pinned this" : "unpinned this",
+      };
+    case "locked":
+      if (!event.locked) {
+        return {
+          Icon: LockSimpleOpenIcon,
+          label: "unlocked this conversation",
+        };
+      }
+      return {
+        Icon: LockSimpleIcon,
+        label: event.reason
+          ? `locked this conversation as ${event.reason.replaceAll("_", " ")}`
+          : "locked this conversation",
+      };
+    case "transferred":
+      return {
+        Icon: ArrowsLeftRightIcon,
+        label: event.fromRepo
+          ? `transferred this from ${event.fromRepo}`
+          : "transferred this from another repository",
+      };
+    case "markedAsDuplicate":
+      if (!event.canonicalNumber) {
+        return { Icon: StackIcon, label: "marked this as a duplicate" };
+      }
+      return {
+        Icon: StackIcon,
+        label: "marked this as a duplicate of",
+        refChip: {
+          kind: event.canonicalKind,
+          number: event.canonicalNumber,
+          title: "",
+          repo: event.canonicalRepo,
+        },
+      };
   }
 }
 
-/** A calm, GitHub-timeline-density event row: rail + icon + actor + muted verb
- *  phrase + relative time. */
-export function TimelineEventRow({ event }: { event: PrTimelineEvent }) {
-  const { Icon, tone, label, colorDot } = eventPresentation(event);
+/** The compact `owner/name#N` + title reference a cross-reference / link / duplicate
+ *  row points at. Interactive only when the caller can navigate there AND the ref is
+ *  in the viewed repo: a cross-repo number would drill into the wrong entity, so it
+ *  renders as text carrying its repo prefix instead. */
+function ReferenceChip({
+  chip,
+  onOpenRef,
+  selfRepo,
+}: {
+  chip: ReferenceChipData;
+  onOpenRef?: (kind: "pr" | "issue", number: number) => void;
+  selfRepo?: string;
+}) {
+  const sameRepo =
+    chip.repo === "" || chip.repo.toLowerCase() === selfRepo?.toLowerCase();
+  const kind = chip.kind === "pr" || chip.kind === "issue" ? chip.kind : null;
+  const ref = `${sameRepo ? "" : chip.repo}#${chip.number}`;
+  const body = (
+    <>
+      <span className="shrink-0 font-mono">{ref}</span>
+      {chip.title && (
+        <span className="min-w-0 truncate" onMouseEnter={clipTitle(chip.title)}>
+          {chip.title}
+        </span>
+      )}
+    </>
+  );
+  if (!onOpenRef || !kind || !sameRepo) {
+    return <span className="flex min-w-0 items-center gap-1">{body}</span>;
+  }
+  return (
+    // No `title` here: the inner span's clipTitle sets title="" when the text isn't
+    // clipped, and an empty title on a descendant SUPPRESSES the ancestor's tooltip
+    // rather than deferring to it — the clipped-text tooltip is the one that matters.
+    <button
+      type="button"
+      onClick={() => onOpenRef(kind, chip.number)}
+      className="flex min-w-0 cursor-pointer items-center gap-1 text-primary underline-offset-2 outline-none hover:underline focus-visible:ring-1 focus-visible:ring-ring/50"
+    >
+      {body}
+    </button>
+  );
+}
+
+/** A calm, GitHub-timeline-density event row: rail + icon + actor avatar + actor +
+ *  muted verb phrase + relative time. The avatar is decorative — the login is right
+ *  beside it, and a metadata row must not add a tab stop per event. */
+export function TimelineEventRow({
+  event,
+  onOpenRef,
+  selfRepo,
+}: {
+  event: ForgeTimelineEvent;
+  /** Drill into a referenced PR/issue from a reference chip. Without it the chip
+   *  stays plain text. */
+  onOpenRef?: (kind: "pr" | "issue", number: number) => void;
+  /** The viewed repo's `owner/name`, so a cross-repo reference can be told apart
+   *  from a local one and rendered non-interactive. */
+  selfRepo?: string;
+}) {
+  const { Icon, tone, label, colorDot, refChip } = eventPresentation(event);
+  const ghHost = useActiveForgeGhHost();
   return (
     <div className="flex items-start gap-2 text-xs">
       <RailIcon Icon={Icon} tone={tone} label={label} />
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 py-0.5 text-muted-foreground">
-        {event.actor && (
-          <span className="font-medium text-foreground">{event.actor}</span>
+        {event.actor.label && (
+          <>
+            <ForgeUserAvatar
+              user={event.actor}
+              ghHost={ghHost}
+              size="sm"
+              decorative
+              className="size-4"
+            />
+            <span className="font-medium text-foreground">
+              {event.actor.label}
+            </span>
+          </>
         )}
         {colorDot && (
           <span
@@ -226,6 +446,13 @@ export function TimelineEventRow({ event }: { event: PrTimelineEvent }) {
         <span className="min-w-0 truncate" onMouseEnter={clipTitle(label)}>
           {label}
         </span>
+        {refChip && (
+          <ReferenceChip
+            chip={refChip}
+            onOpenRef={onOpenRef}
+            selfRepo={selfRepo}
+          />
+        )}
         {parseableDate(event.date) && (
           <span className="shrink-0 text-muted-foreground/80">
             · <RelativeTime date={event.date} />

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -138,8 +138,9 @@ function RailIcon({
 }
 
 /** A referenced PR/issue a timeline row points at. `repo` is its `owner/name`, or
- *  `""` when the provider didn't say — a reference can live in ANOTHER repository,
- *  so the number alone can't address it. */
+ *  `""` when the reference is in the viewed repo — the wire's same-repo guarantee
+ *  the gate in {@link ReferenceChip} relies on; a reference can live in ANOTHER
+ *  repository, so the number alone can't address it. */
 interface ReferenceChipData {
   /** `"pr"` / `"issue"`, or `""` when the entity's type is unknown. */
   kind: string;

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -52,6 +52,7 @@ import type {
   ForgeRepoWriteAccess,
   ForgeSearchList,
   ForgeStatus,
+  ForgeTimelineEvent,
   ForgeUserRef,
   ForkPrMatch,
   GeneratedNotes,
@@ -100,7 +101,6 @@ import type {
   PrPollInfo,
   PrRef,
   PrTask,
-  PrTimelineEvent,
   PunchCard,
   ReconnectEvent,
   ReleaseDetails,
@@ -1554,7 +1554,23 @@ export const forgePrTimeline = (
   repoPath: string,
   number: number,
   lens: RemoteLens,
-) => invoke<PrTimelineEvent[]>("forge_pr_timeline", { repoPath, number, lens });
+) =>
+  invoke<ForgeTimelineEvent[]>("forge_pr_timeline", { repoPath, number, lens });
+
+/** An issue's activity timeline (labels, assignment, milestones, cross-references,
+ *  state changes) for the issue view. Provider-neutral — the backend dispatches
+ *  (GitHub GraphQL, GitLab resource events + system notes; Bitbucket issues are
+ *  unsupported). */
+export const forgeIssueTimeline = (
+  repoPath: string,
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<ForgeTimelineEvent[]>("forge_issue_timeline", {
+    repoPath,
+    number,
+    lens,
+  });
 
 // Provider-neutral merge/pull request reads — the backend resolves the repo's provider
 // and dispatches, returning the same neutral `PrInfo`/`PrDetails` shapes. Neutral

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2222,6 +2222,24 @@ export function useIssueReactions(
   });
 }
 
+/** An issue's activity timeline for the issue view. Provider-neutral (the backend
+ *  dispatches), so the caller passes `enabled = <known provider that has it>` — an
+ *  unresolved provider must NOT fetch. Decoupled from the issue view like
+ *  {@link useIssueReactions}. */
+export function useIssueTimeline(
+  repoPath: string,
+  number: number,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
+  return useQuery({
+    queryKey: ["repo", repoPath, "issue", lens, number, "timeline"] as const,
+    queryFn: () => api.forgeIssueTimeline(repoPath, number, lens),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
 function patchReactionList(
   list: Reaction[],
   content: string,

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1784,8 +1784,13 @@ export type ForgeTimelineEvent =
       sourceNumber: number;
       sourceTitle: string;
       /** The referring entity's `owner/name` — a cross-reference can live in another
-       *  repository, so the number alone can't address it. `""` when unknown. */
+       *  repository, so the number alone can't address it. Empty is a same-repo
+       *  GUARANTEE, not an unknown: GitHub always names the repo, and GitLab only
+       *  emits same-project references. The reference chip's gate relies on it. */
       sourceRepo: string;
+      /** Whether the referring entity would close this one on merge. Carried on the
+       *  wire so a future closing-reference treatment needs no shape change; no
+       *  renderer reads it today. */
       willClose: boolean;
       actor: ForgeUserRef;
       date: string;
@@ -1795,6 +1800,7 @@ export type ForgeTimelineEvent =
       sourceKind: string;
       sourceNumber: number;
       sourceTitle: string;
+      /** Same shape and same-repo contract as `crossReferenced`'s `sourceRepo`. */
       sourceRepo: string;
       /** true when the link was made, false when it was broken. */
       added: boolean;
@@ -1828,8 +1834,8 @@ export type ForgeTimelineEvent =
       kind: "markedAsDuplicate";
       canonicalKind: string;
       canonicalNumber: number;
-      /** The canonical entity's `owner/name` (same cross-repo reason as
-       *  `sourceRepo`); `""` when unknown. */
+      /** The canonical entity's `owner/name` — same cross-repo reason and same
+       *  empty-means-same-repo contract as `sourceRepo`. */
       canonicalRepo: string;
       actor: ForgeUserRef;
       date: string;

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1709,18 +1709,19 @@ export interface PrCheckOut {
 }
 
 /**
- * One PR activity-timeline event, mirroring the Rust `PrTimelineEventOut` tagged enum.
- * Provider-neutral: GitHub renders reviews as cards so it emits no
- * approved/changesRequested, while GitLab/Bitbucket emit approval events here. Events
- * arrive oldest→newest; `actor`/`date`/oid fields are `""` when the provider returned
- * null.
+ * One activity-timeline event on a PR/MR or an issue, mirroring the Rust
+ * `ForgeTimelineEventOut` tagged enum. Provider-neutral: GitHub renders reviews as
+ * cards so it emits no approved/changesRequested, while GitLab/Bitbucket emit approval
+ * events here. Events arrive oldest→newest; every string field is `""` (and every
+ * number `0`) when the provider returned null, so absence reads as empty rather than
+ * missing.
  */
-export type PrTimelineEvent =
+export type ForgeTimelineEvent =
   | {
       kind: "forcePushed";
       before: string;
       after: string;
-      actor: string;
+      actor: ForgeUserRef;
       date: string;
     }
   | {
@@ -1729,23 +1730,108 @@ export type PrTimelineEvent =
       color: string;
       /** true for a LABELED_EVENT, false for an UNLABELED_EVENT. */
       added: boolean;
-      actor: string;
+      actor: ForgeUserRef;
       date: string;
     }
-  | { kind: "reviewRequested"; reviewer: string; actor: string; date: string }
-  | { kind: "readyForReview"; actor: string; date: string }
-  | { kind: "convertToDraft"; actor: string; date: string }
-  | { kind: "approved"; actor: string; date: string }
-  | { kind: "changesRequested"; actor: string; date: string }
-  | { kind: "unapproved"; actor: string; date: string }
-  | { kind: "closed"; actor: string; date: string }
-  | { kind: "reopened"; actor: string; date: string }
-  | { kind: "merged"; actor: string; commitOid?: string; date: string }
+  | {
+      kind: "reviewRequested";
+      reviewer: string;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | { kind: "readyForReview"; actor: ForgeUserRef; date: string }
+  | { kind: "convertToDraft"; actor: ForgeUserRef; date: string }
+  | { kind: "approved"; actor: ForgeUserRef; date: string }
+  | { kind: "changesRequested"; actor: ForgeUserRef; date: string }
+  | { kind: "unapproved"; actor: ForgeUserRef; date: string }
+  | {
+      kind: "closed";
+      actor: ForgeUserRef;
+      /** `"completed" | "not_planned" | "duplicate"` on a GitHub issue close; `""`
+       *  for PRs and for GitLab/Bitbucket, which report no reason. */
+      stateReason: string;
+      date: string;
+    }
+  | { kind: "reopened"; actor: ForgeUserRef; date: string }
+  | { kind: "merged"; actor: ForgeUserRef; commitOid?: string; date: string }
   | {
       kind: "renamed";
       previous: string;
       current: string;
-      actor: string;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "assigned";
+      assignee: string;
+      /** true for an assignment, false for an unassignment. */
+      added: boolean;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "milestoned";
+      milestone: string;
+      /** true when added to the milestone, false when removed. */
+      added: boolean;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "crossReferenced";
+      /** `"pr" | "issue"`, or `""` when the referring entity's type is unknown. */
+      sourceKind: string;
+      sourceNumber: number;
+      sourceTitle: string;
+      /** The referring entity's `owner/name` — a cross-reference can live in another
+       *  repository, so the number alone can't address it. `""` when unknown. */
+      sourceRepo: string;
+      willClose: boolean;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "connected";
+      sourceKind: string;
+      sourceNumber: number;
+      sourceTitle: string;
+      sourceRepo: string;
+      /** true when the link was made, false when it was broken. */
+      added: boolean;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "pinned";
+      /** true for a pin, false for an unpin. */
+      added: boolean;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "locked";
+      locked: boolean;
+      /** The lock reason lowercased (`"off_topic"`, `"too_heated"`, `"resolved"`,
+       *  `"spam"`); `""` when none was given, and on unlock. */
+      reason: string;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "transferred";
+      /** The `owner/name` the issue moved here from; `""` when unknown. */
+      fromRepo: string;
+      actor: ForgeUserRef;
+      date: string;
+    }
+  | {
+      kind: "markedAsDuplicate";
+      canonicalKind: string;
+      canonicalNumber: number;
+      /** The canonical entity's `owner/name` (same cross-repo reason as
+       *  `sourceRepo`); `""` when unknown. */
+      canonicalRepo: string;
+      actor: ForgeUserRef;
       date: string;
     };
 
@@ -1878,19 +1964,23 @@ export interface CompletedReviewerWithState {
   state: string;
 }
 
-/** A provider user reference for pickers — a stable id + a human label.
- *  Bitbucket's reviewer picker emits it today (id = account uuid, label =
- *  display name / nickname): Bitbucket nicknames aren't unique, so the label
- *  alone can't round-trip a mutation. */
+/** A provider user reference — a stable id + a human label — for pickers,
+ *  read-only chips, and timeline actors. Bitbucket carries the account uuid as
+ *  the id with the display name / nickname as the label: its nicknames aren't
+ *  unique, so the label alone can't round-trip a mutation. GitHub and GitLab put
+ *  the login/username in both fields. */
 export interface ForgeUserRef {
   id: string;
   label: string;
-  /** The user's avatar URL when the provider supplies one (GitLab/Bitbucket).
-   *  Empty for GitHub, where the picker derives it from the login. */
+  /** The user's avatar URL whenever the source supplies one — GitLab/Bitbucket
+   *  return it on every user, and the GitHub timeline reads `actor.avatarUrl`.
+   *  Empty means derive it from the login on GitHub, initials elsewhere
+   *  (`ForgeUserAvatar` owns both fallbacks). */
   avatarUrl: string;
-  /** True for a bot requested reviewer (e.g. GitHub Copilot). Bot reviewers are
-   *  display-only: they're rendered as read-only chips, never enter the editable
-   *  picker's managed set, and the reviewer setters never add or remove them. */
+  /** True for a bot account — a bot requested reviewer (e.g. GitHub Copilot), or a
+   *  timeline actor GitHub typed as a `Bot`. Bot reviewers are display-only:
+   *  they're rendered as read-only chips, never enter the editable picker's
+   *  managed set, and the reviewer setters never add or remove them. */
   isBot: boolean;
 }
 


### PR DESCRIPTION
Issues previously showed only their comments, so label changes, assignments, milestone moves, cross-references and state changes were invisible without opening the browser. This adds a provider-neutral issue activity timeline that interleaves those events with the comments in one date-sorted feed, and — since the PR timeline union is now shared — also gives every timeline row on pull requests the actor's avatar.

### Shared timeline model

- Moves `PrTimelineEventOut` out of `src-tauri/src/github/pr.rs` into `src-tauri/src/forge/model.rs` as `ForgeTimelineEventOut`, the neutral union now used by both the PR and issue reads.
- Extends the union with issue events: `Assigned`, `Milestoned`, `CrossReferenced`, `Connected`, `Pinned`, `Locked`, `Transferred` and `MarkedAsDuplicate`, and adds `state_reason` to `Closed` (GitHub's issue close reason; empty for PRs and for the other providers).
- Changes every variant's `actor` from a bare `String` to `ForgeUserRef`, so rows carry an avatar URL and a bot flag. `ForgeUserRef`'s `avatar_url` is no longer GitHub-empty by contract, and `is_bot` now also covers a timeline actor whose GraphQL `__typename` is `Bot`.

### Backend providers

- Adds the `forge_issue_timeline` command in `src-tauri/src/forge/mod.rs` (registered in `src-tauri/src/lib.rs`), dispatching to GitLab, returning an `InvalidArgument` for Bitbucket issues, and defaulting to GitHub.
- Adds `ISSUE_TIMELINE_QUERY` and `gh_issue_timeline` in `src-tauri/src/github/issue.rs`, reusing `pr.rs`'s `map_timeline_node` (now `pub`) over an 18-type `timelineItems` window, with a `forge/github.rs` shim.
- Widens `PR_TIMELINE_QUERY` in `src-tauri/src/github/pr.rs` to select `avatarUrl(size: 48)` and `__typename` on every actor, and extends `map_timeline_node` to cover the new issue node types.
- Adds `gitlab::issue_timeline` plus a `gl_actor` helper in `src-tauri/src/forge/gitlab.rs`, mapping resource label/state/milestone events and the assignment/reference/lock system notes onto the shared union; `timeline_event_date` matches the new variants exhaustively so none can silently sort as `""`.
- Adds `bb_actor` in `src-tauri/src/forge/bitbucket.rs` to build a neutral user ref (display name fills both `id` and `label`, since participants carry no `username`) and fills the empty `state_reason` on Bitbucket closes.
- Adds `issue_timeline_query_selects_every_mapped_field` in `src-tauri/src/github/issue.rs` tests, pinning the GraphQL selection set against the mapper's contract.

### Frontend

- Reworks `src/features/pulls/PrTimeline.tsx`: exports `TimelineEventRow`, renders `ForgeUserAvatar` on each row, adds presentations for the new event kinds, and resolves close copy through a `CLOSE_REASON_PRESENTATION` lookup (`completed` / `duplicate` / `not_planned`).
- Adds reference chips (`ReferenceChipData`) for cross-reference, link and duplicate rows; a chip is only interactive when its `repo` matches `selfRepo`, so a cross-repo reference degrades to inert text rather than a wrong drill-in.
- Builds the interleaved feed in `src/features/issues/RemoteIssueView.tsx` with `sortTimeline` and slot-prefixed keys (comments 2, events 3), and wires `openRef` to `selectPr` + `setRepoTab("pulls")` or `selectIssue` for same-repo references.
- Adds `forgeIssueTimeline` in `src/lib/git/api.ts` and the `useIssueTimeline` hook in `src/lib/git/queries.ts` (30s `staleTime`, gated on a resolved non-Bitbucket provider).
- Renames `PrTimelineEvent` to `ForgeTimelineEvent` in `src/lib/git/types.ts` with the new variants mirrored and `actor: ForgeUserRef`; `src/features/pulls/PrActivityFeed.tsx` follows the rename.

### Documentation

- Adds an "Activity feed" paragraph to the issues section of `README.md`.
- Adds the capability line to `site/src/data/capabilities.ts` and extends the issues copy in `site/src/pages/index.astro`.
- Extends the issues guide section in `src/features/help/content.ts` with the feed's contents and the clickable same-repo references.
- Adds `changelog.d/added-issue-timeline.md` and `changelog.d/changed-timeline-avatars.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date-sorted issue activity timelines combining comments with labels, assignments, milestones, mentions, renames, state changes, references, duplicates, locks, and other events.
  * Added GitHub and GitLab issue timeline support.
  * Added actor avatars, bot indicators, timestamps, and navigable same-repository issue and pull request references.
  * Expanded pull request timelines with close reasons, links, transfers, pins, locks, and duplicate markers.
  * Preserved fork-parent references as non-navigable text when using the Upstream lens.
* **Bug Fixes**
  * Corrected handling of unrecognized issue label and milestone events.
* **Documentation**
  * Updated help content, feature descriptions, and changelog entries for issue activity timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->