### PR TITLE
feat(diff,hotkeys,settings): add selection keybinds and shortcut filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to
 add to a selection, so one selection can mix added and removed lines across
 hunks), including committing or discarding only part of a brand-new
 (untracked) file. Stage or unstage a drag-made selection with
-Ctrl+Shift+Enter (Cmd on macOS), without reaching for the button. Stage,
-unstage, or discard single files or a multi-selection from the context menu
-or the command palette; discarding a whole untracked file goes to the
-recycle bin. Commit with title + body, co-authors suggested from history,
-amend, undo, reset, and revert.
+`Ctrl`/`⌘`+`Shift`+`Enter`, without reaching for the button. Stage, unstage,
+or discard single files or a multi-selection from the context menu (staging
+and unstaging a selection sit in the command palette too); discarding a
+whole untracked file goes to the recycle bin. Commit with title + body,
+co-authors suggested from history, amend, undo, reset, and revert.
 
 ### Branches
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to
 add to a selection, so one selection can mix added and removed lines across
 hunks), including committing or discarding only part of a brand-new
-(untracked) file. Stage, unstage, or discard single files or a
-multi-selection from the context menu; discarding a whole untracked file
-goes to the recycle bin. Commit with title + body,
+(untracked) file. Stage or unstage a drag-made selection with
+Ctrl+Shift+Enter (Cmd on macOS), without reaching for the button. Stage,
+unstage, or discard single files or a multi-selection from the context menu
+or the command palette; discarding a whole untracked file goes to the
+recycle bin. Commit with title + body,
 co-authors suggested from history, amend, undo, reset, and revert.
 
 ### Branches
@@ -839,7 +841,8 @@ review via its subscription login. The full list is under
   and the choice is remembered until you expand it again.
 - **Keyboard-first**: rebindable shortcuts with GitHub-Desktop-compatible
   defaults, a generated cheat sheet (`Ctrl`/`⌘`+`/`), a command palette
-  (`Ctrl`/`⌘`+`K`), and arrow-key navigation everywhere.
+  (`Ctrl`/`⌘`+`K`), a filterable shortcut list in Settings (by name, category,
+  or key), and arrow-key navigation everywhere.
 - **Themes**: System, Light, Dark, and a softer **Slate** (a cool, lifted
   blue-gray) that eases eye strain; switch in **Settings → Appearance** or
   cycle from the command palette.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ hunks), including committing or discarding only part of a brand-new
 Ctrl+Shift+Enter (Cmd on macOS), without reaching for the button. Stage,
 unstage, or discard single files or a multi-selection from the context menu
 or the command palette; discarding a whole untracked file goes to the
-recycle bin. Commit with title + body,
-co-authors suggested from history, amend, undo, reset, and revert.
+recycle bin. Commit with title + body, co-authors suggested from history,
+amend, undo, reset, and revert.
 
 ### Branches
 

--- a/changelog.d/added-keyboard-shortcut-filter.md
+++ b/changelog.d/added-keyboard-shortcut-filter.md
@@ -1,0 +1,6 @@
+- **Filter the keyboard shortcuts list.** **Settings → Keyboard** now opens with
+  a filter box, so reaching one action out of well over a hundred takes a few
+  keystrokes: type part of an action's name, a category like `Branches & stash`,
+  or the shortcut itself (`shift`, `mod+p`, `F5`), and type `unbound` to find the
+  actions that have no key yet. Categories with no matches drop out as you type,
+  and **Focus the filter** jumps straight to the box.

--- a/changelog.d/added-stage-selection-keybinds.md
+++ b/changelog.d/added-stage-selection-keybinds.md
@@ -1,0 +1,6 @@
+- **Stage a line selection from the keyboard.** Drag-select lines in a diff and
+  press Ctrl+Shift+Enter (Cmd+Shift+Enter on macOS) to stage them, or to unstage
+  them on the staged side of a file — a selection that spans several hunks and
+  mixes added and removed lines included. The chord is rebindable in Settings →
+  Keyboard, and **Stage selected files**, **Unstage selected files**, and
+  **Clear line selection** join the command palette.

--- a/changelog.d/fixed-file-row-keyboard.md
+++ b/changelog.d/fixed-file-row-keyboard.md
@@ -1,0 +1,3 @@
+- On the changed-files list, Space selects the focused row and leaves the
+  list's scroll position alone, and Enter or Space on a row's stage/unstage
+  toggle activates just that toggle.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -43,7 +43,7 @@ export const capabilities: Capability[] = [
   {
     group: "Diffs & staging",
     label:
-      "Line, hunk & file staging — drag the line numbers, mixing added and removed lines in one selection",
+      "Line, hunk & file staging — drag the line numbers or use a keybind, mixing added and removed lines in one selection",
   },
   {
     group: "Diffs & staging",
@@ -446,7 +446,7 @@ export const capabilities: Capability[] = [
   // — Keyboard & Markdown —
   {
     group: "Keyboard & Markdown",
-    label: "Command palette + rebindable keys",
+    label: "Command palette + rebindable, filterable keys",
     highlight: true,
   },
   { group: "Keyboard & Markdown", label: "Arrow-key navigation on every list" },

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -773,6 +773,161 @@ mod tests {
         assert!(unstaged.contains("NEW B"));
     }
 
+    /// A selection spanning two hunks and both sides survives real
+    /// `git apply --cached`: the old-side line of one modification and the
+    /// new-side line of another stage independently, each hunk's unselected
+    /// line neutralized by forward semantics.
+    #[tokio::test]
+    async fn partial_patch_stages_mixed_sides_across_hunks() {
+        use crate::git::runner::run_git_input;
+
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-partial-crosshunk-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
+        let repo = dir.to_string_lossy().into_owned();
+        let git = |args: Vec<&'static str>| {
+            let repo = repo.clone();
+            async move { run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap() }
+        };
+
+        git(vec!["init"]).await;
+        git(vec!["config", "user.email", "t@t"]).await;
+        git(vec!["config", "user.name", "t"]).await;
+        // Two modification sites far enough apart (> 6 context lines) to force
+        // two hunks, each carrying both a `-` and a `+`.
+        let base: Vec<String> = (1..=30).map(|i| format!("line {i}")).collect();
+        let file = dir.join("file.txt");
+        std::fs::write(&file, base.join("\n") + "\n").unwrap();
+        git(vec!["add", "."]).await;
+        git(vec!["commit", "-m", "base"]).await;
+        let mut edited = base.clone();
+        edited[2] = "line 3 EDITED".into();
+        edited[24] = "line 25 EDITED".into();
+        std::fs::write(&file, edited.join("\n") + "\n").unwrap();
+        let worktree_before = std::fs::read(&file).unwrap();
+
+        let diff = git(vec!["diff", "--no-color"]).await.stdout_lossy();
+        // Pinned so a context merge can never quietly turn this into one hunk.
+        assert_eq!(
+            diff.lines().filter(|l| l.starts_with("@@")).count(),
+            2,
+            "fixture must produce two hunks:\n{diff}"
+        );
+
+        // Hunk 1's deletion (old-side line 3) plus hunk 2's addition
+        // (new-side line 25) — mixed sides, one line from each hunk.
+        let patch = build_partial_patch(&diff, &[sel(Side::Old, 3), sel(Side::New, 25)], false);
+        run_git_input(
+            Some(&repo),
+            &["apply", "--whitespace=nowarn", "--recount", "--cached", "-"],
+            Some(&patch),
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+
+        // Hunk 1: the selected `-` deletes "line 3" and its unselected `+` is
+        // dropped. Hunk 2: the unselected `-` keeps "line 25" as context and
+        // the selected `+` adds its replacement after it.
+        let mut expected = base.clone();
+        expected.remove(2);
+        let after_kept = expected
+            .iter()
+            .position(|l| l == "line 25")
+            .expect("hunk 2's old line stays in the index")
+            + 1;
+        expected.insert(after_kept, "line 25 EDITED".into());
+        let index_content = git(vec!["show", ":0:file.txt"]).await.stdout_lossy();
+        assert_eq!(index_content, expected.join("\n") + "\n");
+
+        assert_eq!(
+            std::fs::read(&file).unwrap(),
+            worktree_before,
+            "staging must not touch the working tree"
+        );
+    }
+
+    /// The unstage twin: the same cross-hunk, mixed-side selection applied with
+    /// `--cached --reverse` over the STAGED diff. Unstaging half a modification
+    /// is deliberately lossy in one direction — a selected `-` restores its old
+    /// line while the paired `+` stays staged, but a selected `+` is withdrawn
+    /// without its unselected `-` bringing the old line back.
+    #[tokio::test]
+    async fn partial_patch_unstages_mixed_sides_across_hunks() {
+        use crate::git::runner::run_git_input;
+
+        let _tmp = tempfile::Builder::new()
+            .prefix("gd-partial-crosshunk-rev-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let dir = _tmp.path().to_path_buf();
+        let repo = dir.to_string_lossy().into_owned();
+        let git = |args: Vec<&'static str>| {
+            let repo = repo.clone();
+            async move { run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap() }
+        };
+
+        git(vec!["init"]).await;
+        git(vec!["config", "user.email", "t@t"]).await;
+        git(vec!["config", "user.name", "t"]).await;
+        let base: Vec<String> = (1..=30).map(|i| format!("line {i}")).collect();
+        let file = dir.join("file.txt");
+        std::fs::write(&file, base.join("\n") + "\n").unwrap();
+        git(vec!["add", "."]).await;
+        git(vec!["commit", "-m", "base"]).await;
+        let mut edited = base.clone();
+        edited[2] = "line 3 EDITED".into();
+        edited[24] = "line 25 EDITED".into();
+        std::fs::write(&file, edited.join("\n") + "\n").unwrap();
+        // Both modifications fully staged — the unstage path reads HEAD→index.
+        git(vec!["add", "file.txt"]).await;
+        let worktree_before = std::fs::read(&file).unwrap();
+
+        let diff = git(vec!["diff", "--cached", "--no-color"]).await.stdout_lossy();
+        // Pinned so a context merge can never quietly turn this into one hunk.
+        assert_eq!(
+            diff.lines().filter(|l| l.starts_with("@@")).count(),
+            2,
+            "fixture must produce two hunks:\n{diff}"
+        );
+
+        let patch = build_partial_patch(&diff, &[sel(Side::Old, 3), sel(Side::New, 25)], true);
+        run_git_input(
+            Some(&repo),
+            &["apply", "--whitespace=nowarn", "--recount", "--cached", "--reverse", "-"],
+            Some(&patch),
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+
+        // Hunk 1: the selected `-` puts "line 3" back while its unselected `+`
+        // stays staged as context. Hunk 2: the selected `+` is withdrawn and its
+        // unselected `-` was dropped, so "line 25" does NOT return.
+        let mut expected = base.clone();
+        let after_restored = expected
+            .iter()
+            .position(|l| l == "line 3")
+            .expect("hunk 1's old line returns to the index")
+            + 1;
+        expected.insert(after_restored, "line 3 EDITED".into());
+        let withdrawn = expected
+            .iter()
+            .position(|l| l == "line 25")
+            .expect("hunk 2's old line is in the base");
+        expected.remove(withdrawn);
+        let index_content = git(vec!["show", ":0:file.txt"]).await.stdout_lossy();
+        assert_eq!(index_content, expected.join("\n") + "\n");
+
+        assert_eq!(
+            std::fs::read(&file).unwrap(),
+            worktree_before,
+            "unstaging must not touch the working tree"
+        );
+    }
+
     /// End-to-end check of the hunk-staging plumbing: a single hunk cut out
     /// of a two-hunk diff stages via stdin `git apply --cached` and unstages
     /// via `--reverse`. Requires git on PATH (true for this project's dev

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -231,6 +231,11 @@ function WorkingTreeDiff({
     clearSelection,
     hunkMode && selection !== null && !busy && discard === null,
   );
+  // The Discard confirm's `run` captured line numbers at open time — close it
+  // if the selection invalidates underneath (a refetch while the dialog is up).
+  useEffect(() => {
+    if (selection === null) setDiscard(null);
+  }, [selection]);
 
   if (!hunkMode) {
     return (

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -37,7 +37,12 @@ import {
   useFileDiff,
   useRepoStatus,
 } from "@/lib/git/queries";
-import { formatBinding, isMac } from "@/lib/hotkeys/binding";
+import {
+  bindingToAriaKeyshortcuts,
+  formatBinding,
+  isMac,
+} from "@/lib/hotkeys/binding";
+import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import type { SelectedFile } from "@/lib/stores/ui";
@@ -172,6 +177,27 @@ function WorkingTreeDiff({
   // single whole-file view lets a selection span multiple hunks.
   const [selection, setSelection] = useState<SelectedLine[] | null>(null);
   const clearSelection = useCallback(() => setSelection(null), []);
+  // Above the `!hunkMode` early return: the hotkey hooks below must run
+  // unconditionally, and they read `busy`.
+  const busy =
+    applyPatch.isPending ||
+    applyPartial.isPending ||
+    discardUntracked.isPending;
+  const selectionBinding =
+    useEffectiveBindings().get("stage-selected-lines") ?? null;
+  // One contextual chord: stage the selection on an unstaged file's diff,
+  // unstage it on a staged one — mirroring the banner's primary button. Dead
+  // while the Discard confirm is open: the global listener has no dialog guard.
+  useHotkeyAction(
+    "stage-selected-lines",
+    () => applySelection({ cached: true, reverse: file.staged }),
+    selection !== null && !busy && discard === null,
+  );
+  useHotkeyAction(
+    "clear-line-selection",
+    clearSelection,
+    selection !== null && !busy && discard === null,
+  );
 
   const parsed: ParsedDiff | null = useMemo(() => {
     const data = diff.data;
@@ -218,10 +244,18 @@ function WorkingTreeDiff({
   }
 
   const onError = (e: unknown) => toastError(e);
-  const busy =
-    applyPatch.isPending ||
-    applyPartial.isPending ||
-    discardUntracked.isPending;
+  // Shortcut hints on the selection banner: `aria-keyshortcuts` keeps the chord
+  // off the accessible name, the title makes it discoverable. Both omitted when
+  // the action is unbound.
+  const selectionActionLabel = file.staged ? "Unstage" : "Stage";
+  const selectionTitle =
+    selectionBinding === null
+      ? undefined
+      : `${selectionActionLabel} (${formatBinding(selectionBinding)})`;
+  const selectionKeyshortcuts =
+    selectionBinding === null
+      ? undefined
+      : bindingToAriaKeyshortcuts(selectionBinding);
 
   function applyHunk(
     hunk: DiffHunk,
@@ -295,6 +329,8 @@ function WorkingTreeDiff({
               variant="secondary"
               size="xs"
               disabled={busy}
+              title={selectionTitle}
+              aria-keyshortcuts={selectionKeyshortcuts}
               onClick={() => applySelection({ cached: true, reverse: true })}
             >
               Unstage
@@ -305,6 +341,8 @@ function WorkingTreeDiff({
                 variant="secondary"
                 size="xs"
                 disabled={busy}
+                title={selectionTitle}
+                aria-keyshortcuts={selectionKeyshortcuts}
                 onClick={() => applySelection({ cached: true, reverse: false })}
               >
                 Stage
@@ -365,6 +403,13 @@ function WorkingTreeDiff({
               {file.staged ? "unstage" : "stage"} just those lines. Hold{" "}
               {ADDITIVE_MODIFIER} while dragging to add to the selection, so one
               selection can mix added and removed lines.
+              {selectionBinding !== null && (
+                <>
+                  {" "}
+                  Press {formatBinding(selectionBinding)} to{" "}
+                  {file.staged ? "unstage" : "stage"} the selection.
+                </>
+              )}
             </span>
             <button
               type="button"

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -175,29 +175,20 @@ function WorkingTreeDiff({
   const shownDiscard = useRetained(discard);
   // The drag-selected lines to stage/unstage/discard — file-wide, since the
   // single whole-file view lets a selection span multiple hunks.
-  const [selection, setSelection] = useState<SelectedLine[] | null>(null);
-  const clearSelection = useCallback(() => setSelection(null), []);
-  // Above the `!hunkMode` early return: the hotkey hooks below must run
-  // unconditionally, and they read `busy`.
+  const [selectionState, setSelectionState] = useState<{
+    lines: SelectedLine[];
+    forText: string;
+  } | null>(null);
+  const clearSelection = useCallback(() => setSelectionState(null), []);
+  // `parsed`, `hunkMode`, and `busy` are computed above the `!hunkMode` early
+  // return because the hotkey registrations below run unconditionally and read
+  // them.
   const busy =
     applyPatch.isPending ||
     applyPartial.isPending ||
     discardUntracked.isPending;
   const selectionBinding =
     useEffectiveBindings().get("stage-selected-lines") ?? null;
-  // One contextual chord: stage the selection on an unstaged file's diff,
-  // unstage it on a staged one — mirroring the banner's primary button. Dead
-  // while the Discard confirm is open: the global listener has no dialog guard.
-  useHotkeyAction(
-    "stage-selected-lines",
-    () => applySelection({ cached: true, reverse: file.staged }),
-    selection !== null && !busy && discard === null,
-  );
-  useHotkeyAction(
-    "clear-line-selection",
-    clearSelection,
-    selection !== null && !busy && discard === null,
-  );
 
   const parsed: ParsedDiff | null = useMemo(() => {
     const data = diff.data;
@@ -220,6 +211,27 @@ function WorkingTreeDiff({
   // so part of a new file can be committed. Binary/huge untracked files have
   // `parsed === null` and still fall through to the whole-file view below.
   const hunkMode = parsed !== null && parsed.hunks.length > 0;
+  // A selection is valid only against the diff text it was dragged against —
+  // stale by text means every consumer sees no selection at the same instant.
+  const selection =
+    selectionState !== null && selectionState.forText === diff.data?.text
+      ? selectionState.lines
+      : null;
+  // One contextual chord: stage the selection on an unstaged file's diff,
+  // unstage it on a staged one — mirroring the banner's primary button. Dead
+  // while the Discard confirm is open (the global listener has no dialog guard)
+  // and while the non-staging fallback renders.
+  useHotkeyAction(
+    "stage-selected-lines",
+    () => applySelection({ cached: true, reverse: file.staged }),
+    hunkMode && selection !== null && !busy && discard === null,
+  );
+  useHotkeyAction(
+    "clear-line-selection",
+    clearSelection,
+    hunkMode && selection !== null && !busy && discard === null,
+  );
+
   if (!hunkMode) {
     return (
       <DiffSurface
@@ -443,7 +455,11 @@ function WorkingTreeDiff({
           staged={file.staged}
           busy={busy}
           selection={selection}
-          onSelect={setSelection}
+          onSelect={(lines) =>
+            setSelectionState(
+              lines === null ? null : { lines, forText: diff.data?.text ?? "" },
+            )
+          }
           onHunkAction={onHunkAction}
         />
       </div>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -170,6 +170,9 @@ function WorkingTreeDiff({
     // A new (untracked) file has no committed version to revert to — the
     // confirm wording changes from "revert to last committed" to "remove".
     newFile?: boolean;
+    // The diff text the confirm's `run` was built against — see the close
+    // effect below.
+    forText: string;
   } | null>(null);
   // Declared with the hooks above the `!hunkMode` early return below.
   const shownDiscard = useRetained(discard);
@@ -231,12 +234,13 @@ function WorkingTreeDiff({
     clearSelection,
     hunkMode && selection !== null && !busy && discard === null,
   );
-  // The Discard confirm's `run` captured line numbers (or a hunk) at open
-  // time — close it if the selection invalidates underneath (a refetch while
-  // the dialog is up).
+  // Any Discard confirm's `run` captured line numbers (or a hunk) at open
+  // time — close it the moment the diff text moves on from the text it was
+  // opened against (a refetch while the dialog is up), whichever arm opened it.
+  const liveText = diff.data?.text;
   useEffect(() => {
-    if (selection === null) setDiscard(null);
-  }, [selection]);
+    if (discard !== null && discard.forText !== liveText) setDiscard(null);
+  }, [discard, liveText]);
 
   if (!hunkMode) {
     return (
@@ -313,6 +317,7 @@ function WorkingTreeDiff({
       setDiscard({
         label: hunk.header,
         newFile: untracked,
+        forText: diff.data?.text ?? "",
         run: untracked
           ? () => discardLines(hunkAddedNewLines(hunk))
           : () => applyHunk(hunk, { cached: false, reverse: true }),
@@ -374,6 +379,7 @@ function WorkingTreeDiff({
                   setDiscard({
                     label: `${selection.length} selected ${selection.length === 1 ? "line" : "lines"}`,
                     newFile: untracked,
+                    forText: diff.data?.text ?? "",
                     run: untracked
                       ? () =>
                           discardLines(

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -125,7 +125,7 @@ export function DiffViewer({ repoPath }: { repoPath: string }) {
 
   return (
     <WorkingTreeDiff
-      key={`${deferredFile.staged}:${deferredFile.path}`}
+      key={`${repoPath}:${deferredFile.staged}:${deferredFile.path}`}
       repoPath={repoPath}
       file={deferredFile}
     />
@@ -231,8 +231,9 @@ function WorkingTreeDiff({
     clearSelection,
     hunkMode && selection !== null && !busy && discard === null,
   );
-  // The Discard confirm's `run` captured line numbers at open time — close it
-  // if the selection invalidates underneath (a refetch while the dialog is up).
+  // The Discard confirm's `run` captured line numbers (or a hunk) at open
+  // time — close it if the selection invalidates underneath (a refetch while
+  // the dialog is up).
   useEffect(() => {
     if (selection === null) setDiscard(null);
   }, [selection]);
@@ -460,10 +461,8 @@ function WorkingTreeDiff({
           staged={file.staged}
           busy={busy}
           selection={selection}
-          onSelect={(lines) =>
-            setSelectionState(
-              lines === null ? null : { lines, forText: diff.data?.text ?? "" },
-            )
+          onSelect={(lines, forText) =>
+            setSelectionState(lines === null ? null : { lines, forText })
           }
           onHunkAction={onHunkAction}
         />
@@ -680,7 +679,7 @@ function StagingDiffView({
   staged: boolean;
   busy: boolean;
   selection: SelectedLine[] | null;
-  onSelect: (lines: SelectedLine[] | null) => void;
+  onSelect: (lines: SelectedLine[] | null, forText: string) => void;
   onHunkAction: (hunk: DiffHunk, kind: "stage" | "unstage" | "discard") => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -803,7 +802,9 @@ function StagingDiffView({
         const next = additiveRef.current
           ? mergeSelection(selectedRef.current, lines)
           : lines;
-        onSelectRef.current(next.length ? next : null);
+        // Stamp against the text these rows were BUILT from — the live
+        // diff.data.text can already be newer while the deferred render lags.
+        onSelectRef.current(next.length ? next : null, deferredText);
       },
     });
     paintLines(container, selectedRef.current ?? []); // re-assert after (re)mount
@@ -811,7 +812,7 @@ function StagingDiffView({
       container.removeEventListener("mousedown", onMouseDownCapture, true);
       manager.destroy();
     };
-  }, [diffFile, viewMode]);
+  }, [diffFile, viewMode, deferredText]);
 
   // Paint the committed selection from state (incl. cleared → []).
   useEffect(() => {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -342,11 +342,11 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   the selection instead of replacing it, so one selection can mix added and removed lines
   across as many hunks as you like; a plain drag starts a fresh one.
   {{kbd:stage-selected-lines}} stages the selection (or unstages it, on a staged file's
-  diff) without reaching for the button.
+  diff) without reaching for the button, and the command palette offers **Clear line
+  selection**.
 - Select multiple files ({{key:mod}}-click, or Shift-click for a range), then {{secondaryclick}}
   for **Stage / Unstage / Discard / Stash** of the whole selection — or use the command
-  palette ({{kbd:command-palette}}) for Stage / Unstage selected files, or to clear a
-  line selection.
+  palette ({{kbd:command-palette}}) for Stage / Unstage selected files.
 - Filter the list by path, or by category (new / modified / deleted, included /
   excluded) with the funnel button.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -341,8 +341,12 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   then stage or discard just those. Hold {{key:mod}} while dragging and the new run joins
   the selection instead of replacing it, so one selection can mix added and removed lines
   across as many hunks as you like; a plain drag starts a fresh one.
+  {{kbd:stage-selected-lines}} stages the selection (or unstages it, on a staged file's
+  diff) without reaching for the button.
 - Select multiple files ({{key:mod}}-click, or Shift-click for a range), then {{secondaryclick}}
-  for **Stage / Unstage / Discard / Stash** of the whole selection.
+  for **Stage / Unstage / Discard / Stash** of the whole selection — or use the command
+  palette ({{kbd:command-palette}}) for Stage / Unstage selected files, or to clear a
+  line selection.
 - Filter the list by path, or by category (new / modified / deleted, included /
   excluded) with the funnel button.
 
@@ -2273,16 +2277,17 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
   {{kbd:delete-branch}} delete · {{kbd:update-from-default}} update from default ·
   {{kbd:stash-all}} stash all.
 - **Changes:** {{kbd:commit}} commit{{ai}} · {{kbd:generate-commit-message}} generate
-  with AI (the open dialog's Generate when one is up){{/ai}} · {{kbd:undo-commit}} undo
-  last commit.
+  with AI (the open dialog's Generate when one is up){{/ai}} · {{kbd:stage-selected-lines}}
+  stage/unstage the selected diff lines · {{kbd:undo-commit}} undo last commit.
 - **Pull requests:** {{kbd:create-pr}} create pull request.
 {{ai}}- **Agent:** {{kbd:agent-toggle-terminal}} toggle the session terminal.
 {{/ai}}
 Every shortcut is **rebindable** in **Settings → Keyboard**: click a binding, press a new
-combination, and if it clashes with another action the app moves it for you. Many actions
-(creating issues/releases, repository settings, stash views{{ai}}, most agent
-commands{{/ai}}) are palette-only until you bind a key. Defaults match GitHub Desktop where
-there's an equivalent.`,
+combination, and if it clashes with another action the app moves it for you. The list
+there is filterable by action name, category, or key — {{kbd:focus-filter}} jumps to the
+filter while the section is open. Many actions (creating issues/releases, repository
+settings, stash views{{ai}}, most agent commands{{/ai}}) are palette-only until you bind
+a key. Defaults match GitHub Desktop where there's an equivalent.`,
   },
   {
     id: "settings",
@@ -2330,7 +2335,8 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   automated run also lands a *review failed* row in the inbox (gated on the automations
   notification preference) that shows why it failed and offers a one-click **Re-run** right
   from the row, matching manual-run failures (which show their reason too).{{/ai}}
-- **Keyboard** — rebind any shortcut, with live key-capture.
+- **Keyboard** — rebind any shortcut, with live key-capture, filterable by name, category,
+  or key.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**
   connection. **Sign in to GitHub…** and **Sign in to gitlab.com…** run the CLI's
   sign-in in-app (GitHub's one-time device code, GitLab's browser flow) — no terminal

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -674,6 +674,16 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     !mutating && stagedEntries.length > 0,
   );
   useHotkeyAction(
+    "stage-selected-files",
+    stageSelected,
+    !mutating && selectedEntries.some((e) => e.unstaged !== null),
+  );
+  useHotkeyAction(
+    "unstage-selected-files",
+    unstageSelected,
+    !mutating && selectedEntries.some((e) => e.staged !== null),
+  );
+  useHotkeyAction(
     "focus-filter",
     () => filterRef.current?.focus(),
     entries.length > 0,

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -66,8 +66,10 @@ export const FileRow = memo(function FileRow({
         })
       }
       onKeyDown={(e) => {
-        // Space would otherwise scroll the list and leak to the window-level
-        // hotkey listener.
+        // Keys from the nested toggle button pass through untouched, or the
+        // preventDefault below would cancel its native Enter/Space activation.
+        if (e.target !== e.currentTarget) return;
+        // Space on the row itself must be swallowed or it scrolls the list.
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onSelect(entry, staged, { ctrlOrMeta: false, shift: false });

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -66,8 +66,12 @@ export const FileRow = memo(function FileRow({
         })
       }
       onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ")
+        // Space would otherwise scroll the list and leak to the window-level
+        // hotkey listener.
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
           onSelect(entry, staged, { ctrlOrMeta: false, shift: false });
+        }
       }}
       role="option"
       aria-selected={selected}

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -1,11 +1,16 @@
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { withForm } from "@/lib/form";
 import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
-import { dispatchAction } from "@/lib/hotkeys/hotkeys";
-import { ACTIONS, CATEGORY_ORDER } from "@/lib/hotkeys/registry";
+import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import {
+  ACTIONS,
+  type ActionDef,
+  CATEGORY_ORDER,
+} from "@/lib/hotkeys/registry";
 import { cn } from "@/lib/utils";
 import { settingsFormOpts } from "./settings-form";
 
@@ -22,6 +27,14 @@ export const KeyboardSection = withForm({
     const overrides = useSelector(form.store, (s) => s.values.hotkeys);
     const [recordingId, setRecordingId] = useState<string | null>(null);
     const [note, setNote] = useState<string | null>(null);
+    // View state only: the filter never touches the form, so it can't dirty
+    // the Save/Discard bar or survive into saved settings.
+    const [filter, setFilter] = useState("");
+    const filterRef = useRef<HTMLInputElement>(null);
+
+    // Settings replaces the repository view and its panels mount exclusively,
+    // so this is the only live "focus-filter" handler while Keyboard is open.
+    useHotkeyAction("focus-filter", () => filterRef.current?.focus(), true);
 
     const effective = (id: string): string | null => {
       const override = overrides[id];
@@ -95,6 +108,44 @@ export const KeyboardSection = withForm({
       return () => window.removeEventListener("keydown", handler, true);
     }, [recordingId]);
 
+    const query = filter.trim().toLowerCase();
+
+    /** Substring match over what the row shows: its label, its category, and
+     *  the binding in both display ("Ctrl+Shift+P") and canonical
+     *  ("mod+shift+p") form. "unbound" is the word for the empty binding —
+     *  from three characters on, so typing toward it narrows instead of
+     *  flashing the empty state ("un" still means the Unstage/Undo labels). */
+    function matchesQuery(action: ActionDef): boolean {
+      if (query === "") return true;
+      if (action.label.toLowerCase().includes(query)) return true;
+      if (action.category.toLowerCase().includes(query)) return true;
+      const binding = effective(action.id);
+      if (binding === null)
+        return query.length >= 3 && "unbound".startsWith(query);
+      return (
+        binding.includes(query) ||
+        formatBinding(binding).toLowerCase().includes(query)
+      );
+    }
+
+    const groups = CATEGORY_ORDER.map((category) => ({
+      category,
+      actions: ACTIONS.filter(
+        (a) => a.category === category && matchesQuery(a),
+      ),
+    })).filter((group) => group.actions.length > 0);
+    const shownCount = groups.reduce((n, group) => n + group.actions.length, 0);
+
+    // A filter that hides the recording row cancels recording: the window-level
+    // capture listener would otherwise keep swallowing keys for a row nobody
+    // can see.
+    const recordingHidden =
+      recordingId !== null &&
+      !groups.some((g) => g.actions.some((a) => a.id === recordingId));
+    useEffect(() => {
+      if (recordingHidden) setRecordingId(null);
+    }, [recordingHidden]);
+
     const overrideCount = Object.keys(overrides).length;
 
     return (
@@ -117,6 +168,25 @@ export const KeyboardSection = withForm({
           </span>
         </div>
         <div className="flex gap-2">
+          <Input
+            ref={filterRef}
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            // Recording captures every keydown window-wide, so without this
+            // the first thing typed here would be read as a binding attempt.
+            onFocus={() => setRecordingId(null)}
+            placeholder="Filter shortcuts"
+            aria-label="Filter shortcuts"
+            className="h-7 flex-1"
+            autoComplete="off"
+          />
+          {/* Polite, so the filtered count queues behind the recording
+              announcements above instead of interrupting them. */}
+          <span role="status" aria-live="polite" className="sr-only">
+            {query === ""
+              ? ""
+              : `${shownCount} ${shownCount === 1 ? "shortcut" : "shortcuts"} shown`}
+          </span>
           <Button
             variant="outline"
             size="sm"
@@ -136,11 +206,16 @@ export const KeyboardSection = withForm({
             Reset all to defaults
           </Button>
         </div>
-        {CATEGORY_ORDER.map((category) => (
+        {groups.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No shortcuts match — try an action name, category, or key.
+          </p>
+        ) : null}
+        {groups.map(({ category, actions }) => (
           <div key={category}>
             <h3 className="mb-1 text-xs font-semibold">{category}</h3>
             <div className="divide-y border">
-              {ACTIONS.filter((a) => a.category === category).map((action) => {
+              {actions.map((action) => {
                 const binding = effective(action.id);
                 const overridden = overrides[action.id] !== undefined;
                 const recording = recordingId === action.id;

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -600,6 +600,30 @@ export const ACTIONS = [
     category: "Changes",
     defaultBinding: null,
   },
+  {
+    id: "stage-selected-lines",
+    label: "Stage or unstage selected lines",
+    category: "Changes",
+    defaultBinding: "mod+shift+enter",
+  },
+  {
+    id: "clear-line-selection",
+    label: "Clear line selection",
+    category: "Changes",
+    defaultBinding: null,
+  },
+  {
+    id: "stage-selected-files",
+    label: "Stage selected files",
+    category: "Changes",
+    defaultBinding: null,
+  },
+  {
+    id: "unstage-selected-files",
+    label: "Unstage selected files",
+    category: "Changes",
+    defaultBinding: null,
+  },
 
   // Agent (only live on the Agent tab, which exists when AI features are on)
   {


### PR DESCRIPTION
Staging a drag-made line selection previously meant reaching for the banner button with the mouse, and **Settings → Keyboard** listed well over a hundred actions with no way to search them. This adds a rebindable chord that stages (or unstages) the current line selection, four new Changes actions for the palette, and a filter box over the shortcut list.

### Diff line selection keybinds

- Registers four actions in `src/lib/hotkeys/registry.ts` under the **Changes** category: `stage-selected-lines` (default `mod+shift+enter`), plus `clear-line-selection`, `stage-selected-files`, and `unstage-selected-files` as palette-only entries with no default binding.
- Wires the chord in `src/features/diff/DiffViewer.tsx` via `useHotkeyAction`, applying the same contextual behavior as the banner's primary button — stage on an unstaged file's diff, unstage on a staged one — gated on a live selection, no in-flight mutation, and no open Discard confirm. `busy` moves above the `!hunkMode` early return so the hooks run unconditionally.
- Surfaces the binding in the same component: `title` and `aria-keyshortcuts` on the Stage/Unstage banner buttons (via `bindingToAriaKeyshortcuts`), and a sentence in the selection help text, all omitted when the action is unbound.
- Hooks `stage-selected-files` / `unstage-selected-files` to the existing `stageSelected` / `unstageSelected` handlers in `src/features/repository/ChangesPanel.tsx`, enabled only when the current selection actually has unstaged (respectively staged) entries.
- Adds `e.preventDefault()` to the Enter/Space handler in `src/features/repository/FileRow.tsx` so Space no longer scrolls the list or leaks to the window-level hotkey listener.

### Keyboard settings filter

- Adds a filter `Input` to `src/features/settings/KeyboardSection.tsx` with a `matchesQuery` helper that substring-matches an action's label, its category, and its binding in both canonical (`mod+shift+p`) and display (`Ctrl+Shift+P`) form; `unbound` matches key-less actions from three characters on so typing toward it narrows rather than flashing the empty state.
- Categories are computed into `groups` and dropped when empty, with a "No shortcuts match" message when nothing does, and an `sr-only` `role="status"` region announcing the shown count politely.
- Registers a `focus-filter` handler that jumps to the box, cancels recording on filter focus, and clears `recordingId` when a filter hides the row being recorded — otherwise the window-level capture listener keeps swallowing keys for an invisible row.
- Filter state is local `useState` and never touches the form, so it can't dirty the Save/Discard bar or persist into saved settings.

### Rust coverage

- Adds `partial_patch_stages_mixed_sides_across_hunks` and its `--reverse` twin `partial_patch_unstages_mixed_sides_across_hunks` in `src-tauri/src/git/diff.rs`. Both drive `build_partial_patch` through a real `git apply --cached` on a two-hunk fixture with one old-side and one new-side line selected, assert the exact resulting index content (including the deliberately lossy direction on unstage), pin the hunk count so a context merge can't silently collapse the fixture, and check the working tree is untouched.

### Documentation

- `README.md`: the staging paragraph now mentions the chord and the command palette; the *Keyboard-first* highlight mentions the filterable shortcut list.
- `site/src/data/capabilities.ts`: extends the line/hunk/file staging capability with the keybind and the palette capability with "filterable".
- `src/features/help/content.ts`: the Changes section documents `{{kbd:stage-selected-lines}}` and the palette entries, the Keyboard-shortcuts section adds the chord to the Changes list and describes the filter with `{{kbd:focus-filter}}`, and the Settings → Keyboard bullet notes it is filterable.
- Two changelog fragments: `changelog.d/added-stage-selection-keybinds.md` and `changelog.d/added-keyboard-shortcut-filter.md`.

Relates to #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage or unstage selected diff lines, including multi-hunk selections, with keyboard shortcuts or the command palette.
  * Stage or unstage selected files from the Changes panel.
  * Filter keyboard shortcuts in Settings by action, category, key, or unbound status.
  * Quickly focus the shortcut filter and clear line selections with configurable shortcuts.
* **Bug Fixes**
  * Improved stale-selection handling and preserved native keyboard behavior for file-row toggle controls.
* **Documentation**
  * Updated help, capability descriptions, README, and changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->