### PR TITLE
fix(ui,repository): keep tab popups with their panel across switches

### DIFF
--- a/changelog.d/fixed-tab-switch-popups.md
+++ b/changelog.d/fixed-tab-switch-popups.md
@@ -1,0 +1,3 @@
+- Pickers, menus and dropdowns now stay with the tab they belong to: switch
+  away and back, and the one you left open is still there, with whatever you
+  had typed or ticked.

--- a/src/components/mention-autocomplete.tsx
+++ b/src/components/mention-autocomplete.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import type {
   MentionCandidate,
   MentionSource,
@@ -463,8 +464,9 @@ function emptyMessage(loading: boolean, isError: boolean): string {
   return isError ? "Couldn't load suggestions" : "No matches";
 }
 
-/** The caret-anchored suggestion listbox. Portalled to the body and fixed-
- *  positioned: the composer sits inside overflow containers that would clip it. */
+/** The caret-anchored suggestion listbox. Portalled out and fixed-positioned:
+ *  the composer sits inside overflow containers that would clip it. It lands in
+ *  the surrounding tab panel when there is one, so hiding that panel conceals it. */
 function MentionPopover({
   listId,
   listRef,
@@ -489,6 +491,8 @@ function MentionPopover({
   onPick: (candidate: MentionCandidate) => void;
   onHover: (i: number) => void;
 }) {
+  const portalContainer = usePanelPortalContainer();
+
   // Keep the keyboard-highlighted row visible while arrowing through a list that
   // is taller than the box.
   useEffect(() => {
@@ -564,6 +568,6 @@ function MentionPopover({
         ))
       )}
     </div>,
-    document.body,
+    portalContainer ?? document.body,
   );
 }

--- a/src/components/panel-portal.tsx
+++ b/src/components/panel-portal.tsx
@@ -1,0 +1,62 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+/**
+ * Portal target for floating UI (popovers, menus, selects, comboboxes) rendered
+ * inside an `<Activity>` tab panel. Hiding a panel sets `display: none` on its
+ * host children, so a popup portalled into the panel's own subtree is concealed
+ * by CSS alone — no React work that the hidden subtree would defer.
+ *
+ * `undefined` means "no panel boundary above"; Base UI then falls back to
+ * `document.body`. The value must never be `null`: Base UI's portal reads an
+ * explicit `null` as "a container is coming" and renders nothing at all.
+ */
+const PanelPortalContext = createContext<HTMLElement | undefined>(undefined);
+
+/** Container for floating UI in the surrounding panel, or `undefined` at body level. */
+export function usePanelPortalContainer(): HTMLElement | undefined {
+  return useContext(PanelPortalContext);
+}
+
+/**
+ * Wraps one `<Activity>` panel's content and publishes a portal target that
+ * lives inside it.
+ */
+export function PanelPortalBoundary({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  // State, not a ref: Base UI resolves the container from the prop's identity,
+  // so a ref that is still empty on first render would stay pinned to the body.
+  // Detaches (null) are ignored: <Activity> detaches refs on hide, and adopting
+  // that null would re-point a still-open popup at the body mid-hide. On real
+  // unmount the provider dies with the subtree, so no stale element is readable.
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const attach = useCallback((el: HTMLElement | null) => {
+    if (el) setContainer(el);
+  }, []);
+  return (
+    <PanelPortalContext value={container ?? undefined}>
+      {children}
+      <div data-panel-portal ref={attach} />
+    </PanelPortalContext>
+  );
+}
+
+/**
+ * Clears the panel container for a subtree. Used inside modal popups, which
+ * portal to the body: their floating UI must not land in a panel the modal covers.
+ */
+export function PanelPortalReset({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  return <PanelPortalContext value={undefined}>{children}</PanelPortalContext>;
+}

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -3,6 +3,7 @@
 import { Combobox as ComboboxPrimitive } from "@base-ui/react";
 import { CaretDownIcon, CheckIcon, XIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import {
   InputGroup,
@@ -96,8 +97,9 @@ function ComboboxContent({
     ComboboxPrimitive.Positioner.Props,
     "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Portal container={container}>
       <ComboboxPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,6 +1,7 @@
 import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
 import { CaretRightIcon, CheckIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
@@ -38,8 +39,9 @@ function ContextMenuContent({
     ContextMenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Portal container={container}>
       <ContextMenuPrimitive.Positioner
         className="isolate z-50 outline-none"
         align={align}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { PanelPortalReset } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -61,7 +62,9 @@ function DialogContent({
         )}
         {...props}
       >
-        {children}
+        {/* This popup portals to the body, so floating UI inside it must not
+            portal into a tab panel the dialog covers. */}
+        <PanelPortalReset>{children}</PanelPortalReset>
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import { CaretRightIcon, CheckIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
@@ -27,8 +28,9 @@ function DropdownMenuContent({
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <MenuPrimitive.Portal>
+    <MenuPrimitive.Portal container={container}>
       <MenuPrimitive.Positioner
         className="isolate z-50 outline-none"
         align={align}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,5 +1,6 @@
 import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card";
 
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
@@ -24,8 +25,12 @@ function HoverCardContent({
     PreviewCardPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+    <PreviewCardPrimitive.Portal
+      data-slot="hover-card-portal"
+      container={container}
+    >
       <PreviewCardPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,6 +1,7 @@
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import * as React from "react";
 
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
@@ -23,8 +24,9 @@ function PopoverContent({
     PopoverPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,6 +3,7 @@
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { CaretDownIcon, CaretUpIcon, CheckIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 const Select = SelectPrimitive.Root;
@@ -69,8 +70,9 @@ function SelectContent({
     SelectPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
   >) {
+  const container = usePanelPortalContainer();
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container}>
       <SelectPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/src/features/commit/CoAuthorPicker.tsx
+++ b/src/features/commit/CoAuthorPicker.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { UsersIcon, XIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { parseCoAuthorInput } from "@/lib/git/co-authors";
@@ -29,6 +30,7 @@ export function CoAuthorPicker({
   // Which option the keyboard has landed on (typeahead/combobox pattern: focus
   // stays in the input, ↑/↓ move a highlight, Enter adds the highlighted one).
   const [activeIndex, setActiveIndex] = useState(0);
+  const portalContainer = usePanelPortalContainer();
 
   // The commit author is already credited — never offer them as a co-author.
   const selfEmail = identity.data?.email.toLowerCase() || null;
@@ -107,7 +109,7 @@ export function CoAuthorPicker({
           <UsersIcon data-icon="inline-start" />
           Co-authors
         </Popover.Trigger>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { TagIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
@@ -43,6 +44,7 @@ export function LabelsPopover({
   const editLabels = useEditPrLabels(repoPath, lens);
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<Set<string>>(new Set());
+  const portalContainer = usePanelPortalContainer();
 
   function toggleDraft(name: string, on: boolean) {
     setDraft((prev) => {
@@ -111,7 +113,7 @@ export function LabelsPopover({
             Labels
           </Popover.Trigger>
         </span>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -2,6 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { CopyIcon, KanbanIcon } from "@phosphor-icons/react";
 import { type ReactNode, useEffect, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
@@ -96,10 +97,6 @@ export function ProjectsPopover({
     !scopes.data.scopes.includes("project");
   const canRead = enabled && !classicMissing;
 
-  // KNOWN LIMITATION, shared with LabelsPopover: a tab switch while this is open
-  // strands the popup until that tab is revisited — the <Activity> hide freezes the
-  // very subtree whose re-render would remove the portal, so no close initiated
-  // here can win. Class fix is a planned follow-up; don't re-attempt it here.
   const [open, setOpen] = useState(false);
   // The catalog is an owner-wide query; it waits for a first open rather than
   // firing for every issue the user scrolls through.
@@ -114,6 +111,7 @@ export function ProjectsPopover({
   const [seeded, setSeeded] = useState<Set<string>>(new Set());
   const [seededSettled, setSeededSettled] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const portalContainer = usePanelPortalContainer();
 
   const memberships = useItemProjects(repoPath, kind, number, canRead, lens);
   const available = useAvailableProjects(repoPath, canRead && hasOpened, lens);
@@ -291,7 +289,7 @@ export function ProjectsPopover({
             Projects
           </Popover.Trigger>
         </span>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/conversations/ReactionBar.tsx
+++ b/src/features/conversations/ReactionBar.tsx
@@ -2,6 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { SmileyIcon } from "@phosphor-icons/react";
 import { type ComponentProps, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import type { Reaction } from "@/lib/git/types";
 import {
   ARIA_DISABLED_CLASS,
@@ -97,6 +98,7 @@ export function ReactionBar({
   reason?: string | null;
 }) {
   const [open, setOpen] = useState(false);
+  const portalContainer = usePanelPortalContainer();
   const reacted = new Set(
     reactions.filter((r) => r.viewerReacted).map((r) => r.content),
   );
@@ -138,7 +140,7 @@ export function ReactionBar({
         >
           <SmileyIcon className="size-4" />
         </Popover.Trigger>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/history/useAmendCommit.ts
+++ b/src/features/history/useAmendCommit.ts
@@ -23,10 +23,11 @@ export function useAmendCommit(repoPath: string) {
       const details = await gitCommitDetails(repoPath, hash);
       setCommitDraft(details.subject, details.body);
       setAmending(hash);
-      // Defer the tab switch until the just-clicked context/dropdown menu (or
-      // the force-push dialog) has finished closing. Switching to Changes hides
-      // History via <Activity>, which pauses the closing portal and leaves it
-      // frozen on screen; letting it close first (~100ms) avoids that.
+      // Defer the tab switch until the just-dismissed force-push dialog has
+      // finished closing: it portals to the body, so hiding History via
+      // <Activity> mid-close leaves it frozen on screen. Menus conceal with
+      // the panel and need no deferral; the no-confirm path pays the same
+      // 150ms rather than branching for it.
       setTimeout(() => setRepoTab("changes"), 150);
     },
     [repoPath, setCommitDraft, setAmending, setRepoTab],

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -300,6 +300,9 @@ export function CreateIssueDialog({
                   <TagIcon data-icon="inline-start" />
                   Labels
                 </Popover.Trigger>
+                {/* Bare portal on purpose: this hook would read the PANEL
+                    container (the reset lives below, inside DialogContent),
+                    putting the popup behind the dialog backdrop. */}
                 <Popover.Portal>
                   <Popover.Positioner
                     align="start"

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -300,13 +300,12 @@ export function CreateIssueDialog({
                   <TagIcon data-icon="inline-start" />
                   Labels
                 </Popover.Trigger>
-                {/* Bare on purpose: a usePanelPortalContainer() call in
-                    this component's body runs above DialogContent's
-                    PanelPortalReset, so it returns the panel container and
-                    the popup lands behind the dialog backdrop (measured;
-                    PR #254 review notes).
-                    Pickers rendered as children inside the dialog read
-                    undefined and are fine. */}
+                {/* Bare on purpose: this component's body renders above
+                    DialogContent's PanelPortalReset, so a
+                    usePanelPortalContainer() call here returns the panel
+                    container and the popup would land behind the dialog
+                    backdrop. (Pickers rendered as children inside the
+                    dialog read undefined.) */}
                 <Popover.Portal>
                   <Popover.Positioner
                     align="start"

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -300,9 +300,13 @@ export function CreateIssueDialog({
                   <TagIcon data-icon="inline-start" />
                   Labels
                 </Popover.Trigger>
-                {/* Bare portal on purpose: this hook would read the PANEL
-                    container (the reset lives below, inside DialogContent),
-                    putting the popup behind the dialog backdrop. */}
+                {/* Bare on purpose: a usePanelPortalContainer() call in
+                    this component's body runs above DialogContent's
+                    PanelPortalReset, so it returns the panel container and
+                    the popup lands behind the dialog backdrop (measured;
+                    PR #254 review notes).
+                    Pickers rendered as children inside the dialog read
+                    undefined and are fine. */}
                 <Popover.Portal>
                   <Popover.Positioner
                     align="start"

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { type ComponentProps, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -87,6 +88,7 @@ export function AssigneesPopover({
   const ghHost = useForgeGhHost(repoPath);
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<Map<string, ForgeUserRef>>(new Map());
+  const portalContainer = usePanelPortalContainer();
   // Per-toggle mode reads `value`; commit-on-close mode reads the local draft
   // (seeded from `value` on open). Compare by the provider's stable id.
   const checkedIds = commitOnClose
@@ -152,7 +154,7 @@ export function AssigneesPopover({
             Assignees
           </Popover.Trigger>
         </span>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { RelativeTime } from "@/components/relative-time";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -464,6 +465,7 @@ export function JiraLabelsPopover({
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const portalContainer = usePanelPortalContainer();
 
   // Jira labels can't contain whitespace — reject inline rather than let a bad
   // "create" slip through (the backend would 400).
@@ -569,7 +571,7 @@ export function JiraLabelsPopover({
           <TagIcon data-icon="inline-start" />
           Labels
         </Popover.Trigger>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -14,6 +14,7 @@ import {
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -100,6 +101,7 @@ export function LocalIssueView({
   });
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
+  const portalContainer = usePanelPortalContainer();
   const edit = useEditTitleBody({
     onSave: async ({ title, body }) => {
       if (!issue) return;
@@ -230,7 +232,7 @@ export function LocalIssueView({
                   <TagIcon data-icon="inline-start" />
                   Labels
                 </Popover.Trigger>
-                <Popover.Portal>
+                <Popover.Portal container={portalContainer}>
                   <Popover.Positioner
                     align="start"
                     sideOffset={4}

--- a/src/features/plan/ImplementPlanButton.tsx
+++ b/src/features/plan/ImplementPlanButton.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { PlayIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import {
   AgentPicker,
@@ -27,6 +28,7 @@ export function ImplementPlanButton({ run }: { run: PlanRun }) {
   const [agent, setAgent] = useState<AgentKind>(run.agent);
   const [model, setModel] = useState(run.model);
   const [effort, setEffort] = useState(run.effort);
+  const portalContainer = usePanelPortalContainer();
 
   const onStart = async () => {
     if (!run.draft) return;
@@ -56,7 +58,7 @@ export function ImplementPlanButton({ run }: { run: PlanRun }) {
         <PlayIcon weight="fill" data-icon="inline-start" />
         Implement
       </Popover.Trigger>
-      <Popover.Portal>
+      <Popover.Portal container={portalContainer}>
         <Popover.Positioner align="end" sideOffset={6} className="isolate z-50">
           <Popover.Popup className="w-80 bg-popover p-3 text-popover-foreground shadow-md ring-1 ring-foreground/10">
             <p className="text-xs font-medium">Implement with an agent</p>

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -841,9 +841,13 @@ export function CreatePrDialog({
                     <TagIcon data-icon="inline-start" />
                     Labels
                   </Popover.Trigger>
-                  {/* Bare portal on purpose: this hook would read the PANEL
-                      container (the reset lives below, inside DialogContent),
-                      putting the popup behind the dialog backdrop. */}
+                  {/* Bare on purpose: a usePanelPortalContainer() call in
+                      this component's body runs above DialogContent's
+                      PanelPortalReset, so it returns the panel container and
+                      the popup lands behind the dialog backdrop (measured;
+                      PR #254 review notes).
+                      Pickers rendered as children inside the dialog read
+                      undefined and are fine. */}
                   <Popover.Portal>
                     <Popover.Positioner
                       align="start"

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -841,13 +841,12 @@ export function CreatePrDialog({
                     <TagIcon data-icon="inline-start" />
                     Labels
                   </Popover.Trigger>
-                  {/* Bare on purpose: a usePanelPortalContainer() call in
-                      this component's body runs above DialogContent's
-                      PanelPortalReset, so it returns the panel container and
-                      the popup lands behind the dialog backdrop (measured;
-                      PR #254 review notes).
-                      Pickers rendered as children inside the dialog read
-                      undefined and are fine. */}
+                  {/* Bare on purpose: this component's body renders above
+                      DialogContent's PanelPortalReset, so a
+                      usePanelPortalContainer() call here returns the panel
+                      container and the popup would land behind the dialog
+                      backdrop. (Pickers rendered as children inside the
+                      dialog read undefined.) */}
                   <Popover.Portal>
                     <Popover.Positioner
                       align="start"

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -841,6 +841,9 @@ export function CreatePrDialog({
                     <TagIcon data-icon="inline-start" />
                     Labels
                   </Popover.Trigger>
+                  {/* Bare portal on purpose: this hook would read the PANEL
+                      container (the reset lives below, inside DialogContent),
+                      putting the popup behind the dialog backdrop. */}
                   <Popover.Portal>
                     <Popover.Positioner
                       align="start"

--- a/src/features/pulls/LinkedIssuesField.tsx
+++ b/src/features/pulls/LinkedIssuesField.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { LinkIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { type KeyboardEvent, useRef, useState } from "react";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { IssuePicker, StateIcon } from "@/features/issues/IssueRelations";
@@ -93,6 +94,7 @@ function NativeLinkedIssuesField({
   // roved index, which sets which chip is focusable + focused.
   const [focusIndex, setFocusIndex] = useState(0);
   const chipRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const portalContainer = usePanelPortalContainer();
 
   // AI-suggested closes sort first; ties keep insertion order (stable sort).
   const ordered = [...chips].sort(
@@ -158,7 +160,7 @@ function NativeLinkedIssuesField({
             <LinkIcon data-icon="inline-start" />
             Link issue
           </Popover.Trigger>
-          <Popover.Portal>
+          <Popover.Portal container={portalContainer}>
             <Popover.Positioner
               align="end"
               sideOffset={4}
@@ -276,6 +278,7 @@ function JiraMentionsField({
   // roved index, which sets which chip is focusable + focused.
   const [focusIndex, setFocusIndex] = useState(0);
   const chipRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const portalContainer = usePanelPortalContainer();
 
   // AI-suggested chips sort first (parity with the native band's sparkle-first
   // ordering); ties keep insertion order (stable sort).
@@ -339,7 +342,7 @@ function JiraMentionsField({
             <LinkIcon data-icon="inline-start" />
             Link issue
           </Popover.Trigger>
-          <Popover.Portal>
+          <Popover.Portal container={portalContainer}>
             <Popover.Positioner
               align="end"
               sideOffset={4}

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -20,6 +20,7 @@ import type { ReactNode } from "react";
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -145,6 +146,7 @@ export function LocalPrView({
     null,
   );
   const aiEnabled = useAiEnabled();
+  const portalContainer = usePanelPortalContainer();
   // The sub-tabs the strip renders — every writer of `section` gates on this, so
   // no path can select a tab that isn't there. A local PR has no forge, so the
   // Review tab rides the AI setting alone (no capability axis to consult).
@@ -702,7 +704,7 @@ export function LocalPrView({
                   <TagIcon data-icon="inline-start" />
                   Labels
                 </Popover.Trigger>
-                <Popover.Portal>
+                <Popover.Portal container={portalContainer}>
                   <Popover.Positioner
                     align="start"
                     sideOffset={4}

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -2,6 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { UserCheckIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useForgeGhHost } from "@/lib/git/host";
@@ -67,6 +68,7 @@ export function ReviewersPopover({
   const ghHost = useForgeGhHost(repoPath);
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<Map<string, ForgeUserRef>>(new Map());
+  const portalContainer = usePanelPortalContainer();
 
   // Collision universe for the candidate rows: candidates ∪ current value, so a
   // selected colliding reviewer still gets a hint. For the chips: value ∪
@@ -124,7 +126,7 @@ export function ReviewersPopover({
             Reviewers
           </Popover.Trigger>
         </span>
-        <Popover.Portal>
+        <Popover.Portal container={portalContainer}>
           <Popover.Positioner
             align="start"
             sideOffset={4}

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -9,6 +9,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { type MouseEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -151,6 +152,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const stashCount = useStashCount(repoPath);
+  const portalContainer = usePanelPortalContainer();
   // A confirm dialog is open when its scope is non-null. "files" covers a
   // single right-clicked row and a multi-selection alike (1+ entries); "all"
   // is the whole working tree (from the section-header menu).
@@ -792,7 +794,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
                   </span>
                 )}
               </Popover.Trigger>
-              <Popover.Portal>
+              <Popover.Portal container={portalContainer}>
                 <Popover.Positioner
                   align="start"
                   sideOffset={4}

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -20,6 +20,7 @@ import {
   useState,
   useTransition,
 } from "react";
+import { PanelPortalBoundary } from "@/components/panel-portal";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -462,212 +463,276 @@ export function RepositoryView() {
             </TabsList>
           </Tabs>
           <Activity mode={mode("changes")}>
-            <ChangesPanel repoPath={repoPath} />
-            <CommitBox repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <ChangesPanel repoPath={repoPath} />
+              <CommitBox repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("history")}>
-            <HistoryPanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <HistoryPanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("compare")}>
-            <ComparePanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <ComparePanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("pulls")}>
-            <PullRequestsPanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <PullRequestsPanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("issues")}>
-            <IssuesPanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <IssuesPanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("discussions")}>
-            <DiscussionsPanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <DiscussionsPanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("actions")}>
-            <ActionsPanel repoPath={repoPath} active={repoTab === "actions"} />
+            <PanelPortalBoundary>
+              <ActionsPanel
+                repoPath={repoPath}
+                active={repoTab === "actions"}
+              />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("findings")}>
-            <FindingsPanel
-              repoPath={repoPath}
-              active={repoTab === "findings"}
-            />
+            <PanelPortalBoundary>
+              <FindingsPanel
+                repoPath={repoPath}
+                active={repoTab === "findings"}
+              />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("tags")}>
-            <TagsPanel repoPath={repoPath} />
+            <PanelPortalBoundary>
+              <TagsPanel repoPath={repoPath} />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("insights")}>
-            <InsightsPanel
-              repoPath={repoPath}
-              active={repoTab === "insights"}
-            />
+            <PanelPortalBoundary>
+              <InsightsPanel
+                repoPath={repoPath}
+                active={repoTab === "insights"}
+              />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("code-todos")}>
-            <CodeTodosPanel
-              repoPath={repoPath}
-              active={repoTab === "code-todos"}
-            />
+            <PanelPortalBoundary>
+              <CodeTodosPanel
+                repoPath={repoPath}
+                active={repoTab === "code-todos"}
+              />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("tasks")}>
-            <TasksPanel />
+            <PanelPortalBoundary>
+              <TasksPanel />
+            </PanelPortalBoundary>
           </Activity>
           {aiEnabled && (
             <Activity mode={mode("agent")}>
-              {agentSeen && (
-                <Suspense fallback={null}>
-                  <SessionList repoPath={repoPath} />
-                </Suspense>
-              )}
+              <PanelPortalBoundary>
+                {agentSeen && (
+                  <Suspense fallback={null}>
+                    <SessionList repoPath={repoPath} />
+                  </Suspense>
+                )}
+              </PanelPortalBoundary>
             </Activity>
           )}
         </aside>
         <main className="min-w-0 flex-1">
           <Activity mode={mode("changes")}>
-            <Suspense fallback={null}>
-              <DiffViewer repoPath={repoPath} />
-            </Suspense>
+            <PanelPortalBoundary>
+              <Suspense fallback={null}>
+                <DiffViewer repoPath={repoPath} />
+              </Suspense>
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("history")}>
-            {deferredCommitHash ? (
-              <CommitDetailView repoPath={repoPath} hash={deferredCommitHash} />
-            ) : (
-              <DiffPlaceholder
-                icon={GitCommitIcon}
-                message="Select a commit to see its changes"
-              />
-            )}
+            <PanelPortalBoundary>
+              {deferredCommitHash ? (
+                <CommitDetailView
+                  repoPath={repoPath}
+                  hash={deferredCommitHash}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={GitCommitIcon}
+                  message="Select a commit to see its changes"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("compare")}>
-            {deferredCompareCommitHash ? (
-              <CommitDetailView
-                repoPath={repoPath}
-                hash={deferredCompareCommitHash}
-              />
-            ) : compareBranch &&
-              currentName &&
-              compareBranch !== currentName ? (
-              <BranchDiffView
-                repoPath={repoPath}
-                base={compareBranch}
-                compare={currentName}
-              />
-            ) : (
-              <DiffPlaceholder
-                icon={GitBranchIcon}
-                message="Pick a branch to compare against"
-              />
-            )}
+            <PanelPortalBoundary>
+              {deferredCompareCommitHash ? (
+                <CommitDetailView
+                  repoPath={repoPath}
+                  hash={deferredCompareCommitHash}
+                />
+              ) : compareBranch &&
+                currentName &&
+                compareBranch !== currentName ? (
+                <BranchDiffView
+                  repoPath={repoPath}
+                  base={compareBranch}
+                  compare={currentName}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={GitBranchIcon}
+                  message="Pick a branch to compare against"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("pulls")}>
-            {deferredPr?.kind === "remote" ? (
-              <RemotePrView
-                repoPath={repoPath}
-                number={Number(deferredPr.id)}
-              />
-            ) : deferredPr?.kind === "local" ? (
-              <LocalPrView repoPath={repoPath} id={deferredPr.id} />
-            ) : (
-              <DiffPlaceholder
-                icon={GitPullRequestIcon}
-                message="Select a pull request"
-              />
-            )}
+            <PanelPortalBoundary>
+              {deferredPr?.kind === "remote" ? (
+                <RemotePrView
+                  repoPath={repoPath}
+                  number={Number(deferredPr.id)}
+                />
+              ) : deferredPr?.kind === "local" ? (
+                <LocalPrView repoPath={repoPath} id={deferredPr.id} />
+              ) : (
+                <DiffPlaceholder
+                  icon={GitPullRequestIcon}
+                  message="Select a pull request"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("issues")}>
-            {deferredIssue?.kind === "remote" ? (
-              <RemoteIssueView
-                repoPath={repoPath}
-                number={Number(deferredIssue.id)}
-              />
-            ) : deferredIssue?.kind === "local" ? (
-              <LocalIssueView repoPath={repoPath} id={deferredIssue.id} />
-            ) : deferredIssue?.kind === "jira" ? (
-              <JiraIssueView repoPath={repoPath} issueKey={deferredIssue.id} />
-            ) : (
-              <DiffPlaceholder
-                icon={CircleDashedIcon}
-                message="Select an issue"
-              />
-            )}
+            <PanelPortalBoundary>
+              {deferredIssue?.kind === "remote" ? (
+                <RemoteIssueView
+                  repoPath={repoPath}
+                  number={Number(deferredIssue.id)}
+                />
+              ) : deferredIssue?.kind === "local" ? (
+                <LocalIssueView repoPath={repoPath} id={deferredIssue.id} />
+              ) : deferredIssue?.kind === "jira" ? (
+                <JiraIssueView
+                  repoPath={repoPath}
+                  issueKey={deferredIssue.id}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={CircleDashedIcon}
+                  message="Select an issue"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("discussions")}>
-            {deferredDiscussion ? (
-              <DiscussionView
-                repoPath={repoPath}
-                number={deferredDiscussion.number}
-              />
-            ) : (
-              <DiffPlaceholder
-                icon={ChatCircleIcon}
-                message="Select a discussion"
-              />
-            )}
+            <PanelPortalBoundary>
+              {deferredDiscussion ? (
+                <DiscussionView
+                  repoPath={repoPath}
+                  number={deferredDiscussion.number}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={ChatCircleIcon}
+                  message="Select a discussion"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("actions")}>
-            {selectedRunId !== null ? (
-              <RunDetailView
-                key={selectedRunId}
-                repoPath={repoPath}
-                runId={selectedRunId}
-                active={repoTab === "actions"}
-              />
-            ) : (
-              <DiffPlaceholder
-                icon={PlayIcon}
-                message="Select a workflow run"
-              />
-            )}
+            <PanelPortalBoundary>
+              {selectedRunId !== null ? (
+                <RunDetailView
+                  key={selectedRunId}
+                  repoPath={repoPath}
+                  runId={selectedRunId}
+                  active={repoTab === "actions"}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={PlayIcon}
+                  message="Select a workflow run"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("findings")}>
-            {selectedFinding ? (
-              <FindingDetailView
-                key={findingKey(selectedFinding)}
-                repoPath={repoPath}
-                active={repoTab === "findings"}
-              />
-            ) : (
-              <DiffPlaceholder
-                icon={ShieldCheckIcon}
-                message="Select a finding"
-              />
-            )}
+            <PanelPortalBoundary>
+              {selectedFinding ? (
+                <FindingDetailView
+                  key={findingKey(selectedFinding)}
+                  repoPath={repoPath}
+                  active={repoTab === "findings"}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={ShieldCheckIcon}
+                  message="Select a finding"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("tags")}>
-            {deferredTag ? (
-              <TagDetailView repoPath={repoPath} tag={deferredTag.tag} />
-            ) : (
-              <DiffPlaceholder icon={TagIcon} message="Select a tag" />
-            )}
+            <PanelPortalBoundary>
+              {deferredTag ? (
+                <TagDetailView repoPath={repoPath} tag={deferredTag.tag} />
+              ) : (
+                <DiffPlaceholder icon={TagIcon} message="Select a tag" />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("code-todos")}>
-            {deferredTodo ? (
-              <CodeTodoDetailView
-                repoPath={repoPath}
-                path={deferredTodo.path}
-                line={deferredTodo.line}
-                marker={deferredTodo.marker}
-                text={deferredTodo.text}
-              />
-            ) : (
-              <DiffPlaceholder icon={ListChecksIcon} message="Select a TODO" />
-            )}
+            <PanelPortalBoundary>
+              {deferredTodo ? (
+                <CodeTodoDetailView
+                  repoPath={repoPath}
+                  path={deferredTodo.path}
+                  line={deferredTodo.line}
+                  marker={deferredTodo.marker}
+                  text={deferredTodo.text}
+                />
+              ) : (
+                <DiffPlaceholder
+                  icon={ListChecksIcon}
+                  message="Select a TODO"
+                />
+              )}
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("tasks")}>
-            <TaskRunView />
+            <PanelPortalBoundary>
+              <TaskRunView />
+            </PanelPortalBoundary>
           </Activity>
           <Activity mode={mode("insights")}>
-            {insightsSeen && (
-              <Suspense fallback={null}>
-                <InsightsBoard
-                  repoPath={repoPath}
-                  active={repoTab === "insights"}
-                />
-              </Suspense>
-            )}
+            <PanelPortalBoundary>
+              {insightsSeen && (
+                <Suspense fallback={null}>
+                  <InsightsBoard
+                    repoPath={repoPath}
+                    active={repoTab === "insights"}
+                  />
+                </Suspense>
+              )}
+            </PanelPortalBoundary>
           </Activity>
           {aiEnabled && (
             <Activity mode={mode("agent")}>
-              {agentSeen && (
-                <Suspense fallback={null}>
-                  <SessionView repoPath={repoPath} />
-                </Suspense>
-              )}
+              <PanelPortalBoundary>
+                {agentSeen && (
+                  <Suspense fallback={null}>
+                    <SessionView repoPath={repoPath} />
+                  </Suspense>
+                )}
+              </PanelPortalBoundary>
             </Activity>
           )}
         </main>

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -14,6 +14,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   Activity,
   lazy,
+  type ReactNode,
   Suspense,
   useDeferredValue,
   useEffect,
@@ -160,6 +161,27 @@ const FINDING_KEY: {
 // correlation the map already encodes is asserted once, here.
 function findingKey(f: SelectedFinding): string {
   return (FINDING_KEY[f.type] as (finding: SelectedFinding) => string)(f);
+}
+
+// Every repo tab panel goes through this: the <Activity> + boundary pairing is
+// the invariant, and wrapping <Activity> alone re-mints the stranded-popup bug.
+// Module scope is required — declared inside RepositoryView it would be a new
+// component type each render, remounting every panel and losing the state
+// <Activity> exists to preserve (filters, selections, scroll). <Activity>
+// defers hidden panels' *effects* but NOT React Query fetches, so a heavy tab
+// like Insights gates its queries on the panel's own `active`-style props.
+function TabPanel({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Activity mode={active ? "visible" : "hidden"}>
+      <PanelPortalBoundary>{children}</PanelPortalBoundary>
+    </Activity>
+  );
 }
 
 export function RepositoryView() {
@@ -388,12 +410,6 @@ export function RepositoryView() {
 
   if (!repoPath) return null;
 
-  // Panels live inside <Activity> so switching tabs preserves their state
-  // (filters, selections, scroll) instead of unmounting them. <Activity> defers
-  // hidden panels' *effects*, but NOT React Query fetches (those run during
-  // render/commit) — so a heavy tab like Insights must gate its queries on its
-  // own visibility, not rely on being hidden. See `active` below.
-  const mode = (tab: RepoTab) => (repoTab === tab ? "visible" : "hidden");
   const secondaryTabs = SECONDARY_TABS.filter((t) => aiEnabled || !t.ai);
   const activeSecondary = secondaryTabs.find((t) => t.tab === repoTab);
 
@@ -462,278 +478,214 @@ export function RepositoryView() {
               </DropdownMenu>
             </TabsList>
           </Tabs>
-          <Activity mode={mode("changes")}>
-            <PanelPortalBoundary>
-              <ChangesPanel repoPath={repoPath} />
-              <CommitBox repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("history")}>
-            <PanelPortalBoundary>
-              <HistoryPanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("compare")}>
-            <PanelPortalBoundary>
-              <ComparePanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("pulls")}>
-            <PanelPortalBoundary>
-              <PullRequestsPanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("issues")}>
-            <PanelPortalBoundary>
-              <IssuesPanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("discussions")}>
-            <PanelPortalBoundary>
-              <DiscussionsPanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("actions")}>
-            <PanelPortalBoundary>
-              <ActionsPanel
-                repoPath={repoPath}
-                active={repoTab === "actions"}
-              />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("findings")}>
-            <PanelPortalBoundary>
-              <FindingsPanel
-                repoPath={repoPath}
-                active={repoTab === "findings"}
-              />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("tags")}>
-            <PanelPortalBoundary>
-              <TagsPanel repoPath={repoPath} />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("insights")}>
-            <PanelPortalBoundary>
-              <InsightsPanel
-                repoPath={repoPath}
-                active={repoTab === "insights"}
-              />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("code-todos")}>
-            <PanelPortalBoundary>
-              <CodeTodosPanel
-                repoPath={repoPath}
-                active={repoTab === "code-todos"}
-              />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("tasks")}>
-            <PanelPortalBoundary>
-              <TasksPanel />
-            </PanelPortalBoundary>
-          </Activity>
+          <TabPanel active={repoTab === "changes"}>
+            <ChangesPanel repoPath={repoPath} />
+            <CommitBox repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "history"}>
+            <HistoryPanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "compare"}>
+            <ComparePanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "pulls"}>
+            <PullRequestsPanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "issues"}>
+            <IssuesPanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "discussions"}>
+            <DiscussionsPanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "actions"}>
+            <ActionsPanel repoPath={repoPath} active={repoTab === "actions"} />
+          </TabPanel>
+          <TabPanel active={repoTab === "findings"}>
+            <FindingsPanel
+              repoPath={repoPath}
+              active={repoTab === "findings"}
+            />
+          </TabPanel>
+          <TabPanel active={repoTab === "tags"}>
+            <TagsPanel repoPath={repoPath} />
+          </TabPanel>
+          <TabPanel active={repoTab === "insights"}>
+            <InsightsPanel
+              repoPath={repoPath}
+              active={repoTab === "insights"}
+            />
+          </TabPanel>
+          <TabPanel active={repoTab === "code-todos"}>
+            <CodeTodosPanel
+              repoPath={repoPath}
+              active={repoTab === "code-todos"}
+            />
+          </TabPanel>
+          <TabPanel active={repoTab === "tasks"}>
+            <TasksPanel />
+          </TabPanel>
           {aiEnabled && (
-            <Activity mode={mode("agent")}>
-              <PanelPortalBoundary>
-                {agentSeen && (
-                  <Suspense fallback={null}>
-                    <SessionList repoPath={repoPath} />
-                  </Suspense>
-                )}
-              </PanelPortalBoundary>
-            </Activity>
+            <TabPanel active={repoTab === "agent"}>
+              {agentSeen && (
+                <Suspense fallback={null}>
+                  <SessionList repoPath={repoPath} />
+                </Suspense>
+              )}
+            </TabPanel>
           )}
         </aside>
         <main className="min-w-0 flex-1">
-          <Activity mode={mode("changes")}>
-            <PanelPortalBoundary>
+          <TabPanel active={repoTab === "changes"}>
+            <Suspense fallback={null}>
+              <DiffViewer repoPath={repoPath} />
+            </Suspense>
+          </TabPanel>
+          <TabPanel active={repoTab === "history"}>
+            {deferredCommitHash ? (
+              <CommitDetailView repoPath={repoPath} hash={deferredCommitHash} />
+            ) : (
+              <DiffPlaceholder
+                icon={GitCommitIcon}
+                message="Select a commit to see its changes"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "compare"}>
+            {deferredCompareCommitHash ? (
+              <CommitDetailView
+                repoPath={repoPath}
+                hash={deferredCompareCommitHash}
+              />
+            ) : compareBranch &&
+              currentName &&
+              compareBranch !== currentName ? (
+              <BranchDiffView
+                repoPath={repoPath}
+                base={compareBranch}
+                compare={currentName}
+              />
+            ) : (
+              <DiffPlaceholder
+                icon={GitBranchIcon}
+                message="Pick a branch to compare against"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "pulls"}>
+            {deferredPr?.kind === "remote" ? (
+              <RemotePrView
+                repoPath={repoPath}
+                number={Number(deferredPr.id)}
+              />
+            ) : deferredPr?.kind === "local" ? (
+              <LocalPrView repoPath={repoPath} id={deferredPr.id} />
+            ) : (
+              <DiffPlaceholder
+                icon={GitPullRequestIcon}
+                message="Select a pull request"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "issues"}>
+            {deferredIssue?.kind === "remote" ? (
+              <RemoteIssueView
+                repoPath={repoPath}
+                number={Number(deferredIssue.id)}
+              />
+            ) : deferredIssue?.kind === "local" ? (
+              <LocalIssueView repoPath={repoPath} id={deferredIssue.id} />
+            ) : deferredIssue?.kind === "jira" ? (
+              <JiraIssueView repoPath={repoPath} issueKey={deferredIssue.id} />
+            ) : (
+              <DiffPlaceholder
+                icon={CircleDashedIcon}
+                message="Select an issue"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "discussions"}>
+            {deferredDiscussion ? (
+              <DiscussionView
+                repoPath={repoPath}
+                number={deferredDiscussion.number}
+              />
+            ) : (
+              <DiffPlaceholder
+                icon={ChatCircleIcon}
+                message="Select a discussion"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "actions"}>
+            {selectedRunId !== null ? (
+              <RunDetailView
+                key={selectedRunId}
+                repoPath={repoPath}
+                runId={selectedRunId}
+                active={repoTab === "actions"}
+              />
+            ) : (
+              <DiffPlaceholder
+                icon={PlayIcon}
+                message="Select a workflow run"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "findings"}>
+            {selectedFinding ? (
+              <FindingDetailView
+                key={findingKey(selectedFinding)}
+                repoPath={repoPath}
+                active={repoTab === "findings"}
+              />
+            ) : (
+              <DiffPlaceholder
+                icon={ShieldCheckIcon}
+                message="Select a finding"
+              />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "tags"}>
+            {deferredTag ? (
+              <TagDetailView repoPath={repoPath} tag={deferredTag.tag} />
+            ) : (
+              <DiffPlaceholder icon={TagIcon} message="Select a tag" />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "code-todos"}>
+            {deferredTodo ? (
+              <CodeTodoDetailView
+                repoPath={repoPath}
+                path={deferredTodo.path}
+                line={deferredTodo.line}
+                marker={deferredTodo.marker}
+                text={deferredTodo.text}
+              />
+            ) : (
+              <DiffPlaceholder icon={ListChecksIcon} message="Select a TODO" />
+            )}
+          </TabPanel>
+          <TabPanel active={repoTab === "tasks"}>
+            <TaskRunView />
+          </TabPanel>
+          <TabPanel active={repoTab === "insights"}>
+            {insightsSeen && (
               <Suspense fallback={null}>
-                <DiffViewer repoPath={repoPath} />
+                <InsightsBoard
+                  repoPath={repoPath}
+                  active={repoTab === "insights"}
+                />
               </Suspense>
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("history")}>
-            <PanelPortalBoundary>
-              {deferredCommitHash ? (
-                <CommitDetailView
-                  repoPath={repoPath}
-                  hash={deferredCommitHash}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={GitCommitIcon}
-                  message="Select a commit to see its changes"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("compare")}>
-            <PanelPortalBoundary>
-              {deferredCompareCommitHash ? (
-                <CommitDetailView
-                  repoPath={repoPath}
-                  hash={deferredCompareCommitHash}
-                />
-              ) : compareBranch &&
-                currentName &&
-                compareBranch !== currentName ? (
-                <BranchDiffView
-                  repoPath={repoPath}
-                  base={compareBranch}
-                  compare={currentName}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={GitBranchIcon}
-                  message="Pick a branch to compare against"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("pulls")}>
-            <PanelPortalBoundary>
-              {deferredPr?.kind === "remote" ? (
-                <RemotePrView
-                  repoPath={repoPath}
-                  number={Number(deferredPr.id)}
-                />
-              ) : deferredPr?.kind === "local" ? (
-                <LocalPrView repoPath={repoPath} id={deferredPr.id} />
-              ) : (
-                <DiffPlaceholder
-                  icon={GitPullRequestIcon}
-                  message="Select a pull request"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("issues")}>
-            <PanelPortalBoundary>
-              {deferredIssue?.kind === "remote" ? (
-                <RemoteIssueView
-                  repoPath={repoPath}
-                  number={Number(deferredIssue.id)}
-                />
-              ) : deferredIssue?.kind === "local" ? (
-                <LocalIssueView repoPath={repoPath} id={deferredIssue.id} />
-              ) : deferredIssue?.kind === "jira" ? (
-                <JiraIssueView
-                  repoPath={repoPath}
-                  issueKey={deferredIssue.id}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={CircleDashedIcon}
-                  message="Select an issue"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("discussions")}>
-            <PanelPortalBoundary>
-              {deferredDiscussion ? (
-                <DiscussionView
-                  repoPath={repoPath}
-                  number={deferredDiscussion.number}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={ChatCircleIcon}
-                  message="Select a discussion"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("actions")}>
-            <PanelPortalBoundary>
-              {selectedRunId !== null ? (
-                <RunDetailView
-                  key={selectedRunId}
-                  repoPath={repoPath}
-                  runId={selectedRunId}
-                  active={repoTab === "actions"}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={PlayIcon}
-                  message="Select a workflow run"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("findings")}>
-            <PanelPortalBoundary>
-              {selectedFinding ? (
-                <FindingDetailView
-                  key={findingKey(selectedFinding)}
-                  repoPath={repoPath}
-                  active={repoTab === "findings"}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={ShieldCheckIcon}
-                  message="Select a finding"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("tags")}>
-            <PanelPortalBoundary>
-              {deferredTag ? (
-                <TagDetailView repoPath={repoPath} tag={deferredTag.tag} />
-              ) : (
-                <DiffPlaceholder icon={TagIcon} message="Select a tag" />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("code-todos")}>
-            <PanelPortalBoundary>
-              {deferredTodo ? (
-                <CodeTodoDetailView
-                  repoPath={repoPath}
-                  path={deferredTodo.path}
-                  line={deferredTodo.line}
-                  marker={deferredTodo.marker}
-                  text={deferredTodo.text}
-                />
-              ) : (
-                <DiffPlaceholder
-                  icon={ListChecksIcon}
-                  message="Select a TODO"
-                />
-              )}
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("tasks")}>
-            <PanelPortalBoundary>
-              <TaskRunView />
-            </PanelPortalBoundary>
-          </Activity>
-          <Activity mode={mode("insights")}>
-            <PanelPortalBoundary>
-              {insightsSeen && (
+            )}
+          </TabPanel>
+          {aiEnabled && (
+            <TabPanel active={repoTab === "agent"}>
+              {agentSeen && (
                 <Suspense fallback={null}>
-                  <InsightsBoard
-                    repoPath={repoPath}
-                    active={repoTab === "insights"}
-                  />
+                  <SessionView repoPath={repoPath} />
                 </Suspense>
               )}
-            </PanelPortalBoundary>
-          </Activity>
-          {aiEnabled && (
-            <Activity mode={mode("agent")}>
-              <PanelPortalBoundary>
-                {agentSeen && (
-                  <Suspense fallback={null}>
-                    <SessionView repoPath={repoPath} />
-                  </Suspense>
-                )}
-              </PanelPortalBoundary>
-            </Activity>
+            </TabPanel>
           )}
         </main>
       </div>

--- a/src/features/sessions/SessionView.tsx
+++ b/src/features/sessions/SessionView.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -94,6 +95,7 @@ function SessionCanvas({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmKeepEnsemble, setConfirmKeepEnsemble] = useState(false);
   const openLocalPrCreate = useUiStore((s) => s.openLocalPrCreate);
+  const portalContainer = usePanelPortalContainer();
   // Integrated terminal state + actions (dock visibility, launch, the container
   // port popover) live in their own hook.
   const {
@@ -334,7 +336,7 @@ function SessionCanvas({
                 <TerminalWindowIcon className="size-3.5" />
                 Terminal
               </Popover.Trigger>
-              <Popover.Portal>
+              <Popover.Portal container={portalContainer}>
                 <Popover.Positioner
                   align="end"
                   sideOffset={6}


### PR DESCRIPTION
Popovers, menus, selects and comboboxes opened inside a repository tab were portalled straight to `document.body`, so switching tabs left them floating over the new tab — and because `<Activity>` freezes the hidden subtree, no close initiated from inside the popup could ever run. This routes that floating UI into a portal target that lives inside the owning tab panel, so hiding the panel conceals its popups by CSS alone and revisiting the tab restores them with their draft state intact.

### New portal boundary

- Adds `src/components/panel-portal.tsx` with `PanelPortalBoundary` (publishes a `<div data-panel-portal>` target inside the panel), `usePanelPortalContainer` (reads it, `undefined` at body level so Base UI falls back to `document.body`), and `PanelPortalReset` (clears it for a subtree).
- The boundary holds the container in state rather than a ref, since Base UI resolves the container from prop identity, and ignores `null` detaches so an `<Activity>` hide can't re-point a still-open popup at the body.

### Wiring the repository tabs

- Wraps every `<Activity>` panel in both the sidebar `<aside>` and the detail `<main>` of `src/features/repository/RepositoryView.tsx` in `PanelPortalBoundary` — changes, history, compare, pulls, issues, discussions, actions, findings, tags, insights, code-todos, tasks, and the AI-gated agent panels.

### Shared UI primitives

- Threads `container={container}` through the Base UI portals in `src/components/ui/`: `combobox.tsx`, `context-menu.tsx`, `dropdown-menu.tsx`, `hover-card.tsx`, `popover.tsx`, and `select.tsx`.
- `src/components/ui/dialog.tsx` wraps `DialogContent`'s children in `PanelPortalReset`, since the dialog popup itself portals to the body and its floating UI must not land in a panel the dialog covers.
- `src/components/mention-autocomplete.tsx` portals the caret-anchored suggestion listbox into the panel container when one exists, falling back to `document.body`.

### Feature-level popovers

- Passes the panel container to the bare `Popover.Portal` usages in `CoAuthorPicker.tsx`, `LabelsPopover.tsx`, `ProjectsPopover.tsx`, `ReactionBar.tsx`, `IssueMetaPickers.tsx`, `JiraIssueView.tsx`, `LocalIssueView.tsx`, `ImplementPlanButton.tsx`, `LinkedIssuesField.tsx` (both the native and Jira fields), `LocalPrView.tsx`, `ReviewersPopover.tsx`, `ChangesPanel.tsx`, and `SessionView.tsx`.
- Drops the "KNOWN LIMITATION" comment in `ProjectsPopover.tsx` that documented the stranded-popup behaviour this change removes.
- Leaves the label popovers in `CreateIssueDialog.tsx` and `CreatePrDialog.tsx` on bare portals deliberately — their triggers sit above the `PanelPortalReset` inside `DialogContent`, so reading the panel container would push the popup behind the dialog backdrop; both carry a comment saying so.

### Docs

- Adds `changelog.d/fixed-tab-switch-popups.md` describing the fix in user-facing terms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Floating menus, pickers, dropdowns, and autocomplete popovers now stay correctly positioned within their active panel.
  - Dialog-based menus continue appearing above the dialog backdrop.
- **Bug Fixes**
  - Switching tabs preserves open pickers, menus, dropdowns, and entered selections when returning to the tab.
  - Improved popover behavior across repository, issue, pull request, conversation, and session views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->