### PR TITLE
fix(conflicts,help,hotkeys): mark conflicts settled on disk as resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ pushing and pulling stay manual.
   over Incoming (theirs) with Accept current / incoming / both, plus
   whole-file Accept all current / incoming and Open in editor, and Mark
   resolved to stage a file exactly as it stands on disk when you settled it
-  outside the app (edited, emptied, or removed).
+  outside the app (edited, emptied, or deleted while both sides still have
+  a version of it).
 - **AI conflict resolution**: one more option there. Ask your model to merge
   a file, review the proposal as a diff, and accept it (per file or all at
   once). Multi-provider, runs on local Ollama or a keyless Claude Code /

--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ pushing and pulling stay manual.
   gets a conflict banner naming it, with gated Continue / Abort. Selecting
   a conflicted file opens an in-app editor: each region shows Current (ours)
   over Incoming (theirs) with Accept current / incoming / both, plus
-  whole-file Accept all current / incoming and Open in editor.
+  whole-file Accept all current / incoming and Open in editor, and Mark
+  resolved to stage a file exactly as it stands on disk when you settled it
+  outside the app (edited, emptied, or removed).
 - **AI conflict resolution**: one more option there. Ask your model to merge
   a file, review the proposal as a diff, and accept it (per file or all at
   once). Multi-provider, runs on local Ollama or a keyless Claude Code /

--- a/changelog.d/fixed-conflict-editor-external-resolve.md
+++ b/changelog.d/fixed-conflict-editor-external-resolve.md
@@ -1,0 +1,3 @@
+- Conflict editor: files resolved in an external editor can now be marked
+  resolved and staged in place — including modify/delete conflicts where you
+  edited the surviving file, and files you emptied on purpose.

--- a/changelog.d/fixed-conflict-editor-external-resolve.md
+++ b/changelog.d/fixed-conflict-editor-external-resolve.md
@@ -1,3 +1,4 @@
 - Conflict editor: files resolved in an external editor can now be marked
   resolved and staged in place — including modify/delete conflicts where you
-  edited the surviving file, and files you emptied or deleted on purpose.
+  edited the surviving file, and files you emptied, or deleted while both
+  sides still have a version.

--- a/changelog.d/fixed-conflict-editor-external-resolve.md
+++ b/changelog.d/fixed-conflict-editor-external-resolve.md
@@ -1,3 +1,3 @@
 - Conflict editor: files resolved in an external editor can now be marked
   resolved and staged in place — including modify/delete conflicts where you
-  edited the surviving file, and files you emptied on purpose.
+  edited the surviving file, and files you emptied or deleted on purpose.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -127,7 +127,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Rewrite & recovery",
-    label: "In-app conflict editor — current / incoming / both",
+    label:
+      "In-app conflict editor — current / incoming / both, or mark files resolved as they stand on disk",
   },
   { group: "Rewrite & recovery", label: "Stash browser" },
   {

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -40,6 +40,9 @@ pub struct ConflictSides {
     /// The path matches an AI-ignore pattern, so it must never be sent to a
     /// model. The UI refuses to resolve it and says why.
     pub ai_ignored: bool,
+    /// Whether the working file is on disk. `working` collapses to "" for an
+    /// empty file and a deleted one alike; this is what separates them.
+    pub working_exists: bool,
 }
 
 /// Rejects paths that could be read as a git flag or escape the repo root. The
@@ -120,10 +123,16 @@ pub async fn git_conflict_sides(
 
     let ai_ignored = is_ai_ignored(&repo_path, &path, &exclude).await?;
 
-    // A both-deleted conflict has no working file → "".
-    let working_bytes = tokio::fs::read(Path::new(&repo_path).join(&path))
-        .await
-        .unwrap_or_default();
+    // A both-deleted conflict has no working file → "". NotFound is the only
+    // signal that the file is gone; any other read error keeps the swallow-to-
+    // empty behavior but still reports the file as present, so the UI never
+    // offers to stage a removal on the strength of a permissions error.
+    let working_read = tokio::fs::read(Path::new(&repo_path).join(&path)).await;
+    let working_exists = match &working_read {
+        Ok(_) => true,
+        Err(e) => e.kind() != std::io::ErrorKind::NotFound,
+    };
+    let working_bytes = working_read.unwrap_or_default();
     if working_bytes.len() > RESOLVE_MAX_BYTES {
         return Err(AppError::InvalidArgument(
             "file is too large for AI conflict resolution".into(),
@@ -144,6 +153,7 @@ pub async fn git_conflict_sides(
         ours: stage_blob(&repo_path, 2, &path).await?,
         theirs: stage_blob(&repo_path, 3, &path).await?,
         ai_ignored,
+        working_exists,
     })
 }
 
@@ -673,6 +683,37 @@ mod tests {
             .await
             .unwrap();
         assert_deleted_and_resolved(&repo, "file.txt").await;
+    }
+
+    /// `working_exists` is what separates an emptied working file from a deleted
+    /// one, since `working` is "" for both. The wire key is asserted too: the
+    /// frontend reads `workingExists`, and a rename here would go silent.
+    #[tokio::test]
+    async fn working_exists_tracks_the_file_on_disk() {
+        let (_dir, repo) = conflicted_repo("working-exists", "file.txt", &[]).await;
+        let present = git_conflict_sides(repo.clone(), "file.txt".into(), vec![])
+            .await
+            .unwrap();
+        assert!(present.working_exists);
+        let json = serde_json::to_string(&present).unwrap();
+        assert!(
+            json.contains("\"workingExists\":true"),
+            "wire key missing: {json}"
+        );
+
+        std::fs::remove_file(Path::new(&repo).join("file.txt")).unwrap();
+        let gone = git_conflict_sides(repo, "file.txt".into(), vec![])
+            .await
+            .unwrap();
+        assert!(!gone.working_exists);
+        assert_eq!(gone.working, "", "a missing file still reads as empty");
+        // The stages survive the deletion, so the path is still conflicted.
+        assert_eq!(gone.ours.as_deref(), Some("ours\n"));
+        let json = serde_json::to_string(&gone).unwrap();
+        assert!(
+            json.contains("\"workingExists\":false"),
+            "wire key missing: {json}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -686,8 +686,11 @@ mod tests {
     }
 
     /// `working_exists` is what separates an emptied working file from a deleted
-    /// one, since `working` is "" for both. The wire key is asserted too: the
-    /// frontend reads `workingExists`, and a rename here would go silent.
+    /// one, since `working` is "" for both — the discriminator pair the frontend
+    /// rides on, so present, emptied and gone each get a leg (a non-NotFound read
+    /// error is its own class, reported as present at the read site). The wire key
+    /// is asserted too: the frontend reads `workingExists`, and a rename here
+    /// would go silent.
     #[tokio::test]
     async fn working_exists_tracks_the_file_on_disk() {
         let (_dir, repo) = conflicted_repo("working-exists", "file.txt", &[]).await;
@@ -696,6 +699,19 @@ mod tests {
             .unwrap();
         assert!(present.working_exists);
         let json = serde_json::to_string(&present).unwrap();
+        assert!(
+            json.contains("\"workingExists\":true"),
+            "wire key missing: {json}"
+        );
+
+        // Emptied on purpose: same "" content as a deletion, opposite verdict.
+        std::fs::write(Path::new(&repo).join("file.txt"), "").unwrap();
+        let emptied = git_conflict_sides(repo.clone(), "file.txt".into(), vec![])
+            .await
+            .unwrap();
+        assert_eq!(emptied.working, "");
+        assert!(emptied.working_exists);
+        let json = serde_json::to_string(&emptied).unwrap();
         assert!(
             json.contains("\"workingExists\":true"),
             "wire key missing: {json}"
@@ -713,6 +729,37 @@ mod tests {
         assert!(
             json.contains("\"workingExists\":false"),
             "wire key missing: {json}"
+        );
+    }
+
+    /// Mark resolved is a plain `git add` on the unmerged path, and the UI offers
+    /// it while the working file is DELETED: git stages that removal and clears
+    /// the conflict (measured, git 2.51.1). Nothing else records this — the arm
+    /// that offers the button reads only `working_exists`.
+    #[tokio::test]
+    async fn stage_on_deleted_working_file_records_the_removal() {
+        let (_dir, repo) = conflicted_repo("stage-deleted", "file.txt", &[]).await;
+        std::fs::remove_file(Path::new(&repo).join("file.txt")).unwrap();
+        // Pins the premise: without a live conflict here the post-state asserts
+        // nothing.
+        let before = stdout_of(&repo, &["ls-files", "-u"]).await;
+        assert!(before.contains("file.txt"), "fixture not conflicted: {before}");
+
+        let state = AppState::default();
+        crate::git::stage::git_stage_core(
+            &state,
+            repo.clone(),
+            vec![crate::git::pathspec::literal("file.txt")],
+        )
+        .await
+        .unwrap();
+
+        let staged = stdout_of(&repo, &["diff", "--cached", "--name-status"]).await;
+        assert!(staged.contains("D\tfile.txt"), "deletion staged: {staged}");
+        let unmerged = stdout_of(&repo, &["ls-files", "-u"]).await;
+        assert!(
+            unmerged.trim().is_empty(),
+            "conflict left behind: {unmerged}"
         );
     }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -719,19 +719,21 @@ a file, the editor names the removal instead of showing regions, and the same wh
 accept actions choose between keeping the file and taking the deletion; when you've edited
 the surviving file yourself, **Mark resolved** keeps that edit. A file you resolved outside
 GitDesktop (its conflict markers gone, but Git still listing it as conflicted) offers
-**Mark resolved** too, staging it exactly as it is on disk, and so does one you emptied,
-or deleted while both sides still have a version of it.
+**Mark resolved** too, staging it exactly as it is on disk, and so does one you emptied, or
+deleted while both sides still have a version of it. The command palette offers all of
+these as **Mark conflict resolved**.
 
 {{ai}}## Resolve conflicts with AI
 
 Select a conflicted file and click **Resolve with AI** in the conflict editor's header (also
-on the file's context menu, and via the command palette ({{kbd:command-palette}})). Your configured
-**Review** model (Settings → AI) merges the file's sides and streams a proposal; you review
-it as a diff against your side, flip to the proposed file or the *ours* / *theirs* / *base*
-versions, then **Accept & stage** to apply it — nothing is written until you accept.
-**Regenerate** for another attempt, or **Discard** to drop it. The banner's **Resolve all
-with AI** walks every conflict in turn. It runs on any provider, including local Ollama and
-keyless Claude Code / Codex agents, and skips files matched by your AI ignore patterns.{{/ai}}`,
+on the file's context menu, and in the command palette ({{kbd:command-palette}}) as
+**Resolve conflict with AI**). Your configured **Review** model (Settings → AI) merges the
+file's sides and streams a proposal; you review it as a diff against your side, flip to the
+proposed file or the *ours* / *theirs* / *base* versions, then **Accept & stage** to apply
+it — nothing is written until you accept. **Regenerate** for another attempt, or **Discard**
+to drop it. The banner's **Resolve all with AI** walks every conflict in turn. It runs on
+any provider, including local Ollama and keyless Claude Code / Codex agents, and skips files
+matched by your AI ignore patterns.{{/ai}}`,
   },
   {
     id: "pull-requests",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -716,7 +716,11 @@ already settled by hand included. Files mark
 themselves resolved as you go — the \`!\` badge clears — and the finish control stays
 disabled, saying so, until every conflict is resolved. When one side of a conflict removed
 a file, the editor names the removal instead of showing regions, and the same whole-file
-accept actions choose between keeping the file and taking the deletion.
+accept actions choose between keeping the file and taking the deletion; when you've edited
+the surviving file yourself, **Mark resolved** keeps that edit. A file you resolved outside
+GitDesktop (its conflict markers gone, but Git still listing it as conflicted) offers
+**Mark resolved** too, staging it exactly as it is on disk, and so does one you emptied,
+or deleted while both sides still have a version of it.
 
 {{ai}}## Resolve conflicts with AI
 

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { HighlightedCode } from "@/features/diff/HighlightedCode";
 import { hasConflictMarkers } from "@/lib/ai/conflict-prompt";
-import { openWithDefault, openWithProgram } from "@/lib/git/api";
+import { gitStatus, openWithDefault, openWithProgram } from "@/lib/git/api";
 import type { ConflictSides } from "@/lib/git/conflict";
 import {
   type ConflictChoice,
@@ -15,9 +15,11 @@ import {
 import {
   useCheckoutConflictSide,
   useConflictFile,
+  useMarkConflictResolved,
   useResolveConflict,
 } from "@/lib/git/queries";
 import { isWindows } from "@/lib/hotkeys/binding";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import {
   useAiEnabled,
   useReviewConfigured,
@@ -28,6 +30,11 @@ import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { toastError } from "@/lib/toast";
 
 const baseName = (path: string) => path.split("/").pop() || path;
+
+/** Compare working text against a stage blob EOL-agnostically: under autocrlf
+ *  `git show :N:path` hands back raw LF while the merge wrote the working file
+ *  CRLF, so a byte comparison calls every file edited. */
+const nlf = (s: string) => s.replaceAll("\r\n", "\n");
 
 /** The whole-file sides, worded as the header buttons word them. */
 const ACCEPT_ALL_COPY = {
@@ -78,39 +85,149 @@ const DELETION_COPY = {
   },
 } as const;
 
-/**
- * What a conflicted file shows when the parser found no regions to resolve: a
- * side with no version at this path, an empty file, or markers it can't trust.
- * Each keeps the header's whole-file actions as the way through.
- */
-function ConflictFallback({
-  path,
-  sides,
-}: {
-  path: string;
-  sides: ConflictSides;
-}) {
+/** The states a conflicted file can be in once the parser found no regions. */
+type FallbackArm =
+  | "deletion"
+  | "deletionEdited"
+  | "bothDeleted"
+  | "emptiedOnDisk"
+  | "emptiedGone"
+  | "externallyResolved"
+  | "unparsed";
+
+/** The arms where what's on disk IS the resolution, so staging it as-is is the
+ *  way through. Every other arm routes through the header's whole-file accepts. */
+const MARK_RESOLVED_ARMS: ReadonlySet<FallbackArm> = new Set<FallbackArm>([
+  "deletionEdited",
+  "emptiedOnDisk",
+  "emptiedGone",
+  "externallyResolved",
+]);
+
+/** The two working-file states with no text to show, each worded for what
+ *  staging it actually records (content vs. a removal). */
+const EMPTIED_COPY: Record<
+  "emptiedOnDisk" | "emptiedGone",
+  { state: string; action: string }
+> = {
+  emptiedOnDisk: {
+    state: "You've emptied this file",
+    action: "stages it exactly as it is on disk.",
+  },
+  emptiedGone: {
+    state: "This file is gone from your working tree",
+    action: "stages the removal.",
+  },
+};
+
+function fallbackArm(sides: ConflictSides): FallbackArm {
   // The index stages decide first: a modify/delete leaves the SURVIVING side's
   // content in the tree, marker-free, so the parser's null here means a removal
   // to accept rather than markers it failed on. Ordered ahead of the empty-file
   // check, which is a heuristic and would swallow a surviving side that is empty.
   const deleted = deletedSide(sides);
   if (deleted !== null) {
+    const survivor = sides.ours ?? sides.theirs ?? "";
+    const edited = sides.workingExists && nlf(sides.working) !== nlf(survivor);
+    return edited ? "deletionEdited" : "deletion";
+  }
+
+  if (sides.working.trim() === "") {
+    if (sides.ours == null && sides.theirs == null) return "bothDeleted";
+    return sides.workingExists ? "emptiedOnDisk" : "emptiedGone";
+  }
+
+  // Every leg is checked here rather than leaning on the arms above: an entry
+  // with no stages at all but real content is a file we can't classify, and it
+  // must land on the couldn't-parse arm instead of being called resolved.
+  if (
+    sides.ours != null &&
+    sides.theirs != null &&
+    sides.working.trim() !== "" &&
+    !hasConflictMarkers(sides.working)
+  ) {
+    return "externallyResolved";
+  }
+
+  return "unparsed";
+}
+
+/**
+ * What a conflicted file shows when the parser found no regions to resolve: a
+ * side with no version at this path, an empty file, content already resolved
+ * outside the app, or markers it can't trust. Each keeps the header's
+ * whole-file actions as the way through; the arms whose disk content is itself
+ * the resolution also offer Mark resolved.
+ */
+function ConflictFallback({
+  path,
+  sides,
+  busy,
+  onMarkResolved,
+}: {
+  path: string;
+  sides: ConflictSides;
+  busy: boolean;
+  onMarkResolved: () => void;
+}) {
+  const arm = fallbackArm(sides);
+  const markButton = MARK_RESOLVED_ARMS.has(arm) ? (
+    <Button
+      size="xs"
+      variant="outline"
+      disabled={busy}
+      onClick={onMarkResolved}
+    >
+      Mark resolved
+    </Button>
+  ) : null;
+
+  const deleted = deletedSide(sides);
+  if (deleted !== null) {
     const copy = DELETION_COPY[deleted];
+    const lead = (
+      <>
+        {copy.lead} <span className="font-medium">{copy.takesDeletion}</span>{" "}
+        takes the deletion,{" "}
+        <span className="font-medium">{copy.keepsFile}</span> keeps the file.
+      </>
+    );
     return (
       <>
-        <p className="border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
-          {copy.lead} <span className="font-medium">{copy.takesDeletion}</span>{" "}
-          takes the deletion,{" "}
-          <span className="font-medium">{copy.keepsFile}</span> keeps the file.
-        </p>
+        {arm === "deletionEdited" ? (
+          <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+            <p className="min-w-0 flex-1">
+              {lead} You've edited this file —{" "}
+              <span className="font-medium">Mark resolved</span> keeps it
+              exactly as shown.
+            </p>
+            {markButton}
+          </div>
+        ) : (
+          <p className="border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+            {lead}
+          </p>
+        )}
         <HighlightedCode path={path} content={sides.working || " "} />
       </>
     );
   }
 
-  if (sides.working.trim() === "") {
-    // A both-deleted (or empty) conflict — nothing to merge as text.
+  if (arm === "emptiedOnDisk" || arm === "emptiedGone") {
+    return (
+      <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+        <p className="min-w-0 flex-1">
+          {EMPTIED_COPY[arm].state} —{" "}
+          <span className="font-medium">Mark resolved</span>{" "}
+          {EMPTIED_COPY[arm].action}
+        </p>
+        {markButton}
+      </div>
+    );
+  }
+
+  if (arm === "bothDeleted") {
+    // Nothing to merge as text, and nothing on disk worth staging as-is.
     return (
       <p className="p-4 text-xs text-muted-foreground">
         This file was deleted on one or both sides — there's nothing to merge.
@@ -118,6 +235,22 @@ function ConflictFallback({
         / <span className="font-medium">incoming</span>, or open it in your
         editor.
       </p>
+    );
+  }
+
+  if (arm === "externallyResolved") {
+    return (
+      <>
+        <div className="flex items-center gap-2 border-b bg-success/10 px-3 py-1.5 text-[11px] text-success">
+          <p className="min-w-0 flex-1">
+            No conflict markers remain — this file looks resolved. Review it,
+            then <span className="font-medium">Mark resolved</span> to stage it
+            exactly as it is on disk.
+          </p>
+          {markButton}
+        </div>
+        <HighlightedCode path={path} content={sides.working} />
+      </>
     );
   }
 
@@ -154,6 +287,7 @@ export function ConflictFileView({
   const file = useConflictFile(repoPath, path);
   const resolve = useResolveConflict(repoPath);
   const checkoutSide = useCheckoutConflictSide(repoPath);
+  const markResolve = useMarkConflictResolved(repoPath);
   const aiEnabled = useAiEnabled();
   const reviewConfigured = useReviewConfigured();
   const startResolveAi = useConflictResolve((s) => s.startOne);
@@ -167,7 +301,11 @@ export function ConflictFileView({
   // Include the post-accept refetch (file.isFetching) so the per-region buttons
   // stay disabled until fresh segments land — otherwise a fast second click
   // resolves against stale segments and resurrects an already-resolved region.
-  const busy = resolve.isPending || checkoutSide.isPending || file.isFetching;
+  const busy =
+    resolve.isPending ||
+    checkoutSide.isPending ||
+    markResolve.isPending ||
+    file.isFetching;
   // A binary / too-large conflict can't be text-merged (the backend refuses to
   // read it); offer only whole-file resolution + the editor.
   const textResolvable = !file.isError;
@@ -237,6 +375,42 @@ export function ConflictFileView({
     );
   }
 
+  // Which fallback state is on screen, and so whether Mark resolved is offered.
+  // Gated on !isError as well as data: a refetch that errors (the file turned
+  // binary/oversized) keeps the last data while the pane shows the error copy.
+  const arm =
+    file.data && !file.isError && segments === null
+      ? fallbackArm(file.data)
+      : null;
+  const canMarkResolved = arm !== null && MARK_RESOLVED_ARMS.has(arm);
+
+  async function markResolved() {
+    try {
+      await markResolve.mutateAsync(path);
+      toast.success(`Resolved ${baseName(path)}`);
+    } catch (e) {
+      // A stale click: the path can be resolved elsewhere (an AI walk, another
+      // window) between render and click, and `git add` on a path that is fully
+      // gone exits 128. Only a still-conflicted path is a real failure; a status
+      // read that itself fails falls back to surfacing the error.
+      const status = await gitStatus(repoPath).catch(() => null);
+      const resolvedElsewhere = status?.entries.every(
+        (entry) =>
+          entry.path !== path ||
+          (entry.staged !== "conflicted" && entry.unstaged !== "conflicted"),
+      );
+      if (!resolvedElsewhere) toastError(e);
+    }
+  }
+
+  // Palette-only; enabled with the button, busy state included, so the palette
+  // can't fire a second stage while one is in flight.
+  useHotkeyAction(
+    "mark-conflict-resolved",
+    markResolved,
+    canMarkResolved && !busy,
+  );
+
   // Precompute each segment's conflict ordinal (its index among conflicts, for
   // resolveBlock) up front, so the render map only reads a stable array rather
   // than mutating a counter captured by the per-region onClick lambdas.
@@ -304,7 +478,12 @@ export function ConflictFileView({
             editor.
           </p>
         ) : segments === null ? (
-          <ConflictFallback path={path} sides={file.data} />
+          <ConflictFallback
+            path={path}
+            sides={file.data}
+            busy={busy}
+            onMarkResolved={markResolved}
+          />
         ) : (
           segments.map((seg, idx) => {
             if (seg.kind === "context") {

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -137,13 +137,12 @@ function fallbackArm(sides: ConflictSides): FallbackArm {
     return sides.workingExists ? "emptiedOnDisk" : "emptiedGone";
   }
 
-  // Every leg is checked here rather than leaning on the arms above: an entry
+  // Both stage checks are explicit rather than left to the arms above: an entry
   // with no stages at all but real content is a file we can't classify, and it
   // must land on the couldn't-parse arm instead of being called resolved.
   if (
     sides.ours != null &&
     sides.theirs != null &&
-    sides.working.trim() !== "" &&
     !hasConflictMarkers(sides.working)
   ) {
     return "externallyResolved";
@@ -162,15 +161,16 @@ function fallbackArm(sides: ConflictSides): FallbackArm {
 function ConflictFallback({
   path,
   sides,
+  arm,
   busy,
   onMarkResolved,
 }: {
   path: string;
   sides: ConflictSides;
+  arm: FallbackArm;
   busy: boolean;
   onMarkResolved: () => void;
 }) {
-  const arm = fallbackArm(sides);
   const markButton = MARK_RESOLVED_ARMS.has(arm) ? (
     <Button
       size="xs"
@@ -182,9 +182,10 @@ function ConflictFallback({
     </Button>
   ) : null;
 
-  const deleted = deletedSide(sides);
-  if (deleted !== null) {
-    const copy = DELETION_COPY[deleted];
+  if (arm === "deletion" || arm === "deletionEdited") {
+    // The arm doesn't carry WHICH side removed the file, and the notice names
+    // it. Both deletion arms come from a non-null `deletedSide` (asserted).
+    const copy = DELETION_COPY[deletedSide(sides) as "ours" | "theirs"];
     const lead = (
       <>
         {copy.lead} <span className="font-medium">{copy.takesDeletion}</span>{" "}
@@ -230,9 +231,9 @@ function ConflictFallback({
     // Nothing to merge as text, and nothing on disk worth staging as-is.
     return (
       <p className="p-4 text-xs text-muted-foreground">
-        This file was deleted on one or both sides — there's nothing to merge.
-        Take a side with <span className="font-medium">Accept all current</span>{" "}
-        / <span className="font-medium">incoming</span>, or open it in your
+        This file was deleted on both sides — there's nothing to merge. Take a
+        side with <span className="font-medium">Accept all current</span> /{" "}
+        <span className="font-medium">incoming</span>, or open it in your
         editor.
       </p>
     );
@@ -390,9 +391,9 @@ export function ConflictFileView({
       toast.success(`Resolved ${baseName(path)}`);
     } catch (e) {
       // A stale click: the path can be resolved elsewhere (an AI walk, another
-      // window) between render and click, and `git add` on a path that is fully
-      // gone exits 128. Only a still-conflicted path is a real failure; a status
-      // read that itself fails falls back to surfacing the error.
+      // window) between render and click, leaving NO index entry, and `git add`
+      // then exits 128 on a pathspec matching nothing. Only a still-conflicted
+      // path is a real failure; a failed status read falls back to the error.
       const status = await gitStatus(repoPath).catch(() => null);
       const resolvedElsewhere = status?.entries.every(
         (entry) =>
@@ -481,6 +482,9 @@ export function ConflictFileView({
           <ConflictFallback
             path={path}
             sides={file.data}
+            // Non-null on this branch: it's the same data + `segments === null`
+            // + not-error condition `arm` was computed under.
+            arm={arm as FallbackArm}
             busy={busy}
             onMarkResolved={markResolved}
           />

--- a/src/lib/git/conflict.ts
+++ b/src/lib/git/conflict.ts
@@ -13,6 +13,9 @@ export interface ConflictSides {
   theirs: string | null;
   /** The path matches an AI-ignore pattern — never send it to a model. */
   aiIgnored: boolean;
+  /** Whether the working file exists on disk — false when the user deleted it
+   *  (`working` collapses to "" either way). */
+  workingExists: boolean;
 }
 
 /** Reads a conflicted file's base/ours/theirs blobs + the marked working file,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3308,7 +3308,8 @@ export function useCheckoutConflictSide(repo: string) {
   );
 }
 
-/** Stages an externally-resolved conflicted file as-is (marks it resolved). */
+/** Stages a conflicted file exactly as it stands on disk — edited, emptied, or
+ *  removed — which marks the conflict resolved. */
 export function useMarkConflictResolved(repo: string) {
   return useRepoMutation(
     repo,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -20,6 +20,7 @@ import {
   conflictSides,
   resolveConflict,
 } from "./conflict";
+import { literalPathspec } from "./glob";
 import { repoIdentity } from "./repo-identity";
 import type {
   BbEnvironment,
@@ -3303,6 +3304,15 @@ export function useCheckoutConflictSide(repo: string) {
     repo,
     (args: { path: string; side: "ours" | "theirs" }) =>
       checkoutConflictSide(repo, args.path, args.side),
+    { invalidate: conflictFileKeys(repo) },
+  );
+}
+
+/** Stages an externally-resolved conflicted file as-is (marks it resolved). */
+export function useMarkConflictResolved(repo: string) {
+  return useRepoMutation(
+    repo,
+    (path: string) => api.gitStage(repo, [literalPathspec(path)]),
     { invalidate: conflictFileKeys(repo) },
   );
 }

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -577,6 +577,12 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "mark-conflict-resolved",
+    label: "Mark conflict resolved",
+    category: "Changes",
+    defaultBinding: null,
+  },
+  {
     id: "undo-commit",
     label: "Undo last commit",
     category: "Changes",


### PR DESCRIPTION
The conflict editor's fallback pane offered only the header's whole-file accepts, so a file already settled on disk had no way through that preserved your work: markers removed in an external editor, a file emptied on purpose or deleted outright, or a modify/delete conflict whose surviving side you edited. This adds a **Mark resolved** action that stages the working file exactly as it is on disk, along with the backend signal needed to tell an emptied file from a deleted one.

### Conflict editor

- Adds a `fallbackArm` classifier in `src/features/repository/ConflictFileView.tsx` that resolves the no-regions case into one of seven states (`deletion`, `deletionEdited`, `bothDeleted`, `emptiedOnDisk`, `emptiedGone`, `externallyResolved`, `unparsed`), keeping the existing stages-first ordering so a modify/delete isn't swallowed by the empty-file heuristic.
- `MARK_RESOLVED_ARMS` names the four arms whose disk content *is* the resolution; `ConflictFallback` renders a `Mark resolved` button in the banner for those, with per-arm copy (`EMPTIED_COPY`, the edited modify/delete lead, and a new "No conflict markers remain" banner) that states what staging records — file content versus a removal.
- `nlf` normalizes CRLF before comparing the working file against the surviving stage blob, so under `autocrlf` a modify/delete survivor isn't reported as edited on every checkout.
- `markResolved` tolerates a stale click: on failure it re-reads `gitStatus(repoPath)` and surfaces the error only when the path is still conflicted, since an AI walk or another window can resolve it between render and click and `git add` on a fully-gone path exits 128.
- `busy` now folds in `markResolve.isPending`, and the arm used to gate the action is computed only when `file.data && !file.isError`, so an errored refetch (file turned binary or oversized) can't leave the action live behind the error copy.

### Git layer

- `src-tauri/src/git/conflict.rs`: `ConflictSides` gains `working_exists`. `working` collapses to `""` for an empty file and a deleted one alike, so this is the only thing separating them. `NotFound` is the sole "gone" signal; any other read error keeps the swallow-to-empty behavior but still reports the file present, so the UI never offers to stage a removal on the strength of a permissions error.
- New `working_exists_tracks_the_file_on_disk` test covers the present and removed cases, asserts the stages survive deletion, and pins the `workingExists` wire key so a rename can't go silent.
- `src/lib/git/conflict.ts` mirrors `workingExists` on the TypeScript `ConflictSides`.
- `src/lib/git/queries.ts` adds `useMarkConflictResolved`, which stages the path through `api.gitStage` with `literalPathspec` and invalidates `conflictFileKeys`.

### Keyboard

- Registers a `mark-conflict-resolved` action in `src/lib/hotkeys/registry.ts` under **Changes** with `defaultBinding: null` (palette-only), wired via `useHotkeyAction` and enabled on exactly the same condition as the button, busy state included.

### Documentation

- Extends the conflict-resolution section of `src/features/help/content.ts` to cover marking an externally resolved, emptied, deleted, or hand-edited modify/delete file as resolved.
- Adds the changelog fragment `changelog.d/fixed-conflict-editor-external-resolve.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mark externally resolved conflicts as resolved while staging the file exactly as it currently exists.
  - Supports edited, emptied, intentionally deleted, and modify/delete conflict files.
  - Added a Changes command-palette action for marking conflicts resolved.
  - Improved conflict detection and resolution feedback, including files deleted on both sides.

- **Documentation**
  - Updated conflict-resolution guidance to cover additional resolution scenarios and whole-file acceptance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->