### PR TITLE
fix(ai,sessions,editor): pin opencode run directory, spawn .cmd shims directly

### DIFF
--- a/changelog.d/fixed-editor-shim-path-handling.md
+++ b/changelog.d/fixed-editor-shim-path-handling.md
@@ -1,0 +1,3 @@
+- Opening a file in an editor configured as a `.cmd`/`.bat` shim (VS Code's
+  `code.cmd`, for example) now passes the file path to the editor exactly as
+  written, whatever characters the file name contains.

--- a/changelog.d/fixed-opencode-session-dir.md
+++ b/changelog.d/fixed-opencode-session-dir.md
@@ -1,4 +1,4 @@
 - opencode agent sessions and reviews now run in the directory the app gives
   them. When GitDesktop was started from a shell that exports `PWD` (Git Bash,
-  for example), opencode read that path instead and could work in a previously
-  used repository rather than the session's isolated worktree.
+  for example), opencode read that path instead and could work in whatever
+  directory that shell was in rather than the session's isolated worktree.

--- a/changelog.d/fixed-opencode-session-dir.md
+++ b/changelog.d/fixed-opencode-session-dir.md
@@ -1,0 +1,4 @@
+- opencode agent sessions and reviews now run in the directory the app gives
+  them. When GitDesktop was started from a shell that exports `PWD` (Git Bash,
+  for example), opencode read that path instead and could work in a previously
+  used repository rather than the session's isolated worktree.

--- a/changelog.d/fixed-opencode-session-dir.md
+++ b/changelog.d/fixed-opencode-session-dir.md
@@ -1,4 +1,3 @@
-- opencode agent sessions and reviews now run in the directory the app gives
-  them. When GitDesktop was started from a shell that exports `PWD` (Git Bash,
-  for example), opencode read that path instead and could work in whatever
-  directory that shell was in rather than the session's isolated worktree.
+- opencode agent sessions and reviews now always run in the directory the app
+  assigns them (a session's isolated worktree, a review's repository), even when
+  GitDesktop is launched from a shell such as Git Bash that exports `PWD`.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1060,6 +1060,17 @@ fn codex_session_args(
     args
 }
 
+/// The session's worktree as the CLI will see it FOR THIS RUN: `/workspace` in a
+/// container (the bind-mount target — the host path names nothing inside), the real
+/// host path otherwise.
+fn run_dir(container: bool, worktree_path: &str) -> &str {
+    if container {
+        "/workspace"
+    } else {
+        worktree_path
+    }
+}
+
 /// GitHub Copilot CLI write-capable *session* invocation. Unlike Claude/Codex
 /// the prompt is an **argument** (`-p <text>`), not stdin, so the caller passes
 /// it here and feeds empty stdin.
@@ -1235,9 +1246,8 @@ fn copilot_review_args(
 /// a permission hang; the worktree's git isolation is the hard guarantee.
 /// opencode generates its OWN `sessionID` (no flag to set it), so turn 1 omits
 /// `--session`, we capture the id from the stream, and resume passes it back —
-/// the host-Codex thread-id dance, because host sessions share one opencode home
-/// (`~/.local/share/opencode`), so an implicit "continue last" could grab a
-/// concurrent session.
+/// the host-Codex thread-id dance. Naming the id resumes exactly the conversation
+/// we started, rather than whichever one opencode considers most recent.
 fn opencode_session_args(
     model: &str,
     session_id: &str,
@@ -1248,12 +1258,10 @@ fn opencode_session_args(
     // builtin `plan` — `plan` has NO web tools and opencode has no permission CLI
     // flags, so the agent is defined in `OPENCODE_CONFIG` (see mcp.rs).
     web: bool,
-    // The directory the turn must run in, as the path exists FOR THIS RUN.
     dir: &str,
 ) -> Vec<String> {
-    // opencode resolves its working root from `PWD` before the real cwd, so a stale
-    // inherited `PWD` would run the turn in another repo. `--dir` bypasses that and is
-    // stamped into the persisted session row, so resumes stay pinned too.
+    // `--dir` pins opencode's run root (it resolves `PWD` before cwd) and is stamped
+    // into the persisted session row, so resumes stay pinned too.
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -1298,8 +1306,7 @@ fn opencode_session_args(
 /// `--dangerously-skip-permissions` only auto-approves those reads. Diff-only
 /// invokes no tools at all.
 fn opencode_review_args(model: &str, repo_aware: bool, effort: &str, dir: &str) -> Vec<String> {
-    // opencode resolves its working root from `PWD` before the real cwd, so without
-    // `--dir` an inherited `PWD` would point the review at a different repository.
+    // `--dir` pins opencode's run root (it resolves `PWD` before cwd).
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -2598,14 +2605,7 @@ pub async fn agent_session(
             } else {
                 format!("{system_prompt}\n\n{user_prompt}")
             };
-            // `--add-dir` must name the path as it exists FOR THIS RUN: `/workspace` in
-            // a container, the real host path otherwise — the host path names nothing
-            // inside.
-            let add_dir = if container {
-                "/workspace"
-            } else {
-                worktree_path.as_str()
-            };
+            let add_dir = run_dir(container, &worktree_path);
             (
                 copilot_session_args(
                     &model,
@@ -2632,14 +2632,7 @@ pub async fn agent_session(
             } else {
                 format!("{system_prompt}\n\n{user_prompt}")
             };
-            // `--dir` must name the path as it exists FOR THIS RUN: `/workspace` in a
-            // container, the real host path otherwise — the host path names nothing
-            // inside.
-            let dir = if container {
-                "/workspace"
-            } else {
-                worktree_path.as_str()
-            };
+            let dir = run_dir(container, &worktree_path);
             (
                 opencode_session_args(
                     &model,
@@ -2885,7 +2878,7 @@ mod child_env_tests {
     }
 
     #[test]
-    fn every_child_loses_an_inherited_pwd() {
+    fn sanitize_child_env_drops_an_inherited_pwd() {
         let mut env = RecordingEnv::default();
         sanitize_child_env(&mut env);
         assert!(
@@ -4037,6 +4030,14 @@ opencode/x-preview-f-free
     }
 
     // --- opencode run directory ----------------------------------------------
+
+    #[test]
+    fn run_dir_is_the_mount_point_in_a_container_and_the_host_path_otherwise() {
+        // Both call sites (Copilot `--add-dir`, opencode `--dir`) hand the CLI a path
+        // it can actually resolve, so the container arm must not leak the host path.
+        assert_eq!(run_dir(true, "C:/wt/gd-session-1"), "/workspace");
+        assert_eq!(run_dir(false, "C:/wt/gd-session-1"), "C:/wt/gd-session-1");
+    }
 
     #[test]
     fn opencode_session_pins_the_run_directory_on_every_turn() {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -381,9 +381,14 @@ impl ChildEnv for portable_pty::CommandBuilder {
     }
 }
 
-/// Removes the AppImage bundle's paths from a child's environment. Call it FIRST,
-/// before a site's own `.env()` calls, so explicitly-set variables always win.
+/// Removes the AppImage bundle's paths and an inherited `PWD` from a child's
+/// environment. Call it FIRST, before a site's own `.env()` calls, so explicitly-set
+/// variables always win.
 pub(crate) fn sanitize_child_env<C: ChildEnv>(cmd: &mut C) {
+    // Every spawn site sets the child's directory itself, so an inherited `PWD` (a
+    // shell-launched app exports one) only names a stale path — and a tool that reads
+    // `PWD` in preference to its real cwd would run against that path instead.
+    cmd.unset_var("PWD");
     for (name, value) in child_env_overrides() {
         match value {
             Some(v) => cmd.set_var(name, v),
@@ -1243,12 +1248,19 @@ fn opencode_session_args(
     // builtin `plan` — `plan` has NO web tools and opencode has no permission CLI
     // flags, so the agent is defined in `OPENCODE_CONFIG` (see mcp.rs).
     web: bool,
+    // The directory the turn must run in, as the path exists FOR THIS RUN.
+    dir: &str,
 ) -> Vec<String> {
+    // opencode resolves its working root from `PWD` before the real cwd, so a stale
+    // inherited `PWD` would run the turn in another repo. `--dir` bypasses that and is
+    // stamped into the persisted session row, so resumes stay pinned too.
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
         "json".into(),
         "--dangerously-skip-permissions".into(),
+        "--dir".into(),
+        dir.into(),
     ];
     if read_only {
         // A read-only conversation: a hard read-only guarantee via an agent with no
@@ -1285,8 +1297,16 @@ fn opencode_session_args(
 /// write/edit/bash — a hard guarantee even in the live repo);
 /// `--dangerously-skip-permissions` only auto-approves those reads. Diff-only
 /// invokes no tools at all.
-fn opencode_review_args(model: &str, repo_aware: bool, effort: &str) -> Vec<String> {
-    let mut args: Vec<String> = vec!["run".into(), "--format".into(), "json".into()];
+fn opencode_review_args(model: &str, repo_aware: bool, effort: &str, dir: &str) -> Vec<String> {
+    // opencode resolves its working root from `PWD` before the real cwd, so without
+    // `--dir` an inherited `PWD` would point the review at a different repository.
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "--format".into(),
+        "json".into(),
+        "--dir".into(),
+        dir.into(),
+    ];
     if repo_aware {
         args.push("--agent".into());
         args.push("plan".into());
@@ -2310,8 +2330,9 @@ pub async fn agent_review(
         ),
         // opencode review: prompt on stdin (no positional message), so a large or
         // newline-bearing diff prompt doesn't hit the argv / batch-file-arg limits.
+        // A review always runs on the host, so `--dir` names the repo we spawn it in.
         AgentKind::Opencode => (
-            opencode_review_args(&model, repo_aware, &effort),
+            opencode_review_args(&model, repo_aware, &effort, &repo_path),
             format!("{system_prompt}\n\n{user_prompt}"),
         ),
     };
@@ -2611,6 +2632,14 @@ pub async fn agent_session(
             } else {
                 format!("{system_prompt}\n\n{user_prompt}")
             };
+            // `--dir` must name the path as it exists FOR THIS RUN: `/workspace` in a
+            // container, the real host path otherwise — the host path names nothing
+            // inside.
+            let dir = if container {
+                "/workspace"
+            } else {
+                worktree_path.as_str()
+            };
             (
                 opencode_session_args(
                     &model,
@@ -2619,6 +2648,7 @@ pub async fn agent_session(
                     &effort,
                     read_only,
                     web,
+                    dir,
                 ),
                 prompt,
             )
@@ -2835,6 +2865,37 @@ mod child_env_tests {
                 .find(|(k, _)| *k == key)
                 .map(|(_, v)| (*v).to_string())
         }
+    }
+
+    /// Records what an applier did to a child's environment, so the scrub is
+    /// assertable on Windows/macOS too, where the override plan is empty.
+    #[derive(Debug, Default)]
+    struct RecordingEnv {
+        set: Vec<(String, String)>,
+        unset: Vec<String>,
+    }
+
+    impl ChildEnv for RecordingEnv {
+        fn set_var(&mut self, key: &str, value: &str) {
+            self.set.push((key.to_string(), value.to_string()));
+        }
+        fn unset_var(&mut self, key: &str) {
+            self.unset.push(key.to_string());
+        }
+    }
+
+    #[test]
+    fn every_child_loses_an_inherited_pwd() {
+        let mut env = RecordingEnv::default();
+        sanitize_child_env(&mut env);
+        assert!(
+            env.unset.iter().any(|k| k == "PWD"),
+            "PWD must be dropped on every platform: {env:?}"
+        );
+        assert!(
+            !env.set.iter().any(|(k, _)| k == "PWD"),
+            "PWD must be dropped, never re-set: {env:?}"
+        );
     }
 
     /// Expected `strip_appdir_pathlist` result when `list` survived a real strip.
@@ -3973,6 +4034,38 @@ opencode/x-preview-f-free
         assert!(diff_only.iter().any(|a| a == "--allow-all-tools"));
         assert!(diff_only.iter().any(|a| a == "--deny-tool=write"));
         assert!(!diff_only.iter().any(|a| a == "--disable-builtin-mcps"));
+    }
+
+    // --- opencode run directory ----------------------------------------------
+
+    #[test]
+    fn opencode_session_pins_the_run_directory_on_every_turn() {
+        // opencode reads `PWD` before its real cwd, so the directory has to be in argv
+        // on turn 1 and on resume alike.
+        let turn_one =
+            opencode_session_args("m", "", false, "", false, false, "C:/wt/gd-session-1");
+        assert_eq!(flag_value(&turn_one, "--dir"), Some("C:/wt/gd-session-1"));
+        let resumed =
+            opencode_session_args("m", "ses_abc", true, "", false, false, "C:/wt/gd-session-1");
+        assert_eq!(flag_value(&resumed, "--dir"), Some("C:/wt/gd-session-1"));
+        assert!(resumed.iter().any(|a| a == "--session"));
+    }
+
+    #[test]
+    fn opencode_session_dir_is_the_container_mount_point() {
+        // In a container the worktree is bind-mounted at `/workspace`; the host path
+        // names nothing inside, so the call site passes the mount point through.
+        let args = opencode_session_args("m", "", false, "", true, true, "/workspace");
+        assert_eq!(flag_value(&args, "--dir"), Some("/workspace"));
+    }
+
+    #[test]
+    fn opencode_review_pins_the_repo_directory() {
+        let aware = opencode_review_args("m", true, "", "C:/repos/gd");
+        assert_eq!(flag_value(&aware, "--dir"), Some("C:/repos/gd"));
+        // A diff-only review invokes no tools, but the run still resolves a root.
+        let diff_only = opencode_review_args("m", false, "", "C:/repos/gd");
+        assert_eq!(flag_value(&diff_only, "--dir"), Some("C:/repos/gd"));
     }
 
     // --- EventSink seam ------------------------------------------------------

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -385,9 +385,9 @@ impl ChildEnv for portable_pty::CommandBuilder {
 /// environment. Call it FIRST, before a site's own `.env()` calls, so explicitly-set
 /// variables always win.
 pub(crate) fn sanitize_child_env<C: ChildEnv>(cmd: &mut C) {
-    // Every spawn site sets the child's directory itself, so an inherited `PWD` (a
-    // shell-launched app exports one) only names a stale path — and a tool that reads
-    // `PWD` in preference to its real cwd would run against that path instead.
+    // An inherited `PWD` (a shell-launched app exports one) names the LAUNCHER's
+    // directory, never this child's — and a tool that prefers `PWD` over its real
+    // cwd (opencode's run root does) would run against that stale path.
     cmd.unset_var("PWD");
     for (name, value) in child_env_overrides() {
         match value {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -4054,8 +4054,8 @@ opencode/x-preview-f-free
 
     #[test]
     fn opencode_session_dir_is_the_container_mount_point() {
-        // In a container the worktree is bind-mounted at `/workspace`; the host path
-        // names nothing inside, so the call site passes the mount point through.
+        // The builder forwards whatever `dir` it's handed verbatim into `--dir`; the
+        // container-vs-host choice is `run_dir`'s job, asserted separately.
         let args = opencode_session_args("m", "", false, "", true, true, "/workspace");
         assert_eq!(flag_value(&args, "--dir"), Some("/workspace"));
     }

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -1045,6 +1045,10 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     #[cfg(target_os = "macos")]
     if is_app_bundle(&program) {
         let mut c = std::process::Command::new("open");
+        // `open` hands off to LaunchServices, which starts the app in a fresh
+        // session that doesn't inherit our environment, so the scrub only affects
+        // the `open` child itself (belt-and-braces) and no `ELECTRON_RUN_AS_NODE`
+        // removal is needed here.
         crate::agent::sanitize_child_env(&mut c);
         c.args(["-a", program.as_str(), path.as_str()])
             .spawn()
@@ -1052,9 +1056,10 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
         return Ok(());
     }
     // Spawn a `.cmd`/`.bat` shim (e.g. VS Code's `code.cmd`) DIRECTLY, not via
-    // `cmd /C`: std then applies its batch-file argument escaping (CVE-2024-24576),
-    // whereas `cmd /C <shim> <path>` runs the untrusted `path` unquoted, so a
-    // space-free filename like `a&calc&b` from a cloned repo injects commands.
+    // `cmd /C`: std (≥1.77.2) then applies its batch-file argument escaping
+    // (CVE-2024-24576), whereas `cmd /C <shim> <path>` runs the untrusted `path`
+    // unquoted, so a space-free filename like `a&calc&b` from a cloned repo injects
+    // commands. A toolchain pin below that floor would silently reopen this.
     let mut cmd = std::process::Command::new(&program);
     crate::agent::sanitize_child_env(&mut cmd);
     cmd.arg(&path);
@@ -1065,10 +1070,7 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     // The `.cmd`/`.bat` extension only means anything to Windows, which spawns a
     // transient cmd.exe console to run the shim — hide it below.
     #[cfg(windows)]
-    let shim = {
-        let lower = program.to_lowercase();
-        lower.ends_with(".cmd") || lower.ends_with(".bat")
-    };
+    let shim = is_batch_file(&program);
     #[cfg(windows)]
     if shim {
         use std::os::windows::process::CommandExt;

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -333,10 +333,7 @@ fn substitute_path(tokens: &[String], path: &str) -> Vec<String> {
 }
 
 /// True when `program` ends in a Windows batch extension (`.cmd`/`.bat`,
-/// case-insensitive). Rust ≥1.77 routes batch files through `cmd.exe` (the
-/// BatBadBut CVE mitigation), which silently re-introduces a shell and `%VAR%`
-/// expansion — exactly what the shell-free custom-command mode must avoid — so
-/// a resolved batch file is rejected rather than launched.
+/// case-insensitive).
 fn is_batch_file(program: &str) -> bool {
     let lower = program.to_ascii_lowercase();
     lower.ends_with(".cmd") || lower.ends_with(".bat")
@@ -409,7 +406,9 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
     let resolved = ensure_absolute(resolved, &std::env::current_dir().map_err(AppError::Io)?);
 
     // SECURITY: reject batch files on the RESOLVED path — a bare `foo` on PATH
-    // can resolve to `foo.cmd`, which Rust would run through cmd.exe.
+    // can resolve to `foo.cmd`, and Rust ≥1.77 routes batch files through
+    // `cmd.exe` (the BatBadBut CVE mitigation), silently reintroducing a shell
+    // and `%VAR%` expansion that the shell-free custom-command mode must avoid.
     if is_batch_file(&resolved.to_string_lossy()) {
         return Err(AppError::InvalidArgument(format!(
             "terminal command points at a batch file ({}); point at the real \
@@ -1397,7 +1396,7 @@ mod tests {
     }
 
     #[test]
-    fn is_batch_file_rejects_cmd_and_bat_case_insensitively() {
+    fn is_batch_file_matches_cmd_and_bat_case_insensitively() {
         assert!(is_batch_file("C:\\tools\\wt.cmd"));
         assert!(is_batch_file("C:\\tools\\wt.CMD"));
         assert!(is_batch_file("launch.bat"));

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -1055,6 +1055,7 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     let shim = lower.ends_with(".cmd") || lower.ends_with(".bat");
     let mut cmd = if shim {
         let mut c = std::process::Command::new("cmd");
+        crate::agent::sanitize_child_env(&mut c);
         c.args(["/C", &program, &path]);
         c
     } else {

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -406,9 +406,9 @@ async fn launch_custom_command(command: &str, path: &str) -> AppResult<()> {
     let resolved = ensure_absolute(resolved, &std::env::current_dir().map_err(AppError::Io)?);
 
     // SECURITY: reject batch files on the RESOLVED path — a bare `foo` on PATH
-    // can resolve to `foo.cmd`, and Rust ≥1.77 routes batch files through
-    // `cmd.exe` (the BatBadBut CVE mitigation), silently reintroducing a shell
-    // and `%VAR%` expansion that the shell-free custom-command mode must avoid.
+    // can resolve to `foo.cmd`, which runs through `cmd.exe`, silently
+    // reintroducing a shell and `%VAR%` expansion that the shell-free
+    // custom-command mode must avoid.
     if is_batch_file(&resolved.to_string_lossy()) {
         return Err(AppError::InvalidArgument(format!(
             "terminal command points at a batch file ({}); point at the real \

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -1044,30 +1044,31 @@ pub async fn open_with_program(program: String, path: String) -> AppResult<()> {
     // rather than trying to spawn the bundle directory as a command.
     #[cfg(target_os = "macos")]
     if is_app_bundle(&program) {
-        std::process::Command::new("open")
-            .args(["-a", program.as_str(), path.as_str()])
+        let mut c = std::process::Command::new("open");
+        crate::agent::sanitize_child_env(&mut c);
+        c.args(["-a", program.as_str(), path.as_str()])
             .spawn()
             .map_err(AppError::Io)?;
         return Ok(());
     }
-    let lower = program.to_lowercase();
-    // .cmd/.bat shims (like VS Code's `code.cmd`) can't be spawned directly
-    let shim = lower.ends_with(".cmd") || lower.ends_with(".bat");
-    let mut cmd = if shim {
-        let mut c = std::process::Command::new("cmd");
-        crate::agent::sanitize_child_env(&mut c);
-        c.args(["/C", &program, &path]);
-        c
-    } else {
-        let mut c = std::process::Command::new(&program);
-        crate::agent::sanitize_child_env(&mut c);
-        c.arg(&path);
-        c
-    };
+    // Spawn a `.cmd`/`.bat` shim (e.g. VS Code's `code.cmd`) DIRECTLY, not via
+    // `cmd /C`: std then applies its batch-file argument escaping (CVE-2024-24576),
+    // whereas `cmd /C <shim> <path>` runs the untrusted `path` unquoted, so a
+    // space-free filename like `a&calc&b` from a cloned repo injects commands.
+    let mut cmd = std::process::Command::new(&program);
+    crate::agent::sanitize_child_env(&mut cmd);
+    cmd.arg(&path);
     // When this app is launched from a VS Code terminal, ELECTRON_RUN_AS_NODE=1
     // is in our environment; an Electron editor inheriting it runs as plain
     // Node and tries to *execute* the file instead of opening it.
     cmd.env_remove("ELECTRON_RUN_AS_NODE");
+    // The `.cmd`/`.bat` extension only means anything to Windows, which spawns a
+    // transient cmd.exe console to run the shim — hide it below.
+    #[cfg(windows)]
+    let shim = {
+        let lower = program.to_lowercase();
+        lower.ends_with(".cmd") || lower.ends_with(".bat")
+    };
     #[cfg(windows)]
     if shim {
         use std::os::windows::process::CommandExt;

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -523,8 +523,9 @@ pub async fn pty_open(
         tree_kill,
     } = build_command(&opts, &id).await?;
     // portable-pty's CommandBuilder already inherits the parent environment, so we
-    // only subtract (the AppImage bundle's paths, which would poison host tools run
-    // in the terminal) and advertise a capable terminal — re-copying every var is
+    // only subtract (whatever `sanitize_child_env` removes — the AppImage bundle's
+    // paths and an inherited PWD, which would misdirect host tools run in the
+    // terminal) and advertise a capable terminal — re-copying every var is
     // redundant and can introduce odd-cased duplicate Windows vars.
     crate::agent::sanitize_child_env(&mut cmd);
     cmd.env("TERM", "xterm-256color");


### PR DESCRIPTION
opencode resolves its working root from `PWD` before the process's real working directory, so a GitDesktop launched from a shell that exports `PWD` (Git Bash, for example) could run agent turns and reviews against a stale path instead of the session's worktree or the current repository. This pins the run directory explicitly in argv on every opencode invocation and drops the inherited `PWD` from every spawned child.

### opencode invocation (`src-tauri/src/agent.rs`)
- `opencode_session_args` takes a `dir` parameter and emits `--dir <dir>`, so turn 1 and `--session` resumes are both pinned; the value is stamped into the persisted session row.
- `opencode_review_args` gains the same parameter and emits `--dir`, covering repo-aware and diff-only reviews alike.
- `agent_session` derives the directory as the path exists for that run: `/workspace` when the turn runs in a container (where the host path names nothing) and `worktree_path` on the host.
- `agent_review` passes `repo_path`, since a review always runs on the host in the repo it is spawned in.

### Child environment scrub
- `sanitize_child_env` now calls `unset_var("PWD")` ahead of the AppImage path overrides, so an explicitly-set value from a spawn site still wins; the doc comment is updated to describe both jobs.
- `fsops.rs::open_with_program` routes its `cmd /C` shim branch through `sanitize_child_env` before building the argument list.

### Tests (`src-tauri/src/agent.rs`)
- Adds a `RecordingEnv` implementation of `ChildEnv` plus `every_child_loses_an_inherited_pwd`, which makes the scrub assertable on Windows and macOS, where the override plan is otherwise empty. It checks that `PWD` is unset and never re-set.
- `opencode_session_pins_the_run_directory_on_every_turn` asserts `--dir` on both a fresh turn and a resumed one, `opencode_session_dir_is_the_container_mount_point` asserts the `/workspace` pass-through, and `opencode_review_pins_the_repo_directory` covers repo-aware and diff-only review argv.

### Changelog
- Adds `changelog.d/fixed-opencode-session-dir.md` describing the behavior change for users. No README, site, or in-app guide updates: the documented behavior was already that sessions run in their own worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sessions and reviews running in unintended directories.
  * Ensured operations consistently use the selected worktree, including container-based sessions.
  * Improved environment cleanup when launching applications and command scripts.
  * Fixed command scripts launching through an unnecessary intermediary process on Windows.
  * Preserved file paths unchanged when opening files through `.cmd` or `.bat` editor shims, including filenames with special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->