### PR TITLE
feat(compare,history): add commit context menu to Compare tab

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -135,6 +135,9 @@ words the user reads on screen — the palette matcher is a plain substring, so
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.
+- Shared-ContextMenu suppression for non-target right-clicks goes through
+  `suppressContextMenu` (`src/lib/context-menu.ts`) — `preventDefault` alone
+  still opens Base UI's menu as an empty popup.
 
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ PR badge.
   where each worktree row also carries a context menu with the management
   actions it supports, and a branch's own menu can remove its worktree.
 - **Compare**: a tab with a three-dot diff, commits ahead/behind,
-  merge/rebase, and jump-to-PR.
+  merge/rebase, and jump-to-PR. Each ahead/behind commit shows its tag chips
+  and carries a context menu — checkout, cherry-pick, create a branch or tag,
+  copy the SHA, plus revert for commits on your branch.
 - **Local branch-protection rules**: naming, merge methods, require-PR, and
   force-push rules, shareable via a committed file or importable from
   GitHub. A promotion-branches list marks pull requests from those branches

--- a/changelog.d/added-compare-commit-context-menu.md
+++ b/changelog.d/added-compare-commit-context-menu.md
@@ -1,0 +1,3 @@
+- Compare tab: ahead/behind commit rows now have a context menu — check the commit
+  out, cherry-pick it, create a branch or tag from it, or copy its SHA; commits on
+  your branch can also be reverted.

--- a/changelog.d/changed-checkout-commit-toast.md
+++ b/changelog.d/changed-checkout-commit-toast.md
@@ -1,2 +1,2 @@
-- Checking out a commit now confirms with a toast naming the commit and the
+- Checking out a commit now shows a toast naming the commit and the
   detached HEAD state.

--- a/changelog.d/changed-checkout-commit-toast.md
+++ b/changelog.d/changed-checkout-commit-toast.md
@@ -1,0 +1,2 @@
+- Checking out a commit now confirms with a toast naming the commit and the
+  detached HEAD state.

--- a/changelog.d/changed-compare-row-tag-chips.md
+++ b/changelog.d/changed-compare-row-tag-chips.md
@@ -1,0 +1,1 @@
+- Compare tab: ahead/behind commit rows now show tag chips, matching History.

--- a/changelog.d/fixed-context-menu-empty-popup.md
+++ b/changelog.d/fixed-context-menu-empty-popup.md
@@ -1,0 +1,3 @@
+- Right-clicking empty space in the History list, a commit's file list, or the
+  repository list no longer opens an empty context-menu popup that swallowed the
+  next click.

--- a/changelog.d/fixed-context-menu-empty-popup.md
+++ b/changelog.d/fixed-context-menu-empty-popup.md
@@ -1,3 +1,3 @@
-- Right-clicking empty space in the History list, a commit's file list, or the
-  repository list no longer opens an empty context-menu popup that swallowed the
-  next click.
+- Right-clicking empty space in the History list, a file list (commit, PR, or
+  Compare views), or the repository list no longer opens an empty,
+  click-swallowing context-menu popup.

--- a/changelog.d/fixed-context-menu-empty-popup.md
+++ b/changelog.d/fixed-context-menu-empty-popup.md
@@ -1,3 +1,3 @@
-- Right-clicking empty space in the History list, a file list (commit, PR, or
-  Compare views), or the repository list no longer opens an empty,
-  click-swallowing context-menu popup.
+- Right-clicking blank space in the History list, a file list (commit, PR, or
+  Compare views), or the repository list does not open an empty context-menu
+  popup.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -206,6 +206,18 @@ const MUTATE_CALL_RE = /\.mutate\s*\(/;
 // so the joined view adds no reach.
 const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 
+// The broken shared-ContextMenu suppression: a `setMenu<X>(null)` reset followed
+// by a bare `preventDefault()`. Base UI's trigger keeps its own same-element
+// bubble listener, so without the `stopPropagation` that `suppressContextMenu`
+// carries the menu still opens — as an empty popup whose backdrop swallows the
+// next click. A fixed site holds no `preventDefault` token at all, so the helper
+// needs no exemption here and a file mixing one fixed and one broken path still
+// reports. Two deliberate bounds: `[^}]` keeps the pair inside one block, and
+// the order is set-then-prevent (the reverse reads clean — the one fail-open,
+// zero instances today).
+const CONTEXT_MENU_SUPPRESS_RE =
+  /\bset[A-Z]\w*\(\s*null\s*\)[^}]{0,160}?\.preventDefault\s*\(\s*\)/g;
+
 // Vendored shadcn/Base UI primitives are off-limits to edit (CLAUDE.md), so a
 // hit inside them could only ever be silenced by an allowlist entry, never
 // fixed. Their CALL SITES — the app code that composes them — stay scanned.
@@ -287,6 +299,14 @@ export const CHECKS = [
     allowlist: [],
     message:
       "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
+  },
+  {
+    name: "context-menu-suppression",
+    appliesTo: notVendoredUi,
+    scan: perFile(CONTEXT_MENU_SUPPRESS_RE),
+    allowlist: [],
+    message:
+      "a shared ContextMenu's non-target right-click path routes through suppressContextMenu (src/lib/context-menu.ts) — preventDefault alone leaves Base UI's trigger handler to open the menu as an empty, click-swallowing popup",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -213,11 +213,8 @@ const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 // next click. A fixed site holds no `preventDefault` token at all, so the helper
 // needs no exemption here and a file mixing one fixed and one broken path still
 // reports. Two deliberate bounds: `[^}]` keeps the pair inside one block, and
-// the order is set-then-prevent. Both leave a fail-open, zero instances today:
-// the reverse order reads clean, and so does a suppression path with no state
-// reset at all (a bare `preventDefault` in a contextmenu handler). Widening to
-// the handler name would need an appliesTo exclusion for the helper's own
-// definition and adds false-positive surface — declined on record.
+// the order is set-then-prevent. Each leaves a fail-open, zero instances today:
+// the reverse order, and a suppression path with no state reset at all.
 const CONTEXT_MENU_SUPPRESS_RE =
   /\bset[A-Z]\w*\(\s*null\s*\)[^}]{0,160}?\.preventDefault\s*\(\s*\)/g;
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -213,8 +213,11 @@ const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 // next click. A fixed site holds no `preventDefault` token at all, so the helper
 // needs no exemption here and a file mixing one fixed and one broken path still
 // reports. Two deliberate bounds: `[^}]` keeps the pair inside one block, and
-// the order is set-then-prevent (the reverse reads clean — the one fail-open,
-// zero instances today).
+// the order is set-then-prevent. Both leave a fail-open, zero instances today:
+// the reverse order reads clean, and so does a suppression path with no state
+// reset at all (a bare `preventDefault` in a contextmenu handler). Widening to
+// the handler name would need an appliesTo exclusion for the helper's own
+// definition and adds false-positive surface — declined on record.
 const CONTEXT_MENU_SUPPRESS_RE =
   /\bset[A-Z]\w*\(\s*null\s*\)[^}]{0,160}?\.preventDefault\s*\(\s*\)/g;
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -44,6 +44,7 @@ const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
 const setQueryData = scanner("setQueryData-noop");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
+const menuSuppression = scanner("context-menu-suppression");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -264,6 +265,58 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
   ]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
+});
+
+test("context-menu-suppression flags the state-reset-then-preventDefault shape", () => {
+  const inline = [
+    "function handleContextMenu(e) {",
+    "  const row = e.target.closest('[data-repo-path]');",
+    "  if (!row) {",
+    "    setMenuRepo(null);",
+    "    e.preventDefault();",
+    "  }",
+    "}",
+  ].join("\n");
+  assert.deepEqual(menuSuppression(inline), [4]);
+  // stopPropagation written out by hand is the same class: the constraint lives
+  // in the helper's doc comment, so an inline copy is what drifts next.
+  const handRolled = [
+    "setMenuTarget(null);",
+    "e.stopPropagation();",
+    "e.preventDefault();",
+  ].join("\n");
+  assert.deepEqual(menuSuppression(handRolled), [1]);
+});
+
+test("context-menu-suppression leaves the helper route and its definition alone", () => {
+  const fixed = [
+    "setMenuPath(null);",
+    "suppressContextMenu(e);",
+    "return;",
+  ].join("\n");
+  assert.deepEqual(menuSuppression(fixed), []);
+  // The helper itself holds the preventDefault with no state reset to pair with.
+  const helper = [
+    "export function suppressContextMenu(e) {",
+    "  e.stopPropagation();",
+    "  e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(menuSuppression(helper), []);
+});
+
+test("context-menu-suppression does not pair across a block boundary", () => {
+  // `[^}]` is the bound: an unrelated null reset and an unrelated preventDefault
+  // in two different handlers are not this idiom.
+  const separate = [
+    "function clearSelection() {",
+    "  setMenuRepo(null);",
+    "}",
+    "function onKeyDown(e) {",
+    "  e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(menuSuppression(separate), []);
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -66,7 +66,8 @@ export const capabilities: Capability[] = [
   // — Branches & history —
   {
     group: "Branches & history",
-    label: "Branch compare — ahead/behind, three-dot diff, jump to PR",
+    label:
+      "Branch compare — ahead/behind, three-dot diff, jump to PR, commit menu + tags",
     highlight: true,
   },
   {

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 use crate::git::diff::{parse_numstat_z, truncate_at_char_boundary};
+use crate::git::history::{parse_commit_log, LOG_FORMAT};
 use crate::git::runner::{
     run_git, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
@@ -26,31 +27,14 @@ fn validate_ref(name: &str) -> AppResult<()> {
     Ok(())
 }
 
-fn parse_log(text: &str) -> Vec<CommitSummary> {
-    text.lines()
-        .filter_map(|line| {
-            let mut parts = line.split('\0');
-            Some(CommitSummary {
-                hash: parts.next()?.to_string(),
-                subject: parts.next()?.to_string(),
-                author: parts.next()?.to_string(),
-                author_email: parts.next()?.to_string(),
-                date: parts.next()?.to_string(),
-                tags: Vec::new(),
-                is_merge: false,
-            })
-        })
-        .collect()
-}
-
 async fn log_range(repo_path: &str, range: &str) -> AppResult<Vec<CommitSummary>> {
     let out = run_git(
         Some(repo_path),
-        &["log", "--format=%H%x00%s%x00%an%x00%ae%x00%cI", range],
+        &["log", LOG_FORMAT, range],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    Ok(parse_log(&out.stdout_lossy()))
+    Ok(parse_commit_log(&out.stdout_lossy()))
 }
 
 /// Commits unique to each side of `base`/`compare`. `ahead` (compare not in
@@ -722,6 +706,50 @@ mod tests {
         run(&repo_s, &["config", "user.email", "t@t.local"]).await;
         run(&repo_s, &["config", "user.name", "T"]).await;
         (base, repo_s)
+    }
+
+    /// The comparison shares History's log format + parser, so its rows carry the
+    /// `%D` tag decorations rather than an empty list.
+    #[tokio::test]
+    async fn compare_branches_carries_tag_decorations() {
+        let (_base, repo) = seed_repo("compare-tags").await;
+        let root = std::path::Path::new(&repo);
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        // `git init` picks the default branch name from the host's config.
+        let base_branch = run(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo, &["checkout", "-qb", "feature"]).await;
+        std::fs::write(root.join("feature.txt"), "feature\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "feature work"]).await;
+
+        run(&repo, &["checkout", "-q", &base_branch]).await;
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "base work"]).await;
+        run(&repo, &["tag", "v1.0"]).await;
+
+        let cmp = git_compare_branches(repo.clone(), base_branch, "feature".into())
+            .await
+            .unwrap();
+
+        assert_eq!(cmp.ahead.len(), 1, "one commit on feature only");
+        assert_eq!(cmp.behind.len(), 1, "one commit on the base branch only");
+        assert_eq!(
+            cmp.behind[0].tags,
+            vec!["v1.0".to_string()],
+            "a tagged commit reports its tag"
+        );
+        assert!(
+            cmp.ahead[0].tags.is_empty(),
+            "an untagged commit reports no tags"
+        );
     }
 
     /// `exclude` hides matching files from BOTH the diff text and the file list, and

--- a/src-tauri/src/git/history.rs
+++ b/src-tauri/src/git/history.rs
@@ -59,8 +59,8 @@ pub async fn git_log(
 }
 
 /// The `%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P` log format, one commit per line.
-/// Paired with `parse_commit_log`: every commit-listing path shares both, so none
-/// of them can drift into reporting empty tags or merge flags.
+/// Paired with `parse_commit_log` — the history and compare listings share both,
+/// so those paths can't drift into reporting empty tags or merge flags.
 pub(crate) const LOG_FORMAT: &str = "--format=%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P";
 
 pub(crate) fn parse_commit_log(text: &str) -> Vec<CommitSummary> {

--- a/src-tauri/src/git/history.rs
+++ b/src-tauri/src/git/history.rs
@@ -59,9 +59,11 @@ pub async fn git_log(
 }
 
 /// The `%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P` log format, one commit per line.
-const LOG_FORMAT: &str = "--format=%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P";
+/// Paired with `parse_commit_log`: every commit-listing path shares both, so none
+/// of them can drift into reporting empty tags or merge flags.
+pub(crate) const LOG_FORMAT: &str = "--format=%H%x00%s%x00%an%x00%ae%x00%cI%x00%D%x00%P";
 
-fn parse_commit_log(text: &str) -> Vec<CommitSummary> {
+pub(crate) fn parse_commit_log(text: &str) -> Vec<CommitSummary> {
     text.lines()
         .filter_map(|line| {
             let mut parts = line.split('\0');

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -156,8 +156,8 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
     Boolean(compareBranch && compareBranch !== currentName && ahead.length > 0),
   );
 
-  // The commit the one shared context menu acts on. `onCurrentBranch` is true for
-  // an ahead commit, the only side whose changes this branch can revert.
+  // The commit the one shared context menu acts on. Revert is only OFFERED for
+  // ahead commits — the side already in this branch's history.
   const [menuTarget, setMenuTarget] = useState<{
     hash: string;
     onCurrentBranch: boolean;

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -4,12 +4,19 @@ import {
   GitBranchIcon,
   GitCommitIcon,
   GitPullRequestIcon,
+  TagIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   Empty,
   EmptyContent,
@@ -21,22 +28,44 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CompareBranchCombobox } from "@/features/compare/CompareBranchCombobox";
+import { CommitContextMenuItems } from "@/features/history/CommitContextMenu";
+import {
+  checkoutCommitConfirm,
+  checkoutCommitSuccessToast,
+  cherryPickCommitConfirm,
+  revertCommitConfirm,
+} from "@/features/history/commit-confirms";
+import {
+  CreateRefFromCommitDialog,
+  createRefFromCommitFormOpts,
+} from "@/features/history/HistoryDialogs";
 import { CreatePrDialog } from "@/features/pulls/CreatePrDialog";
+import { suppressContextMenu } from "@/lib/context-menu";
+import { useAppForm } from "@/lib/form";
 import {
   forgeFeatureReady,
   useBranches,
+  useCheckoutCommit,
+  useCherryPick,
   useCompareBranches,
+  useCreateBranch,
+  useCreateTag,
   useDefaultBranch,
   useForgeStatus,
   useHoverPrefetch,
   usePrefetchCommit,
   usePrsForBranch,
   useRepoStatus,
+  useRevertCommit,
 } from "@/lib/git/queries";
+import { sanitizeRefName } from "@/lib/git/ref-name";
 import type { CommitSummary } from "@/lib/git/types";
 import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
+import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 
 export function ComparePanel({ repoPath }: { repoPath: string }) {
@@ -126,6 +155,115 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
       }),
     Boolean(compareBranch && compareBranch !== currentName && ahead.length > 0),
   );
+
+  // The commit the one shared context menu acts on. `onCurrentBranch` is true for
+  // an ahead commit, the only side whose changes this branch can revert.
+  const [menuTarget, setMenuTarget] = useState<{
+    hash: string;
+    onCurrentBranch: boolean;
+  } | null>(null);
+  const [branchHash, setBranchHash] = useState<string | null>(null);
+  const [tagHash, setTagHash] = useState<string | null>(null);
+  const shownBranchHash = useRetained(branchHash);
+  const shownTagHash = useRetained(tagHash);
+
+  const checkoutCommit = useCheckoutCommit(repoPath);
+  const revertCommit = useRevertCommit(repoPath);
+  const cherryPick = useCherryPick(repoPath);
+  const createBranch = useCreateBranch(repoPath);
+  const createTag = useCreateTag(repoPath);
+
+  const onError = (e: unknown) => toastError(e);
+
+  const branchForm = useAppForm({
+    ...createRefFromCommitFormOpts,
+    onSubmit: async ({ value }) => {
+      if (!branchHash) return;
+      const name = sanitizeRefName(value.name);
+      try {
+        await createBranch.mutateAsync({
+          name,
+          checkout: true,
+          startPoint: branchHash,
+        });
+        toast.success(`Created branch ${name}`);
+        setBranchHash(null);
+      } catch (e) {
+        onError(e);
+      }
+    },
+  });
+
+  const tagForm = useAppForm({
+    ...createRefFromCommitFormOpts,
+    onSubmit: async ({ value }) => {
+      if (!tagHash) return;
+      const name = sanitizeRefName(value.name);
+      try {
+        await createTag.mutateAsync({ name, hash: tagHash });
+        toast.success(`Created tag ${name}`);
+        setTagHash(null);
+      } catch (e) {
+        onError(e);
+      }
+    },
+  });
+
+  // The commit-level confirms are the shared ones History asks, so no route can
+  // pose a different question than its twin.
+  async function doCheckoutCommit(hash: string) {
+    if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
+    checkoutCommit.mutate(hash, {
+      onSuccess: () => toast.success(checkoutCommitSuccessToast(hash)),
+      onError,
+    });
+  }
+
+  async function doRevertCommit(hash: string) {
+    if (!(await useConfirm.getState().ask(revertCommitConfirm(hash)))) return;
+    revertCommit.mutate(hash, { onError });
+  }
+
+  async function doCherryPick(hash: string) {
+    const ok = await useConfirm
+      .getState()
+      .ask(cherryPickCommitConfirm(hash, currentName));
+    if (!ok) return;
+    cherryPick.mutate(hash, {
+      onSuccess: (applied) => {
+        if (applied) {
+          toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
+        } else {
+          toast.info(
+            "Nothing to cherry-pick — these changes are already on this branch.",
+          );
+        }
+      },
+      onError,
+    });
+  }
+
+  // One shared context menu for both lists (capture phase, so it records the
+  // right-clicked row before the menu opens). Right-clicking a commit selects it
+  // (standard desktop behavior), so the menu and the diff panel always describe
+  // the same commit; non-commit targets (the "All changes" row, headers, blank
+  // space) get no menu.
+  function handleContextMenu(e: MouseEvent) {
+    const suppress = () => {
+      setMenuTarget(null);
+      suppressContextMenu(e);
+    };
+    const hash = (e.target as HTMLElement)
+      .closest("[data-row]")
+      ?.getAttribute("data-row");
+    if (!hash) return suppress();
+    const onCurrentBranch = ahead.some((c) => c.hash === hash);
+    if (!onCurrentBranch && !behind.some((c) => c.hash === hash)) {
+      return suppress();
+    }
+    selectCompareCommit(hash);
+    setMenuTarget({ hash, onCurrentBranch });
+  }
 
   if (status.isPending || branches.isPending)
     return (
@@ -277,62 +415,111 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
         />
       )}
 
-      <div
-        className="flex min-h-0 flex-1 flex-col"
-        onKeyDown={onListKeyDown}
-        role="listbox"
-        aria-label="Compare selection"
-      >
-        <button
-          type="button"
-          data-row="all"
-          role="option"
-          aria-selected={compareCommitHash === null}
-          className={cn(
-            "flex w-full shrink-0 items-center gap-2 border-b px-3 py-2 text-left text-xs",
-            compareCommitHash === null
-              ? "bg-accent text-accent-foreground"
-              : "hover:bg-muted/60",
-          )}
-          onClick={() => selectCompareCommit(null)}
+      <ContextMenu>
+        <ContextMenuTrigger
+          render={
+            <div
+              className="flex min-h-0 flex-1 flex-col"
+              onKeyDown={onListKeyDown}
+              role="listbox"
+              aria-label="Compare selection"
+              onContextMenuCapture={handleContextMenu}
+            />
+          }
         >
-          <FilesIcon className="size-3.5 shrink-0" />
-          <span className="font-medium">All changes</span>
-        </button>
-
-        {comparison.isPending ? (
-          <div className="space-y-2 p-3">
-            <Skeleton className="h-8 w-full" />
-            <Skeleton className="h-8 w-full" />
-          </div>
-        ) : (
-          /* overflow-hidden contains the list's natural height (vendored Root is
-             `relative`-only) so a long list can't leak a window scrollbar. */
-          <ScrollArea className="min-h-0 flex-1 overflow-hidden">
-            <CommitSection
-              title={`${ahead.length} ahead`}
-              subtitle={`on ${currentName}, not on ${compareBranch}`}
-              commits={ahead}
-              selectedHash={compareCommitHash}
-              onSelect={selectCompareCommit}
-              onHover={onHoverCommit}
-            />
-            <CommitSection
-              title={`${behind.length} behind`}
-              subtitle={`on ${compareBranch}, not on ${currentName}`}
-              commits={behind}
-              selectedHash={compareCommitHash}
-              onSelect={selectCompareCommit}
-              onHover={onHoverCommit}
-            />
-            {ahead.length === 0 && behind.length === 0 && (
-              <p className="px-3 py-6 text-center text-xs text-muted-foreground">
-                These branches are even.
-              </p>
+          <button
+            type="button"
+            data-row="all"
+            role="option"
+            aria-selected={compareCommitHash === null}
+            className={cn(
+              "flex w-full shrink-0 items-center gap-2 border-b px-3 py-2 text-left text-xs",
+              compareCommitHash === null
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-muted/60",
             )}
-          </ScrollArea>
-        )}
-      </div>
+            onClick={() => selectCompareCommit(null)}
+          >
+            <FilesIcon className="size-3.5 shrink-0" />
+            <span className="font-medium">All changes</span>
+          </button>
+
+          {comparison.isPending ? (
+            <div className="space-y-2 p-3">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : (
+            /* overflow-hidden contains the list's natural height (vendored Root
+               is `relative`-only) so a long list can't leak a window scrollbar. */
+            <ScrollArea className="min-h-0 flex-1 overflow-hidden">
+              <CommitSection
+                title={`${ahead.length} ahead`}
+                subtitle={`on ${currentName}, not on ${compareBranch}`}
+                commits={ahead}
+                selectedHash={compareCommitHash}
+                onSelect={selectCompareCommit}
+                onHover={onHoverCommit}
+              />
+              <CommitSection
+                title={`${behind.length} behind`}
+                subtitle={`on ${compareBranch}, not on ${currentName}`}
+                commits={behind}
+                selectedHash={compareCommitHash}
+                onSelect={selectCompareCommit}
+                onHover={onHoverCommit}
+              />
+              {ahead.length === 0 && behind.length === 0 && (
+                <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+                  These branches are even.
+                </p>
+              )}
+            </ScrollArea>
+          )}
+        </ContextMenuTrigger>
+        <ContextMenuContent className="min-w-60">
+          {menuTarget && (
+            <CommitContextMenuItems
+              hash={menuTarget.hash}
+              actions={{
+                checkout: doCheckoutCommit,
+                revert: menuTarget.onCurrentBranch ? doRevertCommit : undefined,
+                cherryPick: doCherryPick,
+                createBranch: (hash) => {
+                  branchForm.reset({ name: "" });
+                  setBranchHash(hash);
+                },
+                createTag: (hash) => {
+                  tagForm.reset({ name: "" });
+                  setTagHash(hash);
+                },
+              }}
+            />
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <CreateRefFromCommitDialog
+        form={branchForm}
+        open={branchHash !== null}
+        onClose={() => setBranchHash(null)}
+        title="Create branch from commit"
+        description={`Creates a branch starting at ${shownBranchHash?.slice(0, 7) ?? ""} and switches to it.`}
+        fieldLabel="Branch name"
+        placeholder="feature/from-commit"
+        submitLabel="Create branch"
+      />
+
+      <CreateRefFromCommitDialog
+        form={tagForm}
+        open={tagHash !== null}
+        onClose={() => setTagHash(null)}
+        title="Create tag"
+        description={`Tags commit ${shownTagHash?.slice(0, 7) ?? ""}.`}
+        fieldLabel="Tag name"
+        placeholder="v1.0.0"
+        submitLabel="Create tag"
+      />
     </div>
   );
 }
@@ -380,6 +567,24 @@ function CommitSection({
             <span className="min-w-0 truncate" title={commit.subject}>
               {commit.subject}
             </span>
+            {commit.tags.slice(0, 2).map((tag) => (
+              <span
+                key={tag}
+                className="flex max-w-24 shrink-0 items-center gap-0.5 border px-1 py-px text-[10px] font-normal text-muted-foreground"
+                title={`tag: ${tag}`}
+              >
+                <TagIcon className="size-2.5 shrink-0" />
+                <span className="truncate">{tag}</span>
+              </span>
+            ))}
+            {commit.tags.length > 2 && (
+              <span
+                className="shrink-0 text-[10px] font-normal text-muted-foreground"
+                title={commit.tags.join(", ")}
+              >
+                +{commit.tags.length - 2}
+              </span>
+            )}
           </p>
           <p className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground">
             {commit.author} • <RelativeTime date={commit.date} />

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -601,6 +601,11 @@ shows which branches live in other worktrees plus, when a branch has diverged, h
 is ahead of and behind your current branch. From here you can merge, rebase, or jump
 straight to opening a pull request.
 
+{{Secondaryclick}} any commit in the ahead or behind list for **Checkout commit**,
+**Cherry-pick commit**, **Create branch from commit…**, **Create tag…**, and **Copy SHA**.
+Commits in the ahead list (the ones on your branch) also offer **Revert changes in
+commit**.
+
 ## Branch rules
 
 **Branch rules…** (in the ⋮ menu) sets local protections — naming patterns, blocked

--- a/src/features/history/CommitContextMenu.tsx
+++ b/src/features/history/CommitContextMenu.tsx
@@ -19,7 +19,8 @@ export interface CommitMenuActions {
 /**
  * The position-independent commit actions — no amend/reset/squash/reorder, which
  * assume contiguous recent history. Shared by History's search results and the
- * Compare tab's ahead/behind lists so the two can't drift on wording or order.
+ * Compare tab's ahead/behind lists so the two can't drift on item wording or
+ * order.
  */
 export function CommitContextMenuItems({
   hash,

--- a/src/features/history/CommitContextMenu.tsx
+++ b/src/features/history/CommitContextMenu.tsx
@@ -1,0 +1,57 @@
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from "@/components/ui/context-menu";
+import { copyText } from "@/lib/clipboard";
+
+/** Callbacks the menu items invoke — owned by the parent panel, which holds the
+ *  confirms, mutations, and dialog state so this stays presentational. */
+export interface CommitMenuActions {
+  checkout: (hash: string) => void;
+  /** Omit to hide "Revert changes in commit" — only offered when the commit is
+   *  in the current branch's history. */
+  revert?: (hash: string) => void;
+  cherryPick: (hash: string) => void;
+  createBranch: (hash: string) => void;
+  createTag: (hash: string) => void;
+}
+
+/**
+ * The position-independent commit actions — no amend/reset/squash/reorder, which
+ * assume contiguous recent history. Shared by History's search results and the
+ * Compare tab's ahead/behind lists so the two can't drift on wording or order.
+ */
+export function CommitContextMenuItems({
+  hash,
+  actions,
+}: {
+  hash: string;
+  actions: CommitMenuActions;
+}) {
+  return (
+    <>
+      <ContextMenuItem onClick={() => actions.checkout(hash)}>
+        Checkout commit
+      </ContextMenuItem>
+      {actions.revert && (
+        <ContextMenuItem onClick={() => actions.revert?.(hash)}>
+          Revert changes in commit
+        </ContextMenuItem>
+      )}
+      <ContextMenuItem onClick={() => actions.cherryPick(hash)}>
+        Cherry-pick commit
+      </ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem onClick={() => actions.createBranch(hash)}>
+        Create branch from commit…
+      </ContextMenuItem>
+      <ContextMenuItem onClick={() => actions.createTag(hash)}>
+        Create tag…
+      </ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem onClick={() => copyText(hash, "SHA copied")}>
+        Copy SHA
+      </ContextMenuItem>
+    </>
+  );
+}

--- a/src/features/history/CommitContextMenu.tsx
+++ b/src/features/history/CommitContextMenu.tsx
@@ -29,24 +29,27 @@ export function CommitContextMenuItems({
   hash: string;
   actions: CommitMenuActions;
 }) {
+  // Destructured so the optional `revert` narrows: TypeScript narrows a local
+  // binding, not a property read, so the guard alone would still need `?.`.
+  const { checkout, revert, cherryPick, createBranch, createTag } = actions;
   return (
     <>
-      <ContextMenuItem onClick={() => actions.checkout(hash)}>
+      <ContextMenuItem onClick={() => checkout(hash)}>
         Checkout commit
       </ContextMenuItem>
-      {actions.revert && (
-        <ContextMenuItem onClick={() => actions.revert?.(hash)}>
+      {revert && (
+        <ContextMenuItem onClick={() => revert(hash)}>
           Revert changes in commit
         </ContextMenuItem>
       )}
-      <ContextMenuItem onClick={() => actions.cherryPick(hash)}>
+      <ContextMenuItem onClick={() => cherryPick(hash)}>
         Cherry-pick commit
       </ContextMenuItem>
       <ContextMenuSeparator />
-      <ContextMenuItem onClick={() => actions.createBranch(hash)}>
+      <ContextMenuItem onClick={() => createBranch(hash)}>
         Create branch from commit…
       </ContextMenuItem>
-      <ContextMenuItem onClick={() => actions.createTag(hash)}>
+      <ContextMenuItem onClick={() => createTag(hash)}>
         Create tag…
       </ContextMenuItem>
       <ContextMenuSeparator />

--- a/src/features/history/CommitContextMenu.tsx
+++ b/src/features/history/CommitContextMenu.tsx
@@ -29,8 +29,8 @@ export function CommitContextMenuItems({
   hash: string;
   actions: CommitMenuActions;
 }) {
-  // Destructured so the optional `revert` narrows: TypeScript narrows a local
-  // binding, not a property read, so the guard alone would still need `?.`.
+  // Destructured so `revert` stays narrowed inside the item callbacks: a
+  // property narrowing doesn't survive into a closure, a const binding's does.
   const { checkout, revert, cherryPick, createBranch, createTag } = actions;
   return (
     <>

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -49,6 +49,7 @@ import { toastError } from "@/lib/toast";
 import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
 import {
   checkoutCommitConfirm,
+  checkoutCommitSuccessToast,
   cherryPickCommitConfirm,
   revertCommitConfirm,
 } from "./commit-confirms";
@@ -241,7 +242,10 @@ export function CommitDetailView({
   // menu. All three act on the `hash` PROP for the same reason `copyHash` does.
   async function doCheckoutCommit() {
     if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
-    checkoutCommit.mutate(hash, { onError });
+    checkoutCommit.mutate(hash, {
+      onSuccess: () => toast.success(checkoutCommitSuccessToast(hash)),
+      onError,
+    });
   }
 
   async function doRevertCommit() {

--- a/src/features/history/FileRowActions.tsx
+++ b/src/features/history/FileRowActions.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { suppressContextMenu } from "@/lib/context-menu";
 import { BlameDialog } from "./BlameDialog";
 import { FileHistoryDialog } from "./FileHistoryDialog";
 
@@ -58,7 +59,12 @@ export function FileRowActions({
     const path = (e.target as HTMLElement)
       .closest("[data-path]")
       ?.getAttribute("data-path");
-    setMenuPath(path ?? null);
+    if (!path) {
+      setMenuPath(null);
+      suppressContextMenu(e);
+      return;
+    }
+    setMenuPath(path);
   }
 
   return (

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -31,6 +31,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { copyText } from "@/lib/clipboard";
+import { suppressContextMenu } from "@/lib/context-menu";
 import { useAppForm } from "@/lib/form";
 import { gitCommitDetails, gitRecentCommits } from "@/lib/git/api";
 import {
@@ -60,8 +61,10 @@ import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
+import { CommitContextMenuItems } from "./CommitContextMenu";
 import {
   checkoutCommitConfirm,
+  checkoutCommitSuccessToast,
   cherryPickCommitConfirm,
   revertCommitConfirm,
   UNDO_ROOT_COMMIT_CONFIRM,
@@ -251,7 +254,10 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
   // the single-commit menu can't diverge on whether they ask.
   async function doCheckoutCommit(hash: string) {
     if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
-    checkoutCommit.mutate(hash, { onError });
+    checkoutCommit.mutate(hash, {
+      onSuccess: () => toast.success(checkoutCommitSuccessToast(hash)),
+      onError,
+    });
   }
 
   async function doRevertCommit(hash: string) {
@@ -548,7 +554,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     const index = hash ? visibleCommits.findIndex((c) => c.hash === hash) : -1;
     if (index < 0) {
       setMenuTarget(null);
-      e.preventDefault();
+      suppressContextMenu(e);
       return;
     }
     onRowContextMenu(index, visibleCommits[index].hash);
@@ -561,48 +567,28 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     if (!menuTarget) return null;
     const { commit, index } = menuTarget;
     if (searchActive) {
-      // Search results: only position-independent, single-commit actions (no
-      // amend/reset/squash/reorder, which assume contiguous recent history).
+      // Search results aren't contiguous recent history, so only the shared set.
       return (
-        <>
-          <ContextMenuItem onClick={() => doCheckoutCommit(commit.hash)}>
-            Checkout commit
-          </ContextMenuItem>
-          <ContextMenuItem onClick={() => doRevertCommit(commit.hash)}>
-            Revert changes in commit
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() =>
+        <CommitContextMenuItems
+          hash={commit.hash}
+          actions={{
+            checkout: doCheckoutCommit,
+            revert: doRevertCommit,
+            cherryPick: (hash) =>
               doCherryPick(
-                commit.hash,
+                hash,
                 "Nothing to cherry-pick — already on this branch.",
-              )
-            }
-          >
-            Cherry-pick commit
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem
-            onClick={() => {
+              ),
+            createBranch: (hash) => {
               branchForm.reset({ name: "" });
-              setBranchHash(commit.hash);
-            }}
-          >
-            Create branch from commit…
-          </ContextMenuItem>
-          <ContextMenuItem
-            onClick={() => {
+              setBranchHash(hash);
+            },
+            createTag: (hash) => {
               tagForm.reset({ name: "" });
-              setTagHash(commit.hash);
-            }}
-          >
-            Create tag…
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem onClick={() => copyText(commit.hash, "SHA copied")}>
-            Copy SHA
-          </ContextMenuItem>
-        </>
+              setTagHash(hash);
+            },
+          }}
+        />
       );
     }
     if (selected.has(commit.hash) && selected.size > 1) {

--- a/src/features/history/commit-confirms.ts
+++ b/src/features/history/commit-confirms.ts
@@ -21,7 +21,8 @@ export const checkoutCommitConfirm = (hash: string) =>
   checkoutDetachedConfirm("commit", short(hash));
 
 /** A silent checkout reads as a dead end from Compare, which flips to its
- *  detached-HEAD empty state, so every route confirms with the same sentence. */
+ *  detached-HEAD empty state, so every commit-checkout route confirms with this
+ *  same sentence. */
 export function checkoutCommitSuccessToast(hash: string) {
   return `Checked out ${short(hash)} — HEAD is detached`;
 }

--- a/src/features/history/commit-confirms.ts
+++ b/src/features/history/commit-confirms.ts
@@ -21,8 +21,8 @@ export const checkoutCommitConfirm = (hash: string) =>
   checkoutDetachedConfirm("commit", short(hash));
 
 /** A silent checkout reads as a dead end from Compare, which flips to its
- *  detached-HEAD empty state, so every commit-checkout route confirms with this
- *  same sentence. */
+ *  detached-HEAD empty state, so every commit-checkout route reports success
+ *  with this same sentence. */
 export function checkoutCommitSuccessToast(hash: string) {
   return `Checked out ${short(hash)} — HEAD is detached`;
 }

--- a/src/features/history/commit-confirms.ts
+++ b/src/features/history/commit-confirms.ts
@@ -20,6 +20,12 @@ export function checkoutDetachedConfirm(kind: "commit" | "tag", name: string) {
 export const checkoutCommitConfirm = (hash: string) =>
   checkoutDetachedConfirm("commit", short(hash));
 
+/** A silent checkout reads as a dead end from Compare, which flips to its
+ *  detached-HEAD empty state, so every route confirms with the same sentence. */
+export function checkoutCommitSuccessToast(hash: string) {
+  return `Checked out ${short(hash)} — HEAD is detached`;
+}
+
 export const revertCommitConfirm = (hash: string) => ({
   title: `Revert commit ${short(hash)}?`,
   body: `Creates a new commit that undoes what ${short(hash)} changed, so history keeps both and nothing already recorded is rewritten. If it conflicts, the revert pauses in Changes for you to resolve.`,

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { copyText } from "@/lib/clipboard";
+import { suppressContextMenu } from "@/lib/context-menu";
 import {
   forgeRepoUrl,
   forgeRepoVisibility,
@@ -319,7 +320,7 @@ export function RepoList({
       setMenuRepo(repo);
     } else {
       setMenuRepo(null);
-      e.preventDefault();
+      suppressContextMenu(e);
     }
   }
 

--- a/src/lib/context-menu.ts
+++ b/src/lib/context-menu.ts
@@ -1,0 +1,9 @@
+import type { MouseEvent } from "react";
+
+/** Suppress a shared ContextMenu for a non-target right-click. stopPropagation,
+ *  not just preventDefault: Base UI's own trigger handler (a same-element
+ *  bubble listener) would still open the menu as an empty popup. */
+export function suppressContextMenu(e: MouseEvent) {
+  e.stopPropagation();
+  e.preventDefault();
+}


### PR DESCRIPTION
Compare's ahead/behind lists were read-only — you could select a commit to see its diff, but acting on it meant switching to History and searching for it. This adds the same commit context menu Compare's rows now share with History's search results, extracts it into one component so the two can't drift, and fixes an empty-popup bug that showed up while wiring the shared trigger.

### Shared commit menu

- Extracts the position-independent commit actions (checkout, revert, cherry-pick, create branch/tag, copy SHA) into `CommitContextMenuItems` in `src/features/history/CommitContextMenu.tsx`. The component is presentational — the parent panel owns confirms, mutations, and dialog state via the `CommitMenuActions` callbacks. `revert` is optional so a caller can hide it.
- `src/features/history/HistoryPanel.tsx` replaces its inline search-results menu with `CommitContextMenuItems`, keeping the existing cherry-pick messaging and branch/tag dialog wiring at the call site.
- `src/features/compare/ComparePanel.tsx` wraps both commit lists in one `ContextMenu`, records the right-clicked row in a capture-phase `handleContextMenu` (which also selects the row, so the menu and diff panel describe the same commit), and derives `onCurrentBranch` from the `ahead` list to gate the revert item. It adds the confirm-then-mutate handlers plus `CreateRefFromCommitDialog` instances for branch and tag creation.
- Compare reuses History's confirm copy from `src/features/history/commit-confirms.ts`, so no route poses a different question than its twin.

### Empty-popup fix

- Adds `suppressContextMenu` in `src/lib/context-menu.ts`, which calls `stopPropagation` alongside `preventDefault` — Base UI's trigger handler is a same-element bubble listener, so `preventDefault` alone still opened an empty popup.
- Routes the non-target right-click paths through it: `HistoryPanel.tsx`, `RepoList.tsx`, and `FileRowActions.tsx` (the last previously just cleared `menuPath` without suppressing at all).
- Records the rule in `.claude/skills/gd-conventions/SKILL.md`.

### Tag decorations on Compare rows

- `src-tauri/src/git/compare.rs` drops its local `parse_log` (which hardcoded empty `tags` and `is_merge: false`) and reuses History's `LOG_FORMAT` + `parse_commit_log`, now `pub(crate)` in `src-tauri/src/git/history.rs` with a comment pairing the two so no commit-listing path can drift again.
- Adds `compare_branches_carries_tag_decorations`, a real-repo test asserting a tagged commit reports its tag and an untagged one reports none.
- `CommitSection` in `ComparePanel.tsx` renders up to two tag chips per row with a `+N` overflow indicator, matching History.

### Checkout feedback

- Adds `checkoutCommitSuccessToast` to `commit-confirms.ts` and fires it from both `HistoryPanel` and `ComparePanel` on success — a silent checkout read as a dead end from Compare, which flips to its detached-HEAD empty state.

### Documentation

- `src/features/help/content.ts`: documents the new Compare menu, including the ahead-list-only revert item.
- Changelog fragments: `added-compare-commit-context-menu.md`, `changed-compare-row-tag-chips.md`, `changed-checkout-commit-toast.md`, and `fixed-context-menu-empty-popup.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Compare commit context-menu actions for checkout, cherry-pick, branch/tag creation, SHA copying, and reverting eligible commits.
  * Compare commit rows now display up to two tag chips with overflow counts.
  * Checkout actions show a success message naming the commit and detached HEAD state.

* **Bug Fixes**
  * Prevented empty context menus from opening when right-clicking blank areas in History, file lists, and repository lists.
  * Preserved tag information in Compare commit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->