### PR TITLE
perf(forge,repository): gate Fork on namespaces without listing repos

### DIFF
--- a/changelog.d/changed-bitbucket-fork-gate-light.md
+++ b/changelog.d/changed-bitbucket-fork-gate-light.md
@@ -1,0 +1,3 @@
+- Opening a Bitbucket repository is lighter on the Bitbucket API: deciding whether
+  to offer **Fork** now reads only your workspace list, instead of every repository
+  in every workspace you belong to.

--- a/changelog.d/changed-bitbucket-fork-gate-light.md
+++ b/changelog.d/changed-bitbucket-fork-gate-light.md
@@ -1,3 +1,3 @@
 - Opening a Bitbucket repository is lighter on the Bitbucket API: deciding whether
-  to offer **Fork** now reads only your workspace list, instead of every repository
-  in every workspace you belong to.
+  to offer **Fork** now reads only your workspace list, instead of listing
+  repositories from every workspace you belong to.

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -519,9 +519,8 @@ fn best_effort_page_step<T>(
 /// does (Explore search pages through it), but inline rather than via `bb_paginate` so a
 /// later page's failure degrades instead of sinking the read: a short workspace list
 /// drops a member workspace from `owned_namespaces`, and the Fork gate then fails open
-/// on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of
-/// more workspaces than those pages hold silently loses the excess. Empty/absent slugs
-/// are skipped.
+/// on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of more workspaces than
+/// those pages hold silently loses the excess. Empty/absent slugs are skipped.
 async fn workspace_slugs(creds: &BbCredentials) -> AppResult<Vec<String>> {
     let mut accesses: Vec<BbWorkspaceAccess> = Vec::new();
     let mut ws_url = "user/workspaces?pagelen=100".to_string();

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -519,7 +519,8 @@ fn best_effort_page_step<T>(
 /// through `bb_paginate`, matching `workspaces()` (which Explore search pages through):
 /// a short workspace list drops a member workspace from `owned_namespaces`, and the Fork
 /// gate then fails open on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of
-/// more workspaces than that silently loses the excess. Empty/absent slugs are skipped.
+/// more workspaces than those pages hold silently loses the excess. Empty/absent slugs
+/// are skipped.
 async fn workspace_slugs(creds: &BbCredentials) -> AppResult<Vec<String>> {
     let mut accesses: Vec<BbWorkspaceAccess> = Vec::new();
     let mut ws_url = "user/workspaces?pagelen=100".to_string();

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -514,14 +514,42 @@ fn best_effort_page_step<T>(
     }
 }
 
+/// The slugs of the workspaces the viewer belongs to (`GET /2.0/user/workspaces`, whose
+/// items are `workspace_access` membership wrappers). Follows `next` inline rather than
+/// through `bb_paginate`, matching `workspaces()` (which Explore search pages through):
+/// a short workspace list drops a member workspace from `owned_namespaces`, and the Fork
+/// gate then fails open on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of
+/// more workspaces than that silently loses the excess. Empty/absent slugs are skipped.
+async fn workspace_slugs(creds: &BbCredentials) -> AppResult<Vec<String>> {
+    let mut accesses: Vec<BbWorkspaceAccess> = Vec::new();
+    let mut ws_url = "user/workspaces?pagelen=100".to_string();
+    for page in 0..BB_MAX_PAGES {
+        let fetched =
+            http::bb_get_json::<BbPage<BbWorkspaceAccess>>(creds, &ws_url, "workspaces").await;
+        match best_effort_page_step(fetched, &mut accesses, page == 0)? {
+            Some(next) => ws_url = next,
+            None => break,
+        }
+    }
+    Ok(accesses
+        .into_iter()
+        .filter_map(|a| a.workspace.map(|w| w.slug).filter(|s| !s.is_empty()))
+        .collect())
+}
+
+/// The viewer's owned namespaces for the Fork gate — the workspace slugs alone, with
+/// none of `list_repos`' per-workspace repo pages. No `/user` probe either: Bitbucket's
+/// namespace set never includes the viewer's username, only workspaces they belong to.
+pub async fn owned_namespaces() -> AppResult<Vec<String>> {
+    let creds = http::load_credentials().await?;
+    Ok(namespace_set(workspace_slugs(&creds).await?))
+}
+
 /// The signed-in user's repositories, for the clone browser. Both `GET
 /// /2.0/repositories?role=member` AND `GET /2.0/workspaces` were removed (CHANGE-2770,
-/// Feb 2026); the replacement is `GET /2.0/user/workspaces` (CHANGE-3022), whose items
-/// are `workspace_access` membership wrappers (nested `workspace_base` with
-/// uuid/slug/links — no `name`). We follow `next` over the viewer's workspaces up to 5
-/// pages (best-effort past the first), then read each workspace's member repos as a
-/// single page at the max `pagelen` (100), sorted `-updated_on`, so repos past
-/// 100/workspace drop off.
+/// Feb 2026); the replacement is `GET /2.0/user/workspaces` (CHANGE-3022). We walk the
+/// viewer's workspaces, then read each one's member repos as a single page at the max
+/// `pagelen` (100), sorted `-updated_on`, so repos past 100/workspace drop off.
 pub async fn list_repos() -> AppResult<ForgeRepoList> {
     let creds = http::load_credentials().await?;
     let viewer = http::bb_get_json::<BbUser>(&creds, "user", "user")
@@ -530,45 +558,24 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         .and_then(|u| u.username.or(u.display_name))
         .unwrap_or_default();
 
-    // Follow `next` here, matching `workspaces()` (which Explore search pages through):
-    // a short workspace list would leave a member workspace out of `owned_namespaces`,
-    // and the Fork gate would then fail open on a search row from that workspace. Walked
-    // inline rather than through `bb_paginate` so a later page's failure degrades the way
-    // the per-workspace loop below does, instead of sinking the whole read.
-    let mut workspaces: Vec<BbWorkspaceAccess> = Vec::new();
-    let mut ws_url = "user/workspaces?pagelen=100".to_string();
-    for page in 0..BB_MAX_PAGES {
-        let fetched = http::bb_get_json::<BbPage<BbWorkspaceAccess>>(&creds, &ws_url, "workspaces")
-            .await;
-        match best_effort_page_step(fetched, &mut workspaces, page == 0)? {
-            Some(next) => ws_url = next,
-            None => break,
-        }
-    }
-
-    let mut repos = Vec::new();
     // Bitbucket has no usable personal-workspace signal (`is_personal` reads false even
     // on it, and the user uuid 404s as a workspace), so "yours" here means a workspace
     // you belong to — these same slugs, which `owner` already carries.
-    let mut slugs = Vec::new();
+    let slugs = workspace_slugs(&creds).await?;
+
+    let mut repos = Vec::new();
     // Best-effort per workspace (one erroring shouldn't sink the others), but if EVERY
     // fetch fails, surface the last error rather than an empty "no repositories" list.
-    let mut workspace_count = 0usize;
+    // Membership, not fetch success, decides the namespace: a workspace you belong to
+    // stays yours even if its repo page errors, and its repos can still reach the gate
+    // via Explore search.
     let mut any_ok = false;
     let mut last_err: Option<AppError> = None;
-    for access in workspaces {
-        // Skip an entry with no nested workspace or an empty slug rather than error.
-        let Some(slug) = access.workspace.map(|w| w.slug).filter(|s| !s.is_empty()) else {
-            continue;
-        };
-        workspace_count += 1;
+    for slug in &slugs {
         let path = format!(
             "repositories/{}?role=member&sort=-updated_on&pagelen=100",
-            encode_query_value(&slug)
+            encode_query_value(slug)
         );
-        // Membership, not fetch success: a workspace you belong to stays yours even if
-        // its repo page errors, and its repos can still reach the gate via Explore search.
-        slugs.push(slug);
         match http::bb_get_json::<BbPage<BbRepo>>(&creds, &path, "repositories").await {
             Ok(page) => {
                 any_ok = true;
@@ -577,7 +584,7 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
             Err(e) => last_err = Some(e),
         }
     }
-    if workspace_count > 0 && !any_ok {
+    if !slugs.is_empty() && !any_ok {
         // Every workspace fetch failed — return the last error, not an empty Ok.
         return Err(last_err.unwrap_or_else(|| {
             AppError::Bitbucket("could not list Bitbucket repositories".into())

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -515,10 +515,11 @@ fn best_effort_page_step<T>(
 }
 
 /// The slugs of the workspaces the viewer belongs to (`GET /2.0/user/workspaces`, whose
-/// items are `workspace_access` membership wrappers). Follows `next` inline rather than
-/// through `bb_paginate`, matching `workspaces()` (which Explore search pages through):
-/// a short workspace list drops a member workspace from `owned_namespaces`, and the Fork
-/// gate then fails open on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of
+/// items are `workspace_access` membership wrappers). Follows `next` like `workspaces()`
+/// does (Explore search pages through it), but inline rather than via `bb_paginate` so a
+/// later page's failure degrades instead of sinking the read: a short workspace list
+/// drops a member workspace from `owned_namespaces`, and the Fork gate then fails open
+/// on its repos. Bounded at [`BB_MAX_PAGES`] pages, so a member of
 /// more workspaces than those pages hold silently loses the excess. Empty/absent slugs
 /// are skipped.
 async fn workspace_slugs(creds: &BbCredentials) -> AppResult<Vec<String>> {

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -14,7 +14,7 @@ use crate::forge::model::{
 use crate::forge::{
     validate_owner, validate_repo_name, Forge, FORK_POLL_ATTEMPTS, FORK_POLL_DELAY,
 };
-use crate::github::pr::{gh_list_repos, gh_status, GhRepo, GhStatus};
+use crate::github::pr::{gh_list_repos, gh_status, gh_viewer_login, GhRepo, GhStatus};
 use crate::github::runner::{run_gh, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
 
 /// GitHub via the `gh` CLI. Unit struct — `gh` carries all the state (auth, host).
@@ -77,6 +77,15 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         viewer: gh.viewer,
         repos: gh.repos.into_iter().map(from_gh_repo).collect(),
     })
+}
+
+/// The viewer's owned namespaces for the Fork gate, without `list_repos`' repo page.
+/// Shares [`gh_viewer_login`] with it, so a failed viewer read errors here exactly as
+/// it does there.
+pub async fn owned_namespaces() -> AppResult<Vec<String>> {
+    // A GitHub login IS its personal namespace, so the viewer is the whole set;
+    // org repos stay forkable.
+    Ok(namespace_set([gh_viewer_login().await?]))
 }
 
 // ── Pull requests ────────────────────────────────────────────────────────────
@@ -1032,11 +1041,7 @@ pub async fn fork_repo(owner: &str, name: &str) -> AppResult<ForgeForkResult> {
     let source = format!("{owner}/{name}");
     run_gh(None, &fork_args(&source), GH_NETWORK_TIMEOUT).await?;
     // The fork owner is the signed-in user.
-    let login = run_gh(None, &["api", "user", "-q", ".login"], GH_TIMEOUT)
-        .await?
-        .stdout_lossy()
-        .trim()
-        .to_string();
+    let login = gh_viewer_login().await?;
     if login.is_empty() {
         return Err(AppError::Gh("could not resolve your GitHub login".into()));
     }

--- a/src-tauri/src/forge/github.rs
+++ b/src-tauri/src/forge/github.rs
@@ -79,9 +79,11 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
     })
 }
 
-/// The viewer's owned namespaces for the Fork gate, without `list_repos`' repo page.
-/// Shares [`gh_viewer_login`] with it, so a failed viewer read errors here exactly as
-/// it does there.
+/// The viewer's owned namespaces, without `list_repos`' repo page. Shares
+/// [`gh_viewer_login`] with it, so a failed viewer read errors here exactly as it does
+/// there. Ambient identity (default host): the GitHub Fork gate itself reads
+/// `gh_status`'s host-scoped login, so this arm is not a drop-in for it on
+/// multi-account or Enterprise setups.
 pub async fn owned_namespaces() -> AppResult<Vec<String>> {
     // A GitHub login IS its personal namespace, so the viewer is the whole set;
     // org repos stay forkable.

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -140,17 +140,24 @@ fn from_glab_project(p: GlabProject) -> ForgeRepo {
     }
 }
 
+/// The signed-in user's username, on the short timeout. The one source of this probe:
+/// the project list and the owned-namespace read must resolve the viewer identically,
+/// or their namespace answers drift. An unresolved probe answers empty (fail-open).
+async fn viewer_username() -> String {
+    run_glab(None, &["api", "user"], GLAB_TIMEOUT)
+        .await
+        .ok()
+        .and_then(|o| serde_json::from_str::<GlabUser>(&o.stdout_lossy()).ok())
+        .map(|u| u.username)
+        .unwrap_or_default()
+}
+
 /// The signed-in GitLab user's projects, for the clone browser, via the `glab api`
 /// REST escape hatch; `membership=true` = projects the user belongs to. Caps at 100
 /// (`--paginate`'s multi-page output needs its own validation); ordering by activity
 /// means the cap drops the least-recently-active projects, not an arbitrary 100.
 pub async fn list_repos() -> AppResult<ForgeRepoList> {
-    let viewer = run_glab(None, &["api", "user"], GLAB_TIMEOUT)
-        .await
-        .ok()
-        .and_then(|o| serde_json::from_str::<GlabUser>(&o.stdout_lossy()).ok())
-        .map(|u| u.username)
-        .unwrap_or_default();
+    let viewer = viewer_username().await;
     let out = run_glab(
         None,
         &[
@@ -169,6 +176,15 @@ pub async fn list_repos() -> AppResult<ForgeRepoList> {
         viewer,
         repos: projects.into_iter().map(from_glab_project).collect(),
     })
+}
+
+/// The viewer's owned namespaces for the Fork gate, without `list_repos`' projects
+/// read. Shares [`viewer_username`] with it, including its fail-open: an unresolved
+/// viewer yields an empty set rather than an error, so Fork stays offered.
+pub async fn owned_namespaces() -> AppResult<Vec<String>> {
+    // A GitLab username IS the personal namespace's full path. Groups you own are a
+    // separate namespace and aren't resolved here, so Fork still shows on those.
+    Ok(namespace_set([viewer_username().await]))
 }
 
 /// The one-shot `git -c` credential entries that let a network op on a private

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -140,9 +140,10 @@ fn from_glab_project(p: GlabProject) -> ForgeRepo {
     }
 }
 
-/// The signed-in user's username, on the short timeout. The one source of this probe:
-/// the project list and the owned-namespace read must resolve the viewer identically,
-/// or their namespace answers drift. An unresolved probe answers empty (fail-open).
+/// The signed-in user's username, on the short timeout. The one source of the ambient
+/// (default-host) probe: the project list and the owned-namespace read must resolve
+/// the viewer identically, or their namespace answers drift. An unresolved probe
+/// answers empty (fail-open).
 async fn viewer_username() -> String {
     run_glab(None, &["api", "user"], GLAB_TIMEOUT)
         .await

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -903,6 +903,21 @@ pub async fn forge_list_repos(provider: Provider) -> AppResult<ForgeRepoList> {
     }
 }
 
+/// The namespaces the signed-in user owns on a provider — the Fork gate's whole input,
+/// without the repository list [`forge_list_repos`] fetches to reach it (on Bitbucket
+/// that means skipping a repo request per workspace). Parity invariant: per provider
+/// this returns the same set as that command's `owned_namespaces` whenever that command
+/// resolves (this one can still resolve where failing repo pages made that one error),
+/// so switching source never changes a verdict the heavier read could deliver.
+#[tauri::command]
+pub async fn forge_owned_namespaces(provider: Provider) -> AppResult<Vec<String>> {
+    match provider {
+        Provider::GitHub => github::owned_namespaces().await,
+        Provider::GitLab => gitlab::owned_namespaces().await,
+        Provider::Bitbucket => bitbucket::owned_namespaces().await,
+    }
+}
+
 // ── Explore: repo search / fork-by-name / star / README / provider features ────
 // Account-scoped (no repo path) — Explore browses arbitrary repos across a provider,
 // so each command dispatches on an explicit `provider` argument. The frontend

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -903,12 +903,12 @@ pub async fn forge_list_repos(provider: Provider) -> AppResult<ForgeRepoList> {
     }
 }
 
-/// The namespaces the signed-in user owns on a provider — the Fork gate's whole input,
-/// without the repository list [`forge_list_repos`] fetches to reach it (on Bitbucket
-/// that means skipping a repo request per workspace). Parity invariant: per provider
-/// this returns the same set as that command's `owned_namespaces` whenever that command
-/// resolves (this one can still resolve where failing repo pages made that one error),
-/// so switching source never changes a verdict the heavier read could deliver.
+/// The namespaces the signed-in user owns on a provider — the only remote read the
+/// Bitbucket Fork gate needs, without the repository list [`forge_list_repos`] fetches
+/// to reach it (skipping a repo request per workspace). Each arm derives the set from
+/// the same probe as that command's `owned_namespaces`, so independent calls agree
+/// whenever their probes do — and a probe failure degrades exactly as it does there
+/// (GitHub errors; GitLab, and Bitbucket pages past the first, drop to fail-open).
 #[tauri::command]
 pub async fn forge_owned_namespaces(provider: Provider) -> AppResult<Vec<String>> {
     match provider {

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -152,9 +152,10 @@ pub struct GhRepoList {
     pub repos: Vec<GhRepo>,
 }
 
-/// The signed-in user's login. The one source of this probe: the repo list and the
-/// forge layer's owned-namespace read must resolve the viewer identically, or their
-/// namespace answers drift. Errors when `gh` can't answer — callers decide the fallout.
+/// The signed-in user's login. The one source of the ambient (default-host) probe: the
+/// repo list and the forge layer's owned-namespace read must resolve the viewer
+/// identically, or their namespace answers drift. Errors when `gh` can't answer; an
+/// empty-but-successful answer passes through — callers decide the fallout.
 pub async fn gh_viewer_login() -> AppResult<String> {
     Ok(run_gh(None, &["api", "user", "-q", ".login"], GH_TIMEOUT)
         .await?

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -152,6 +152,17 @@ pub struct GhRepoList {
     pub repos: Vec<GhRepo>,
 }
 
+/// The signed-in user's login. The one source of this probe: the repo list and the
+/// forge layer's owned-namespace read must resolve the viewer identically, or their
+/// namespace answers drift. Errors when `gh` can't answer — callers decide the fallout.
+pub async fn gh_viewer_login() -> AppResult<String> {
+    Ok(run_gh(None, &["api", "user", "-q", ".login"], GH_TIMEOUT)
+        .await?
+        .stdout_lossy()
+        .trim()
+        .to_string())
+}
+
 /// Every repository the signed-in user can access (owned, collaborator, and
 /// org member), newest-push first, plus the viewer's login. Used by the
 /// clone dialog's GitHub.com tab. `--paginate` merges all pages into one
@@ -159,11 +170,7 @@ pub struct GhRepoList {
 #[tauri::command]
 pub async fn gh_list_repos() -> AppResult<GhRepoList> {
     // The viewer's login is cheap and lets the UI group their repos first.
-    let viewer = run_gh(None, &["api", "user", "-q", ".login"], GH_TIMEOUT)
-        .await?
-        .stdout_lossy()
-        .trim()
-        .to_string();
+    let viewer = gh_viewer_login().await?;
 
     let out = run_gh(
         None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -325,6 +325,7 @@ pub fn run() {
             forge::jira_worklog_update,
             forge::jira_worklog_delete,
             forge::forge_list_repos,
+            forge::forge_owned_namespaces,
             forge::forge_clone,
             forge::forge_search_repos,
             forge::forge_fork_repo,

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -193,8 +193,9 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // repositories. Fetched for every Bitbucket repo rather than on menu-open, because
   // the palette twin below reads the verdict with no menu to trigger one. Unresolved
   // (empty) falls open.
-  const ownedNs = useForgeOwnedNamespaces("bitbucket", canGh && isBitbucket);
-  const ownedNamespaces = ownedNs.data ?? EMPTY_NAMESPACES;
+  const ownedNamespaces =
+    useForgeOwnedNamespaces("bitbucket", canGh && isBitbucket).data ??
+    EMPTY_NAMESPACES;
   // GitHub: the in-app dialog always forks under your own account, so a repo you own
   // personally is never a target (org repos stay forkable). GitLab: its fork page picks
   // the destination namespace, and forking your own project into a group you own is

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -63,7 +63,7 @@ import {
   EMPTY_NAMESPACES,
   forgeFeatureReady,
   forgeSupports,
-  useForgeRepos,
+  useForgeOwnedNamespaces,
   useForgeStatus,
   useForkRepo,
   useRepoAdmin,
@@ -189,11 +189,12 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const ownRepo = !!owner && !!gh.data?.login && owner === gh.data.login;
   // Bitbucket's `login` is a /user username (a display name where that's absent) and
   // never matches the workspace slug a repo carries, so its ownership answer can only
-  // come from the workspaces you belong to. Fetched for every Bitbucket repo rather
-  // than on menu-open, because the palette twin below reads the verdict with no menu
-  // to trigger one. Unresolved (empty) falls open.
-  const ownRepos = useForgeRepos("bitbucket", canGh && isBitbucket);
-  const ownedNamespaces = ownRepos.data?.ownedNamespaces ?? EMPTY_NAMESPACES;
+  // come from the workspaces you belong to — read here as the namespaces alone, no
+  // repositories. Fetched for every Bitbucket repo rather than on menu-open, because
+  // the palette twin below reads the verdict with no menu to trigger one. Unresolved
+  // (empty) falls open.
+  const ownedNs = useForgeOwnedNamespaces("bitbucket", canGh && isBitbucket);
+  const ownedNamespaces = ownedNs.data ?? EMPTY_NAMESPACES;
   // GitHub: the in-app dialog always forks under your own account, so a repo you own
   // personally is never a target (org repos stay forkable). GitLab: its fork page picks
   // the destination namespace, and forking your own project into a group you own is

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1300,8 +1300,9 @@ export const forgeStatus = (repoPath: string) =>
 export const forgeListRepos = (provider: ForgeProvider) =>
   invoke<ForgeRepoList>("forge_list_repos", { provider });
 
-/** The namespaces the signed-in user owns on a provider — the same set
- *  `forgeListRepos` carries, without the repository list. */
+/** The namespaces the signed-in user owns on a provider — derived from the
+ *  same probes as `forgeListRepos`' `ownedNamespaces`, without the repository
+ *  list. */
 export const forgeOwnedNamespaces = (provider: ForgeProvider) =>
   invoke<string[]>("forge_owned_namespaces", { provider });
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1300,6 +1300,11 @@ export const forgeStatus = (repoPath: string) =>
 export const forgeListRepos = (provider: ForgeProvider) =>
   invoke<ForgeRepoList>("forge_list_repos", { provider });
 
+/** The namespaces the signed-in user owns on a provider — the same set
+ *  `forgeListRepos` carries, without the repository list. */
+export const forgeOwnedNamespaces = (provider: ForgeProvider) =>
+  invoke<string[]>("forge_owned_namespaces", { provider });
+
 // ── Explore: search / browse / fork / star / README ──────────────────────────
 //
 // The Explore surface searches and browses repositories on a provider. An empty

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3022,10 +3022,11 @@ export function useForgeRepos(provider: ForgeProvider, enabled: boolean) {
 }
 
 /** The namespaces the signed-in user owns on a provider, feeding the repo menu's
- *  Fork gate. Not {@link useForgeRepos}: its Bitbucket arm walks every workspace's
- *  repositories to reach the same set, and the gate needs no repository. The key
- *  carries no host/account axis, same as `["forge-repos", provider]` — one ambient
- *  account per provider today, and the self-managed-forge work owns adding it. */
+ *  Fork gate. Not {@link useForgeRepos}: its Bitbucket arm lists repositories
+ *  from every workspace to reach the same set, and the gate needs no repository.
+ *  The key carries no host/account axis, same as `["forge-repos", provider]` —
+ *  one ambient account per provider today, and the self-managed-forge work owns
+ *  adding it. */
 export function useForgeOwnedNamespaces(
   provider: ForgeProvider,
   enabled: boolean,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3008,9 +3008,10 @@ export function useGhRepos(enabled: boolean) {
 export const EMPTY_NAMESPACES: readonly string[] = [];
 
 /** The signed-in user's repositories on a provider (GitHub via gh, GitLab via
- *  glab), for the clone browser — and its `ownedNamespaces` feeds the repo
- *  menu's Fork gate. The provider-neutral successor to {@link useGhRepos} on
- *  that surface. */
+ *  glab), for the clone browser — and its `ownedNamespaces` feeds Explore's
+ *  yours-first grouping and its detail pane's Fork gate. (The repo menu's Fork
+ *  gate reads {@link useForgeOwnedNamespaces} instead.) The provider-neutral
+ *  successor to {@link useGhRepos} on that surface. */
 export function useForgeRepos(provider: ForgeProvider, enabled: boolean) {
   return useQuery({
     queryKey: ["forge-repos", provider] as const,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3032,7 +3032,7 @@ export function useForgeOwnedNamespaces(
   enabled: boolean,
 ) {
   return useQuery({
-    queryKey: ["forge-namespaces", provider] as const,
+    queryKey: ["forge-owned-namespaces", provider] as const,
     queryFn: () => api.forgeOwnedNamespaces(provider),
     enabled,
     staleTime: 5 * 60_000,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3002,8 +3002,9 @@ export function useGhRepos(enabled: boolean) {
   });
 }
 
-/** Stable fallback for an unresolved {@link useForgeRepos} read, so a pending
- *  query doesn't hand its consumers a fresh array identity every render. */
+/** Stable fallback for an unresolved {@link useForgeRepos} or
+ *  {@link useForgeOwnedNamespaces} read, so a pending query doesn't hand its
+ *  consumers a fresh array identity every render. */
 export const EMPTY_NAMESPACES: readonly string[] = [];
 
 /** The signed-in user's repositories on a provider (GitHub via gh, GitLab via
@@ -3014,6 +3015,24 @@ export function useForgeRepos(provider: ForgeProvider, enabled: boolean) {
   return useQuery({
     queryKey: ["forge-repos", provider] as const,
     queryFn: () => api.forgeListRepos(provider),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+/** The namespaces the signed-in user owns on a provider, feeding the repo menu's
+ *  Fork gate. Not {@link useForgeRepos}: its Bitbucket arm walks every workspace's
+ *  repositories to reach the same set, and the gate needs no repository. The key
+ *  carries no host/account axis, same as `["forge-repos", provider]` — one ambient
+ *  account per provider today, and the self-managed-forge work owns adding it. */
+export function useForgeOwnedNamespaces(
+  provider: ForgeProvider,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["forge-namespaces", provider] as const,
+    queryFn: () => api.forgeOwnedNamespaces(provider),
     enabled,
     staleTime: 5 * 60_000,
     retry: false,


### PR DESCRIPTION
The repository menu's Fork gate only needs to know which namespaces you own, but on Bitbucket it was reaching that answer through `useForgeRepos` — a full repository listing that fetches a page of repos for every workspace you belong to. This adds a dedicated `forge_owned_namespaces` command that returns just the namespace set, so opening a Bitbucket repo no longer costs one repo request per workspace.

### Backend: new `forge_owned_namespaces` command

- Adds the `forge_owned_namespaces` Tauri command in `src-tauri/src/forge/mod.rs`, dispatching per provider, and registers it in `src-tauri/src/lib.rs`. Its doc comment states the parity invariant: it returns the same set as `forge_list_repos`' `ownedNamespaces` whenever that command resolves, so switching source can't change a verdict.
- Bitbucket (`src-tauri/src/forge/bitbucket.rs`): extracts the paginated `GET /2.0/user/workspaces` walk into a shared `workspace_slugs` helper and builds `owned_namespaces` from it alone, with no per-workspace repo pages and no `/user` probe. `list_repos` now consumes the same helper; its `workspace_count` counter is replaced by `slugs.is_empty()` for the all-fetches-failed guard, and the membership-not-fetch-success rationale moves onto the loop.
- GitHub (`src-tauri/src/forge/github.rs`, `src-tauri/src/github/pr.rs`): hoists the `gh api user -q .login` probe into `gh_viewer_login` in `pr.rs`, now shared by `gh_list_repos`, `fork_repo`, and the new `owned_namespaces` — one viewer resolution so namespace answers can't drift.
- GitLab (`src-tauri/src/forge/gitlab.rs`): extracts `viewer_username` from `list_repos` and builds `owned_namespaces` from it, preserving the fail-open behavior (an unresolved viewer yields an empty set rather than an error, so Fork stays offered).

### Frontend wiring

- Adds `forgeOwnedNamespaces` in `src/lib/git/api.ts` and the `useForgeOwnedNamespaces` hook in `src/lib/git/queries.ts`, keyed `["forge-namespaces", provider]` with the same 5-minute `staleTime` / `retry: false` posture as `useForgeRepos`. The `EMPTY_NAMESPACES` doc comment now covers both readers.
- Switches `src/features/repository/RepositoryMenu.tsx` from `useForgeRepos("bitbucket", …)` to the new hook and updates the surrounding comment; the unresolved-falls-open behavior is unchanged.

### Changelog

- `changelog.d/changed-bitbucket-fork-gate-light.md` records the lighter Bitbucket API usage when opening a repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fork availability checks across GitHub, GitLab, and Bitbucket.
  * Bitbucket now checks workspace membership directly instead of scanning repositories, improving reliability and reducing unnecessary loading.
  * Fork eligibility more accurately recognizes repositories owned by the signed-in user.
  * Added consistent handling for personal namespaces across supported Git providers.
  * Improved behavior when workspace information is partially unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->