### PR TITLE
fix(ui,checks): route clip-measured tooltips through a shared helper

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -90,8 +90,11 @@ words the user reads on screen — the palette matcher is a plain substring, so
 - No hover-revealed per-row buttons — contextual actions are always-visible,
   or live in keyboard/context-menu/toolbar.
 - Truncated user/repo content gets a `title` tooltip, added
-  only-when-actually-clipped; Base UI Select clips at the POPUP — measure the
-  `SelectItem`, not the span.
+  only-when-actually-clipped via `clipTitle`/`clipTitleFromText`
+  (`src/lib/clip-title.ts`) — never inline: blanking with `title=""`
+  suppresses a titled ancestor's tooltip, and the `inline-clip-title` guard
+  in `pnpm run checks` fails on rewrites. Base UI Select clips at the
+  POPUP — put the handler on the `SelectItem`, not the span.
 - Disabled actions explain why via `DisabledReasonButton`
   (`src/components/disabled-reason-button.tsx`) — reason as tooltip + AT
   announcement; menu/popover trigger sites keep the reason on a titled span

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,8 @@ pnpm run checks   # banned patterns · Rust invariants · IPC surface drift · g
 They run as the `guards` job in [`quality.yml`](.github/workflows/quality.yml),
 which is meant to be registered as a required check on master once it lands
 there. The checks cover banned frontend UI and state patterns (hover-revealed
-row actions, hand-rolled modifier keys, `setQueryData(key, undefined)`), the
+row actions, hand-rolled modifier keys, `setQueryData(key, undefined)`, bare
+`.mutate(` calls in the converted trees, inline clip-measured tooltips), the
 Rust refspec-argv and sync-`#[tauri::command]` invariants, and Tauri IPC drift —
 every registered command needs a caller, every `invoke()` a registration.
 

--- a/changelog.d/fixed-clipped-tooltip-ancestor.md
+++ b/changelog.d/fixed-clipped-tooltip-ancestor.md
@@ -1,0 +1,2 @@
+- Row tooltips ("View commit" in the PR timeline, "Open this check" on a
+  check run) no longer vanish when the mouse rests on the row's name.

--- a/changelog.d/fixed-clipped-tooltip-ancestor.md
+++ b/changelog.d/fixed-clipped-tooltip-ancestor.md
@@ -1,2 +1,2 @@
 - Row tooltips ("View commit" in the PR timeline, "Open this check" on a
-  check run) no longer vanish when the mouse rests on the row's name.
+  check run) now appear when the mouse rests on the row's name.

--- a/changelog.d/fixed-default-branch-select-tooltip.md
+++ b/changelog.d/fixed-default-branch-select-tooltip.md
@@ -1,0 +1,2 @@
+- Long branch names in the default-branch picker of a GitHub repository's
+  settings show their full name on hover.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -190,9 +190,9 @@ const SET_QUERY_DATA_RE =
 // overflow measure, in either order. Anchoring on the write — never a bare
 // `.title` read — is what keeps data reads (`draft.title` near a
 // scroll-to-bottom, measured on PlanView) from pairing; the idiom's direct
-// spellings all write `.title` in range of their measure, while setAttribute
-// or a hoisted measure would evade — a tripwire, not a boundary. `(?!=)`
-// keeps `==`/`===` comparisons out.
+// spellings all write `.title` in range of their measure, while setAttribute,
+// a hoisted measure, or a JSX `title={…}` prop would evade — a tripwire, not
+// a boundary. `(?!=)` keeps `==`/`===` comparisons out.
 const INLINE_CLIP_TITLE_RE = new RegExp(
   `\\.title\\s*=(?!=)[\\s\\S]{0,${PAIR_GAP}}?\\b(?:scrollWidth|scrollHeight)\\b` +
     `|\\b(?:scrollWidth|scrollHeight)\\b[\\s\\S]{0,${PAIR_GAP}}?\\.title\\s*=(?!=)`,

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -186,6 +186,18 @@ const HOVER_REVEAL_PAIRS = [
 const SET_QUERY_DATA_RE =
   /setQueryData\s*(?:<[^(]*?>)?\s*\([^;]{0,200},\s*undefined\s*[),]/g;
 
+// An inline clip-measured tooltip: a `.title` ASSIGNMENT within PAIR_GAP of an
+// overflow measure, in either order. Anchoring on the write — never a bare
+// `.title` read — is what keeps data reads (`draft.title` near a
+// scroll-to-bottom, measured on PlanView) from pairing; every
+// reimplementation writes `.title` in range of its measure. `(?!=)` keeps
+// `==`/`===` comparisons out.
+const INLINE_CLIP_TITLE_RE = new RegExp(
+  `\\.title\\s*=(?!=)[\\s\\S]{0,${PAIR_GAP}}?\\b(?:scrollWidth|scrollHeight)\\b` +
+    `|\\b(?:scrollWidth|scrollHeight)\\b[\\s\\S]{0,${PAIR_GAP}}?\\.title\\s*=(?!=)`,
+  "g",
+);
+
 // A `.mutate(` call in any spelling — the token, not the callbacks object it
 // may carry. Matching the object instead would have to recognize every way one
 // reaches the call: inline literal, hoisted variable (`.mutate(v, opts)` — the
@@ -259,6 +271,16 @@ export const CHECKS = [
     ],
     message:
       "derive the platform modifier via the hotkeys helpers (formatBinding/isMac) — new hand-rolled ctrl/meta checks need an allowlist entry with rationale",
+  },
+  {
+    name: "inline-clip-title",
+    // The helper file IS the idiom; everything else routes through it.
+    appliesTo: (file) =>
+      file !== "src/lib/clip-title.ts" && notVendoredUi(file),
+    scan: perFile(INLINE_CLIP_TITLE_RE),
+    allowlist: [],
+    message:
+      "clip-measured tooltips route through clipTitle/clipTitleFromText (src/lib/clip-title.ts) — an inline rewrite re-opens the blank-title ancestor-suppression class; if the pairing is a false positive, add an allowlist entry with rationale",
   },
   {
     name: "setQueryData-noop",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -189,9 +189,10 @@ const SET_QUERY_DATA_RE =
 // An inline clip-measured tooltip: a `.title` ASSIGNMENT within PAIR_GAP of an
 // overflow measure, in either order. Anchoring on the write — never a bare
 // `.title` read — is what keeps data reads (`draft.title` near a
-// scroll-to-bottom, measured on PlanView) from pairing; every
-// reimplementation writes `.title` in range of its measure. `(?!=)` keeps
-// `==`/`===` comparisons out.
+// scroll-to-bottom, measured on PlanView) from pairing; the idiom's direct
+// spellings all write `.title` in range of their measure, while setAttribute
+// or a hoisted measure would evade — a tripwire, not a boundary. `(?!=)`
+// keeps `==`/`===` comparisons out.
 const INLINE_CLIP_TITLE_RE = new RegExp(
   `\\.title\\s*=(?!=)[\\s\\S]{0,${PAIR_GAP}}?\\b(?:scrollWidth|scrollHeight)\\b` +
     `|\\b(?:scrollWidth|scrollHeight)\\b[\\s\\S]{0,${PAIR_GAP}}?\\.title\\s*=(?!=)`,

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -42,6 +42,7 @@ function scanner(name) {
 
 const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
+const inlineClipTitle = scanner("inline-clip-title");
 const setQueryData = scanner("setQueryData-noop");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
 
@@ -113,6 +114,62 @@ test("hand-rolled-mod-key flags a single raw flag and each half of a split pair"
 test("hand-rolled-mod-key ignores other modifiers and the helper's own name", () => {
   assert.deepEqual(modKey("if (e.shiftKey || e.altKey) return;"), []);
   assert.deepEqual(modKey("const label = formatBinding(binding);"), []);
+});
+
+test("inline-clip-title flags each local spelling of the clip-tooltip idiom", () => {
+  // The blank-on-else ternary — the ancestor-suppressing defect shape.
+  const ternary = [
+    "onMouseEnter={(e) => {",
+    "  const el = e.currentTarget;",
+    '  el.title = el.scrollWidth > el.clientWidth ? name : "";',
+    "}}",
+  ].join("\n");
+  assert.deepEqual(inlineClipTitle(ternary), [3]);
+  // The corrected if/else form is still an inline copy: the ratchet points
+  // both shapes at the shared helper.
+  const ifElse = [
+    "const el = e.currentTarget;",
+    "if (el.scrollWidth > el.clientWidth) el.title = value;",
+    'else el.removeAttribute("title");',
+  ].join("\n");
+  assert.deepEqual(inlineClipTitle(ifElse), [2]);
+  // The set-if-absent, both-axes variant: the guard READ doesn't pair (no
+  // assignment), but the write downstream is still in range of the measure.
+  const guarded = [
+    "if (",
+    "  !el.title &&",
+    "  (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)",
+    ")",
+    '  el.title = el.textContent ?? "";',
+  ].join("\n");
+  assert.deepEqual(inlineClipTitle(guarded), [3]);
+});
+
+test("inline-clip-title leaves title data reads and plain scroll code alone", () => {
+  // A `.title` read is not the idiom — only the write anchors a pair. This is
+  // the PlanView shape: a scroll-to-bottom near `{ title: draft.title }`.
+  const dataRead = [
+    "scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });",
+    "setPendingIssueDraft({ title: draft.title, body: draft.body });",
+  ].join("\n");
+  assert.deepEqual(inlineClipTitle(dataRead), []);
+  assert.deepEqual(
+    inlineClipTitle("<span onMouseEnter={clipTitle(member.title)} />"),
+    [],
+  );
+  // Scroll-stick and textarea autosize measure without touching `title`.
+  assert.deepEqual(inlineClipTitle("el.scrollTop = el.scrollHeight;"), []);
+  assert.deepEqual(
+    inlineClipTitle("ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;"),
+    [],
+  );
+});
+
+test("inline-clip-title exempts the helper file and vendored ui only", () => {
+  const { appliesTo } = CHECKS.find((c) => c.name === "inline-clip-title");
+  assert.equal(appliesTo("src/lib/clip-title.ts"), false);
+  assert.equal(appliesTo("src/components/ui/select.tsx"), false);
+  assert.equal(appliesTo("src/features/pulls/PrTimeline.tsx"), true);
 });
 
 test("setQueryData-noop catches a call wrapped across lines", () => {

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -15,6 +15,7 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { clipTitle } from "@/lib/clip-title";
 import { normPath } from "@/lib/git/path";
 import { useBranchDivergence, useUserWorktrees } from "@/lib/git/queries";
 import type { Branch, BranchDivergence } from "@/lib/git/types";
@@ -170,15 +171,7 @@ function BranchRow({
 }) {
   return (
     <ComboboxItem value={name}>
-      <span
-        className="min-w-0 flex-1 truncate"
-        // Only expose the full name as a tooltip when it's actually clipped —
-        // measured just-in-time on hover, so no per-row refs.
-        onMouseEnter={(e) => {
-          const el = e.currentTarget;
-          el.title = el.scrollWidth > el.clientWidth ? name : "";
-        }}
-      >
+      <span className="min-w-0 flex-1 truncate" onMouseEnter={clipTitle(name)}>
         {name}
         {name === defaultName && (
           <span className="ml-1.5 text-[10px] text-muted-foreground">

--- a/src/features/conversations/CommitsList.tsx
+++ b/src/features/conversations/CommitsList.tsx
@@ -1,6 +1,6 @@
-import type { MouseEvent } from "react";
 import { RelativeTime } from "@/components/relative-time";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { clipTitle } from "@/lib/clip-title";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { parseableDate } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -13,14 +13,6 @@ export interface CommitRow {
   author: string;
   date?: string | null;
 }
-
-/** Sets a hover title only when the subject is actually clipped by `truncate`;
- *  mirrors the only-when-clipped pattern used across the repo (WorktreesDialog,
- *  BranchSwitcher). Measures `currentTarget`, the `truncate`d element itself. */
-const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
-  const el = e.currentTarget;
-  el.title = el.scrollWidth > el.clientWidth ? value : "";
-};
 
 /**
  * The commits tab of a pull request: a scrollable list of commit rows

--- a/src/features/conversations/ConversationFilterPopover.tsx
+++ b/src/features/conversations/ConversationFilterPopover.tsx
@@ -11,6 +11,7 @@ import {
   ComboboxLabel,
   ComboboxList,
 } from "@/components/ui/combobox";
+import { clipTitle } from "@/lib/clip-title";
 import { cn } from "@/lib/utils";
 
 /** A filter row is an Author or a Label, carried as an OBJECT (never a
@@ -297,12 +298,7 @@ function FilterRow({
       </span>
       <span
         className="min-w-0 flex-1 truncate"
-        // Expose the full name as a tooltip only when actually clipped —
-        // measured just-in-time on hover, so no per-row refs.
-        onMouseEnter={(e) => {
-          const el = e.currentTarget;
-          el.title = el.scrollWidth > el.clientWidth ? item.name : "";
-        }}
+        onMouseEnter={clipTitle(item.name)}
       >
         {item.name}
       </span>

--- a/src/features/pulls/ChecksRollup.tsx
+++ b/src/features/pulls/ChecksRollup.tsx
@@ -13,7 +13,6 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   type Dispatch,
   type KeyboardEvent,
-  type MouseEvent,
   type SetStateAction,
   useEffect,
   useRef,
@@ -25,6 +24,7 @@ import { LogBlock } from "@/components/LogBlock";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusIcon, statusLabel } from "@/features/actions/status";
+import { clipTitle } from "@/lib/clip-title";
 import {
   useApproveWorkflowRun,
   useRepoWriteAccess,
@@ -95,13 +95,6 @@ function jobForCheck(
 function currentStep(job: RunJob | undefined) {
   return job?.steps.find((s) => s.status === "in_progress") ?? null;
 }
-
-/** Sets a hover title only when the name is actually clipped by `truncate`;
- *  mirrors the only-when-clipped pattern in CommitsList/WorktreesDialog. */
-const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
-  const el = e.currentTarget;
-  el.title = el.scrollWidth > el.clientWidth ? value : "";
-};
 
 /** A GitHub-Actions check's inline log tail (Skeleton → log tail), matching
  *  RunDetailView's `<pre>` idiom. Only mounted while the row is expanded, so the

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -378,9 +378,8 @@ function ReferenceChip({
     return <span className="flex min-w-0 items-center gap-1">{body}</span>;
   }
   return (
-    // No `title` here: the inner span's clipTitle sets title="" when the text isn't
-    // clipped, and an empty title on a descendant SUPPRESSES the ancestor's tooltip
-    // rather than deferring to it — the clipped-text tooltip is the one that matters.
+    // Deliberately no `title`: the chip's visible ref + title text already say
+    // what it opens, and the span's clipTitle supplies the full text when clipped.
     <button
       type="button"
       onClick={() => onOpenRef(kind, chip.number)}

--- a/src/features/pulls/PrTimeline.tsx
+++ b/src/features/pulls/PrTimeline.tsx
@@ -25,15 +25,11 @@ import {
   WarningIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  type ReactNode,
-  useState,
-} from "react";
+import { type KeyboardEvent, type ReactNode, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { RelativeTime } from "@/components/relative-time";
 import type { CommitRow } from "@/features/conversations/CommitsList";
+import { clipTitle } from "@/lib/clip-title";
 import type { ForgeTimelineEvent } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { parseableDate } from "@/lib/time";
@@ -103,13 +99,6 @@ export function coalesceCommitRuns(
   flush();
   return rendered;
 }
-
-/** Sets a hover title only when the content is actually clipped by `truncate`;
- *  mirrors the only-when-clipped pattern across the repo (CommitsList). */
-const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
-  const el = e.currentTarget;
-  el.title = el.scrollWidth > el.clientWidth ? value : "";
-};
 
 /** The thin neutral rail + centered icon that every light event row hangs off.
  *  A 1px structural connective line (NOT a colored side-stripe) — the icon

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -1,7 +1,6 @@
 import { CaretRightIcon, CopyIcon } from "@phosphor-icons/react";
 import {
   type KeyboardEvent,
-  type MouseEvent,
   type ReactNode,
   useEffect,
   useLayoutEffect,
@@ -17,6 +16,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { Spinner } from "@/components/ui/spinner";
 import { Thread } from "@/features/conversations/Thread";
 import type { MentionSource } from "@/features/conversations/useMentionCandidates";
+import { clipTitle } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import type {
   ApplyLinesResult,
@@ -28,13 +28,6 @@ import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { synthesizeThreadHunk } from "./suggestion-utils";
-
-/** Sets a hover title only when the element is actually clipped (measures
- *  `currentTarget`, not an inner span) — the file-group header truncates. */
-const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
-  const el = e.currentTarget;
-  el.title = el.scrollWidth > el.clientWidth ? value : "";
-};
 
 /**
  * File:line-anchored review threads (Copilot/CodeRabbit/human line comments on

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -16,6 +16,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { clipTitle } from "@/lib/clip-title";
 import { useActiveGhHost } from "@/lib/git/host";
 import {
   useBranches,
@@ -358,14 +359,7 @@ function GeneralForm({
             <SelectContent className="max-w-[min(20rem,80vw)]">
               {branchOptions.map((b) => (
                 <SelectItem key={b} value={b}>
-                  <span
-                    className="block truncate"
-                    // Tooltip only when the branch name is actually clipped.
-                    onMouseEnter={(e) => {
-                      const el = e.currentTarget;
-                      el.title = el.scrollWidth > el.clientWidth ? b : "";
-                    }}
-                  >
+                  <span className="block truncate" onMouseEnter={clipTitle(b)}>
                     {b}
                   </span>
                 </SelectItem>

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -358,10 +358,11 @@ function GeneralForm({
             </SelectTrigger>
             <SelectContent className="max-w-[min(20rem,80vw)]">
               {branchOptions.map((b) => (
-                <SelectItem key={b} value={b}>
-                  <span className="block truncate" onMouseEnter={clipTitle(b)}>
-                    {b}
-                  </span>
+                // Base UI Select clips at the popup (the vendored ItemText is
+                // shrink-0, so an inner span never measures clipped) — the
+                // item is the element to measure.
+                <SelectItem key={b} value={b} onMouseEnter={clipTitle(b)}>
+                  <span className="block truncate">{b}</span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitle } from "@/lib/clip-title";
 import {
   useDeleteSecret,
   useDeleteVariable,
@@ -145,15 +146,10 @@ export function SecretsSection({
                 <SelectItem
                   key={e}
                   value={e}
-                  // The dropdown is pinned to the narrow trigger width, so long
-                  // environment names clip. Surface the full name on hover, but
-                  // only when it's actually cut off. The clip happens at the
-                  // popup (overflow-x-hidden), not the inner span, so measure the
-                  // item itself — a span-level check wouldn't fire here.
-                  onMouseEnter={(ev) => {
-                    const el = ev.currentTarget;
-                    el.title = el.scrollWidth > el.clientWidth ? e : "";
-                  }}
+                  // The clip happens at the popup (overflow-x-hidden), not the
+                  // inner span, so the item is the element to measure — a
+                  // span-level clipTitle wouldn't fire here.
+                  onMouseEnter={clipTitle(e)}
                 >
                   <span className="block truncate">{e}</span>
                 </SelectItem>

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -14,6 +14,7 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { clipTitle } from "@/lib/clip-title";
 import { normPath } from "@/lib/git/path";
 import {
   useBranches,
@@ -286,15 +287,7 @@ function BaseBranchRow({
 }) {
   return (
     <ComboboxItem value={name}>
-      <span
-        className="min-w-0 flex-1 truncate"
-        // Only expose the full name as a tooltip when it's actually clipped —
-        // measured just-in-time on hover, so no per-row refs.
-        onMouseEnter={(e) => {
-          const el = e.currentTarget;
-          el.title = el.scrollWidth > el.clientWidth ? name : "";
-        }}
-      >
+      <span className="min-w-0 flex-1 truncate" onMouseEnter={clipTitle(name)}>
         {name}
         {name === currentName && (
           <span className="ml-1.5 text-[10px] text-muted-foreground">

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -32,6 +32,7 @@ import {
   requiresPullRequest,
 } from "@/lib/branch-rules/match";
 import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import { clipTitle } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
 import { forgeDetectForkPrForBranch } from "@/lib/git/api";
@@ -1497,13 +1498,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               <span className="flex w-full items-center gap-2">
                 <span
                   className="min-w-0 flex-1 truncate"
-                  // Only expose the full name as a tooltip when it's actually
-                  // clipped — measured just-in-time on hover, so no per-row refs.
-                  onMouseEnter={(e) => {
-                    const el = e.currentTarget;
-                    el.title =
-                      el.scrollWidth > el.clientWidth ? branch.name : "";
-                  }}
+                  onMouseEnter={clipTitle(branch.name)}
                 >
                   {branch.name}
                   {branch.name === defaultName && (
@@ -1954,19 +1949,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 <GitBranchIcon data-icon="inline-start" />
                 <span
                   className="min-w-0 truncate"
-                  // Only expose the full label as a tooltip when it's actually
-                  // clipped — measured just-in-time on hover, so no ref needed.
-                  // Remove the attribute (not title="") when unclipped: an empty
-                  // title="" is still a title in Chromium and would suppress the
-                  // wrapper's conditional (amending) title above.
-                  onMouseEnter={(e) => {
-                    const el = e.currentTarget;
-                    if (el) {
-                      if (el.scrollWidth > el.clientWidth)
-                        el.title = currentLabel;
-                      else el.removeAttribute("title");
-                    }
-                  }}
+                  // Sits under the wrapper's conditional (amending) title — a
+                  // static or blanked title here would suppress that tooltip.
+                  onMouseEnter={clipTitle(currentLabel)}
                 >
                   {currentLabel}
                 </span>
@@ -2128,15 +2113,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                               )}
                               <span
                                 className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
-                                onMouseEnter={(e) => {
-                                  const el = e.currentTarget;
-                                  // Full path is the useful tooltip (the row already
-                                  // shows the folder name). removeAttribute, not
-                                  // title="", so an unclipped row leaves no empty tooltip.
-                                  if (el.scrollWidth > el.clientWidth)
-                                    el.title = w.path;
-                                  else el.removeAttribute("title");
-                                }}
+                                // Full path, not the folder name the row already
+                                // shows — the path is what disambiguates.
+                                onMouseEnter={clipTitle(w.path)}
                               >
                                 {baseName(w.path)}
                               </span>

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { clipTitle } from "@/lib/clip-title";
 import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import type { RecentRepo } from "@/lib/settings/api";
 import { useRepoAlias } from "@/lib/settings/queries";
@@ -66,18 +67,7 @@ export function RepoSwitcher() {
             >
               <span
                 className="min-w-0 truncate text-sm font-medium"
-                // Only expose the full name as a tooltip when it's actually
-                // clipped — measured just-in-time on hover, so no ref needed.
-                // Remove the attribute (not title="") when unclipped: an empty
-                // title="" is still a title in Chromium and would suppress any
-                // ancestor tooltip.
-                onMouseEnter={(e) => {
-                  const el = e.currentTarget;
-                  if (el) {
-                    if (el.scrollWidth > el.clientWidth) el.title = repoLabel;
-                    else el.removeAttribute("title");
-                  }
-                }}
+                onMouseEnter={clipTitle(repoLabel)}
               >
                 {repoLabel}
               </span>

--- a/src/features/settings/mcp/BrowseRegistryDialog.tsx
+++ b/src/features/settings/mcp/BrowseRegistryDialog.tsx
@@ -9,12 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useRelativeNow } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -28,6 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import type { McpServer } from "@/lib/settings/api";
 import { entriesFor } from "@/lib/settings/mcp";
@@ -57,18 +53,6 @@ function runSummary(server: McpServer): string {
   return server.transport === "stdio"
     ? [server.command, ...server.args].join(" ").trim()
     : server.url;
-}
-
-/** Set a hover `title` only when the element's content is actually clipped
- *  (truncate horizontally or line-clamp vertically), so long registry strings
- *  stay readable without redundant tooltips on the short ones. */
-function markTitleIfClipped(e: ReactMouseEvent<HTMLElement>) {
-  const el = e.currentTarget;
-  if (
-    !el.title &&
-    (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)
-  )
-    el.title = el.textContent ?? "";
 }
 
 /**
@@ -371,7 +355,7 @@ export function BrowseRegistryDialog({
                       <div className="flex items-center gap-1.5">
                         <span
                           className="truncate font-medium"
-                          onMouseEnter={markTitleIfClipped}
+                          onMouseEnter={clipTitleFromText}
                         >
                           {c.title}
                         </span>
@@ -413,14 +397,14 @@ export function BrowseRegistryDialog({
                       </div>
                       <p
                         className="truncate font-mono text-[10px] text-muted-foreground"
-                        onMouseEnter={markTitleIfClipped}
+                        onMouseEnter={clipTitleFromText}
                       >
                         {c.registryName}
                       </p>
                       {c.server.description && (
                         <p
                           className="line-clamp-2 text-muted-foreground"
-                          onMouseEnter={markTitleIfClipped}
+                          onMouseEnter={clipTitleFromText}
                         >
                           {c.server.description}
                         </p>

--- a/src/lib/clip-title.ts
+++ b/src/lib/clip-title.ts
@@ -10,8 +10,9 @@ export const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
   const el = e.currentTarget;
   // Clear by REMOVING the attribute: an empty `title` states that the ancestor's
   // does not apply, which would suppress a titled parent's tooltip (HTML). An
-  // empty `value` takes the remove branch for the same reason.
-  if (value && el.scrollWidth > el.clientWidth) el.title = value;
+  // empty or whitespace-only `value` takes the remove branch for the same reason.
+  const v = value.trim();
+  if (v && el.scrollWidth > el.clientWidth) el.title = v;
   else el.removeAttribute("title");
 };
 

--- a/src/lib/clip-title.ts
+++ b/src/lib/clip-title.ts
@@ -9,8 +9,9 @@ import type { MouseEvent } from "react";
 export const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
   const el = e.currentTarget;
   // Clear by REMOVING the attribute: an empty `title` states that the ancestor's
-  // does not apply, which would suppress a titled parent's tooltip (HTML).
-  if (el.scrollWidth > el.clientWidth) el.title = value;
+  // does not apply, which would suppress a titled parent's tooltip (HTML). An
+  // empty `value` takes the remove branch for the same reason.
+  if (value && el.scrollWidth > el.clientWidth) el.title = value;
   else el.removeAttribute("title");
 };
 
@@ -22,7 +23,13 @@ export const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
  */
 export const clipTitleFromText = (e: MouseEvent<HTMLElement>) => {
   const el = e.currentTarget;
-  if (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)
-    el.title = el.textContent ?? "";
+  // Empty/whitespace text takes the remove branch — assigning "" here would
+  // re-mint the blank-title suppression this helper exists to eliminate.
+  const text = el.textContent?.trim();
+  if (
+    text &&
+    (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)
+  )
+    el.title = text;
   else el.removeAttribute("title");
 };

--- a/src/lib/clip-title.ts
+++ b/src/lib/clip-title.ts
@@ -13,3 +13,16 @@ export const clipTitle = (value: string) => (e: MouseEvent<HTMLElement>) => {
   if (el.scrollWidth > el.clientWidth) el.title = value;
   else el.removeAttribute("title");
 };
+
+/**
+ * `clipTitle` for elements whose full text IS their own `textContent`: no value
+ * to pass, and clipping is measured on both axes so `line-clamp-*` (vertical)
+ * counts as clipped alongside `truncate` (horizontal). Same remove-don't-blank
+ * contract as `clipTitle`.
+ */
+export const clipTitleFromText = (e: MouseEvent<HTMLElement>) => {
+  const el = e.currentTarget;
+  if (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)
+    el.title = el.textContent ?? "";
+  else el.removeAttribute("title");
+};


### PR DESCRIPTION
Twelve components each carried their own copy of the "set a `title` only when the text is actually clipped" hover handler, and several blanked the attribute with `title=""` when unclipped — an empty title is still a title in Chromium, so it suppressed the tooltip on a titled ancestor (the row-level "View commit" / "Open this check"). Every call site now routes through the shared `src/lib/clip-title.ts` helper, which removes the attribute instead, and a new `checks` guard keeps an inline rewrite from reintroducing the class.

### Shared helper

- Adds `clipTitleFromText` to `src/lib/clip-title.ts` for elements whose full text is their own `textContent`: no value to pass, and clipping is measured on both axes so `line-clamp-*` counts alongside `truncate`. Same remove-don't-blank contract as the existing `clipTitle`.

### Call-site migration

- Deletes the local `clipTitle` definitions in `src/features/conversations/CommitsList.tsx`, `src/features/pulls/ChecksRollup.tsx`, `src/features/pulls/PrTimeline.tsx` and `src/features/pulls/ReviewThreads.tsx`, plus `markTitleIfClipped` in `src/features/settings/mcp/BrowseRegistryDialog.tsx`, whose three usages (title, registry name, description) now call `clipTitleFromText`.
- Replaces the inline blank-on-else handlers with `clipTitle(...)` in `CompareBranchCombobox.tsx`, `BaseBranchCombobox.tsx`, `ConversationFilterPopover.tsx`, `GeneralSettingsSection.tsx`, `SecretsSection.tsx`, `RepoSwitcher.tsx`, and at three sites in `BranchSwitcher.tsx` — the branch row, the current-branch label that sits under the wrapper's conditional "amending" title, and the worktree path.
- Trims each surviving comment to the constraint the move doesn't already show: `SecretsSection.tsx` keeps the note that the Base UI Select clips at the popup, so the handler stays on the `SelectItem` rather than the inner span. Now-unused `MouseEvent` type imports drop out of the touched files.

### Guard and conventions

- New `inline-clip-title` check in `scripts/check-banned-patterns.mjs`: `INLINE_CLIP_TITLE_RE` pairs a `.title` assignment with a `scrollWidth`/`scrollHeight` measure within `PAIR_GAP` in either order, anchored on the write (never a bare read) so data reads such as `draft.title` near a scroll-to-bottom don't pair, with `(?!=)` excluding comparisons. `appliesTo` exempts only `src/lib/clip-title.ts` and vendored UI.
- `scripts/checks.test.mjs` adds three tests: the local spellings that must flag (blank-on-else ternary, if/else with `removeAttribute`, set-if-absent both-axes), the shapes that must not (title data read, scroll-stick, textarea autosize, a `clipTitle(...)` call), and the `appliesTo` exemptions.
- `.claude/skills/gd-conventions/SKILL.md` repoints the truncation convention at `clipTitle`/`clipTitleFromText`, states why blanking suppresses an ancestor tooltip, and names the guard that fails on rewrites.
- Adds two changelog fragments — `fixed-clipped-tooltip-ancestor.md` (the restored row tooltips) and `fixed-default-branch-select-tooltip.md` (the default-branch picker's hover name); README, site, and in-app guide need no edit.

### Review rounds

- `d622e265` (round zero, self-review): moves the default-branch tooltip handler onto the `SelectItem` — the vendored `ItemText` is `flex flex-1 shrink-0` (`select.tsx:129`), so a span-level measure structurally never fires; rewrites the `PrTimeline` ReferenceChip comment that still described the deleted blanking helper; scopes the guard comment's reimplementation claim.
- Round 1 (rides the next push): `clipTitleFromText` takes a trimmed-truthy text guard and `clipTitle` an equivalent `value` guard, so an empty value can never mint the blank `title` either helper exists to remove (Copilot and the app review, converged); the ancestor fragment now states current behavior; the second fragment covers the default-branch picker fix, scoped to the GitHub section; the guard comment names the JSX-prop evasion. The sibling Select pickers that never had tooltips (GitLab/Bitbucket sections, Pages, history dialogs) are deferred to a recorded backlog entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-text hover tooltips for clipped labels across branch switchers, repository selectors, conversation filters, settings, and registry views.
  - Long default-branch names in repository settings are now fully visible on hover.
  - PR timeline commit and check-run row names now display tooltips when their text is truncated.

- **Bug Fixes**
  - Improved tooltip behavior so titles appear only for genuinely clipped, nonempty content and are removed when no longer applicable.
  - Corrected clipping detection for selectable items, improving tooltip reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->