### PR TITLE
fix(ai,settings): defer CLI model probes and bound captured output

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -750,7 +750,9 @@ where
 
 /// Runs a short command and returns (exit code, stdout, stderr) as separate
 /// streams — what a line parser needs, since a banner on stderr must not
-/// interleave into the data being parsed.
+/// interleave into the data being parsed. Each stream is capped at
+/// `MAX_CAPTURE_BYTES`: a child that writes past it is killed and the call
+/// fails with `AppError::Command` rather than returning a truncated capture.
 pub(crate) async fn run_capture_parts(
     program: &Path,
     args: &[&str],
@@ -789,7 +791,7 @@ pub(crate) async fn run_capture_parts(
         // output are meaningless — fail deterministically rather than let a caller
         // parse a fragment (or a racing exit 0) as a complete, successful result.
         return Err(AppError::Command(format!(
-            "{} produced more than {MAX_CAPTURE_BYTES} bytes of output",
+            "{} produced more than {MAX_CAPTURE_BYTES} bytes on stdout or stderr",
             program.display()
         )));
     }
@@ -3196,14 +3198,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn capture_capped_truncates_and_flags_over_cap_on_stderr() {
+        // The stderr arm is a twin of the stdout arm — cover its boundary
+        // independently so a drift there can't hide behind stdout-only tests.
+        let big = vec![b'x'; 100];
+        let (mut o, mut e): (&[u8], &[u8]) = (b"", big.as_slice());
+        let (out, err, overflowed) = capture_capped(&mut o, &mut e, 16).await.unwrap();
+        assert!(out.is_empty());
+        assert_eq!(err.len(), 16);
+        assert!(overflowed);
+    }
+
+    #[tokio::test]
     async fn capture_capped_allows_output_exactly_at_cap() {
-        // Output landing exactly on the cap is within the limit, not truncation.
+        // Output landing exactly on the cap is within the limit, not truncation
+        // — on either stream (each arm carries its own boundary comparison, so
+        // an over-cap test alone can't tell `>` from `>=`).
         let exact = vec![b'y'; 16];
         let (mut o, mut e): (&[u8], &[u8]) = (exact.as_slice(), b"");
         let (out, err, overflowed) = capture_capped(&mut o, &mut e, 16).await.unwrap();
         assert_eq!(out.len(), 16);
         assert!(!overflowed);
         assert!(err.is_empty());
+
+        let (mut o, mut e): (&[u8], &[u8]) = (b"", exact.as_slice());
+        let (out, err, overflowed) = capture_capped(&mut o, &mut e, 16).await.unwrap();
+        assert_eq!(err.len(), 16);
+        assert!(!overflowed);
+        assert!(out.is_empty());
     }
 
     // Real opencode `run --format json` lines (captured 2026-06-23, v1.17.9).

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -686,6 +686,12 @@ async fn resolve(kind: AgentKind, bin_path: Option<&str>) -> Option<PathBuf> {
 
 // --- detection -------------------------------------------------------------
 
+/// Per-stream cap on captured output. `Command::output` buffers without limit,
+/// so a runaway or compromised child could exhaust memory before the timeout
+/// (which bounds duration, not bytes). No legitimate capture here approaches it
+/// — the largest, `opencode models`, is tens of KB.
+const MAX_CAPTURE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Runs a short command and returns (exit code, stdout, stderr) as separate
 /// streams — what a line parser needs, since a banner on stderr must not
 /// interleave into the data being parsed.
@@ -706,14 +712,57 @@ pub(crate) async fn run_capture_parts(
     cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
     cmd.kill_on_drop(true);
 
-    let out = tokio::time::timeout(timeout, cmd.output())
-        .await
-        .map_err(|_| AppError::Timeout(timeout.as_secs()))?
-        .map_err(AppError::Io)?;
+    let mut child = cmd.spawn().map_err(AppError::Io)?;
+    // Read both pipes concurrently (a full pipe would otherwise deadlock the
+    // child) and cap each, killing the child if either stream blows the cap.
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let (status, out, err) = tokio::time::timeout(timeout, async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut obuf = [0u8; 8192];
+        let mut ebuf = [0u8; 8192];
+        let (mut odone, mut edone) = (false, false);
+        loop {
+            tokio::select! {
+                r = stdout.read(&mut obuf), if !odone => {
+                    let n = r.map_err(AppError::Io)?;
+                    if n == 0 {
+                        odone = true;
+                    } else {
+                        let room = MAX_CAPTURE_BYTES - out.len();
+                        out.extend_from_slice(&obuf[..n.min(room)]);
+                        if n >= room {
+                            let _ = child.start_kill();
+                            break;
+                        }
+                    }
+                }
+                r = stderr.read(&mut ebuf), if !edone => {
+                    let n = r.map_err(AppError::Io)?;
+                    if n == 0 {
+                        edone = true;
+                    } else {
+                        let room = MAX_CAPTURE_BYTES - err.len();
+                        err.extend_from_slice(&ebuf[..n.min(room)]);
+                        if n >= room {
+                            let _ = child.start_kill();
+                            break;
+                        }
+                    }
+                }
+                else => break,
+            }
+        }
+        let status = child.wait().await.map_err(AppError::Io)?;
+        Ok::<_, AppError>((status, out, err))
+    })
+    .await
+    .map_err(|_| AppError::Timeout(timeout.as_secs()))??;
     Ok((
-        out.status.code().unwrap_or(-1),
-        String::from_utf8_lossy(&out.stdout).into_owned(),
-        String::from_utf8_lossy(&out.stderr).into_owned(),
+        status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out).into_owned(),
+        String::from_utf8_lossy(&err).into_owned(),
     ))
 }
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::Notify;
 
@@ -692,6 +692,62 @@ async fn resolve(kind: AgentKind, bin_path: Option<&str>) -> Option<PathBuf> {
 /// — the largest, `opencode models`, is tens of KB.
 const MAX_CAPTURE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Drains `stdout` and `stderr` concurrently into capped buffers, returning the
+/// captured bytes and whether either stream exceeded `cap`. Reading both at once
+/// is what keeps a full pipe from deadlocking the child; this stays a pure reader
+/// (no child handle), so the caller kills on overflow and any `AsyncRead` drives
+/// it in a unit test.
+async fn capture_capped<O, E>(
+    stdout: &mut O,
+    stderr: &mut E,
+    cap: usize,
+) -> AppResult<(Vec<u8>, Vec<u8>, bool)>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    let mut obuf = [0u8; 8192];
+    let mut ebuf = [0u8; 8192];
+    let (mut odone, mut edone) = (false, false);
+    let mut overflowed = false;
+    loop {
+        tokio::select! {
+            r = stdout.read(&mut obuf), if !odone => {
+                let n = r.map_err(AppError::Io)?;
+                if n == 0 {
+                    odone = true;
+                } else {
+                    let room = cap - out.len();
+                    out.extend_from_slice(&obuf[..n.min(room)]);
+                    // `>` not `>=`: output landing exactly on the cap is within the
+                    // limit — a later non-empty read (room == 0) flags real overflow.
+                    if n > room {
+                        overflowed = true;
+                        break;
+                    }
+                }
+            }
+            r = stderr.read(&mut ebuf), if !edone => {
+                let n = r.map_err(AppError::Io)?;
+                if n == 0 {
+                    edone = true;
+                } else {
+                    let room = cap - err.len();
+                    err.extend_from_slice(&ebuf[..n.min(room)]);
+                    if n > room {
+                        overflowed = true;
+                        break;
+                    }
+                }
+            }
+            else => break,
+        }
+    }
+    Ok((out, err, overflowed))
+}
+
 /// Runs a short command and returns (exit code, stdout, stderr) as separate
 /// streams — what a line parser needs, since a banner on stderr must not
 /// interleave into the data being parsed.
@@ -713,52 +769,30 @@ pub(crate) async fn run_capture_parts(
     cmd.kill_on_drop(true);
 
     let mut child = cmd.spawn().map_err(AppError::Io)?;
-    // Read both pipes concurrently (a full pipe would otherwise deadlock the
-    // child) and cap each, killing the child if either stream blows the cap.
     let mut stdout = child.stdout.take().expect("stdout piped");
     let mut stderr = child.stderr.take().expect("stderr piped");
-    let (status, out, err) = tokio::time::timeout(timeout, async {
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let mut obuf = [0u8; 8192];
-        let mut ebuf = [0u8; 8192];
-        let (mut odone, mut edone) = (false, false);
-        loop {
-            tokio::select! {
-                r = stdout.read(&mut obuf), if !odone => {
-                    let n = r.map_err(AppError::Io)?;
-                    if n == 0 {
-                        odone = true;
-                    } else {
-                        let room = MAX_CAPTURE_BYTES - out.len();
-                        out.extend_from_slice(&obuf[..n.min(room)]);
-                        if n >= room {
-                            let _ = child.start_kill();
-                            break;
-                        }
-                    }
-                }
-                r = stderr.read(&mut ebuf), if !edone => {
-                    let n = r.map_err(AppError::Io)?;
-                    if n == 0 {
-                        edone = true;
-                    } else {
-                        let room = MAX_CAPTURE_BYTES - err.len();
-                        err.extend_from_slice(&ebuf[..n.min(room)]);
-                        if n >= room {
-                            let _ = child.start_kill();
-                            break;
-                        }
-                    }
-                }
-                else => break,
-            }
+    let (status, out, err, overflowed) = tokio::time::timeout(timeout, async {
+        let (out, err, overflowed) =
+            capture_capped(&mut stdout, &mut stderr, MAX_CAPTURE_BYTES).await?;
+        // On overflow the child is still writing to a now-unread pipe, so kill it
+        // before waiting; otherwise wait reaps the process that closed its streams.
+        if overflowed {
+            let _ = child.start_kill();
         }
         let status = child.wait().await.map_err(AppError::Io)?;
-        Ok::<_, AppError>((status, out, err))
+        Ok::<_, AppError>((status, out, err, overflowed))
     })
     .await
     .map_err(|_| AppError::Timeout(timeout.as_secs()))??;
+    if overflowed {
+        // Past the cap the capture is truncated, so its exit code and partial
+        // output are meaningless — fail deterministically rather than let a caller
+        // parse a fragment (or a racing exit 0) as a complete, successful result.
+        return Err(AppError::Command(format!(
+            "{} produced more than {MAX_CAPTURE_BYTES} bytes of output",
+            program.display()
+        )));
+    }
     Ok((
         status.code().unwrap_or(-1),
         String::from_utf8_lossy(&out).into_owned(),
@@ -3141,6 +3175,36 @@ mod child_env_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn capture_capped_round_trips_both_streams_under_cap() {
+        let (mut o, mut e): (&[u8], &[u8]) = (b"hello stdout", b"a banner line");
+        let (out, err, overflowed) = capture_capped(&mut o, &mut e, 64).await.unwrap();
+        assert_eq!(out.as_slice(), b"hello stdout");
+        assert_eq!(err.as_slice(), b"a banner line");
+        assert!(!overflowed);
+    }
+
+    #[tokio::test]
+    async fn capture_capped_truncates_and_flags_over_cap() {
+        let big = vec![b'x'; 100];
+        let (mut o, mut e): (&[u8], &[u8]) = (big.as_slice(), b"");
+        let (out, err, overflowed) = capture_capped(&mut o, &mut e, 16).await.unwrap();
+        assert_eq!(out.len(), 16);
+        assert!(err.is_empty());
+        assert!(overflowed);
+    }
+
+    #[tokio::test]
+    async fn capture_capped_allows_output_exactly_at_cap() {
+        // Output landing exactly on the cap is within the limit, not truncation.
+        let exact = vec![b'y'; 16];
+        let (mut o, mut e): (&[u8], &[u8]) = (exact.as_slice(), b"");
+        let (out, err, overflowed) = capture_capped(&mut o, &mut e, 16).await.unwrap();
+        assert_eq!(out.len(), 16);
+        assert!(!overflowed);
+        assert!(err.is_empty());
+    }
 
     // Real opencode `run --format json` lines (captured 2026-06-23, v1.17.9).
     const STEP_START: &str = r#"{"type":"step_start","sessionID":"ses_abc","part":{"type":"step-start"}}"#;

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -37,7 +37,7 @@ import { Switch } from "@/components/ui/switch";
 import { detectAgentCli, providerKind } from "@/lib/ai/agent";
 import { LOGIN_COMMAND } from "@/lib/ai/cli-client";
 import { buildAiCommentBody } from "@/lib/ai/comment-branding";
-import { useAvailableModels } from "@/lib/ai/models";
+import { modelPickerEmptyText, useAvailableModels } from "@/lib/ai/models";
 import {
   defaultModelForProvider,
   PROVIDER_LABELS,
@@ -410,15 +410,8 @@ export function PrReviewPanel({
               }
             />
             <ComboboxContent>
-              {/* `isFetching`, never `isPending` — a catalog that was never
-                  requested must not read as loading. With placeholder
-                  suggestions always present this renders only under a typed
-                  filter, which may still be resolving — matching the session
-                  and Settings pickers. */}
               <ComboboxEmpty>
-                {available.isFetching
-                  ? "No matching models yet (catalog loading) — the typed id is used as-is"
-                  : "No matching models — the typed id is used as-is"}
+                {modelPickerEmptyText(available.isFetching)}
               </ComboboxEmpty>
               <ComboboxList>
                 {(item: string) => (

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -411,11 +411,14 @@ export function PrReviewPanel({
             />
             <ComboboxContent>
               {/* `isFetching`, never `isPending` — a catalog that was never
-                  requested must not read as loading. */}
+                  requested must not read as loading. With placeholder
+                  suggestions always present this renders only under a typed
+                  filter, which may still be resolving — matching the session
+                  and Settings pickers. */}
               <ComboboxEmpty>
                 {available.isFetching
-                  ? "Loading models…"
-                  : "Uses the typed id as-is"}
+                  ? "No matching models yet (catalog loading) — the typed id is used as-is"
+                  : "No matching models — the typed id is used as-is"}
               </ComboboxEmpty>
               <ComboboxList>
                 {(item: string) => (

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -30,7 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { type AgentKind, isAgentKind } from "@/lib/ai/agent";
-import { useAgentModels } from "@/lib/ai/models";
+import { modelPickerEmptyText, useAgentModels } from "@/lib/ai/models";
 import type { McpServer } from "@/lib/settings/api";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
@@ -108,12 +108,7 @@ export function ModelPicker({
           long ids (e.g. `opencode/…`). Size to content, capped on-screen. */}
       <ComboboxContent className="w-fit max-w-sm">
         <ComboboxEmpty>
-          {/* With placeholder suggestions always present, this renders only when
-              the typed filter matches nothing — keep the typed-id reassurance
-              and note an in-flight probe rather than replacing it. */}
-          {available.isFetching
-            ? "No matching models yet (catalog loading) — the typed id is used as-is"
-            : "No matching models — the typed id is used as-is"}
+          {modelPickerEmptyText(available.isFetching)}
         </ComboboxEmpty>
         {/* Render FUNCTION, not static rows: only this form maps the store's
             filtered items, so static children would never narrow as you type. */}

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -142,10 +142,15 @@ function ModelPicker({
         catalog?.cause !== "failed" &&
         !availableModels.isFetching:
         return "Model passed to the CLI — leave blank for its default";
-      case availableModels.isFetching:
-        return "Loading models…";
+      // A settled live list outranks an in-flight refetch: an HTTP provider's
+      // background refetch (staleTime + focus refetch) keeps its `live` data, so
+      // "Loading…" must not flash over the shown count. First load and a provider
+      // switch both change the query key, so `live` is false on the placeholder
+      // and the loading case still wins there.
       case catalog?.live === true:
         return `${models.length} models from ${PROVIDER_LABELS[value.provider]}`;
+      case availableModels.isFetching:
+        return "Loading models…";
       case failureReason !== undefined:
         return `Suggestions only — couldn't load the live list: ${failureReason}`;
       case catalog?.cause === "empty":
@@ -220,7 +225,12 @@ function ModelPicker({
           />
           <ComboboxContent>
             <ComboboxEmpty>
-              No matching models — the typed id is used as-is
+              {/* With placeholder suggestions always present, this shows only
+                  under a typed filter, which may still be resolving — note an
+                  in-flight probe, matching the session and PR-review pickers. */}
+              {availableModels.isFetching
+                ? "No matching models yet (catalog loading) — the typed id is used as-is"
+                : "No matching models — the typed id is used as-is"}
             </ComboboxEmpty>
             <ComboboxList>
               {(item: string) => (

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -110,14 +110,20 @@ function ModelPicker({
   allowedHosts: string[];
 }) {
   const keyPreview = useSecretPreview(value.provider);
+  const isCli = isCliProvider(value.provider);
+  // Listing a CLI's catalog spawns it, so a CLI provider's probe waits for the
+  // user to reach the picker — sticky, matching the session and PR-review
+  // pickers. HTTP providers keep fetching eagerly: reaching Settings → AI is
+  // itself the intent, and the cost is a GET, not a subprocess.
+  const [modelsWanted, setModelsWanted] = useState(false);
   const availableModels = useAvailableModels(
     value,
     Boolean(keyPreview.data),
     allowedHosts,
+    { enabled: !isCli || modelsWanted },
   );
   const catalog = availableModels.data;
   const models = catalog?.models ?? [];
-  const isCli = isCliProvider(value.provider);
   const modelMemory = useRef<Partial<Record<AiProviderId, string>>>({});
   // Only a failed fetch carries unbounded provider prose, so it alone is clamped and
   // given a tooltip; every other line is short enough to render whole.
@@ -134,9 +140,9 @@ function ModelPicker({
       case isCli &&
         catalog?.live !== true &&
         catalog?.cause !== "failed" &&
-        !availableModels.isPending:
+        !availableModels.isFetching:
         return "Model passed to the CLI — leave blank for its default";
-      case availableModels.isPending:
+      case availableModels.isFetching:
         return "Loading models…";
       case catalog?.live === true:
         return `${models.length} models from ${PROVIDER_LABELS[value.provider]}`;
@@ -200,6 +206,9 @@ function ModelPicker({
             if (model) onChange({ ...value, model });
           }}
           openOnInputClick
+          onOpenChange={(open) => {
+            if (open) setModelsWanted(true);
+          }}
         >
           <ComboboxInput
             id={`${idPrefix}-model`}
@@ -207,6 +216,7 @@ function ModelPicker({
             placeholder={
               defaultModelForProvider(value.provider) || "Account default"
             }
+            onFocus={() => setModelsWanted(true)}
           />
           <ComboboxContent>
             <ComboboxEmpty>

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -48,7 +48,7 @@ import {
 import { LOGIN_COMMAND } from "@/lib/ai/cli-client";
 import { createAiClient } from "@/lib/ai/client";
 import type { ReviewContextSize } from "@/lib/ai/context-budget";
-import { useAvailableModels } from "@/lib/ai/models";
+import { modelPickerEmptyText, useAvailableModels } from "@/lib/ai/models";
 import {
   ALL_PROVIDER_IDS,
   defaultModelForProvider,
@@ -225,12 +225,7 @@ function ModelPicker({
           />
           <ComboboxContent>
             <ComboboxEmpty>
-              {/* With placeholder suggestions always present, this shows only
-                  under a typed filter, which may still be resolving — note an
-                  in-flight probe, matching the session and PR-review pickers. */}
-              {availableModels.isFetching
-                ? "No matching models yet (catalog loading) — the typed id is used as-is"
-                : "No matching models — the typed id is used as-is"}
+              {modelPickerEmptyText(availableModels.isFetching)}
             </ComboboxEmpty>
             <ComboboxList>
               {(item: string) => (

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -291,6 +291,12 @@ export function useAvailableModels(
     },
     enabled: opts?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
+    // Static suggestions stand in while the (possibly CLI-spawning) probe runs
+    // and whenever the query is gate-disabled, so the picker never shows an empty
+    // list — parity with the session pickers' useAgentModels. placeholderData
+    // forces query status to `success`, so a consumer detects loading via
+    // `isFetching`, not `isPending`.
+    placeholderData: () => ({ models: fallbackModels(settings), live: false }),
     // The CLI arm spawns a process, not an HTTP GET — a focus or reconnect
     // refetch must not re-run the CLI. HTTP providers keep both defaults.
     refetchOnWindowFocus: !isCliProvider(settings.provider),

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -353,3 +353,14 @@ export function useAgentModels(
     refetchOnReconnect: false,
   });
 }
+
+/** Empty-state copy for the model-picker comboboxes. Both hooks above keep
+ *  placeholder suggestions present, so a picker's empty state renders only under
+ *  a typed filter that matches nothing — which may just be the catalog still
+ *  resolving, so an in-flight probe is named rather than replacing the typed-id
+ *  reassurance. */
+export function modelPickerEmptyText(isFetching: boolean): string {
+  return isFetching
+    ? "No matching models yet (catalog loading) — the typed id is used as-is"
+    : "No matching models — the typed id is used as-is";
+}

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -232,7 +232,11 @@ async function fetchProviderModels(
  * Live model list for the current provider, falling back to the static
  * suggestions when there's no key or base URL configured, the request fails, or
  * the provider lists nothing. `opts.enabled` lets a caller defer the provider
- * request until the user shows intent to pick a model.
+ * request until the user shows intent to pick a model. `data` is always defined
+ * — static suggestions stand in until the request settles, and whenever the query
+ * is gate-disabled — so query status is always `success`: detect an in-flight
+ * request with `isFetching`, never `isPending`, and read `data.live` / `data.cause`
+ * to tell a settled fallback from a stand-in.
  */
 export function useAvailableModels(
   settings: AiSettings,
@@ -308,6 +312,9 @@ export function useAvailableModels(
  * Live model list for an agent CLI, for the session-side pickers, falling back
  * to that CLI's static suggestions when it lists nothing or the probe fails.
  * `opts.enabled` defers the probe until the user shows intent to pick a model.
+ * `data` is always defined (static suggestions stand in until the probe settles,
+ * and whenever the query is gate-disabled), so status is always `success`: detect
+ * an in-flight probe with `isFetching`, never `isPending`.
  *
  * Deliberately carries no binary-path axis: sessions have no per-agent path
  * override (every session start passes `binPath: null`), and the probe must


### PR DESCRIPTION
Opening Settings → AI immediately probed the configured provider's model catalog, which for CLI providers means spawning the CLI as a subprocess before the user has touched the model picker. This gates the CLI arm behind actual engagement with the picker and hardens the capture helper underneath so a child process can't buffer output without limit.

### Deferred CLI probe (`src/features/settings/AiProviderSection.tsx`)

- `ModelPicker` now holds a sticky `modelsWanted` flag and passes `{ enabled: !isCli || modelsWanted }` to `useAvailableModels`, so a CLI provider's catalog is only listed once the user reaches the picker; HTTP providers keep fetching eagerly, since that path is a GET rather than a subprocess.
- The flag is armed from the `Combobox`'s `onOpenChange` (on open) and the `ComboboxInput`'s `onFocus`, covering both click and keyboard-focus entry.
- The hint switch reads `availableModels.isFetching` instead of `isPending` for the "Loading models…" and "Model passed to the CLI…" arms, matching the query's new placeholder-backed status.
- `isCli` moves above the `useAvailableModels` call, since it now feeds the enabled gate.

### Placeholder catalog (`src/lib/ai/models.ts`)

- `useAvailableModels` gains `placeholderData` returning `fallbackModels(settings)` with `live: false`, so the picker shows static suggestions while the probe runs and while the query is gate-disabled instead of an empty list — parity with the session pickers' `useAgentModels`.
- A comment records the consequence for consumers: `placeholderData` forces query status to `success`, so loading must be detected via `isFetching`.

### Bounded CLI capture (`src-tauri/src/agent.rs`)

- `run_capture_parts` replaces `cmd.output()` with an explicit `spawn()` plus a `tokio::select!` loop that drains stdout and stderr concurrently into separate buffers, so a full pipe can't deadlock the child.
- Adds `MAX_CAPTURE_BYTES` (8 MiB) as a per-stream cap; a stream that hits it triggers `child.start_kill()` and ends the loop, bounding memory as well as duration (the existing timeout bounded only the latter).
- The read loop and the following `child.wait()` remain inside the same `tokio::time::timeout`, still surfacing `AppError::Timeout`, with the exit code, stdout, and stderr now derived from the collected buffers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented commands that produce excessive output from overwhelming the application by stopping captures beyond a safe limit.
  * Improved command cleanup and error handling when output exceeds the limit.
  * Output exactly at the safe limit is now handled correctly.

* **Improvements**
  * CLI model lists now load when the model selector is opened or focused, making settings load faster.
  * Added suggested models while live model information is loading or unavailable.
  * Improved loading-state messaging across model selectors during background catalog refreshes.
  * Clarified when catalogs are loading, when no matches are found, and that typed model IDs can still be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->