### PR TITLE
fix(ui,pulls): keep dialogs with their tab and PR creates visible

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -149,6 +149,9 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   one breaks Resume. Hard invariant.
 - `<Activity>`-hidden subtrees still render and fetch — gate query `enabled`
   on the active tab; gate agent-surface notifications on the tab being watched.
+- Seed-on-open dialogs use `useSeedOnOpen` (`src/lib/use-seed-on-open.ts`) — a
+  bare `useEffect(() => { if (open) seed(); }, [open])` re-fires when a hidden
+  `<Activity>` tab re-mounts its effects on show, wiping the user's draft.
 - Zustand + view transitions: `openRepo`/`closeRepo`/`openSettings` issue
   deferred sets that clobber a plain `set()` right after — navigate in ONE
   atomic action.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -21,7 +21,9 @@ Where this file and generic best practice disagree, this file wins.
    in the session scratchpad or `C:/temp`, never the repo; destructive
    experiments happen in a throwaway repo under `C:/temp`.
 3. **Don't edit `src/components/ui/`** — vendored shadcn/Base UI primitives.
-   Fix at the feature/call-site level.
+   Fix at the feature/call-site level. That folder's `README.md` inventories
+   the sanctioned local modifications (a re-vendor silently reverts them);
+   any future sanctioned edit updates it in the same change.
 4. **Never repo-wide `cargo fmt`** in `src-tauri` (~35 files of collateral).
    New files only: `rustfmt <that file>`.
 5. **Report from evidence.** Verification claims come from command output in

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -149,9 +149,12 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   one breaks Resume. Hard invariant.
 - `<Activity>`-hidden subtrees still render and fetch — gate query `enabled`
   on the active tab; gate agent-surface notifications on the tab being watched.
-- Seed-on-open dialogs use `useSeedOnOpen` (`src/lib/use-seed-on-open.ts`) — a
-  bare `useEffect(() => { if (open) seed(); }, [open])` re-fires when a hidden
-  `<Activity>` tab re-mounts its effects on show, wiping the user's draft.
+- Open-TRANSITION resets ride `useSeedOnOpen` (`src/lib/use-seed-on-open.ts`) —
+  a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires when a hidden
+  `<Activity>` tab re-mounts its effects on show, wiping the user's draft. The
+  carve-out: data-arrival seeds (`[open, thatQuery.data]`) and `onOpenChange`
+  seeds stay bare, and each must be idempotent — never stomping a user's pick.
+  The `seed-effect-on-open` guard allowlists the recorded ones.
 - Zustand + view transitions: `openRepo`/`closeRepo`/`openSettings` issue
   deferred sets that clobber a plain `set()` right after — navigate in ONE
   atomic action.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -49,8 +49,9 @@ and Windows.
 ## Deliberate conventions — not defects
 
 - `src/components/ui/` is vendored (shadcn / Base UI primitives) and is never
-  edited; issues route to feature-level call sites. The vendored Button is
-  deliberately square (`rounded-none`).
+  edited; issues route to feature-level call sites, except the sanctioned local
+  deltas inventoried in `src/components/ui/README.md` (a re-vendor silently
+  reverts them). The vendored Button is deliberately square (`rounded-none`).
 - `gd/session/*` branches are filtered from every branch surface by design
   (agent sessions run on them); the filter is an invariant, not a bug.
 - Snowflake/u64 IDs cross the Tauri IPC boundary as strings (JS number

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ pnpm changelog:preview  # preview pending changelog.d/ fragments
   may stay and cite their source — a PR or run reference is fine there.) Trim any
   comment you touch to this standard.
 - **Don't edit `src/components/ui/`** — those are vendored shadcn/Base UI primitives;
-  fix at the feature/call-site level.
+  fix at the feature/call-site level, except the sanctioned local deltas inventoried
+  in `src/components/ui/README.md` (a re-vendor silently reverts them).
 - **Keyboard-first, WCAG AA** — wire arrow-key nav for any new selectable list in the
   same change; never convey meaning by color alone; keep destructive paths confirmed.
 - **React best practices** — before writing or refactoring any React component or hook,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,9 @@ GitDesktop is keyboard-first and aims for WCAG AA. When you add or change UI:
   force-push, merge) must confirm clearly and give feedback (Design Principle #2).
 - Don't convey meaning by color alone; keep focus indicators visible.
 - The shadcn / Base UI primitives under `src/components/ui/` are vendored — fix
-  things at the feature/call-site level rather than editing those files.
+  things at the feature/call-site level rather than editing those files, except
+  the sanctioned local deltas inventoried in `src/components/ui/README.md` (a
+  re-vendor silently reverts them).
 
 ### AI-assisted contributions
 

--- a/changelog.d/fixed-dialog-mid-op-dismissal.md
+++ b/changelog.d/fixed-dialog-mid-op-dismissal.md
@@ -1,3 +1,3 @@
-- Dialogs running a history rewrite or a worktree rename or lock now stay put
-  until the operation settles: Escape and clicking outside no longer dismiss
-  them mid-flight.
+- Dialogs running a history rewrite, a worktree rename, or a worktree lock now
+  stay put until the operation settles: Escape, clicking outside, and the close
+  button no longer dismiss them mid-flight.

--- a/changelog.d/fixed-dialog-mid-op-dismissal.md
+++ b/changelog.d/fixed-dialog-mid-op-dismissal.md
@@ -1,0 +1,3 @@
+- Dialogs running a history rewrite or a worktree rename or lock now stay put
+  until the operation settles: Escape and clicking outside no longer dismiss
+  them mid-flight.

--- a/changelog.d/fixed-pr-create-dismissed.md
+++ b/changelog.d/fixed-pr-create-dismissed.md
@@ -1,5 +1,3 @@
 - Creating a pull request now stays visible if you close the dialog before it
   finishes: a status strip shows it running, reopening keeps what you typed, and
-  a duplicate create for the same branch is refused with a reason. Dialogs
-  running a history rewrite or a worktree rename or lock no longer close from
-  Escape or a backdrop click until the operation settles.
+  a duplicate create for the same branch is refused with a reason.

--- a/changelog.d/fixed-pr-create-dismissed.md
+++ b/changelog.d/fixed-pr-create-dismissed.md
@@ -1,0 +1,5 @@
+- Creating a pull request now stays visible if you close the dialog before it
+  finishes: a status strip shows it running, reopening keeps what you typed, and
+  a duplicate create for the same branch is refused with a reason. Dialogs
+  running a history rewrite or a worktree rename or lock no longer close from
+  Escape or a backdrop click until the operation settles.

--- a/changelog.d/fixed-tab-switch-dialogs.md
+++ b/changelog.d/fixed-tab-switch-dialogs.md
@@ -1,0 +1,3 @@
+- Dialogs now stay with the tab that opened them: switch tabs and back, and the
+  dialog you left open is still there with everything you had entered, instead
+  of floating over the wrong tab.

--- a/changelog.d/fixed-tab-switch-dialogs.md
+++ b/changelog.d/fixed-tab-switch-dialogs.md
@@ -1,3 +1,2 @@
-- Dialogs now stay with the tab that opened them: switch tabs and back, and the
-  dialog you left open is still there with everything you had entered, instead
-  of floating over the wrong tab.
+- Dialogs now survive tab switches too: switch away and back, and the one you
+  left open is still there with everything you had entered.

--- a/changelog.d/fixed-tab-switch-dialogs.md
+++ b/changelog.d/fixed-tab-switch-dialogs.md
@@ -1,2 +1,2 @@
-- Dialogs now survive tab switches too: switch away and back, and the one you
-  left open is still there with everything you had entered.
+- Dialogs now survive tab switches: switch away and back, and the one you left
+  open is still there with everything you had entered.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -211,6 +211,11 @@ const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 // fixed. Their CALL SITES — the app code that composes them — stay scanned.
 const notVendoredUi = (file) => !file.startsWith("src/components/ui/");
 
+// `<Activity` as a JSX open tag. The lookahead is what separates it from the
+// app's own `<ActivityDock>`/`<ActivityBell>`/`<ActivityStrip>` components, and
+// comment stripping is what keeps the many prose mentions of `<Activity>` clean.
+const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
+
 export const CHECKS = [
   {
     name: "hover-reveal",
@@ -287,6 +292,18 @@ export const CHECKS = [
     allowlist: [],
     message:
       "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
+  },
+  {
+    name: "lone-activity-boundary",
+    // Both directions ride the allowlist: a hit anywhere else is a violation,
+    // and TabPanel losing its own `<Activity>` reads as a stale entry. Residual:
+    // a SECOND `<Activity` added inside RepositoryView.tsx is not caught, since
+    // the allowlist works per file rather than per occurrence.
+    appliesTo: () => true,
+    scan: perLine(ACTIVITY_JSX_RE),
+    allowlist: ["src/features/repository/RepositoryView.tsx"],
+    message:
+      "a tab panel's <Activity> must be paired with PanelPortalBoundary and PanelActivityBoundary, or its dialogs and popups strand over the wrong tab — render TabPanel (RepositoryView.tsx), never a second <Activity>",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -216,6 +216,8 @@ const notVendoredUi = (file) => !file.startsWith("src/components/ui/");
 // whole-file view because the guard sits on the line after the arrow. Matching
 // the first statement rather than an `open` read anywhere in the body is what
 // keeps this off the many effects that merely gate a query on the same flag.
+// Bounded by the identifier: a dialog whose flag is `isOpen` or `show` passes
+// unseen, so this catches the house spelling rather than the whole class.
 const SEED_ON_OPEN_RE =
   /use(?:Layout)?Effect\(\(\)\s*=>\s*\{\s*if\s*\(!?open\b/g;
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -211,6 +211,14 @@ const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 // fixed. Their CALL SITES — the app code that composes them — stay scanned.
 const notVendoredUi = (file) => !file.startsWith("src/components/ui/");
 
+// An effect whose FIRST statement is an `open` guard — the seed-on-open shape,
+// in both its spellings (`if (open) …` / `if (!open) return`). Run over the
+// whole-file view because the guard sits on the line after the arrow. Matching
+// the first statement rather than an `open` read anywhere in the body is what
+// keeps this off the many effects that merely gate a query on the same flag.
+const SEED_ON_OPEN_RE =
+  /use(?:Layout)?Effect\(\(\)\s*=>\s*\{\s*if\s*\(!?open\b/g;
+
 // `<Activity` as a JSX open tag. The lookahead is what separates it from the
 // app's own `<ActivityDock>`/`<ActivityBell>`/`<ActivityStrip>` components, and
 // comment stripping is what keeps the many prose mentions of `<Activity>` clean.
@@ -294,6 +302,56 @@ export const CHECKS = [
       "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
   },
   {
+    name: "seed-effect-on-open",
+    // The hook itself opens with the very guard it exists to replace.
+    appliesTo: (file) => file !== "src/lib/use-seed-on-open.ts",
+    scan: perFile(SEED_ON_OPEN_RE),
+    // Three kinds of entry, none of them an open-transition reset:
+    // DATA-ARRIVAL seeds (the trigger is the value landing, which the hook's
+    // once-per-open latch would fire before), effects that already carry their
+    // own ref latch keyed on something the hook doesn't know (a scope, a task
+    // id, the previous `open`), and effects that merely tear down or register
+    // on `open` and are idempotent by construction. Every one of them is safe
+    // to repeat — the property the open-transition resets lack.
+    allowlist: [
+      // Seeds the category once the async list arrives; `if (!categoryId)`.
+      "src/features/discussions/CreateDiscussionDialog.tsx",
+      // Defaults the workflow once `dispatchable` arrives; `!workflow`.
+      "src/features/actions/RunWorkflowDialog.tsx",
+      // Seeds the Bitbucket workspace once workspaces load; empty-field only.
+      "src/features/repository/PublishDialog.tsx",
+      // Seeds the URL field once the current remote URL query resolves.
+      "src/features/repository/RemoteUrlDialog.tsx",
+      // Base reconciler: re-seeds only when the current base isn't a valid
+      // option for the active target, so it never fights the user's edit.
+      "src/features/pulls/CreatePrDialog.tsx",
+      // Re-seeds when the caller re-requests a mode while already open (the
+      // add action fired from the palette over an open list), and is a layout
+      // effect so a reopen never paints one frame of the mode it closed on.
+      "src/features/repository/SubmodulesDialog.tsx",
+      // Seeds the draft once `automations.data` arrives, behind its own latch.
+      "src/features/automations/RepoAutomationsDialog.tsx",
+      // Same, latched per SCOPE — switching scope re-seeds deliberately.
+      "src/features/branch-rules/BranchRulesDialog.tsx",
+      // Seeds the applied set once memberships settle, behind `seededSettled`.
+      "src/features/conversations/ProjectsPopover.tsx",
+      // Latched per task id, and the close arm aborts in-flight AI streams
+      // whose callbacks would otherwise resolve into the NEXT task opened.
+      "src/features/scripts/TaskDialog.tsx",
+      // Close-side only: clears the selection, a no-op while open.
+      "src/features/history/FileHistoryDialog.tsx",
+      // A scroll listener with a cleanup, plus a close-side key-set clear —
+      // re-registering on a re-show is the correct behavior, not a reset.
+      "src/components/mention-autocomplete.tsx",
+      // Prefetch loop; `prefetchQuery` honors staleTime, so a repeat is free.
+      "src/features/repository/BranchSwitcher.tsx",
+      // Registers the open dialog with the native-menu gate; add/remove pair.
+      "src/lib/hotkeys/modal-gate.ts",
+    ],
+    message:
+      "an open-transition reset must ride useSeedOnOpen (src/lib/use-seed-on-open.ts) — a hidden <Activity> tab re-mounts its effects on show, so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires and wipes the user's draft; a data-arrival or otherwise idempotent seed needs an allowlist entry with rationale",
+  },
+  {
     name: "lone-activity-boundary",
     // Both directions ride the allowlist: a hit anywhere else is a violation,
     // and TabPanel losing its own `<Activity>` reads as a stale entry. Residual:
@@ -303,7 +361,7 @@ export const CHECKS = [
     scan: perLine(ACTIVITY_JSX_RE),
     allowlist: ["src/features/repository/RepositoryView.tsx"],
     message:
-      "a tab panel's <Activity> must be paired with PanelPortalBoundary and PanelActivityBoundary, or its dialogs and popups strand over the wrong tab — render TabPanel (RepositoryView.tsx), never a second <Activity>",
+      "a tab panel's <Activity> must be paired with PanelPortalBoundary and PanelActivityBoundary, or its dialogs and popups strand over the wrong tab — render TabPanel (RepositoryView.tsx) rather than a second <Activity>, or extend the allowlist deliberately for a non-tab Activity",
   },
 ];
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -45,6 +45,7 @@ const modKey = scanner("hand-rolled-mod-key");
 const setQueryData = scanner("setQueryData-noop");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
 const loneActivity = scanner("lone-activity-boundary");
+const seedOnOpen = scanner("seed-effect-on-open");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -265,6 +266,31 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
   ]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
+});
+
+test("seed-effect-on-open flags both spellings of the open guard", () => {
+  const guarded = [
+    "useEffect(() => {\n  if (open) seedOnOpen();\n}, [open]);",
+    "useEffect(() => {\n  if (!open) return;\n  setTyped('');\n}, [open]);",
+    "useEffect(() => {\n  if (open && ready) seed();\n}, [open, ready]);",
+    "useLayoutEffect(() => {\n  if (open) setMode(initialMode);\n}, [open]);",
+  ];
+  for (const source of guarded)
+    assert.deepEqual(seedOnOpen(source), [1], `should flag ${source}`);
+});
+
+test("seed-effect-on-open ignores the hook and non-first-statement reads", () => {
+  assert.deepEqual(seedOnOpen("useSeedOnOpen(open, seedOnOpen);"), []);
+  // `open` read somewhere in the body is a gate, not a seed — only an effect
+  // that OPENS with the guard is the shape this check is about.
+  const gate = [
+    "useEffect(() => {",
+    "  const el = ref.current;",
+    "  if (!open || !el) return;",
+    "  place(el);",
+    "}, [open]);",
+  ].join("\n");
+  assert.deepEqual(seedOnOpen(gate), []);
 });
 
 test("lone-activity-boundary flags a JSX Activity in either spelling", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -44,6 +44,7 @@ const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
 const setQueryData = scanner("setQueryData-noop");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
+const loneActivity = scanner("lone-activity-boundary");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -264,6 +265,28 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
   ]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
+});
+
+test("lone-activity-boundary flags a JSX Activity in either spelling", () => {
+  assert.deepEqual(
+    loneActivity('<Activity mode="hidden">{kids}</Activity>'),
+    [1],
+  );
+  assert.deepEqual(loneActivity("<Activity>{kids}</Activity>"), [1]);
+});
+
+test("lone-activity-boundary ignores same-prefixed components and prose", () => {
+  for (const tag of [
+    "<ActivityDock />",
+    "<ActivityBell />",
+    "<ActivityStrip/>",
+  ])
+    assert.deepEqual(loneActivity(tag), [], `should ignore ${tag}`);
+  // The many comments naming <Activity> are what comment stripping keeps clean.
+  assert.deepEqual(
+    loneActivity("// a hidden <Activity> subtree still fetches"),
+    [],
+  );
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/src/components/form/submit-button.tsx
+++ b/src/components/form/submit-button.tsx
@@ -6,7 +6,9 @@ import { useFormContext } from "@/lib/form-context";
 /**
  * Submit button bound to the surrounding form (use inside `<form.AppForm>`):
  * disabled until the form can submit, spinner while submitting. Extra
- * `disabled` reasons (e.g. an AI generation in flight) are OR'd in.
+ * `disabled` reasons (e.g. an AI generation in flight) are OR'd in, and every
+ * other prop reaches the Button — a caller explaining a disabled submit points
+ * `aria-describedby` at its own hint.
  */
 export function SubmitButton({
   children,

--- a/src/components/panel-portal.tsx
+++ b/src/components/panel-portal.tsx
@@ -24,11 +24,12 @@ export function usePanelPortalContainer(): HTMLElement | undefined {
 }
 
 /**
- * Whether the surrounding panel is the visible one. A concealed panel hides its
- * popups by CSS alone, so anything that keeps acting on the whole document while
- * open — a modal's scroll lock, its `aria-hidden` marking of everything outside
- * it, its document-level dismissal listeners — has to stand down for as long as
- * the user cannot see it. `true` outside any panel.
+ * Whether the surrounding panel is the visible one. Defense in depth: hiding a
+ * panel does tear down its subtree's effects, taking a modal's scroll lock,
+ * `aria-hidden` marking and dismissal listeners with them — but that teardown is
+ * deferred, so the modal state has to stand down on its own for the window
+ * between the tab switch and it. Escape must never reach a concealed dialog.
+ * `true` outside any panel.
  */
 const PanelActivityContext = createContext(true);
 

--- a/src/components/panel-portal.tsx
+++ b/src/components/panel-portal.tsx
@@ -24,6 +24,41 @@ export function usePanelPortalContainer(): HTMLElement | undefined {
 }
 
 /**
+ * Whether the surrounding panel is the visible one. A concealed panel hides its
+ * popups by CSS alone, so anything that keeps acting on the whole document while
+ * open — a modal's scroll lock, its `aria-hidden` marking of everything outside
+ * it, its document-level dismissal listeners — has to stand down for as long as
+ * the user cannot see it. `true` outside any panel.
+ */
+const PanelActivityContext = createContext(true);
+
+/** `false` while the surrounding panel is concealed; `true` at body level. */
+export function usePanelActive(): boolean {
+  return useContext(PanelActivityContext);
+}
+
+// Base UI close reasons where the user acted on the document rather than on the
+// popup itself. While a panel is concealed these belong to the tab the user can
+// actually see, so a hidden popup must neither take them nor swallow the key.
+const USER_DISMISSAL_REASONS = ["escape-key", "outside-press", "focus-out"];
+
+/** Whether a Base UI close request came from the user acting outside the popup. */
+export function isUserDismissal(reason: string): boolean {
+  return USER_DISMISSAL_REASONS.includes(reason);
+}
+
+/** Publishes the surrounding panel's visibility to the popups inside it. */
+export function PanelActivityBoundary({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: ReactNode;
+}): ReactNode {
+  return <PanelActivityContext value={active}>{children}</PanelActivityContext>;
+}
+
+/**
  * Wraps one `<Activity>` panel's content and publishes a portal target that
  * lives inside it.
  */

--- a/src/components/panel-portal.tsx
+++ b/src/components/panel-portal.tsx
@@ -86,8 +86,9 @@ export function PanelPortalBoundary({
 }
 
 /**
- * Clears the panel container for a subtree. Used inside modal popups, which
- * portal to the body: their floating UI must not land in a panel the modal covers.
+ * Clears the panel container for a subtree. Used inside modal popups: their
+ * floating UI must not land in a panel the modal covers. Base UI chains it onto
+ * the popup's own portal node instead, so pickers still stack above the modal.
  */
 export function PanelPortalReset({
   children,

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,0 +1,82 @@
+# Vendored primitives: local modifications
+
+These are shadcn / Base UI primitives, normally regenerated rather than
+edited. Nine of them carry a sanctioned local delta for one cross-file
+contract: **panel-scoped portals plus activity-aware modality**. Repo tabs
+render inside `<Activity>` (`TabPanel` in `RepositoryView.tsx`), which
+conceals a hidden tab with CSS and keeps its subtree mounted. A popup that
+portals to `<body>` is not covered by that conceal, so it stays on screen
+over whichever tab the user switched to. The files below portal into the
+surrounding panel instead, and the two dialog-shaped ones also stand their
+modal state down while concealed.
+
+## Detecting a lost customization
+
+Regenerating any file here (`shadcn add`, a registry refresh) silently
+reverts its delta. After regenerating, grep the file:
+
+```sh
+grep -l "@/components/panel-portal" src/components/ui/<file>.tsx
+```
+
+No match means the customization is gone. Restore it from git history
+rather than rewriting it from scratch. The marker imports are
+`usePanelPortalContainer`, `usePanelActive`, `isUserDismissal`, and
+`PanelPortalReset`.
+
+Coverage is partial and indirect. `pnpm run checks` runs
+`lone-activity-boundary`, which pins the `<Activity>` side of the contract
+(exactly one JSX `<Activity`, in `RepositoryView.tsx`) but cannot see a
+missing `container` prop here. Nothing else guards this folder, so the
+live smoke is the real proof: open a dialog from a repo tab, switch tabs
+and switch back. It must conceal with its tab and come back intact, never
+float over the new tab.
+
+## The modifications
+
+- **`popover.tsx`**, **`select.tsx`**, **`combobox.tsx`**,
+  **`hover-card.tsx`** — the `*Content` component reads
+  `usePanelPortalContainer()` and passes it to its `Portal` as `container`.
+  Without it the popup renders at `<body>` and survives its tab's conceal.
+- **`tooltip.tsx`** — same container read on `TooltipContent`'s inline
+  portal. This one has no exported portal wrapper.
+- **`dropdown-menu.tsx`**, **`context-menu.tsx`** — the same container read
+  on `*Content`, plus the exported `*Portal` wrapper defaulting `container`
+  to the panel when the caller passes none. The default tests
+  `container === undefined`, never `??`: Base UI reads an explicit `null` as
+  "a container is coming" and renders nothing, so `null` has to survive.
+- **`sheet.tsx`** — portal wrapper container default as above;
+  `SheetContent` wraps children in `PanelPortalReset` so floating UI inside
+  the sheet does not portal into a panel the sheet covers; the root `Sheet`
+  derives `modal` from panel visibility and cancels user-initiated
+  dismissals while concealed. A concealed modal would otherwise keep the
+  document scroll-locked, keep everything outside it `aria-hidden`, and take
+  the Escape key from the tab the user can see.
+- **`dialog.tsx`** — every delta `sheet.tsx` carries (both are Base UI
+  `Dialog.Root` underneath), plus `DialogContent` re-homing focus into the
+  popup when its panel returns to view, and composing the caller's `ref`
+  with its own rather than replacing it.
+
+Deliberately unmodified: `menubar.tsx` inherits the container default by
+delegating to `DropdownMenuPortal`, so regenerating it into a direct
+`Menu.Portal` call would break it silently. `drawer.tsx` is vaul and has no
+container prop, so its popups are not panel-scoped.
+
+## Check before re-applying
+
+If one of these has to be re-created, confirm it is still needed. Verify
+first, then decide. Suspicion alone is not grounds for dropping one.
+
+1. **React's Activity visibility walk.** It styles only the topmost host
+   element per fiber path (react-dom latches on the first host it finds and
+   skips deeper ones), and a portal's DOM sits outside that element, so the
+   style never reaches it. If react-dom starts styling portal hosts too,
+   body-level portals would conceal on their own. Containment would still
+   carry draft preservation and stacking, so that weakens the argument
+   rather than ending it.
+2. **Base UI gaining container-scoped modality**, or a modal that tracks
+   visibility. That would subsume the `modal` flip and the dismissal
+   suppression in `dialog.tsx` and `sheet.tsx`, though not the container
+   reads.
+3. **The app no longer rendering tabs through `<Activity>` / `TabPanel`.**
+   That removes the premise for all of it.

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -8,9 +8,19 @@ function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
 }
 
-function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
+function ContextMenuPortal({
+  container,
+  ...props
+}: ContextMenuPrimitive.Portal.Props) {
+  // Default to the surrounding panel so a raw portal can't strand over another
+  // tab; an explicit `null` still means "a container is coming", never the body.
+  const panelContainer = usePanelPortalContainer();
   return (
-    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+    <ContextMenuPrimitive.Portal
+      data-slot="context-menu-portal"
+      container={container === undefined ? panelContainer : container}
+      {...props}
+    />
   );
 }
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,20 +1,53 @@
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "@phosphor-icons/react";
 import * as React from "react";
-import { PanelPortalReset } from "@/components/panel-portal";
+import {
+  isUserDismissal,
+  PanelPortalReset,
+  usePanelActive,
+  usePanelPortalContainer,
+} from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+function Dialog({ modal, onOpenChange, ...props }: DialogPrimitive.Root.Props) {
+  const panelActive = usePanelActive();
+  return (
+    <DialogPrimitive.Root
+      data-slot="dialog"
+      // `modal` gates both the document scroll lock and the `aria-hidden`
+      // marking of everything outside the popup, so a dialog concealed with its
+      // panel drops it and hands the visible tab back to the user.
+      modal={panelActive && (modal ?? true)}
+      onOpenChange={(open, eventDetails) => {
+        if (!open && !panelActive && isUserDismissal(eventDetails.reason)) {
+          // Cancelling also suppresses Base UI's `preventDefault()` on Escape,
+          // leaving the key to the surface the user is looking at.
+          eventDetails.cancel();
+          return;
+        }
+        onOpenChange?.(open, eventDetails);
+      }}
+      {...props}
+    />
+  );
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+function DialogPortal({ container, ...props }: DialogPrimitive.Portal.Props) {
+  // Default to the surrounding panel so a raw portal can't strand over another
+  // tab; an explicit `null` still means "a container is coming", never the body.
+  const panelContainer = usePanelPortalContainer();
+  return (
+    <DialogPrimitive.Portal
+      data-slot="dialog-portal"
+      container={container === undefined ? panelContainer : container}
+      {...props}
+    />
+  );
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
@@ -45,6 +78,28 @@ function DialogContent({
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
 }) {
+  const panelActive = usePanelActive();
+  // DialogContent owns the popup ref — no call site passes one, and re-homing
+  // focus after a conceal needs the element.
+  const popupRef = React.useRef<HTMLDivElement | null>(null);
+  // Derived during render because a concealed panel still renders but runs no
+  // effects, so the flip back to visible is the only moment an effect can see.
+  const [wasConcealed, setWasConcealed] = React.useState(false);
+  if (!panelActive && !wasConcealed) setWasConcealed(true);
+
+  React.useLayoutEffect(() => {
+    if (!panelActive || !wasConcealed) return;
+    // One frame, to outlast the close-time focus-return of the menu or tab
+    // control that switched panels. The flag clears inside the frame, not
+    // before it: clearing here would re-run this effect and cancel it.
+    const frame = requestAnimationFrame(() => {
+      setWasConcealed(false);
+      const popup = popupRef.current;
+      if (popup && !popup.contains(document.activeElement)) popup.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [panelActive, wasConcealed]);
+
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -61,9 +116,11 @@ function DialogContent({
           className,
         )}
         {...props}
+        ref={popupRef}
       >
-        {/* This popup portals to the body, so floating UI inside it must not
-            portal into a tab panel the dialog covers. */}
+        {/* Floating UI inside the popup must not portal into a tab panel the
+            dialog covers; Base UI still chains it onto this popup's own portal
+            node, so pickers keep stacking above the dialog either way. */}
         <PanelPortalReset>{children}</PanelPortalReset>
         {showCloseButton && (
           <DialogPrimitive.Close

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -74,14 +74,23 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  ref,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
 }) {
   const panelActive = usePanelActive();
-  // DialogContent owns the popup ref — no call site passes one, and re-homing
-  // focus after a conceal needs the element.
+  // Re-homing focus after a conceal needs the popup element, so this tracks it
+  // alongside — never instead of — whatever ref the caller passed.
   const popupRef = React.useRef<HTMLDivElement | null>(null);
+  const attachPopup = React.useCallback(
+    (el: HTMLDivElement | null) => {
+      popupRef.current = el;
+      if (typeof ref === "function") return ref(el);
+      if (ref) ref.current = el;
+    },
+    [ref],
+  );
   // Derived during render because a concealed panel still renders but runs no
   // effects, so the flip back to visible is the only moment an effect can see.
   const [wasConcealed, setWasConcealed] = React.useState(false);
@@ -116,7 +125,7 @@ function DialogContent({
           className,
         )}
         {...props}
-        ref={popupRef}
+        ref={attachPopup}
       >
         {/* Floating UI inside the popup must not portal into a tab panel the
             dialog covers; Base UI still chains it onto this popup's own portal

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -93,6 +93,8 @@ function DialogContent({
   );
   // Derived during render because a concealed panel still renders but runs no
   // effects, so the flip back to visible is the only moment an effect can see.
+  // State, not a ref: React sanctions adjusting state during render, while a
+  // render-phase ref write is exactly what the React Compiler forbids.
   const [wasConcealed, setWasConcealed] = React.useState(false);
   if (!panelActive && !wasConcealed) setWasConcealed(true);
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -8,8 +8,20 @@ function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
   return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
-function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
-  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+function DropdownMenuPortal({
+  container,
+  ...props
+}: MenuPrimitive.Portal.Props) {
+  // Default to the surrounding panel so a raw portal can't strand over another
+  // tab; an explicit `null` still means "a container is coming", never the body.
+  const panelContainer = usePanelPortalContainer();
+  return (
+    <MenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      container={container === undefined ? panelContainer : container}
+      {...props}
+    />
+  );
 }
 
 function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,11 +1,34 @@
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "@phosphor-icons/react";
 import * as React from "react";
+import {
+  isUserDismissal,
+  PanelPortalReset,
+  usePanelActive,
+  usePanelPortalContainer,
+} from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-function Sheet({ ...props }: SheetPrimitive.Root.Props) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+function Sheet({ modal, onOpenChange, ...props }: SheetPrimitive.Root.Props) {
+  const panelActive = usePanelActive();
+  return (
+    <SheetPrimitive.Root
+      data-slot="sheet"
+      // Same contract as Dialog (this IS a Base UI Dialog root): `modal` gates
+      // the document scroll lock and the `aria-hidden` marking outside the
+      // popup, and a concealed sheet must not take the visible tab's dismissals.
+      modal={panelActive && (modal ?? true)}
+      onOpenChange={(open, eventDetails) => {
+        if (!open && !panelActive && isUserDismissal(eventDetails.reason)) {
+          eventDetails.cancel();
+          return;
+        }
+        onOpenChange?.(open, eventDetails);
+      }}
+      {...props}
+    />
+  );
 }
 
 function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
@@ -16,8 +39,17 @@ function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
-function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+function SheetPortal({ container, ...props }: SheetPrimitive.Portal.Props) {
+  // Default to the surrounding panel so a raw portal can't strand over another
+  // tab; an explicit `null` still means "a container is coming", never the body.
+  const panelContainer = usePanelPortalContainer();
+  return (
+    <SheetPrimitive.Portal
+      data-slot="sheet-portal"
+      container={container === undefined ? panelContainer : container}
+      {...props}
+    />
+  );
 }
 
 function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
@@ -55,7 +87,10 @@ function SheetContent({
         )}
         {...props}
       >
-        {children}
+        {/* Floating UI inside the popup must not portal into a tab panel the
+            sheet covers; Base UI still chains it onto this popup's own portal
+            node, so pickers keep stacking above the sheet either way. */}
+        <PanelPortalReset>{children}</PanelPortalReset>
         {showCloseButton && (
           <SheetPrimitive.Close
             data-slot="sheet-close"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
+import { usePanelPortalContainer } from "@/components/panel-portal";
 import { cn } from "@/lib/utils";
 
 function TooltipProvider({
@@ -38,8 +39,11 @@ function TooltipContent({
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  // Portal into the surrounding panel like every other popup here, so a tooltip
+  // still showing at tab-switch time conceals with its tab instead of the body.
+  const container = usePanelPortalContainer();
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={container}>
       <TooltipPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/github/actions";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 export function RunWorkflowDialog({
   repoPath,
@@ -96,12 +97,11 @@ export function RunWorkflowDialog({
   >([]);
 
   // Reset the form each time the dialog opens, defaulting to the first workflow.
-  useEffect(() => {
-    if (!open) return;
+  useSeedOnOpen(open, () => {
     setGitRef(defaultRef);
     setInputs([]);
     setPipeline("");
-  }, [open, defaultRef]);
+  });
   useEffect(() => {
     if (open && !workflow && dispatchable.length > 0) {
       setWorkflow(String(dispatchable[0].id));

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -96,7 +96,7 @@ export function RunWorkflowDialog({
     { id: number; key: string; value: string }[]
   >([]);
 
-  // Reset the form each time the dialog opens, defaulting to the first workflow.
+  // Reset the form each time the dialog opens.
   useSeedOnOpen(open, () => {
     setGitRef(defaultRef);
     setInputs([]);

--- a/src/features/commit/AmendForcePushDialog.tsx
+++ b/src/features/commit/AmendForcePushDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 /**
  * Asks before amending a commit that's already on the remote, since the
@@ -32,9 +33,7 @@ export function AmendForcePushDialog({
   const [dontShowAgain, setDontShowAgain] = useState(false);
 
   // Reset the checkbox each time the dialog opens.
-  useEffect(() => {
-    if (open) setDontShowAgain(false);
-  }, [open]);
+  useSeedOnOpen(open, () => setDontShowAgain(false));
 
   function confirm() {
     if (dontShowAgain && settings.data) {

--- a/src/features/discussions/CreateDiscussionDialog.tsx
+++ b/src/features/discussions/CreateDiscussionDialog.tsx
@@ -15,6 +15,7 @@ import { required, useAppForm } from "@/lib/form";
 import { useCreateDiscussion, useDiscussionMeta } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 export function CreateDiscussionDialog({
   repoPath,
@@ -67,9 +68,7 @@ export function CreateDiscussionDialog({
   const ensureCategory = useEffectEvent(() => {
     if (!categoryId) form.setFieldValue("categoryId", categories[0].id);
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
   useEffect(() => {
     if (open && categories.length > 0) ensureCategory();
   }, [open, categories.length]);

--- a/src/features/explore/ExploreCloneDialog.tsx
+++ b/src/features/explore/ExploreCloneDialog.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { useEffect, useEffectEvent } from "react";
+import { useEffectEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -17,6 +17,7 @@ import type { ForgeProvider } from "@/lib/git/types";
 import { useAddRecentRepo, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 /** The repo an Explore clone is pinned to. */
 export interface ExploreCloneTarget {
@@ -82,9 +83,7 @@ export function ExploreCloneDialog({
     );
   });
   const open = target !== null;
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   const values = useSelector(form.store, (s) => s.values);
   const isSubmitting = useSelector(form.store, (s) => s.isSubmitting);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1119,7 +1119,11 @@ conversation comment** (under a *🗒️ Notes for reviewers* header, from your 
 before any automated review runs, and that review reads them as context; on GitHub and
 GitLab the code reviews and security audits you start yourself read them too — so a
 deliberate, documented decision isn't re-flagged. Notes present here also ground the
-**AI-generated** description{{/ai}}. Press {{key:mod+enter}} from any field to submit either the
+**AI-generated** description{{/ai}}. Creating a pull request pushes your branch first, so it
+can run for a while: close the dialog and it carries on — a line at the top of the repository
+view names the branch until it finishes, reopening the dialog keeps everything you had typed,
+and a second create for the same branch is refused while the first is still running.
+Press {{key:mod+enter}} from any field to submit either the
 **Create** or the **Edit** dialog. The **Edit** dialog also carries a **base branch**
 select, so you can **retarget** a pull request at a different branch without recreating it —
 on GitHub, GitLab, and Bitbucket alike. On a **stacked GitHub** pull request that select is

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -198,8 +198,8 @@ function BlameLines({
         // (all-zero sha) rows and continuation rows keep the plain gutter cell.
         const interactive = newCommit && isRealCommit(line.hash);
         // Close the dialog AND navigate in the SAME synchronous handler: from
-        // the ChangesPanel host, landing on History conceals this subtree, and a
-        // close that lands after would leave the dialog open behind Changes.
+        // the ChangesPanel host, landing on History conceals this subtree, so a
+        // close that lands after it would wait for Changes to be shown again.
         const goToCommit = () => {
           onOpenChange(false);
           openCommit(line.hash);

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -198,8 +198,8 @@ function BlameLines({
         // (all-zero sha) rows and continuation rows keep the plain gutter cell.
         const interactive = newCommit && isRealCommit(line.hash);
         // Close the dialog AND navigate in the SAME synchronous handler: from
-        // the ChangesPanel host, landing on History hides this subtree, so a
-        // deferred close would stick the dialog open (the <Activity> gotcha).
+        // the ChangesPanel host, landing on History conceals this subtree, and a
+        // close that lands after would leave the dialog open behind Changes.
         const goToCommit = () => {
           onOpenChange(false);
           openCommit(line.hash);

--- a/src/features/history/EditHistoryDialog.tsx
+++ b/src/features/history/EditHistoryDialog.tsx
@@ -199,7 +199,16 @@ export function EditHistoryDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      // Escape and a backdrop press are ignored while the rewrite runs: it is a
+      // seconds-scale local operation whose outcome this dialog still owes the
+      // user, and unmounting mid-flight drops the hand-off to the Changes tab.
+      onOpenChange={(next) => {
+        if (!next && busy) return;
+        onOpenChange(next);
+      }}
+    >
       <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Edit history</DialogTitle>
@@ -393,9 +402,14 @@ export function EditHistoryDialog({
               </>
             )}
           </div>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <DisabledReasonButton
+            variant="outline"
+            disabled={busy}
+            reason="The rewrite is still running."
+            onClick={() => onOpenChange(false)}
+          >
             Cancel
-          </Button>
+          </DisabledReasonButton>
           <Button
             disabled={
               busy ||

--- a/src/features/history/EditHistoryDialog.tsx
+++ b/src/features/history/EditHistoryDialog.tsx
@@ -201,15 +201,20 @@ export function EditHistoryDialog({
   return (
     <Dialog
       open={open}
-      // Escape and a backdrop press are ignored while the rewrite runs: it is a
-      // seconds-scale local operation whose outcome this dialog still owes the
-      // user, and unmounting mid-flight drops the hand-off to the Changes tab.
+      // Close requests are ignored while the rewrite runs: it is a seconds-scale
+      // local operation whose outcome this dialog still owes the user, and
+      // unmounting mid-flight drops the hand-off to the Changes tab.
       onOpenChange={(next) => {
         if (!next && busy) return;
         onOpenChange(next);
       }}
     >
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+      {/* The corner X would be a dead control while the guard above swallows
+          every close path, so it goes away for the duration. */}
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-2xl"
+        showCloseButton={!busy}
+      >
         <DialogHeader>
           <DialogTitle>Edit history</DialogTitle>
           <DialogDescription>

--- a/src/features/history/useAmendCommit.ts
+++ b/src/features/history/useAmendCommit.ts
@@ -23,12 +23,7 @@ export function useAmendCommit(repoPath: string) {
       const details = await gitCommitDetails(repoPath, hash);
       setCommitDraft(details.subject, details.body);
       setAmending(hash);
-      // Defer the tab switch until the just-dismissed force-push dialog has
-      // finished closing: it portals to the body, so hiding History via
-      // <Activity> mid-close leaves it frozen on screen. Menus conceal with
-      // the panel and need no deferral; the no-confirm path pays the same
-      // 150ms rather than branching for it.
-      setTimeout(() => setRepoTab("changes"), 150);
+      setRepoTab("changes");
     },
     [repoPath, setCommitDraft, setAmending, setRepoTab],
   );

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -2,7 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { SparkleIcon, TagIcon, XIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffectEvent, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -29,6 +29,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import {
   AssigneesPopover,
   IssueTypeMenu,
@@ -156,9 +157,7 @@ export function CreateIssueDialog({
     setMilestone(null);
     setIssueType(null);
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   function toggleLabel(name: string, on: boolean) {
     setLabels((prev) => {

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -27,6 +27,7 @@ import type { JiraLink } from "@/lib/jira/store";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { useGenerateIssueDraft } from "./useGenerateIssueDraft";
 
 /**
@@ -105,9 +106,7 @@ export function CreateJiraIssueDialog({
     form.reset({ summary: "", body: "" }, { keepDefaultValues: true });
     setCreateError(null);
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // Default to the first creatable type once they load; clear the selection if a
   // refetch dropped the currently-picked one (e.g. project changed).

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -1,6 +1,6 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent } from "react";
+import { useEffectEvent } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +17,7 @@ import { useCreateLocalIssue } from "@/lib/issues/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { useGenerateIssueDraft } from "./useGenerateIssueDraft";
 
 export function CreateLocalIssueDialog({
@@ -67,9 +68,7 @@ export function CreateLocalIssueDialog({
       { keepDefaultValues: true },
     );
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // Shared by the Draft-with-AI button and the generate chord below.
   function runGenerate() {

--- a/src/features/issues/RepoJiraDialog.tsx
+++ b/src/features/issues/RepoJiraDialog.tsx
@@ -37,6 +37,7 @@ import type { JiraLink } from "@/lib/jira/store";
 import type { JiraAccountInfo, JiraProject } from "@/lib/jira/types";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 /** Where an Atlassian API token is created (same page the Bitbucket account
  *  section links to). */
@@ -113,8 +114,7 @@ export function RepoJiraDialog({
 
   // Seed the draft from an existing link when the dialog opens; reset on close so
   // a reopen reflects persisted state, not stale in-flight edits.
-  useEffect(() => {
-    if (!open) return;
+  useSeedOnOpen(open, () => {
     if (existingLink) {
       setSiteInput(existingLink.siteHost);
       setProject({
@@ -135,7 +135,7 @@ export function RepoJiraDialog({
     setConnectError(null);
     setDebouncedQuery("");
     setShowCredentialForm(false);
-  }, [open, existingLink]);
+  });
 
   // Debounced locally, not via useDebouncedValue: the dialog stays mounted across
   // open/close, so the reset above must clear this SYNCHRONOUSLY — the search is

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -1,7 +1,7 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent } from "react";
+import { useEffectEvent } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +31,7 @@ import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { useBranchPickerOptions } from "./useBranchPickerOptions";
@@ -41,8 +42,8 @@ import {
 } from "./useLinkedIssueChips";
 
 // Rendered exactly ONCE, hoisted in RepositoryView — never render it inside a tab
-// panel. Its success handler's `setRepoTab("pulls")` would hide a panel host's
-// <Activity> subtree and defer the `onOpenChange(false)`, stranding the dialog open.
+// panel. Its success handler's `setRepoTab("pulls")` conceals a panel host with the
+// tab it left, so the dialog would stay open behind Pulls instead of closing.
 export function CreateLocalPrDialog({
   repoPath,
   defaultBase,
@@ -197,9 +198,7 @@ export function CreateLocalPrDialog({
       { keepDefaultValues: true },
     );
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // Live head/base drive the "N commits to merge" hint and AI generation.
   const head = useSelector(form.store, (s) => s.values.head);

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -43,7 +43,7 @@ import {
 
 // Rendered exactly ONCE, hoisted in RepositoryView — never render it inside a tab
 // panel. Its success handler's `setRepoTab("pulls")` conceals a panel host with the
-// tab it left, so the dialog would stay open behind Pulls instead of closing.
+// tab it left, so the close and unmount would wait until that tab is next shown.
 export function CreateLocalPrDialog({
   repoPath,
   defaultBase,

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -56,7 +56,7 @@ import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import {
   consumeLastFailed,
-  isCreatingPrInRepo,
+  isCreatingPrFor,
   settlePrCreate,
   startPrCreate,
   useIsCreatingPr,
@@ -368,8 +368,8 @@ export function CreatePrDialog({
         });
         // This dialog is panel-hosted under <Activity>, so the success path must
         // only close — never setRepoTab/selectPr, which would conceal this panel
-        // and leave the dialog open behind the tab it landed on. Want navigation?
-        // Hoist it to RepositoryView first, like CreateLocalPrDialog.
+        // mid-close and defer the close and unmount until it is next shown. Want
+        // navigation? Hoist it to RepositoryView first, like CreateLocalPrDialog.
         onOpenChange(false);
         // Draft gate: a draft PR fires no review unless the user opted into reviewing
         // drafts. A gated-out draft is NOT a lost review — an in-app Mark-ready fires
@@ -404,10 +404,13 @@ export function CreatePrDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // seeded values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
+    const h = defaultHead ?? currentName ?? names[0] ?? "";
     // A create still running in the background — or one that failed while the
     // dialog was closed — leaves everything the user typed in form state, and
-    // this reset would blank it on reopen.
-    if (isCreatingPrInRepo(repoPath) || consumeLastFailed(repoPath)) return;
+    // this reset would blank it on reopen. Both signals are judged against the
+    // head this seed WOULD land on: a create running on another branch must not
+    // preserve its draft in a dialog the user opened for this one.
+    if (isCreatingPrFor(repoPath, h) || consumeLastFailed(repoPath, h)) return;
     aiDescriptionRef.current = false;
     setReviewers([]);
     setLabels(new Set());
@@ -420,7 +423,6 @@ export function CreatePrDialog({
     // Reset the target to the default (parent) every open, so a prior fork/parent
     // choice doesn't leak into the next PR.
     setTarget("upstream");
-    const h = defaultHead ?? currentName ?? names[0] ?? "";
     const fallbackBase =
       defaultBranch.data && defaultBranch.data !== h
         ? defaultBranch.data
@@ -457,6 +459,11 @@ export function CreatePrDialog({
   // Survives this dialog closing, unlike `isSubmitting` — a create dismissed
   // mid-flight still owns the head branch until it settles.
   const creatingThisHead = useIsCreatingPr(repoPath, head);
+  // The RE-ENTRY case only. This submit claims the lane synchronously, so the
+  // flag is also true during the user's own create — which `isSubmitting`
+  // already covers, and where a "someone else is creating this" refusal would
+  // be nonsense under a spinning button.
+  const creatingElsewhere = creatingThisHead && !isSubmitting;
 
   // Fork-side fallback base, mirroring the seed logic (default branch, else first
   // non-head) — reused when reconciling back from the parent target.
@@ -1040,7 +1047,7 @@ export function CreatePrDialog({
           </div>
 
           <DialogFooter className="sm:items-center">
-            {creatingThisHead && (
+            {creatingElsewhere && (
               // Why the submit is disabled. It lives here rather than in the
               // scrollable body so it can't scroll out of view, and the button
               // points `aria-describedby` at it.
@@ -1074,11 +1081,11 @@ export function CreatePrDialog({
                       generating ||
                       nothingToMerge ||
                       baseLoading ||
-                      creatingThisHead ||
+                      creatingElsewhere ||
                       Boolean(existingPr)
                     }
                     aria-describedby={
-                      creatingThisHead ? creatingHintId : undefined
+                      creatingElsewhere ? creatingHintId : undefined
                     }
                     title={SUBMIT_HINT}
                   >

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -194,6 +194,9 @@ export function CreatePrDialog({
   const { generate, cancel, generating } = useGeneratePrDescription(repoPath);
   const aiEnabled = useAiEnabled();
   const aiDescriptionRef = useRef(false);
+  // Whether THIS mount has seeded, so the skip below can tell a reopen (form
+  // state may hold a draft the user typed) from a fresh mount (it cannot).
+  const seededRef = useRef(false);
 
   const currentName = status.data?.branch?.name ?? null;
   // Branch options with per-branch worktree chips; drops the app-internal
@@ -407,10 +410,25 @@ export function CreatePrDialog({
     const h = defaultHead ?? currentName ?? names[0] ?? "";
     // A create still running in the background — or one that failed while the
     // dialog was closed — leaves everything the user typed in form state, and
-    // this reset would blank it on reopen. Both signals are judged against the
-    // head this seed WOULD land on: a create running on another branch must not
-    // preserve its draft in a dialog the user opened for this one.
-    if (isCreatingPrFor(repoPath, h) || consumeLastFailed(repoPath, h)) return;
+    // this reset would blank it on reopen. The draft's identity is the RETAINED
+    // form head, not this open's default: the user may have submitted a head
+    // that differs from the branch they are on now. The `||` short-circuit is
+    // deliberate — while a create is in flight the latch stays unconsumed, so a
+    // later reopen after it fails still preserves the draft.
+    if (seededRef.current) {
+      const retained = form.state.values.head || h;
+      if (
+        isCreatingPrFor(repoPath, retained) ||
+        consumeLastFailed(repoPath, retained)
+      )
+        return;
+    } else {
+      // A fresh mount holds no draft (form state died with the last one), so it
+      // always seeds — and disposes the latch for the head it is seeding, whose
+      // draft the unmount already destroyed.
+      consumeLastFailed(repoPath, h);
+    }
+    seededRef.current = true;
     aiDescriptionRef.current = false;
     setReviewers([]);
     setLabels(new Set());

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -54,7 +54,15 @@ import {
 } from "@/lib/repo-lens/queries";
 import { deleteReviewNote } from "@/lib/review-notes/store";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
+import {
+  consumeLastFailed,
+  isCreatingPrInRepo,
+  settlePrCreate,
+  startPrCreate,
+  useIsCreatingPr,
+} from "@/lib/stores/pr-create";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { ReviewerNotesField } from "./ReviewerNotesField";
 import { ReviewersPopover } from "./ReviewersPopover";
@@ -173,6 +181,7 @@ export function CreatePrDialog({
   // and popover triggers) that carry their own aria-label, so the visible field
   // label names the surrounding group via aria-labelledby rather than htmlFor.
   const createInGroupId = useId();
+  const creatingHintId = useId();
   const reviewersGroupId = useId();
   const assigneesGroupId = useId();
   // Labels come from whichever repo the PR targets (parent's own labels when
@@ -258,6 +267,16 @@ export function CreatePrDialog({
           : undefined,
     },
     onSubmit: async ({ value }) => {
+      // Fire-time admission, claimed before the first await: the push plus the
+      // forge call runs for minutes and the user can dismiss the dialog the
+      // moment it starts, so a second attempt on the same head would queue on
+      // the repo lock and then open a duplicate PR.
+      const refusal = startPrCreate(repoPath, value.head, value.base);
+      if (refusal) {
+        toast.error(refusal);
+        return;
+      }
+      let outcome: "success" | "error" = "error";
       try {
         // Append the linked-issue chips as their exact keyword lines via the shared
         // composer (the single ref-block composition used by every create/edit save
@@ -296,6 +315,7 @@ export function CreatePrDialog({
             ? { assignees: assignees.map((a) => a.id) }
             : {}),
         });
+        outcome = "success";
         const notes = value.notes.trim();
         track({
           name: "pull_request_created",
@@ -347,9 +367,9 @@ export function CreatePrDialog({
           action: { label: "View", onClick: () => openUrl(url) },
         });
         // This dialog is panel-hosted under <Activity>, so the success path must
-        // only close — never setRepoTab/selectPr (a hidden Activity subtree would
-        // defer the close and strand the dialog). Want navigation? Hoist it to
-        // RepositoryView first, like CreateLocalPrDialog.
+        // only close — never setRepoTab/selectPr, which would conceal this panel
+        // and leave the dialog open behind the tab it landed on. Want navigation?
+        // Hoist it to RepositoryView first, like CreateLocalPrDialog.
         onOpenChange(false);
         // Draft gate: a draft PR fires no review unless the user opted into reviewing
         // drafts. A gated-out draft is NOT a lost review — an in-app Mark-ready fires
@@ -373,6 +393,8 @@ export function CreatePrDialog({
         }
       } catch (e) {
         toastError(e);
+      } finally {
+        settlePrCreate(repoPath, value.head, outcome);
       }
     },
   });
@@ -382,6 +404,10 @@ export function CreatePrDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // seeded values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
+    // A create still running in the background — or one that failed while the
+    // dialog was closed — leaves everything the user typed in form state, and
+    // this reset would blank it on reopen.
+    if (isCreatingPrInRepo(repoPath) || consumeLastFailed(repoPath)) return;
     aiDescriptionRef.current = false;
     setReviewers([]);
     setLabels(new Set());
@@ -419,9 +445,7 @@ export function CreatePrDialog({
       { keepDefaultValues: true },
     );
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // Live head/base drive the "N commits" hint, AI generation, and submit gate.
   const head = useSelector(form.store, (s) => s.values.head);
@@ -429,6 +453,10 @@ export function CreatePrDialog({
   // Live notes feed the AI-description prompt (so a generated description can
   // reflect the reviewer notes) and the ReviewerNotesField's seeding provenance.
   const notes = useSelector(form.store, (s) => s.values.notes);
+  const isSubmitting = useSelector(form.store, (s) => s.isSubmitting);
+  // Survives this dialog closing, unlike `isSubmitting` — a create dismissed
+  // mid-flight still owns the head branch until it settles.
+  const creatingThisHead = useIsCreatingPr(repoPath, head);
 
   // Fork-side fallback base, mirroring the seed logic (default branch, else first
   // non-head) — reused when reconciling back from the parent target.
@@ -622,6 +650,8 @@ export function CreatePrDialog({
                 generating ||
                 nothingToMerge ||
                 baseLoading ||
+                isSubmitting ||
+                creatingThisHead ||
                 Boolean(existingPr)
               )
             ) {
@@ -1010,6 +1040,17 @@ export function CreatePrDialog({
           </div>
 
           <DialogFooter className="sm:items-center">
+            {creatingThisHead && (
+              // Why the submit is disabled. It lives here rather than in the
+              // scrollable body so it can't scroll out of view, and the button
+              // points `aria-describedby` at it.
+              <p
+                id={creatingHintId}
+                className="basis-full text-xs text-warning"
+              >
+                A pull request for this branch is already being created.
+              </p>
+            )}
             <form.AppField name="draft">
               {(field) => (
                 <field.CheckboxField
@@ -1033,7 +1074,11 @@ export function CreatePrDialog({
                       generating ||
                       nothingToMerge ||
                       baseLoading ||
+                      creatingThisHead ||
                       Boolean(existingPr)
+                    }
+                    aria-describedby={
+                      creatingThisHead ? creatingHintId : undefined
                     }
                     title={SUBMIT_HINT}
                   >

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -57,8 +57,10 @@ export function PromoteLocalPrDialog({
   const pending = createPr.isPending || update.isPending || posting;
   // Shares the PR-create lane with CreatePrDialog: both push the same head and
   // open a PR for it, so either one running blocks the other (and paints the
-  // same strip above the panels).
-  const creatingHead = useIsCreatingPr(repoPath, pr.head);
+  // same strip above the panels). `!pending` narrows it to the RE-ENTRY case —
+  // promote claims the lane synchronously, so the flag is also true during this
+  // dialog's own run, where `pending` is the honest thing to show.
+  const creatingElsewhere = useIsCreatingPr(repoPath, pr.head) && !pending;
   const creatingHintId = useId();
 
   // Visible comments, in order — skip empty + hidden (collapsed) ones.
@@ -165,7 +167,7 @@ export function PromoteLocalPrDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="sm:items-center">
-          {creatingHead && (
+          {creatingElsewhere && (
             <p id={creatingHintId} className="basis-full text-xs text-warning">
               A pull request for this branch is already being created.
             </p>
@@ -186,8 +188,8 @@ export function PromoteLocalPrDialog({
           </Button>
           <Button
             onClick={promote}
-            disabled={pending || creatingHead}
-            aria-describedby={creatingHead ? creatingHintId : undefined}
+            disabled={pending || creatingElsewhere}
+            aria-describedby={creatingElsewhere ? creatingHintId : undefined}
           >
             {pending && <Spinner data-icon="inline-start" />}
             {draft ? "Publish as draft" : `Publish to ${remoteLabel}`}

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -17,6 +17,11 @@ import { useCreatePr, useForgeStatus } from "@/lib/git/queries";
 import type { LocalPr } from "@/lib/pulls/local";
 import { useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useSetRepoLens } from "@/lib/repo-lens/queries";
+import {
+  settlePrCreate,
+  startPrCreate,
+  useIsCreatingPr,
+} from "@/lib/stores/pr-create";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
@@ -50,11 +55,25 @@ export function PromoteLocalPrDialog({
   const [draft, setDraft] = useState(false);
   const [posting, setPosting] = useState(false);
   const pending = createPr.isPending || update.isPending || posting;
+  // Shares the PR-create lane with CreatePrDialog: both push the same head and
+  // open a PR for it, so either one running blocks the other (and paints the
+  // same strip above the panels).
+  const creatingHead = useIsCreatingPr(repoPath, pr.head);
+  const creatingHintId = useId();
 
   // Visible comments, in order — skip empty + hidden (collapsed) ones.
   const carried = pr.comments.filter((c) => c.body.trim() && !c.hidden);
 
   async function promote() {
+    // Fire-time admission, claimed before the first await: the push plus the
+    // forge call outlives this dialog, and a second create for the same head
+    // would queue on the repo lock and then open a duplicate PR.
+    const refusal = startPrCreate(repoPath, pr.head, pr.base);
+    if (refusal) {
+      toast.error(refusal);
+      return;
+    }
+    let outcome: "success" | "error" = "error";
     // Once the remote PR exists, later steps (comment carry-over, closing the
     // local PR) failing must NOT re-arm the submit — retrying would open a
     // duplicate. Track it so the catch can disclose instead of re-running.
@@ -69,6 +88,7 @@ export function PromoteLocalPrDialog({
         draft,
       });
       created = { number, url };
+      outcome = "success";
       // Carry the local comments over, in order, so none are lost.
       failedStep = "carrying over comments";
       setPosting(true);
@@ -122,6 +142,8 @@ export function PromoteLocalPrDialog({
           action: { label: "View", onClick: () => openUrl(url) },
         },
       );
+    } finally {
+      settlePrCreate(repoPath, pr.head, outcome);
     }
   }
 
@@ -143,6 +165,11 @@ export function PromoteLocalPrDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="sm:items-center">
+          {creatingHead && (
+            <p id={creatingHintId} className="basis-full text-xs text-warning">
+              A pull request for this branch is already being created.
+            </p>
+          )}
           <label className="mr-auto flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
             <Checkbox
               checked={draft}
@@ -157,7 +184,11 @@ export function PromoteLocalPrDialog({
           >
             Cancel
           </Button>
-          <Button onClick={promote} disabled={pending}>
+          <Button
+            onClick={promote}
+            disabled={pending || creatingHead}
+            aria-describedby={creatingHead ? creatingHintId : undefined}
+          >
             {pending && <Spinner data-icon="inline-start" />}
             {draft ? "Publish as draft" : `Publish to ${remoteLabel}`}
           </Button>

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -75,7 +75,9 @@ export function PromoteLocalPrDialog({
       toast.error(refusal);
       return;
     }
-    let outcome: "success" | "error" = "error";
+    // "release", not "error": a failed promote produced no draft, so it frees
+    // the lane without latching over a real create failure for this branch.
+    let outcome: "success" | "release" = "release";
     // Once the remote PR exists, later steps (comment carry-over, closing the
     // local PR) failing must NOT re-arm the submit — retrying would open a
     // duplicate. Track it so the catch can disclose instead of re-running.

--- a/src/features/repo-settings/DangerZone.tsx
+++ b/src/features/repo-settings/DangerZone.tsx
@@ -1,11 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import {
-  type ComponentProps,
-  type ReactNode,
-  useEffect,
-  useState,
-} from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
@@ -49,6 +44,7 @@ import { deleteRepoLens } from "@/lib/repo-lens/store";
 import { settingsKeys, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { InlineConfirm } from "./parts";
 import { ScopeRefreshHint } from "./ScopeRefreshHint";
 
@@ -91,9 +87,8 @@ function DangerDialog({
   children?: ReactNode;
 }) {
   const [typed, setTyped] = useState("");
-  useEffect(() => {
-    if (open) setTyped("");
-  }, [open]);
+  useSeedOnOpen(open, () => setTyped(""));
+
   const matches = typed.trim() === confirmPhrase;
 
   return (

--- a/src/features/repo-settings/SecuritySection.tsx
+++ b/src/features/repo-settings/SecuritySection.tsx
@@ -1,6 +1,6 @@
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -33,6 +33,7 @@ import {
 } from "@/lib/git/queries";
 import type { SecurityFeature, SecurityStatus } from "@/lib/git/types";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { AsyncErrorCard, InlineConfirm } from "./parts";
 
 /** Dependabot / dependency-graph options GitHub exposes to NO repo-level API —
@@ -298,12 +299,10 @@ function DependabotDialog({
 }) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [interval, setInterval] = useState("weekly");
-  useEffect(() => {
-    if (open) {
-      setSelected(new Set());
-      setInterval("weekly");
-    }
-  }, [open]);
+  useSeedOnOpen(open, () => {
+    setSelected(new Set());
+    setInterval("weekly");
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "@tanstack/react-store";
-import { useEffect, useEffectEvent, useId, useState } from "react";
+import { useEffectEvent, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,6 +18,7 @@ import { refNameWarning, sanitizeRefName } from "@/lib/git/ref-name";
 import type { FileEntry } from "@/lib/git/types";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import {
   BaseBranchCombobox,
   useHasBaseOptions,
@@ -148,9 +149,7 @@ export function CreateBranchDialog({
     // remote value, so tracking stays on.
     setBaseIsRemote(false);
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // One generate pair for the button and the chord — see
   // `useBranchNameGenerateAction`.

--- a/src/features/repository/PrCreateBanner.tsx
+++ b/src/features/repository/PrCreateBanner.tsx
@@ -1,0 +1,37 @@
+import { Spinner } from "@/components/ui/spinner";
+import { usePrCreates } from "@/lib/stores/pr-create";
+
+/**
+ * Keeps a running pull-request creation visible after its dialog is dismissed.
+ * The push plus the forge call hold the repo lock and can run for minutes, so
+ * this lives in the repo view's layout flow (one line per create, pushing
+ * content down) rather than in a toast that expires or an overlay that covers
+ * the header. There is nothing to press: `git push` has no clean mid-flight
+ * cancel, so a create can only be waited out.
+ */
+export function PrCreateBanner({ repoPath }: { repoPath: string }) {
+  const creates = usePrCreates(repoPath);
+
+  return (
+    // Mounted unconditionally: a live region created together with its text
+    // announces unreliably, so the region pre-exists and only its CONTENT
+    // changes. `sr-only` keeps the empty state out of layout entirely, so no
+    // phantom border sits above the panels.
+    // No aria-busy: on a live region it tells a screen reader to withhold
+    // announcements until it clears, the opposite of what this line is for.
+    <div role="status" className={creates.length > 0 ? "border-b" : "sr-only"}>
+      {creates.map((c) => (
+        <div
+          key={c.head}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs"
+        >
+          <Spinner aria-hidden className="size-3.5 shrink-0" />
+          <span className="min-w-0 truncate">
+            Creating pull request <span className="font-mono">{c.head}</span> →{" "}
+            <span className="font-mono">{c.base}</span>…
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -18,6 +18,7 @@ import { useBbWorkspaces, usePublishRepo } from "@/lib/git/queries";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { useGenerateRepoDescription } from "../repo-settings/useGenerateRepoDescription";
 
 /** Bitbucket repo slugs must start alphanumeric, then allow dot/underscore/hyphen.
@@ -133,9 +134,7 @@ export function PublishDialog({
       isPrivate: true,
     }),
   );
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   // Workspaces load after the dialog opens, so seed the picker once they arrive
   // (and only while the field is still empty — never stomp a user's pick).

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -1,5 +1,5 @@
 import { InfoIcon, WarningIcon } from "@phosphor-icons/react";
-import { useEffect, useEffectEvent, useId, useState } from "react";
+import { useEffectEvent, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -20,6 +20,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { useCompareBranches } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 const PREVIEW_CAP = 6;
 
@@ -73,9 +74,7 @@ export function RebaseOntoDialog({
     setNewBase(seededNew);
     setOldBase(names.find((n) => n !== seededNew) ?? "");
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   const sameBranch = Boolean(newBase) && newBase === oldBase;
   // The commits `oldBase..HEAD` — exactly what `--onto` will replay. Compares

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/settings/queries";
 import { ignoreToast, toastError, toastErrorWithNote } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
 /** Which list the dialog opens on — exported for the palette actions that route
@@ -248,14 +249,10 @@ export function RepositoryFilesDialog({
   // user picks inside an open dialog isn't pulled back by a re-render. Gated on
   // aiEnabled here too — the callers all gate already, but a future opener must
   // not be able to land the dialog on a tab whose button isn't rendered.
-  const wasOpen = useRef(open);
-  useEffect(() => {
-    if (open && !wasOpen.current) {
-      const target = initialTab ?? "tracked";
-      setTab(target === "ai" && !aiEnabled ? "tracked" : target);
-    }
-    wasOpen.current = open;
-  }, [open, initialTab, aiEnabled]);
+  useSeedOnOpen(open, () => {
+    const target = initialTab ?? "tracked";
+    setTab(target === "ai" && !aiEnabled ? "tracked" : target);
+  });
 
   // Hiding AI features takes their tab with it, mid-open included.
   useEffect(() => {

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -717,7 +717,8 @@ export function RepositoryView() {
       )}
       {/* Hoisted: its success handler navigates to the Pulls tab, so a
           panel-hosted instance would conceal with the tab that launched it
-          mid-close. One instance here serves every opener. */}
+          mid-close and not finish closing until that tab is next shown. One
+          instance here serves every opener. */}
       <CreateLocalPrDialog
         repoPath={repoPath}
         defaultHead={localPrCreate?.defaultHead}

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -21,7 +21,10 @@ import {
   useState,
   useTransition,
 } from "react";
-import { PanelPortalBoundary } from "@/components/panel-portal";
+import {
+  PanelActivityBoundary,
+  PanelPortalBoundary,
+} from "@/components/panel-portal";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -83,6 +86,7 @@ import { cn } from "@/lib/utils";
 import { ChangesPanel } from "./ChangesPanel";
 import { InsightsPanel } from "./insights/InsightsPanel";
 import { OpRecoveryBanner } from "./OpRecoveryBanner";
+import { PrCreateBanner } from "./PrCreateBanner";
 import { RepoHeader } from "./RepoHeader";
 import { usePrNotifications } from "./usePrNotifications";
 import { useRepoVisibilityProbe } from "./useRepoVisibilityProbe";
@@ -179,7 +183,9 @@ function TabPanel({
 }) {
   return (
     <Activity mode={active ? "visible" : "hidden"}>
-      <PanelPortalBoundary>{children}</PanelPortalBoundary>
+      <PanelActivityBoundary active={active}>
+        <PanelPortalBoundary>{children}</PanelPortalBoundary>
+      </PanelActivityBoundary>
     </Activity>
   );
 }
@@ -418,6 +424,7 @@ export function RepositoryView() {
       <RepoHeader repoPath={repoPath} />
       <OpRecoveryBanner repoPath={repoPath} />
       <WorktreeRemovalBanner repoPath={repoPath} />
+      <PrCreateBanner repoPath={repoPath} />
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-96 shrink-0 flex-col border-r">
           <Tabs
@@ -708,9 +715,9 @@ export function RepositoryView() {
           }}
         />
       )}
-      {/* Hoisted: its success handler navigates to the Pulls tab, which hides whichever
-          tab launched it — a panel-hosted instance under <Activity> would have its
-          close deferred and stick open. One instance here serves every opener. */}
+      {/* Hoisted: its success handler navigates to the Pulls tab, so a
+          panel-hosted instance would conceal with the tab that launched it
+          mid-close. One instance here serves every opener. */}
       <CreateLocalPrDialog
         repoPath={repoPath}
         defaultHead={localPrCreate?.defaultHead}

--- a/src/features/repository/StashReapplyDialog.tsx
+++ b/src/features/repository/StashReapplyDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 /** What the pending recovery is for: the lower-case operation word used in the
  *  copy, plus an optional phrase naming its target (e.g. `upstream/main`). */
@@ -49,9 +50,7 @@ export function StashReapplyDialog({
 
   // Reset the checkbox each time the dialog opens — it only ever shows while
   // the preference is off, so a remembered tick would be meaningless.
-  useEffect(() => {
-    if (open) setAlways(false);
-  }, [open]);
+  useSeedOnOpen(open, () => setAlways(false));
 
   return (
     <Dialog

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -1,5 +1,5 @@
 import { TrashIcon } from "@phosphor-icons/react";
-import { useDeferredValue, useEffect, useEffectEvent, useState } from "react";
+import { useDeferredValue, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { RelativeTime } from "@/components/relative-time";
@@ -32,6 +32,7 @@ import {
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
 /** Which source the left list is drawn from. */
@@ -114,9 +115,7 @@ export function StashesDialog({
   // The dialog can be opened straight to either view; seed `view` from the
   // caller's intent each time it opens (mirrors the seed-on-open idiom).
   const seedOnOpen = useEffectEvent(() => setView(initialView));
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   const list = stashes.data ?? [];
   // Default to the newest stash; fall back when the selected one is gone.

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -633,11 +634,16 @@ export function RenameWorktreeDialog({
         )}
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={move.isPending}>
+          <DisabledReasonButton
+            variant="outline"
+            onClick={onClose}
+            disabled={move.isPending}
+            reason="The rename is still running."
+          >
             {/* Nothing here can call the removal off, so "Cancel" would promise
                 more than closing this dialog does. */}
             {removing ? "Close" : "Cancel"}
-          </Button>
+          </DisabledReasonButton>
           <Button
             disabled={
               !trimmed || unchanged || invalid || move.isPending || removing
@@ -732,11 +738,16 @@ export function LockWorktreeDialog({
         )}
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={lock.isPending}>
+          <DisabledReasonButton
+            variant="outline"
+            onClick={onClose}
+            disabled={lock.isPending}
+            reason="The lock is still running."
+          >
             {/* Nothing here can call the removal off, so "Cancel" would promise
                 more than closing this dialog does. */}
             {removing ? "Close" : "Cancel"}
-          </Button>
+          </DisabledReasonButton>
           <Button onClick={handleLock} disabled={lock.isPending || removing}>
             {lock.isPending && <Spinner data-icon="inline-start" />}
             Lock

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -584,13 +584,14 @@ export function RenameWorktreeDialog({
   return (
     <Dialog
       open={worktree !== null}
-      // Escape and a backdrop press are ignored while the move runs, matching
-      // the Cancel button that is already disabled for it.
+      // Close requests are ignored while the move runs, matching the Cancel
+      // button that is already disabled for it — and the corner X goes with
+      // them, rather than sitting there dead.
       onOpenChange={(o) => {
         if (!o && !move.isPending) onClose();
       }}
     >
-      <DialogContent>
+      <DialogContent showCloseButton={!move.isPending}>
         <DialogHeader>
           <DialogTitle>Rename worktree</DialogTitle>
           <DialogDescription>
@@ -685,13 +686,14 @@ export function LockWorktreeDialog({
   return (
     <Dialog
       open={worktree !== null}
-      // Escape and a backdrop press are ignored while the lock runs, matching
-      // the Cancel button that is already disabled for it.
+      // Close requests are ignored while the lock runs, matching the Cancel
+      // button that is already disabled for it — and the corner X goes with
+      // them, rather than sitting there dead.
       onOpenChange={(o) => {
         if (!o && !lock.isPending) onClose();
       }}
     >
-      <DialogContent>
+      <DialogContent showCloseButton={!lock.isPending}>
         <DialogHeader>
           <DialogTitle>Lock worktree</DialogTitle>
           <DialogDescription>

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -582,7 +582,14 @@ export function RenameWorktreeDialog({
   }
 
   return (
-    <Dialog open={worktree !== null} onOpenChange={(o) => !o && onClose()}>
+    <Dialog
+      open={worktree !== null}
+      // Escape and a backdrop press are ignored while the move runs, matching
+      // the Cancel button that is already disabled for it.
+      onOpenChange={(o) => {
+        if (!o && !move.isPending) onClose();
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Rename worktree</DialogTitle>
@@ -676,7 +683,14 @@ export function LockWorktreeDialog({
   }
 
   return (
-    <Dialog open={worktree !== null} onOpenChange={(o) => !o && onClose()}>
+    <Dialog
+      open={worktree !== null}
+      // Escape and a backdrop press are ignored while the lock runs, matching
+      // the Cancel button that is already disabled for it.
+      onOpenChange={(o) => {
+        if (!o && !lock.isPending) onClose();
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Lock worktree</DialogTitle>

--- a/src/features/scripts/RunTaskPicker.tsx
+++ b/src/features/scripts/RunTaskPicker.tsx
@@ -6,6 +6,7 @@ import { clipTitle } from "@/lib/clip-title";
 import { useScripts } from "@/lib/scripts/queries";
 import { INTERPRETERS } from "@/lib/scripts/types";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
 const INTERPRETER_LABELS: Record<string, string> = Object.fromEntries(
@@ -30,12 +31,10 @@ export function RunTaskPicker({
   const [highlight, setHighlight] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
 
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-      setHighlight(0);
-    }
-  }, [open]);
+  useSeedOnOpen(open, () => {
+    setQuery("");
+    setHighlight(0);
+  });
 
   const q = query.trim().toLowerCase();
   const items = tasks.filter(

--- a/src/features/shortcuts/CommandPalette.tsx
+++ b/src/features/shortcuts/CommandPalette.tsx
@@ -8,6 +8,7 @@ import {
   useEffectiveBindings,
 } from "@/lib/hotkeys/hotkeys";
 import { ACTIONS, type ActionId } from "@/lib/hotkeys/registry";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
 /**
@@ -29,12 +30,10 @@ export function CommandPalette({
   const listRef = useRef<HTMLUListElement>(null);
 
   // Fresh search every time the palette opens.
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-      setHighlight(0);
-    }
-  }, [open]);
+  useSeedOnOpen(open, () => {
+    setQuery("");
+    setHighlight(0);
+  });
 
   const q = query.trim().toLowerCase();
   const items = ACTIONS.filter(

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   MarkdownEditor,
@@ -64,6 +64,7 @@ import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 import { useGenerateReleaseNotes } from "./useGenerateReleaseNotes";
 import { findPreviousTag } from "./version";
@@ -205,9 +206,7 @@ export function CreateReleaseDialog({
     setPreviousTagOverride(null);
     // The editor remounts with the dialog (Write tab) — no explicit reset needed.
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   function createNewTag(name: string) {
     const n = name.trim();

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -33,6 +33,7 @@ import { useAddRecentRepo, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage, isAppError } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 import { nameFromUrl, parentDir } from "./clone-utils";
 
@@ -134,9 +135,7 @@ export function CloneRepoDialog({
       { keepDefaultValues: true },
     );
   });
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   const values = useSelector(form.store, (s) => s.values);
   const isSubmitting = useSelector(form.store, (s) => s.isSubmitting);

--- a/src/features/welcome/CreateRepoDialog.tsx
+++ b/src/features/welcome/CreateRepoDialog.tsx
@@ -1,5 +1,5 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { useEffect, useEffectEvent } from "react";
+import { useEffectEvent } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,6 +16,7 @@ import { useGlobalDefaultBranch } from "@/lib/git/queries";
 import { useAddRecentRepo } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
 const NONE = "__none__";
 const GITIGNORE_TEMPLATES = ["Node", "Python", "Rust", "Go"];
@@ -78,9 +79,7 @@ export function CreateRepoDialog({
   });
 
   const seedOnOpen = useEffectEvent(() => form.reset(DEFAULTS));
-  useEffect(() => {
-    if (open) seedOnOpen();
-  }, [open]);
+  useSeedOnOpen(open, seedOnOpen);
 
   async function pickParentDir() {
     const path = await openDialog({

--- a/src/lib/stores/pr-create.ts
+++ b/src/lib/stores/pr-create.ts
@@ -1,0 +1,112 @@
+import { create } from "zustand";
+import { normPath } from "@/lib/git/path";
+
+/** A pull-request creation the app is still waiting on. */
+export interface PrCreate {
+  /** The head branch being pushed and proposed. */
+  head: string;
+  /** What it is being proposed against, as the dialog spelled it. */
+  base: string;
+  /** Epoch ms the create started. */
+  startedAt: number;
+}
+
+interface PrCreateState {
+  /** repoPath → head branch → the create in flight. Keyed by repo so a repo
+   *  switch reads an empty set rather than another repo's creates, and by head
+   *  because that is what a duplicate would collide on: two creates for
+   *  DIFFERENT heads in one repo are fine — they queue on the per-repo git lock
+   *  and each opens its own PR. */
+  byRepo: Record<string, Record<string, PrCreate>>;
+}
+
+const NO_CREATES: PrCreate[] = [];
+
+export const usePrCreateStore = create<PrCreateState>()(() => ({
+  byRepo: {},
+}));
+
+/** Repos whose most recent create FAILED, keyed by {@link normPath}. Read once
+ *  and cleared by {@link consumeLastFailed}: it exists only so the dialog that
+ *  reopens after a background failure knows not to blank what the user typed.
+ *  Deliberately not store state — nothing renders from it. */
+const lastFailed = new Set<string>();
+
+/**
+ * Claims the lane for one head branch. Returns null once claimed, or the reason
+ * it was refused. Call this SYNCHRONOUSLY before the first await: a `git push`
+ * plus `gh pr create` runs for minutes behind a closed dialog, and a second
+ * attempt on the same head would only queue on the repo lock and then open a
+ * duplicate PR.
+ */
+export function startPrCreate(
+  repoPath: string,
+  head: string,
+  base: string,
+): string | null {
+  if (usePrCreateStore.getState().byRepo[repoPath]?.[head])
+    return "A pull request for this branch is already being created.";
+  usePrCreateStore.setState((s) => ({
+    byRepo: {
+      ...s.byRepo,
+      [repoPath]: {
+        ...s.byRepo[repoPath],
+        [head]: { head, base, startedAt: Date.now() },
+      },
+    },
+  }));
+  return null;
+}
+
+/** Releases the lane. An "error" outcome latches {@link consumeLastFailed} so a
+ *  reopen after a failure the user never saw keeps their draft. */
+export function settlePrCreate(
+  repoPath: string,
+  head: string,
+  outcome: "success" | "error",
+): void {
+  // Success clears the latch as well as setting it on failure: a stale flag left
+  // by an older failure would skip a legitimate reset days later, on any branch.
+  if (outcome === "error") lastFailed.add(normPath(repoPath));
+  else lastFailed.delete(normPath(repoPath));
+  usePrCreateStore.setState((s) => {
+    const repo = s.byRepo[repoPath];
+    if (!repo?.[head]) return s;
+    const { [head]: _settled, ...rest } = repo;
+    const { [repoPath]: _emptied, ...otherRepos } = s.byRepo;
+    return {
+      byRepo:
+        Object.keys(rest).length > 0
+          ? { ...s.byRepo, [repoPath]: rest }
+          : otherRepos,
+    };
+  });
+}
+
+/** True while ANY create is in flight for this repo. A FIRE-TIME check: call it
+ *  where a decision is made, never to decide what a component paints — use
+ *  {@link useIsCreatingPr} or {@link usePrCreates} for render. */
+export function isCreatingPrInRepo(repoPath: string): boolean {
+  const entries = usePrCreateStore.getState().byRepo[repoPath];
+  return entries !== undefined && Object.keys(entries).length > 0;
+}
+
+/** Reads and clears the failed-create latch for one repo. */
+export function consumeLastFailed(repoPath: string): boolean {
+  return lastFailed.delete(normPath(repoPath));
+}
+
+/** The creates in flight for one repo, oldest first. */
+export function usePrCreates(repoPath: string): PrCreate[] {
+  const entries = usePrCreateStore((s) => s.byRepo[repoPath]);
+  if (!entries) return NO_CREATES;
+  return Object.values(entries).sort((a, b) => a.startedAt - b.startedAt);
+}
+
+/** True while a pull request for this exact head branch is being created. */
+export function useIsCreatingPr(
+  repoPath: string,
+  head: string | undefined,
+): boolean {
+  return usePrCreateStore((s) => Boolean(head && s.byRepo[repoPath]?.[head]));
+}

--- a/src/lib/stores/pr-create.ts
+++ b/src/lib/stores/pr-create.ts
@@ -32,7 +32,9 @@ export const usePrCreateStore = create<PrCreateState>()(() => ({
  *  {@link consumeLastFailed}: it exists only so the dialog that reopens after a
  *  background failure knows not to blank what the user typed. Per HEAD, not per
  *  repo — a failure on one branch must not preserve its draft in a dialog the
- *  user opened for another. Deliberately not store state: nothing renders it. */
+ *  user opened for another. The lane has several writers but only CreatePrDialog
+ *  holds a draft this can protect, so it is the only one that latches; see the
+ *  outcome union on {@link settlePrCreate}. Not store state: nothing renders it. */
 const lastFailed = new Set<string>();
 
 // NUL is the one separator neither a path nor a ref name can contain, so
@@ -68,17 +70,24 @@ export function startPrCreate(
   return null;
 }
 
-/** Releases the lane. An "error" outcome latches {@link consumeLastFailed} so a
- *  reopen after a failure the user never saw keeps their draft. */
+/**
+ * Releases the lane. The outcome says what the caller owes
+ * {@link consumeLastFailed}, and only a caller that owns a preservable draft may
+ * speak for it:
+ * - `"error"` latches, so a reopen after a failure the user never saw keeps
+ *   their draft. CreatePrDialog's form is the only draft this protects.
+ * - `"success"` clears, because a stale flag from an older failure would skip a
+ *   legitimate reset later — and once the branch has a PR the point is moot.
+ * - `"release"` is for a lane holder with no draft to protect. It only frees the
+ *   entry, leaving an earlier create's latch standing.
+ */
 export function settlePrCreate(
   repoPath: string,
   head: string,
-  outcome: "success" | "error",
+  outcome: "success" | "error" | "release",
 ): void {
-  // Success clears the latch as well as setting it on failure: a stale flag left
-  // by an older failure would skip a legitimate reset days later.
   if (outcome === "error") lastFailed.add(failKey(repoPath, head));
-  else lastFailed.delete(failKey(repoPath, head));
+  else if (outcome === "success") lastFailed.delete(failKey(repoPath, head));
   const repo = normPath(repoPath);
   usePrCreateStore.setState((s) => {
     const entries = s.byRepo[repo];

--- a/src/lib/stores/pr-create.ts
+++ b/src/lib/stores/pr-create.ts
@@ -12,11 +12,13 @@ export interface PrCreate {
 }
 
 interface PrCreateState {
-  /** repoPath → head branch → the create in flight. Keyed by repo so a repo
-   *  switch reads an empty set rather than another repo's creates, and by head
-   *  because that is what a duplicate would collide on: two creates for
-   *  DIFFERENT heads in one repo are fine — they queue on the per-repo git lock
-   *  and each opens its own PR. */
+  /** repoPath → head branch → the create in flight. The repo key is ALWAYS a
+   *  {@link normPath} spelling, applied at every entry point, so a writer
+   *  holding git's spelling and a reader holding the ui store's land in the
+   *  same bucket. Keyed by repo so a repo switch reads an empty set rather than
+   *  another repo's creates, and by head because that is what a duplicate would
+   *  collide on: two creates for DIFFERENT heads in one repo are fine — they
+   *  queue on the per-repo git lock and each opens its own PR. */
   byRepo: Record<string, Record<string, PrCreate>>;
 }
 
@@ -26,11 +28,18 @@ export const usePrCreateStore = create<PrCreateState>()(() => ({
   byRepo: {},
 }));
 
-/** Repos whose most recent create FAILED, keyed by {@link normPath}. Read once
- *  and cleared by {@link consumeLastFailed}: it exists only so the dialog that
- *  reopens after a background failure knows not to blank what the user typed.
- *  Deliberately not store state — nothing renders from it. */
+/** Repo+head pairs whose most recent create FAILED. Read once and cleared by
+ *  {@link consumeLastFailed}: it exists only so the dialog that reopens after a
+ *  background failure knows not to blank what the user typed. Per HEAD, not per
+ *  repo — a failure on one branch must not preserve its draft in a dialog the
+ *  user opened for another. Deliberately not store state: nothing renders it. */
 const lastFailed = new Set<string>();
+
+// NUL is the one separator neither a path nor a ref name can contain, so
+// ("a b", "c") and ("a", "b c") can't share a key — the same join
+// worktree-removal uses for its listener keys.
+const failKey = (repoPath: string, head: string) =>
+  `${normPath(repoPath)}\u0000${head}`;
 
 /**
  * Claims the lane for one head branch. Returns null once claimed, or the reason
@@ -44,13 +53,14 @@ export function startPrCreate(
   head: string,
   base: string,
 ): string | null {
-  if (usePrCreateStore.getState().byRepo[repoPath]?.[head])
+  const repo = normPath(repoPath);
+  if (usePrCreateStore.getState().byRepo[repo]?.[head])
     return "A pull request for this branch is already being created.";
   usePrCreateStore.setState((s) => ({
     byRepo: {
       ...s.byRepo,
-      [repoPath]: {
-        ...s.byRepo[repoPath],
+      [repo]: {
+        ...s.byRepo[repo],
         [head]: { head, base, startedAt: Date.now() },
       },
     },
@@ -66,39 +76,41 @@ export function settlePrCreate(
   outcome: "success" | "error",
 ): void {
   // Success clears the latch as well as setting it on failure: a stale flag left
-  // by an older failure would skip a legitimate reset days later, on any branch.
-  if (outcome === "error") lastFailed.add(normPath(repoPath));
-  else lastFailed.delete(normPath(repoPath));
+  // by an older failure would skip a legitimate reset days later.
+  if (outcome === "error") lastFailed.add(failKey(repoPath, head));
+  else lastFailed.delete(failKey(repoPath, head));
+  const repo = normPath(repoPath);
   usePrCreateStore.setState((s) => {
-    const repo = s.byRepo[repoPath];
-    if (!repo?.[head]) return s;
-    const { [head]: _settled, ...rest } = repo;
-    const { [repoPath]: _emptied, ...otherRepos } = s.byRepo;
+    const entries = s.byRepo[repo];
+    if (!entries?.[head]) return s;
+    const { [head]: _settled, ...rest } = entries;
+    const { [repo]: _emptied, ...otherRepos } = s.byRepo;
     return {
       byRepo:
         Object.keys(rest).length > 0
-          ? { ...s.byRepo, [repoPath]: rest }
+          ? { ...s.byRepo, [repo]: rest }
           : otherRepos,
     };
   });
 }
 
-/** True while ANY create is in flight for this repo. A FIRE-TIME check: call it
- *  where a decision is made, never to decide what a component paints — use
- *  {@link useIsCreatingPr} or {@link usePrCreates} for render. */
-export function isCreatingPrInRepo(repoPath: string): boolean {
-  const entries = usePrCreateStore.getState().byRepo[repoPath];
-  return entries !== undefined && Object.keys(entries).length > 0;
+/** True while a create for this exact head is in flight. A FIRE-TIME check:
+ *  call it where a decision is made, never to decide what a component paints —
+ *  use {@link useIsCreatingPr} or {@link usePrCreates} for render. */
+export function isCreatingPrFor(repoPath: string, head: string): boolean {
+  return Boolean(
+    usePrCreateStore.getState().byRepo[normPath(repoPath)]?.[head],
+  );
 }
 
-/** Reads and clears the failed-create latch for one repo. */
-export function consumeLastFailed(repoPath: string): boolean {
-  return lastFailed.delete(normPath(repoPath));
+/** Reads and clears the failed-create latch for one repo+head. */
+export function consumeLastFailed(repoPath: string, head: string): boolean {
+  return lastFailed.delete(failKey(repoPath, head));
 }
 
 /** The creates in flight for one repo, oldest first. */
 export function usePrCreates(repoPath: string): PrCreate[] {
-  const entries = usePrCreateStore((s) => s.byRepo[repoPath]);
+  const entries = usePrCreateStore((s) => s.byRepo[normPath(repoPath)]);
   if (!entries) return NO_CREATES;
   return Object.values(entries).sort((a, b) => a.startedAt - b.startedAt);
 }
@@ -108,5 +120,7 @@ export function useIsCreatingPr(
   repoPath: string,
   head: string | undefined,
 ): boolean {
-  return usePrCreateStore((s) => Boolean(head && s.byRepo[repoPath]?.[head]));
+  return usePrCreateStore((s) =>
+    Boolean(head && s.byRepo[normPath(repoPath)]?.[head]),
+  );
 }

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -279,8 +279,8 @@ interface UiState {
   /** The hoisted "create local PR" dialog: null = closed; an object = open, with
    *  optional branch seeds. Lives at RepositoryView level (outside the tab
    *  <Activity> wrappers) because its success handler navigates to the Pulls tab —
-   *  a panel-hosted instance would have its close deferred by the newly-hidden
-   *  Activity subtree and stick open. */
+   *  a panel-hosted instance would conceal with the tab that launched it and stay
+   *  open behind it. */
   localPrCreate: { defaultHead?: string; defaultBase?: string } | null;
   /** Selected workflow run (databaseId) on the Actions tab. */
   selectedRunId: number | null;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -279,8 +279,8 @@ interface UiState {
   /** The hoisted "create local PR" dialog: null = closed; an object = open, with
    *  optional branch seeds. Lives at RepositoryView level (outside the tab
    *  <Activity> wrappers) because its success handler navigates to the Pulls tab —
-   *  a panel-hosted instance would conceal with the tab that launched it and stay
-   *  open behind it. */
+   *  a panel-hosted instance would conceal with the tab that launched it mid-close,
+   *  deferring its close and unmount until that tab is next shown. */
   localPrCreate: { defaultHead?: string; defaultBase?: string } | null;
   /** Selected workflow run (databaseId) on the Actions tab. */
   selectedRunId: number | null;

--- a/src/lib/use-seed-on-open.ts
+++ b/src/lib/use-seed-on-open.ts
@@ -1,0 +1,25 @@
+import { useEffect, useEffectEvent, useRef } from "react";
+
+/**
+ * Runs `seed` once per open TRANSITION, not once per effect-mount. A hidden
+ * `<Activity>` tab unmounts its subtree's effects and re-creates them on show,
+ * so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires with the
+ * dialog still open and blanks whatever the user had typed. The latch is a ref
+ * because refs and state survive the hide — only effects re-mount — and a
+ * conditionally-mounted dialog still seeds, since remounting gives it a fresh one.
+ */
+export function useSeedOnOpen(open: boolean, seed: () => void): void {
+  const seeded = useRef(false);
+  const run = useEffectEvent(seed);
+  useEffect(() => {
+    if (!open) {
+      seeded.current = false;
+      return;
+    }
+    // Latch BEFORE seeding: StrictMode's setup → cleanup → setup would
+    // otherwise seed twice, and a seed that sets state re-enters this effect.
+    if (seeded.current) return;
+    seeded.current = true;
+    run();
+  }, [open]);
+}


### PR DESCRIPTION
Dialogs opened from a repository tab portalled to the document body, so switching tabs left them floating over the wrong panel — still modal, still swallowing Escape and backdrop presses aimed at the tab the user could actually see, and re-seeding their form state when the panel's effects re-mounted. This binds a popup's behavior to the visibility of the panel that opened it, and gives a pull-request creation a life of its own so dismissing the dialog mid-flight no longer hides the operation or discards the draft.

### Panel-aware popups

- Adds a `PanelActivityContext` alongside the existing portal context in `src/components/panel-portal.tsx`, exposing `usePanelActive()`, the `PanelActivityBoundary` provider, and `isUserDismissal()` over Base UI's `escape-key` / `outside-press` / `focus-out` close reasons. It defaults to `true`, so anything rendered outside a panel is unaffected.
- `Dialog` and `Sheet` roots (`src/components/ui/dialog.tsx`, `src/components/ui/sheet.tsx`) now drop `modal` while their panel is concealed — releasing the document scroll lock and the `aria-hidden` marking outside the popup — and cancel user dismissals so the visible tab keeps its Escape key.
- `DialogContent` tracks a conceal→reveal transition through a `wasConcealed` flag and re-focuses the popup one frame after the panel comes back, outlasting the close-time focus-return of whatever switched tabs. `SheetContent` gains the `PanelPortalReset` wrapper `DialogContent` already had.
- `DialogPortal`, `SheetPortal`, `DropdownMenuPortal`, and `ContextMenuPortal` default their `container` to the surrounding panel, while an explicit `null` still means a container is coming.
- `TabPanel` in `src/features/repository/RepositoryView.tsx` wraps each `<Activity>` panel in `PanelActivityBoundary`, and `src/features/history/useAmendCommit.ts` drops the 150 ms `setTimeout` that previously deferred the tab switch around a closing dialog.

### Seed-on-open

- Adds `useSeedOnOpen` (`src/lib/use-seed-on-open.ts`), which latches on the open *transition* through a ref rather than on effect-mount, so an `<Activity>` panel re-creating its effects on show can't re-run a form reset over what the user typed.
- Converts the bare `useEffect(() => { if (open) seed(); }, [open])` idiom across every dialog using it, including `CreatePrDialog`, `CreateLocalPrDialog`, `CreateIssueDialog`, `CreateJiraIssueDialog`, `CreateLocalIssueDialog`, `RepoJiraDialog`, `CreateDiscussionDialog`, `CreateBranchDialog`, `RebaseOntoDialog`, `PublishDialog`, `StashesDialog`, `StashReapplyDialog`, `AmendForcePushDialog`, `RunWorkflowDialog`, `CreateReleaseDialog`, `CloneRepoDialog`, `CreateRepoDialog`, `ExploreCloneDialog`, `RunTaskPicker`, `CommandPalette`, and the `DangerZone` / `SecuritySection` dialogs.

### Pull-request creation outliving its dialog

- Adds `src/lib/stores/pr-create.ts`: a Zustand store keyed repo → head branch, with `startPrCreate` claiming the lane synchronously before the first await (returning a refusal reason if the head is already taken), `settlePrCreate` releasing it, and `usePrCreates` / `useIsCreatingPr` / `isCreatingPrInRepo` readers. A `lastFailed` latch, consumed by `consumeLastFailed`, records a background failure the user never saw.
- Adds `src/features/repository/PrCreateBanner.tsx`, a `role="status"` strip mounted unconditionally (`sr-only` when empty) in `RepositoryView`'s layout flow, naming each running create's head → base rather than using a toast or an overlay.
- `CreatePrDialog` claims the lane in `onSubmit`, settles it in a `finally`, skips its seed reset while a create is running or after a failed one, and disables both the submit button and the ⌘/Ctrl+Enter path while the head is claimed, with a footer hint wired through `aria-describedby`.
- `PromoteLocalPrDialog` shares the same lane and hint, since it pushes the same head and opens a PR for it.
- Documents the pass-through prop spread on `SubmitButton` (`src/components/form/submit-button.tsx`) that lets a caller point `aria-describedby` at its own disabled-submit hint.

### Dismissal guards for in-flight operations

- `EditHistoryDialog` ignores Escape and backdrop presses while a rewrite runs, and its Cancel becomes a `DisabledReasonButton` explaining why.
- `RenameWorktreeDialog` and `LockWorktreeDialog` in `WorktreesDialog.tsx` match their already-disabled Cancel buttons by ignoring Escape and backdrop presses while the move or lock is pending.

### Guardrail and docs

- Adds a `lone-activity-boundary` check to `scripts/check-banned-patterns.mjs` that flags any `<Activity` JSX outside the allowlisted `RepositoryView.tsx`, with `scripts/checks.test.mjs` covering the `<ActivityDock>` / `<ActivityBell>` / `<ActivityStrip>` near-misses and comment stripping. The allowlist ratchets both ways, so `TabPanel` losing its `<Activity>` reads as a stale entry.
- Two changelog fragments (`changelog.d/fixed-tab-switch-dialogs.md`, `changelog.d/fixed-pr-create-dismissed.md`), a pull-request section update in `src/features/help/content.ts` covering the dismissable create, and a `useSeedOnOpen` note in `.claude/skills/gd-conventions/SKILL.md`.
- Refreshes the `<Activity>`-related comments in `BlameDialog.tsx`, `CreateLocalPrDialog.tsx`, `CreatePrDialog.tsx`, `RepositoryView.tsx`, and `src/lib/stores/ui.ts` to describe conceal-with-the-panel behavior rather than the old deferred-close failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request creation continues after closing the dialog, preserves entered details when reopened, shows progress, and prevents duplicate creation for the same branch.
  * Dialogs, menus, sheets, and tooltips remain correctly scoped to their active panel when switching tabs.
* **Bug Fixes**
  * Dialogs stay open during history rewrites, rebases, worktree renames, and locks until operations finish.
  * Dialog content and focus are preserved when switching tabs and returning.
  * Pending-operation controls now explain why cancellation is unavailable.
* **Documentation**
  * Added guidance covering updated dialog, panel, and UI customization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->