### PR TITLE
feat(ai,sessions): list opencode's live model catalog in model pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,7 +896,7 @@ review via its subscription login. The full list is under
   an API key), and the **Claude Code / Codex / GitHub Copilot / opencode
   CLIs** (keyless, via your subscription, or opencode's free hosted models).
   Separate models for generation vs. review; live model lists in a
-  searchable picker.
+  searchable picker (opencode's CLI catalog included).
 - **Custom and LAN servers**: point Ollama or an OpenAI-compatible endpoint
   at a box on your network, not just `localhost`. Non-built-in hosts must be
   added to the **Allowed hosts** list (Settings → AI; one-click *Allow

--- a/changelog.d/added-opencode-live-models.md
+++ b/changelog.d/added-opencode-live-models.md
@@ -1,0 +1,3 @@
+- The model picker for opencode sessions now lists your full catalog from
+  `opencode models` (custom providers included); the Settings → AI and PR
+  review pickers show the same live list.

--- a/changelog.d/added-opencode-live-models.md
+++ b/changelog.d/added-opencode-live-models.md
@@ -1,3 +1,3 @@
-- The model picker for opencode sessions now lists your full catalog from
+- The model picker for opencode sessions now lists your catalog from
   `opencode models` (custom providers included); the Settings → AI and PR
   review pickers show the same live list.

--- a/changelog.d/changed-opencode-default-model.md
+++ b/changelog.d/changed-opencode-default-model.md
@@ -1,0 +1,3 @@
+- Choosing the opencode CLI as an AI provider now starts on the CLI's account
+  default model instead of pinning a hosted id — opencode rotates those, so a
+  pinned one can go stale; clear the model box if an older saved id lingers.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -582,7 +582,7 @@ export const capabilities: Capability[] = [
     group: "AI · agents & sessions",
     ai: true,
     label:
-      "Delegate a task to a Claude, Codex, Copilot or opencode agent — searchable model picker, any typed id accepted",
+      "Delegate a task to a Claude, Codex, Copilot or opencode agent — searchable model picker (opencode's live catalog), any typed id accepted",
     highlight: true,
   },
   {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -688,14 +688,12 @@ pub(crate) async fn run_capture_parts(
     program: &Path,
     args: &[&str],
     timeout: Duration,
-    extra_env: &[(&str, String)],
 ) -> AppResult<(i32, String, String)> {
     let mut cmd = Command::new(program);
     sanitize_child_env(&mut cmd);
     cmd.args(args)
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
-        .envs(extra_env.iter().map(|(k, v)| (*k, v.as_str())))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -720,7 +718,7 @@ pub(crate) async fn run_capture(
     args: &[&str],
     timeout: Duration,
 ) -> AppResult<(i32, String)> {
-    let (code, mut text, stderr) = run_capture_parts(program, args, timeout, &[]).await?;
+    let (code, mut text, stderr) = run_capture_parts(program, args, timeout).await?;
     text.push_str(&stderr);
     Ok((code, text))
 }
@@ -766,10 +764,10 @@ pub async fn agent_detect(kind: AgentKind, bin_path: Option<String>) -> AppResul
 const MODELS_LIMIT: usize = 2000;
 
 /// Picks model ids out of a catalog listing: one bare `provider/model` id per
-/// line, everything else dropped. The whitespace and control-character gates
-/// reject banners, warnings, `--verbose` JSON, and ANSI-wrapped ids from a
-/// wrapper that ignores `NO_COLOR`. Input order is the CLI's deliberate sort
-/// (opencode-own providers first), so it is preserved.
+/// line, everything else dropped. The whitespace, control-character, and
+/// empty-segment gates reject banners, warnings, `--verbose` JSON, URLs, and
+/// ANSI-wrapped ids from a wrapper that ignores `NO_COLOR`. Input order is the
+/// CLI's deliberate sort (opencode-own providers first), so it is preserved.
 fn parse_models_output(stdout: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut seen: HashSet<&str> = HashSet::new();
@@ -778,6 +776,7 @@ fn parse_models_output(stdout: &str) -> Vec<String> {
         if id.is_empty()
             || id.chars().any(|c| c.is_whitespace() || c < '\x20' || c == '\x7f')
             || !id.contains('/')
+            || id.split('/').any(|seg| seg.is_empty())
         {
             continue;
         }
@@ -805,7 +804,7 @@ pub async fn agent_models(kind: AgentKind, bin_path: Option<String>) -> AppResul
             kind.label()
         ))
     })?;
-    let (code, stdout, stderr) = run_capture_parts(&binary, args, MODELS_TIMEOUT, &[]).await?;
+    let (code, stdout, stderr) = run_capture_parts(&binary, args, MODELS_TIMEOUT).await?;
     if code != 0 {
         let reason = stderr
             .lines()
@@ -3114,6 +3113,21 @@ opencode/x-preview-f-free
             parse_models_output(out),
             ["opencode/keep-one", "opencode/keep-two"]
         );
+    }
+
+    #[test]
+    fn models_output_rejects_ids_with_empty_segments() {
+        // A URL splits to an empty middle segment. Multi-slash ids whose segments
+        // are all non-empty stay accepted — custom providers may nest.
+        let out = concat!(
+            "/model\n",
+            "provider/\n",
+            "https://host\n",
+            "//\n",
+            "a/b-c\n",
+            "a/b/c\n",
+        );
+        assert_eq!(parse_models_output(out), ["a/b-c", "a/b/c"]);
     }
 
     #[test]

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -21,6 +21,9 @@ use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 
 pub(crate) const DETECT_TIMEOUT: Duration = Duration::from_secs(20);
+/// A warm `opencode models` returns in ~1.5s, but a cold one waits on opencode's
+/// own catalog HTTP leg (10s timeout, two retries) before printing.
+const MODELS_TIMEOUT: Duration = Duration::from_secs(20);
 const REVIEW_TIMEOUT: Duration = Duration::from_secs(300);
 /// Repo-aware (Tier 2) runs explore the tree with tools and take longer — a
 /// self-MCP review pulling the full diff routinely runs past ten minutes, so
@@ -106,6 +109,14 @@ impl AgentKind {
             AgentKind::Claude => Some(&["auth", "status"]),
             AgentKind::Codex => Some(&["login", "status"]),
             AgentKind::Copilot | AgentKind::Opencode => None,
+        }
+    }
+
+    /// argv for the CLI's own model-catalog listing; None = no such surface.
+    fn models_args(self) -> Option<&'static [&'static str]> {
+        match self {
+            AgentKind::Opencode => Some(&["models"]),
+            AgentKind::Claude | AgentKind::Codex | AgentKind::Copilot => None,
         }
     }
 
@@ -668,17 +679,21 @@ async fn resolve(kind: AgentKind, bin_path: Option<&str>) -> Option<PathBuf> {
 
 // --- detection -------------------------------------------------------------
 
-/// Runs a short command and returns (exit code, stdout+stderr).
-pub(crate) async fn run_capture(
+/// Runs a short command and returns (exit code, stdout, stderr) as separate
+/// streams — what a line parser needs, since a banner on stderr must not
+/// interleave into the data being parsed.
+pub(crate) async fn run_capture_parts(
     program: &Path,
     args: &[&str],
     timeout: Duration,
-) -> AppResult<(i32, String)> {
+    extra_env: &[(&str, String)],
+) -> AppResult<(i32, String, String)> {
     let mut cmd = Command::new(program);
     sanitize_child_env(&mut cmd);
     cmd.args(args)
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
+        .envs(extra_env.iter().map(|(k, v)| (*k, v.as_str())))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -690,9 +705,22 @@ pub(crate) async fn run_capture(
         .await
         .map_err(|_| AppError::Timeout(timeout.as_secs()))?
         .map_err(AppError::Io)?;
-    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
-    text.push_str(&String::from_utf8_lossy(&out.stderr));
-    Ok((out.status.code().unwrap_or(-1), text))
+    Ok((
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    ))
+}
+
+/// Runs a short command and returns (exit code, stdout+stderr).
+pub(crate) async fn run_capture(
+    program: &Path,
+    args: &[&str],
+    timeout: Duration,
+) -> AppResult<(i32, String)> {
+    let (code, mut text, stderr) = run_capture_parts(program, args, timeout, &[]).await?;
+    text.push_str(&stderr);
+    Ok((code, text))
 }
 
 #[tauri::command]
@@ -728,6 +756,63 @@ pub async fn agent_detect(kind: AgentKind, bin_path: Option<String>) -> AppResul
         version,
         authed,
     })
+}
+
+/// Upper bound on ids handed to the (non-virtualized) model pickers; a
+/// credentialed opencode catalog measured 423, so this only bounds pathological
+/// output.
+const MODELS_LIMIT: usize = 2000;
+
+/// Picks model ids out of a catalog listing: one bare `provider/model` id per
+/// line, everything else dropped. The whitespace and control-character gates
+/// reject banners, warnings, `--verbose` JSON, and ANSI-wrapped ids from a
+/// wrapper that ignores `NO_COLOR`. Input order is the CLI's deliberate sort
+/// (opencode-own providers first), so it is preserved.
+fn parse_models_output(stdout: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in stdout.split('\n') {
+        let id = line.trim();
+        if id.is_empty()
+            || id.chars().any(|c| c.is_whitespace() || c < '\x20' || c == '\x7f')
+            || !id.contains('/')
+        {
+            continue;
+        }
+        if !out.iter().any(|seen| seen == id) {
+            out.push(id.to_string());
+        }
+        if out.len() == MODELS_LIMIT {
+            break;
+        }
+    }
+    out
+}
+
+/// Lists the model ids the CLI itself reports, for the model pickers. Kinds with
+/// no catalog surface answer with an empty list rather than an error, so a caller
+/// can ask about any agent unconditionally.
+#[tauri::command]
+pub async fn agent_models(kind: AgentKind, bin_path: Option<String>) -> AppResult<Vec<String>> {
+    let Some(args) = kind.models_args() else {
+        return Ok(Vec::new());
+    };
+    let binary = resolve(kind, bin_path.as_deref()).await.ok_or_else(|| {
+        AppError::Command(format!(
+            "{} CLI not found. Install it or set its path in Settings.",
+            kind.label()
+        ))
+    })?;
+    let (code, stdout, stderr) = run_capture_parts(&binary, args, MODELS_TIMEOUT, &[]).await?;
+    if code != 0 {
+        let reason = stderr
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("{} models exited with code {code}", kind.label()));
+        return Err(AppError::Command(reason));
+    }
+    Ok(parse_models_output(&stdout))
 }
 
 // --- review ----------------------------------------------------------------
@@ -2231,10 +2316,16 @@ pub async fn agent_review(
 
     // opencode reads its MCP config from `OPENCODE_CONFIG` (no flag); the others carry
     // it in argv. Set the env only when we actually wrote an opencode config.
-    let extra_env: Vec<(&str, String)> = match (kind, &mcp_config_path) {
+    let mut extra_env: Vec<(&str, String)> = match (kind, &mcp_config_path) {
         (AgentKind::Opencode, Some(path)) => vec![("OPENCODE_CONFIG", path.clone())],
         _ => Vec::new(),
     };
+    if kind == AgentKind::Opencode {
+        // Every opencode invocation otherwise forks a detached catalog refresh,
+        // which on an app-managed run is stray-grandchild churn; the cache is
+        // refreshed by the `agent_models` probe when a user opens a model picker.
+        extra_env.push(("OPENCODE_DISABLE_MODELS_FETCH", "1".to_string()));
+    }
 
     // Codex always explores the repo, so it gets the longer agentic budget too — and
     // a self-MCP review is agentic regardless of `repo_aware` (the agent pulls the
@@ -2652,6 +2743,9 @@ pub async fn agent_session(
                 }
                 _ => Vec::new(),
             };
+        if kind == AgentKind::Opencode {
+            container_env.push(("OPENCODE_DISABLE_MODELS_FETCH", "1".to_string()));
+        }
         if opencode_research {
             // Enable opencode's Exa-backed websearch tool (webfetch works regardless).
             container_env.push(("OPENCODE_ENABLE_EXA", "1".to_string()));
@@ -2701,6 +2795,9 @@ pub async fn agent_session(
         (AgentKind::Opencode, Some(path)) => vec![("OPENCODE_CONFIG", path.clone())],
         _ => Vec::new(),
     };
+    if kind == AgentKind::Opencode {
+        host_extra_env.push(("OPENCODE_DISABLE_MODELS_FETCH", "1".to_string()));
+    }
     if opencode_research {
         // Enable opencode's Exa-backed websearch tool (webfetch works regardless).
         host_extra_env.push(("OPENCODE_ENABLE_EXA", "1".to_string()));
@@ -2947,6 +3044,101 @@ mod tests {
     const TEXT_B: &str = r#"{"type":"text","sessionID":"ses_abc","part":{"id":"p2","type":"text","text":"Second."}}"#;
     const FINISH_TOOLS: &str = r#"{"type":"step_finish","sessionID":"ses_abc","part":{"type":"step-finish","reason":"tool-calls"}}"#;
     const FINISH_STOP: &str = r#"{"type":"step_finish","sessionID":"ses_abc","part":{"type":"step-finish","reason":"stop"}}"#;
+
+    /// Real `opencode models` stdout (captured 2026-08-23, v1.18.18, uncredentialed;
+    /// the free catalog rotates within days). rustc normalizes CRLF to LF inside
+    /// string literals, so this const is LF whatever autocrlf checked the file out
+    /// as — which is what lets the cases below vary the EOLs from a known baseline.
+    const OPENCODE_MODELS_OUTPUT: &str = "opencode/big-pickle
+opencode/hy3-free
+opencode/mimo-v2.5-free
+opencode/muse-spark-1.2-contributor-free
+opencode/nemotron-3-ultra-free
+opencode/nemotron-3.5-lightning-free
+opencode/x-preview-f-free
+";
+
+    const OPENCODE_MODEL_IDS: [&str; 7] = [
+        "opencode/big-pickle",
+        "opencode/hy3-free",
+        "opencode/mimo-v2.5-free",
+        "opencode/muse-spark-1.2-contributor-free",
+        "opencode/nemotron-3-ultra-free",
+        "opencode/nemotron-3.5-lightning-free",
+        "opencode/x-preview-f-free",
+    ];
+
+    #[test]
+    fn models_output_parses_to_the_cli_ids_in_order() {
+        assert_eq!(
+            parse_models_output(OPENCODE_MODELS_OUTPUT),
+            OPENCODE_MODEL_IDS
+        );
+    }
+
+    #[test]
+    fn models_output_parses_identically_with_crlf_endings() {
+        // Pins the lexer's CRLF normalization: were the fixture to reach runtime
+        // with its own CR, this would build `\r\r\n` and the real CRLF case would
+        // go untested on a CRLF checkout.
+        assert!(!OPENCODE_MODELS_OUTPUT.contains('\r'));
+        let crlf = OPENCODE_MODELS_OUTPUT.replace('\n', "\r\n");
+        assert_eq!(parse_models_output(&crlf), OPENCODE_MODEL_IDS);
+    }
+
+    #[test]
+    fn models_output_parses_identically_without_a_trailing_newline() {
+        let unterminated = OPENCODE_MODELS_OUTPUT.trim_end_matches('\n');
+        assert!(!unterminated.ends_with(['\n', '\r']));
+        assert_eq!(parse_models_output(unterminated), OPENCODE_MODEL_IDS);
+    }
+
+    #[test]
+    fn models_output_drops_noise_and_keeps_its_neighbours() {
+        // Each reject carries a `/` except the last, so the warning and JSON lines
+        // are rejected by the whitespace gate and the wrapped id by the control gate
+        // — one line per branch rather than three that all fail the same check.
+        let out = concat!(
+            "opencode/keep-one\n",
+            "Warning: 2 providers unavailable, showing opencode/free models only\n",
+            r#"{"level":"debug","msg":"refreshed opencode/catalog"}"#,
+            "\n",
+            "\x1b[32mopencode/ansi-wrapped\x1b[0m\n",
+            "not-an-id\n",
+            "opencode/keep-two\n",
+        );
+        assert_eq!(
+            parse_models_output(out),
+            ["opencode/keep-one", "opencode/keep-two"]
+        );
+    }
+
+    #[test]
+    fn models_output_is_empty_for_empty_input() {
+        assert!(parse_models_output("").is_empty());
+        assert!(parse_models_output("\n\n  \n").is_empty());
+    }
+
+    #[test]
+    fn models_output_dedupes_to_the_first_occurrence() {
+        assert_eq!(
+            parse_models_output("b/two\na/one\nb/two\na/one\n"),
+            ["b/two", "a/one"]
+        );
+    }
+
+    #[test]
+    fn models_output_truncates_at_the_cap() {
+        let mut input = String::new();
+        for i in 0..(MODELS_LIMIT + 500) {
+            input.push_str(&format!("p/m{i}\n"));
+        }
+        let ids = parse_models_output(&input);
+        let last = format!("p/m{}", MODELS_LIMIT - 1);
+        assert_eq!(ids.len(), MODELS_LIMIT);
+        assert_eq!(ids.first().map(String::as_str), Some("p/m0"));
+        assert_eq!(ids.last().map(String::as_str), Some(last.as_str()));
+    }
 
     #[test]
     fn cancel_id_gate_accepts_uuids_and_rejects_the_rest() {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -5,6 +5,7 @@
 //! Reuses the user's existing CLI subscription auth, so no API key is needed.
 //! Reviews are read-only: Tier 1 exposes no tools at all.
 
+use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -21,8 +22,9 @@ use crate::error::{AppError, AppResult};
 use crate::state::AppState;
 
 pub(crate) const DETECT_TIMEOUT: Duration = Duration::from_secs(20);
-/// A warm `opencode models` returns in ~1.5s, but a cold one waits on opencode's
-/// own catalog HTTP leg (10s timeout, two retries) before printing.
+/// A warm `opencode models` returns in ~1.5s (measured); the catalog resolves
+/// from opencode's disk cache or its binary-bundled snapshot, so the sync HTTP
+/// leg is a last resort — 20s is a bound on a hung CLI, not an expected wait.
 const MODELS_TIMEOUT: Duration = Duration::from_secs(20);
 const REVIEW_TIMEOUT: Duration = Duration::from_secs(300);
 /// Repo-aware (Tier 2) runs explore the tree with tools and take longer — a
@@ -770,6 +772,7 @@ const MODELS_LIMIT: usize = 2000;
 /// (opencode-own providers first), so it is preserved.
 fn parse_models_output(stdout: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
     for line in stdout.split('\n') {
         let id = line.trim();
         if id.is_empty()
@@ -778,7 +781,7 @@ fn parse_models_output(stdout: &str) -> Vec<String> {
         {
             continue;
         }
-        if !out.iter().any(|seen| seen == id) {
+        if seen.insert(id) {
             out.push(id.to_string());
         }
         if out.len() == MODELS_LIMIT {
@@ -2321,9 +2324,9 @@ pub async fn agent_review(
         _ => Vec::new(),
     };
     if kind == AgentKind::Opencode {
-        // Every opencode invocation otherwise forks a detached catalog refresh,
-        // which on an app-managed run is stray-grandchild churn; the cache is
-        // refreshed by the `agent_models` probe when a user opens a model picker.
+        // Long-lived app-managed runs must not fork opencode's detached catalog
+        // refresh (stray-grandchild churn). The short-lived probes keep opencode's
+        // default behavior — the `agent_models` probe is what refreshes the cache.
         extra_env.push(("OPENCODE_DISABLE_MODELS_FETCH", "1".to_string()));
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -650,6 +650,7 @@ pub fn run() {
             hooks::git_hook_delete,
             hooks::git_run_hook_manager,
             agent::agent_detect,
+            agent::agent_models,
             health::system_health,
             agent::agent_review,
             agent::agent_review_cancel,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1823,7 +1823,7 @@ to an implementing session**.
 opens on your **Settings → AI** default agent), **model**, and **reasoning effort**
 (Low / Medium / High / Max), and send. The model box (the same one on research and plan
 runs) filters its suggestions as you type and takes any model id you type, so a custom
-provider's models work without being on the list; for opencode it lists your CLI's full
+provider's models work without being on the list; for opencode it lists your CLI's
 catalog (custom providers included). Leave it empty for your account's default. The
 agent works in an **isolated git worktree**
 — a throwaway branch (\`gd/session/…\`) that never touches your working tree — and
@@ -2048,12 +2048,14 @@ Bring your own model:
 - **Ollama (local or LAN)** — a local model (your code never leaves your machine), or one
   running on another machine on your network — set its URL in Settings.
 - **Claude Code, Codex, GitHub Copilot, opencode CLIs** — *keyless*: they reuse your
-  existing CLI login, with no API key. The CLI agents are **write-capable** — they power
-  agent sessions and plan mode — and can read repo files for deeper reviews. They also
-  drive **generation** (commit messages, PR descriptions, and the rest): pick one under
-  the AI provider or review model in Settings. Generation runs the CLI per request, so
-  it's noticeably slower than an HTTP provider and draws on your plan's quota; the agent
-  only completes the prepared prompt and never explores the repo on the generation path.
+  existing CLI login, with no API key. Pick **opencode** and its model picker fills from
+  the CLI's own catalog (custom providers included), starting on your account's default
+  model. The CLI agents are **write-capable** — they power agent sessions and plan
+  mode — and can read repo files for deeper reviews. They also drive **generation**
+  (commit messages, PR descriptions, and the rest): pick one under the AI provider or
+  review model in Settings. Generation runs the CLI per request, so it's noticeably
+  slower than an HTTP provider and draws on your plan's quota; the agent only completes
+  the prepared prompt and never explores the repo on the generation path.
 
 You can set **separate models** for generation (commit/PR messages) versus review. Toggle
 **Use a different model for security audits** under the review model to give audits their own

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1823,8 +1823,9 @@ to an implementing session**.
 opens on your **Settings → AI** default agent), **model**, and **reasoning effort**
 (Low / Medium / High / Max), and send. The model box (the same one on research and plan
 runs) filters its suggestions as you type and takes any model id you type, so a custom
-provider's models work without being on the list; leave it empty for your account's
-default. The agent works in an **isolated git worktree**
+provider's models work without being on the list; for opencode it lists your CLI's full
+catalog (custom providers included). Leave it empty for your account's default. The
+agent works in an **isolated git worktree**
 — a throwaway branch (\`gd/session/…\`) that never touches your working tree — and
 commits a **checkpoint** each turn. It works in the open: the conversation shows a
 **step-by-step transcript** of each file it reads, edits, searches, and command it

--- a/src/features/plan/ImplementPlanButton.tsx
+++ b/src/features/plan/ImplementPlanButton.tsx
@@ -6,7 +6,6 @@ import {
   AgentPicker,
   EffortPicker,
   ModelPicker,
-  modelsForAgent,
 } from "@/features/sessions/AgentPickers";
 import { clearAgentSelection } from "@/features/sessions/agentSelect";
 import { useSessionsStore } from "@/features/sessions/store";
@@ -73,11 +72,7 @@ export function ImplementPlanButton({ run }: { run: PlanRun }) {
                   setModel(""); // model lists differ between agents
                 }}
               />
-              <ModelPicker
-                value={model}
-                onChange={setModel}
-                models={modelsForAgent(agent)}
-              />
+              <ModelPicker value={model} onChange={setModel} agent={agent} />
               <EffortPicker value={effort} onChange={setEffort} />
             </div>
             <Button size="sm" className="mt-2.5 w-full" onClick={onStart}>

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -13,7 +13,6 @@ import {
   AgentPicker,
   ComposerOptions,
   ModelPicker,
-  modelsForAgent,
 } from "@/features/sessions/AgentPickers";
 import { AgentTranscript } from "@/features/sessions/AgentTranscript";
 import { selectSession } from "@/features/sessions/agentSelect";
@@ -200,7 +199,7 @@ export function PlanComposer({
                 setModel(m);
                 setModelAgent(agent);
               }}
-              models={modelsForAgent(agent)}
+              agent={agent}
             />
             <ComposerOptions effort={effort} onEffort={setEffort} />
             <div className="ml-auto flex items-center gap-2">

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -23,7 +23,6 @@ import {
   AgentPicker,
   ComposerOptions,
   ModelPicker,
-  modelsForAgent,
 } from "@/features/sessions/AgentPickers";
 import { AgentTranscript } from "@/features/sessions/AgentTranscript";
 import {
@@ -292,7 +291,7 @@ export function ResearchComposer({
                 setModel(m);
                 setModelAgent(agent);
               }}
-              models={modelsForAgent(agent)}
+              agent={agent}
             />
             <ComposerOptions effort={effort} onEffort={setEffort} />
             <div className="ml-auto flex items-center gap-2">
@@ -679,11 +678,7 @@ function ResearchFollowUp({ run }: { run: ResearchRun }) {
         >
           {AGENT_LABEL[run.agent]}
         </span>
-        <ModelPicker
-          value={model}
-          onChange={setModel}
-          models={modelsForAgent(run.agent)}
-        />
+        <ModelPicker value={model} onChange={setModel} agent={run.agent} />
         <span className="hidden truncate text-[11px] text-muted-foreground sm:inline">
           ↵ send · ⇧↵ newline
         </span>

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -108,16 +108,12 @@ export function ModelPicker({
           long ids (e.g. `opencode/…`). Size to content, capped on-screen. */}
       <ComboboxContent className="w-fit max-w-sm">
         <ComboboxEmpty>
-          {(() => {
-            switch (true) {
-              // `isFetching`, never `isPending` — a catalog that was never
-              // requested must not read as loading.
-              case available.isFetching:
-                return "Loading models…";
-              default:
-                return "No matching models — the typed id is used as-is";
-            }
-          })()}
+          {/* With placeholder suggestions always present, this renders only when
+              the typed filter matches nothing — keep the typed-id reassurance
+              and note an in-flight probe rather than replacing it. */}
+          {available.isFetching
+            ? "No matching models yet (catalog loading) — the typed id is used as-is"
+            : "No matching models — the typed id is used as-is"}
         </ComboboxEmpty>
         {/* Render FUNCTION, not static rows: only this form maps the store's
             filtered items, so static children would never narrow as you type. */}

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -6,7 +6,7 @@ import {
   UsersThreeIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
-import { type ReactNode, useId, useRef } from "react";
+import { type ReactNode, useId, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -30,7 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { type AgentKind, isAgentKind } from "@/lib/ai/agent";
-import { MODEL_SUGGESTIONS } from "@/lib/ai/providers";
+import { useAgentModels } from "@/lib/ai/models";
 import type { McpServer } from "@/lib/settings/api";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
@@ -40,11 +40,6 @@ import { cn } from "@/lib/utils";
 // their own module so those surfaces don't import each other (the composer imports
 // the ensemble dialog, which needs the pickers — a cycle if they lived together).
 
-const CLAUDE_MODELS = MODEL_SUGGESTIONS["claude-cli"];
-const CODEX_MODELS = MODEL_SUGGESTIONS["codex-cli"];
-const COPILOT_MODELS = MODEL_SUGGESTIONS["copilot-cli"];
-const OPENCODE_MODELS = MODEL_SUGGESTIONS["opencode-cli"];
-
 /** Compact display labels for each agent CLI — for list rows, headers, badges. */
 export const AGENT_LABELS: Record<AgentKind, string> = {
   claude: "Claude",
@@ -53,32 +48,33 @@ export const AGENT_LABELS: Record<AgentKind, string> = {
   opencode: "opencode",
 };
 
-/** The suggested model list for an agent (each CLI exposes different models). */
-export function modelsForAgent(agent: AgentKind): string[] {
-  switch (agent) {
-    case "codex":
-      return CODEX_MODELS;
-    case "copilot":
-      return COPILOT_MODELS;
-    case "opencode":
-      return OPENCODE_MODELS;
-    default:
-      return CLAUDE_MODELS;
-  }
-}
-
-/** The model for a run: the agent's suggestions are searchable, and any other id
- *  typed here reaches the CLI verbatim (custom providers publish ids no static
- *  list can carry). `""` is the account default and shows the placeholder. */
+/** The model for a run: the agent's models are searchable — its live catalog
+ *  where the CLI can list one (opencode), else that CLI's static suggestions —
+ *  and any other id typed here reaches the CLI verbatim (custom providers publish
+ *  ids no static list can carry). `""` is the account default and shows the
+ *  placeholder. */
 export function ModelPicker({
   value,
   onChange,
-  models,
+  agent,
 }: {
   value: string;
   onChange: (m: string) => void;
-  models: string[];
+  agent: AgentKind;
 }) {
+  // Listing a CLI's catalog spawns it, so the probe waits for intent to pick a
+  // model — sticky, so the list stays put for the rest of the picker's life.
+  const [wanted, setWanted] = useState(false);
+  // Agent-tab-scoped by design: every call site renders under the agent tab's
+  // <Activity>, and a hidden subtree still fetches.
+  const agentTabShowing = useUiStore((s) => s.repoTab === "agent");
+  const available = useAgentModels(agent, {
+    enabled: wanted && agentTabShowing,
+  });
+  // Verbatim: the CLI orders its own catalog (its providers first), and the
+  // fallback is that CLI's static suggestions.
+  const models = available.data?.models ?? [];
+
   return (
     <Combobox
       items={models}
@@ -93,6 +89,9 @@ export function ModelPicker({
         if (model) onChange(model);
       }}
       openOnInputClick
+      onOpenChange={(open) => {
+        if (open) setWanted(true);
+      }}
     >
       {/* Composer-toolbar weight: quiet until focus, matching the sibling
           Select-based pickers on the same row. */}
@@ -103,12 +102,22 @@ export function ModelPicker({
         // an input has no truncation tooltip of its own.
         title={value || undefined}
         className="h-7 w-auto max-w-44 min-w-28 border-transparent text-muted-foreground hover:bg-muted dark:bg-transparent"
+        onFocus={() => setWanted(true)}
       />
       {/* The input is narrow, so the default `w-(--anchor-width)` popup clips
           long ids (e.g. `opencode/…`). Size to content, capped on-screen. */}
       <ComboboxContent className="w-fit max-w-sm">
         <ComboboxEmpty>
-          No matching models — the typed id is used as-is
+          {(() => {
+            switch (true) {
+              // `isFetching`, never `isPending` — a catalog that was never
+              // requested must not read as loading.
+              case available.isFetching:
+                return "Loading models…";
+              default:
+                return "No matching models — the typed id is used as-is";
+            }
+          })()}
         </ComboboxEmpty>
         {/* Render FUNCTION, not static rows: only this form maps the store's
             filtered items, so static children would never narrow as you type. */}

--- a/src/features/sessions/EnsembleRunDialog.tsx
+++ b/src/features/sessions/EnsembleRunDialog.tsx
@@ -11,12 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import type { AgentKind } from "@/lib/ai/agent";
 import { formatUsd, type RunCostEstimate } from "@/lib/ai/cost";
-import {
-  AgentPicker,
-  EffortPicker,
-  ModelPicker,
-  modelsForAgent,
-} from "./AgentPickers";
+import { AgentPicker, EffortPicker, ModelPicker } from "./AgentPickers";
 
 /** One arm of a best-of-N run: which agent/model/effort attacks the task. */
 export interface EnsembleArm {
@@ -133,7 +128,7 @@ function EnsembleArms({
             <ModelPicker
               value={arm.model}
               onChange={(model) => patchArm(i, { model })}
-              models={modelsForAgent(arm.agent)}
+              agent={arm.agent}
             />
             <EffortPicker
               value={arm.effort}

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -41,7 +41,6 @@ import {
   type Isolation,
   type IsolationNote,
   ModelPicker,
-  modelsForAgent,
   type RunMode,
 } from "./AgentPickers";
 import { EnsembleRunDialog } from "./EnsembleRunDialog";
@@ -257,7 +256,6 @@ export function SessionComposer({
   const model = session ? session.model : startModelForAgent;
   // Agent is fixed once a session exists; while starting, it's user-selectable.
   const agent = session ? session.agent : startAgent;
-  const models = modelsForAgent(agent);
   const onModel = session
     ? (m: string) => setModel(session.id, m)
     : (m: string) => {
@@ -973,7 +971,7 @@ export function SessionComposer({
                 />
               )}
               {(session || mode === "single") && (
-                <ModelPicker value={model} onChange={onModel} models={models} />
+                <ModelPicker value={model} onChange={onModel} agent={agent} />
               )}
               <ComposerOptions
                 effort={session || mode === "single" ? effort : undefined}

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -128,7 +128,13 @@ function ModelPicker({
   // cause) — a saved-but-rejected key must never be told to save a key.
   const hint = ((): string => {
     switch (true) {
-      case isCli:
+      // Derived, not a provider literal: a CLI with a live catalog (opencode)
+      // falls through to the loading/live branches like an HTTP provider — and
+      // a failed probe falls through so its reason surfaces.
+      case isCli &&
+        catalog?.live !== true &&
+        catalog?.cause !== "failed" &&
+        !availableModels.isPending:
         return "Model passed to the CLI — leave blank for its default";
       case availableModels.isPending:
         return "Loading models…";

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -156,23 +156,24 @@ export type ReviewEvent =
    *  care; reviews ignore it. */
   | { kind: "nativeSession"; id: string };
 
-/** Maps a review provider id to its backend agent kind, or null if not a CLI. */
-export function providerKind(provider: AiProviderId): AgentKind | null {
-  if (provider === "claude-cli") return "claude";
-  if (provider === "codex-cli") return "codex";
-  if (provider === "copilot-cli") return "copilot";
-  if (provider === "opencode-cli") return "opencode";
-  return null;
-}
-
 /** The provider id each agent kind belongs to — a total map, so a new kind can't
- *  silently lose its provider. */
+ *  silently lose its provider. Both directions read it, so the relation has a
+ *  single definition. */
 const KIND_PROVIDERS: Record<AgentKind, AiProviderId> = {
   claude: "claude-cli",
   codex: "codex-cli",
   copilot: "copilot-cli",
   opencode: "opencode-cli",
 };
+
+/** Maps a review provider id to its backend agent kind, or null if not a CLI. */
+export function providerKind(provider: AiProviderId): AgentKind | null {
+  return (
+    (Object.keys(KIND_PROVIDERS) as AgentKind[]).find(
+      (k) => KIND_PROVIDERS[k] === provider,
+    ) ?? null
+  );
+}
 
 /** The inverse of {@link providerKind}: the review provider id an agent kind is
  *  configured under. */

--- a/src/lib/ai/agent.ts
+++ b/src/lib/ai/agent.ts
@@ -165,6 +165,21 @@ export function providerKind(provider: AiProviderId): AgentKind | null {
   return null;
 }
 
+/** The provider id each agent kind belongs to — a total map, so a new kind can't
+ *  silently lose its provider. */
+const KIND_PROVIDERS: Record<AgentKind, AiProviderId> = {
+  claude: "claude-cli",
+  codex: "codex-cli",
+  copilot: "copilot-cli",
+  opencode: "opencode-cli",
+};
+
+/** The inverse of {@link providerKind}: the review provider id an agent kind is
+ *  configured under. */
+export function kindProvider(kind: AgentKind): AiProviderId {
+  return KIND_PROVIDERS[kind];
+}
+
 /** The agent a NEW session, plan, or research run starts on: the explicit
  *  Settings → AI default when set, else the main AI provider when it's an
  *  agent CLI, else Claude — including while settings are still loading. */
@@ -183,6 +198,11 @@ export const detectAgentCli = (kind: AgentKind, path?: string) =>
     kind,
     binPath: path?.trim() || null,
   });
+
+/** The model ids the CLI itself lists, for the model pickers' live catalog.
+ *  Empty for the kinds whose CLI exposes no catalog. */
+export const listAgentModels = (kind: AgentKind, path?: string) =>
+  invoke<string[]>("agent_models", { kind, binPath: path?.trim() || null });
 
 export interface AgentReviewArgs {
   kind: AgentKind;

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { getSecret } from "@/lib/git/api";
+import { type AgentKind, kindProvider, listAgentModels } from "./agent";
 import { guardedFetch } from "./guarded-fetch";
 import { providerErrorMessage } from "./provider-error";
 import {
@@ -36,9 +37,10 @@ export interface AvailableModels {
   reason?: string;
   /** Which fallback route produced these suggestions. The four are not
    *  interchangeable to a user: no key saved yet, no base URL configured, the
-   *  request failed, or the provider listed nothing. A CLI provider has no live
-   *  catalog at all and lands on `empty`, so any consumer branching on `cause`
-   *  must handle the CLI case ahead of it. */
+   *  request failed, or the provider listed nothing. Among the CLI providers only
+   *  opencode has a catalog to list — the others reach `empty` without a request
+   *  having been made, so a consumer branching on `cause` must tell those apart
+   *  from a provider that genuinely listed nothing. */
   cause?: "no-key" | "no-base" | "failed" | "empty";
 }
 
@@ -218,9 +220,10 @@ async function fetchProviderModels(
     case "claude-cli":
     case "codex-cli":
     case "copilot-cli":
-    case "opencode-cli":
       // No live model list; the static MODEL_SUGGESTIONS aliases are used.
       return [];
+    case "opencode-cli":
+      return await listAgentModels("opencode", settings.cliPath);
   }
 }
 
@@ -244,6 +247,7 @@ export function useAvailableModels(
       settings.ollamaBaseUrl,
       settings.openaiCompatibleBaseUrl,
       allowedHosts ?? [],
+      settings.cliPath ?? null,
     ] as const,
     queryFn: async (): Promise<AvailableModels> => {
       try {
@@ -286,5 +290,43 @@ export function useAvailableModels(
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+/**
+ * Live model list for an agent CLI, for the session-side pickers, falling back
+ * to that CLI's static suggestions when it lists nothing or the probe fails.
+ * `opts.enabled` defers the probe until the user shows intent to pick a model.
+ *
+ * Deliberately carries no binary-path axis: sessions have no per-agent path
+ * override (every session start passes `binPath: null`), and the probe must
+ * target the binary the run will actually use.
+ */
+export function useAgentModels(
+  kind: AgentKind,
+  opts?: { enabled?: boolean },
+): UseQueryResult<AvailableModels> {
+  return useQuery({
+    queryKey: ["agent-models", kind] as const,
+    queryFn: async (): Promise<AvailableModels> => {
+      const fallback = MODEL_SUGGESTIONS[kindProvider(kind)];
+      try {
+        const models = await listAgentModels(kind);
+        if (models.length > 0) return { models, live: true };
+        return { models: fallback, live: false, cause: "empty" };
+      } catch (e) {
+        return {
+          models: fallback,
+          live: false,
+          reason: providerErrorMessage(e),
+          cause: "failed",
+        };
+      }
+    },
+    enabled: opts?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+    // A refetch here spawns a process, not an HTTP GET — alt-tabbing back into
+    // the app must not re-run the CLI.
+    refetchOnWindowFocus: false,
   });
 }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -291,9 +291,10 @@ export function useAvailableModels(
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
-    // The CLI arm spawns a process, not an HTTP GET — alt-tabbing back into the
-    // app must not re-run the CLI. HTTP providers keep the default focus refresh.
+    // The CLI arm spawns a process, not an HTTP GET — a focus or reconnect
+    // refetch must not re-run the CLI. HTTP providers keep both defaults.
     refetchOnWindowFocus: !isCliProvider(settings.provider),
+    refetchOnReconnect: !isCliProvider(settings.provider),
   });
 }
 
@@ -333,8 +334,9 @@ export function useAgentModels(
     // SESSION pickers show the CLI's static suggestions — the pre-live
     // behavior. No `cause`: this is not a settled fallback.
     placeholderData: () => ({ models: fallback, live: false }),
-    // A refetch here spawns a process, not an HTTP GET — alt-tabbing back into
-    // the app must not re-run the CLI.
+    // A refetch here spawns a process, not an HTTP GET — a focus or reconnect
+    // refetch must not re-run the CLI.
     refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -325,6 +325,13 @@ export function useAgentModels(
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
+    // Until the probe resolves (and whenever the query is gate-disabled), the
+    // SESSION pickers show the CLI's static suggestions — the pre-live
+    // behavior. No `cause`: this is not a settled fallback.
+    placeholderData: () => ({
+      models: MODEL_SUGGESTIONS[kindProvider(kind)],
+      live: false,
+    }),
     // A refetch here spawns a process, not an HTTP GET — alt-tabbing back into
     // the app must not re-run the CLI.
     refetchOnWindowFocus: false,

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -5,6 +5,7 @@ import { guardedFetch } from "./guarded-fetch";
 import { providerErrorMessage } from "./provider-error";
 import {
   GOOGLE_AI_STUDIO_BASE_URL,
+  isCliProvider,
   MODEL_SUGGESTIONS,
   OLLAMA_CLOUD_HOST,
   OPENAI_COMPATIBLE_PRESETS,
@@ -290,6 +291,9 @@ export function useAvailableModels(
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
+    // The CLI arm spawns a process, not an HTTP GET — alt-tabbing back into the
+    // app must not re-run the CLI. HTTP providers keep the default focus refresh.
+    refetchOnWindowFocus: !isCliProvider(settings.provider),
   });
 }
 
@@ -306,10 +310,10 @@ export function useAgentModels(
   kind: AgentKind,
   opts?: { enabled?: boolean },
 ): UseQueryResult<AvailableModels> {
+  const fallback = MODEL_SUGGESTIONS[kindProvider(kind)];
   return useQuery({
     queryKey: ["agent-models", kind] as const,
     queryFn: async (): Promise<AvailableModels> => {
-      const fallback = MODEL_SUGGESTIONS[kindProvider(kind)];
       try {
         const models = await listAgentModels(kind);
         if (models.length > 0) return { models, live: true };
@@ -328,10 +332,7 @@ export function useAgentModels(
     // Until the probe resolves (and whenever the query is gate-disabled), the
     // SESSION pickers show the CLI's static suggestions — the pre-live
     // behavior. No `cause`: this is not a settled fallback.
-    placeholderData: () => ({
-      models: MODEL_SUGGESTIONS[kindProvider(kind)],
-      live: false,
-    }),
+    placeholderData: () => ({ models: fallback, live: false }),
     // A refetch here spawns a process, not an HTTP GET — alt-tabbing back into
     // the app must not re-run the CLI.
     refetchOnWindowFocus: false,

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -163,24 +163,34 @@ export const MODEL_SUGGESTIONS: Record<AiProviderId, string[]> = {
     "claude-opus-4.7",
     "claude-opus-4.6",
   ],
-  // opencode takes `provider/model`. These hosted models run keyless (no API key,
-  // cost $0) — handy defaults. With a configured provider, type e.g.
-  // `anthropic/claude-sonnet-4-6`; blank = opencode's own default.
+  // opencode takes `provider/model`. The `opencode/…` namespace is its own hosted
+  // catalog — what the CLI lists before any provider key is configured — and it
+  // rotates ids in and out within days, so these are pick-from hints rather than
+  // stable ids (blank = opencode's own default). Captured from `opencode models`
+  // (v1.18.18) on 2026-08-23. With a provider configured, type e.g.
+  // `anthropic/claude-sonnet-4-6`.
   "opencode-cli": [
-    "opencode/north-mini-code-free",
-    "opencode/deepseek-v4-flash-free",
+    "opencode/big-pickle",
+    "opencode/hy3-free",
     "opencode/mimo-v2.5-free",
+    "opencode/muse-spark-1.2-contributor-free",
     "opencode/nemotron-3-ultra-free",
+    "opencode/nemotron-3.5-lightning-free",
+    "opencode/x-preview-f-free",
   ],
 };
 
-/** CLI providers whose suggested model ids are plan-specific rather than
- *  universally valid: codex ids depend on the account's ChatGPT plan, so no
- *  single suggestion is a safe forced default. Switching to one leaves the model
- *  blank — the CLI's own account default, which always works — while the
- *  suggestions stay pick-from hints. (Contrast claude-cli `sonnet` / copilot
- *  `auto`, whose first suggestion is a universally-valid alias.) */
-const PROVIDERS_WITHOUT_DEFAULT_MODEL: readonly AiProviderId[] = ["codex-cli"];
+/** CLI providers whose suggested model ids aren't universally valid, so no single
+ *  suggestion is a safe forced default: codex ids depend on the account's ChatGPT
+ *  plan, and opencode's hosted catalog rotates ids in and out within days.
+ *  Switching to one leaves the model blank — the CLI's own account default, which
+ *  always works — while the suggestions stay pick-from hints. (Contrast claude-cli
+ *  `sonnet` / copilot `auto`, whose first suggestion is a universally-valid
+ *  alias.) */
+const PROVIDERS_WITHOUT_DEFAULT_MODEL: readonly AiProviderId[] = [
+  "codex-cli",
+  "opencode-cli",
+];
 
 /** The model id to pre-select when switching TO a provider with no remembered
  *  choice: its first suggestion, except providers whose suggestions are


### PR DESCRIPTION
opencode's hosted catalog rotates model ids within days, so any hardcoded suggestion list goes stale — and it can't know about a user's configured providers at all. This queries `opencode models` from the CLI and feeds the result into every model picker, falling back to the static suggestions when the probe fails or lists nothing.

### Backend: `agent_models` command

- Adds `agent_models` in `src-tauri/src/agent.rs` — resolves the CLI, runs its catalog argv (`AgentKind::models_args`, `Some(&["models"])` only for opencode), and returns the parsed ids; kinds with no catalog surface answer with an empty list instead of an error so callers can ask unconditionally. Registered in `src-tauri/src/lib.rs`.
- Splits `run_capture` into a new `run_capture_parts`, which keeps stdout and stderr separate (a banner on stderr must not interleave into parsed lines) and accepts `extra_env`; the old `run_capture` is now a thin wrapper that re-concatenates.
- `parse_models_output` keeps only bare `provider/model` lines, dropping banners, warnings, JSON, and ANSI-wrapped ids via whitespace/control-character gates; dedupes to first occurrence, preserves the CLI's own ordering, and caps at `MODELS_LIMIT` (2000).
- Sets `OPENCODE_DISABLE_MODELS_FETCH=1` on opencode invocations in `agent_review` and both the container and host paths of `agent_session`, so app-managed runs stop forking a detached catalog refresh; the cache is refreshed by the `agent_models` probe instead.
- Non-zero exits surface the first non-empty stderr line as the error reason, else a coded fallback message.
- Adds seven unit tests covering a real captured `opencode models` fixture, CRLF endings, a missing trailing newline, noise rejection, empty input, dedupe, and cap truncation.

### Frontend: pickers consume the live catalog

- `ModelPicker` in `src/features/sessions/AgentPickers.tsx` now takes `agent` instead of a pre-computed `models` array and resolves the list itself via the new `useAgentModels`. The probe is gated on user intent (sticky `wanted` set from `onFocus`/`onOpenChange`) *and* on the agent tab being active, since a hidden `<Activity>` subtree still fetches. `ComboboxEmpty` shows "Loading models…" while `isFetching`.
- Adds `useAgentModels` in `src/lib/ai/models.ts`, keyed on kind alone (sessions have no per-agent path override), with `refetchOnWindowFocus: false` because a refetch spawns a process rather than an HTTP GET, and a fallback to that CLI's `MODEL_SUGGESTIONS` on empty or failed probes.
- `fetchProviderModels` now routes `opencode-cli` to `listAgentModels`, and `useAvailableModels`'s query key gains a `settings.cliPath` axis.
- Adds `listAgentModels` and a `kindProvider` inverse map in `src/lib/ai/agent.ts`.
- Drops the exported `modelsForAgent` helper; call sites updated in `PlanView.tsx`, `ImplementPlanButton.tsx`, `ResearchView.tsx`, `EnsembleRunDialog.tsx`, and `SessionComposer.tsx`.
- `AiProviderSection.tsx`'s hint is now derived rather than keyed on `isCli`, so opencode falls through to the loading/live/failed branches like an HTTP provider and a probe failure surfaces its reason.

### Suggestions & docs

- Refreshes the `opencode-cli` entries in `src/lib/ai/providers.ts` against `opencode models` (v1.18.18) and adds `opencode-cli` to `PROVIDERS_WITHOUT_DEFAULT_MODEL`, since its rotating hosted ids make no single suggestion a safe forced default.
- Updates the model-picker line in `README.md`, the agent capability label in `site/src/data/capabilities.ts`, the sessions guide section in `src/features/help/content.ts`, and adds `changelog.d/added-opencode-live-models.md`.

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model pickers now load the live opencode catalog, including custom providers and provider-qualified models.
  * Users can enter custom model IDs or leave the model blank to use their account default.
  * Catalogs load on demand with loading and error feedback.
  * Session, Settings → AI, and PR review pickers now share the expanded catalog.

* **Documentation**
  * Updated AI generation documentation and capability descriptions to reflect live model discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->