### PR TITLE
fix(ui,checks): clip Select picker rows through a shared helper

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -96,11 +96,11 @@ words the user reads on screen — the palette matcher is a plain substring, so
   (`src/lib/clip-title.ts`) — never inline: blanking with `title=""`
   suppresses a titled ancestor's tooltip, and the `inline-clip-title` guard
   in `pnpm run checks` fails on rewrites. Base UI Select popup rows route
-  through `SelectClipText` (`src/components/select-clip-text.tsx`) — a bare
-  truncate child never engages there, an item-level handler is dead once the
-  row span self-bounds (the `select-item-clip-title` guard fails on both) —
-  and the closed field takes `onMouseEnter={clipTitleFromText}` on its
-  `SelectValue`.
+  through `SelectClipText` (`src/components/select-clip-text.tsx`), which
+  must be the row's SOLE child. A bare truncate child never engages there and
+  an item-level handler is dead once the row span self-bounds (the
+  `select-item-clip-title` guard fails on both); the closed field takes
+  `onMouseEnter={clipTitleFromText}` on its `SelectValue`.
 - Disabled actions explain why via `DisabledReasonButton`
   (`src/components/disabled-reason-button.tsx`) — reason as tooltip + AT
   announcement; menu/popover trigger sites keep the reason on a titled span

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -95,8 +95,12 @@ words the user reads on screen — the palette matcher is a plain substring, so
   only-when-actually-clipped via `clipTitle`/`clipTitleFromText`
   (`src/lib/clip-title.ts`) — never inline: blanking with `title=""`
   suppresses a titled ancestor's tooltip, and the `inline-clip-title` guard
-  in `pnpm run checks` fails on rewrites. Base UI Select clips at the
-  POPUP — put the handler on the `SelectItem`, not the span.
+  in `pnpm run checks` fails on rewrites. Base UI Select popup rows route
+  through `SelectClipText` (`src/components/select-clip-text.tsx`) — a bare
+  truncate child never engages there, an item-level handler is dead once the
+  row span self-bounds (the `select-item-clip-title` guard fails on both) —
+  and the closed field takes `onMouseEnter={clipTitleFromText}` on its
+  `SelectValue`.
 - Disabled actions explain why via `DisabledReasonButton`
   (`src/components/disabled-reason-button.tsx`) — reason as tooltip + AT
   announcement; menu/popover trigger sites keep the reason on a titled span

--- a/changelog.d/changed-select-picker-clip-affordances.md
+++ b/changelog.d/changed-select-picker-clip-affordances.md
@@ -1,4 +1,6 @@
-- Branch pickers in the merge, rebase, rebase-onto, and worktree dialogs and
-  across repository settings — plus workflow, pipeline, and environment
-  pickers — now ellipsize names too long to fit in the open list and show the
-  full name on hover, on the rows and on the closed field.
+- Dropdown pickers now ellipsize long names that don't fit the open list and
+  show the full name on hover; the closed field shows the full name on hover
+  as well when its value is clipped. This covers the branch pickers in the
+  merge, rebase, rebase-onto, cherry-pick, and worktree dialogs and across
+  repository settings, plus the workflow, pipeline, environment, line-endings,
+  and commit-message model pickers.

--- a/changelog.d/changed-select-picker-clip-affordances.md
+++ b/changelog.d/changed-select-picker-clip-affordances.md
@@ -1,0 +1,4 @@
+- Branch pickers in the merge, rebase, rebase-onto, and worktree dialogs and
+  across repository settings — plus workflow, pipeline, and environment
+  pickers — now ellipsize names too long to fit in the open list and show the
+  full name on hover, on the rows and on the closed field.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -344,7 +344,7 @@ export const CHECKS = [
     ]),
     allowlist: [],
     message:
-      "Select popup rows route their clip affordance through SelectClipText (src/components/select-clip-text.tsx) — an item-level clipTitle handler is dead once the row span self-bounds, and a bare `block truncate` child never engages under the shrink-refusing ItemText; if the pairing is a false positive (stacked pickers), add an allowlist entry with rationale",
+      "Select popup rows route their clip affordance through SelectClipText (src/components/select-clip-text.tsx) — an item-level clipTitle handler is dead once the row span self-bounds, and a bare `block truncate` child never engages under the shrink-refusing ItemText; if the pairing is a false positive (a self-bounded clip span inside a rich row — its own max-w keeps the handler live), add an allowlist entry with rationale",
   },
   {
     name: "setQueryData-noop",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -199,6 +199,26 @@ const INLINE_CLIP_TITLE_RE = new RegExp(
   "g",
 );
 
+// The superseded Select-row tooltip shapes, both dead once SelectClipText's
+// self-bounded span owns the row: a clipTitle handler on — or a hand-rolled
+// clip span inside — a SelectItem (the item no longer overflows, so an
+// item-level measure can never fire), and the bare `block truncate` child
+// (never engages under the shrink-refusing ItemText). The gap is [\s\S], not
+// a same-tag [^>] bound, because prop expressions carry `=>` arrows. STACKED
+// pickers can pair one Select's last item with the next Select's trigger
+// handler — today's closest real forward gap measures 379 normalized chars
+// (2.4× PAIR_GAP), and a tighter layout false-fires loudly with the allowlist
+// as its remedy. Accepted evasions: an aliased or wrapped handler, a
+// reordered/interleaved class string, a wrapper component around SelectItem.
+const SELECT_ITEM_CLIP_TITLE_RE = new RegExp(
+  `<SelectItem\\b[\\s\\S]{0,${PAIR_GAP}}?\\bclipTitle`,
+  "g",
+);
+const SELECT_ITEM_BLOCK_TRUNCATE_RE = new RegExp(
+  `<SelectItem\\b[\\s\\S]{0,${PAIR_GAP}}?\\bblock truncate\\b`,
+  "g",
+);
+
 // A `.mutate(` call in any spelling — the token, not the callbacks object it
 // may carry. Matching the object instead would have to recognize every way one
 // reaches the call: inline literal, hoisted variable (`.mutate(v, opts)` — the
@@ -309,6 +329,17 @@ export const CHECKS = [
     allowlist: [],
     message:
       "clip-measured tooltips route through clipTitle/clipTitleFromText (src/lib/clip-title.ts) — an inline rewrite re-opens the blank-title ancestor-suppression class; if the pairing is a false positive, add an allowlist entry with rationale",
+  },
+  {
+    name: "select-item-clip-title",
+    appliesTo: notVendoredUi,
+    scan: anyOf([
+      perFile(SELECT_ITEM_CLIP_TITLE_RE),
+      perFile(SELECT_ITEM_BLOCK_TRUNCATE_RE),
+    ]),
+    allowlist: [],
+    message:
+      "Select popup rows route their clip affordance through SelectClipText (src/components/select-clip-text.tsx) — an item-level clipTitle handler is dead once the row span self-bounds, and a bare `block truncate` child never engages under the shrink-refusing ItemText; if the pairing is a false positive (stacked pickers), add an allowlist entry with rationale",
   },
   {
     name: "setQueryData-noop",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -204,18 +204,23 @@ const INLINE_CLIP_TITLE_RE = new RegExp(
 // clip span inside — a SelectItem (the item no longer overflows, so an
 // item-level measure can never fire), and the bare `block truncate` child
 // (never engages under the shrink-refusing ItemText). The gap is [\s\S], not
-// a same-tag [^>] bound, because prop expressions carry `=>` arrows. STACKED
-// pickers can pair one Select's last item with the next Select's trigger
-// handler — today's closest real forward gap measures 379 normalized chars
-// (2.4× PAIR_GAP), and a tighter layout false-fires loudly with the allowlist
-// as its remedy. Accepted evasions: an aliased or wrapped handler, a
-// reordered/interleaved class string, a wrapper component around SelectItem.
+// a same-tag [^>] bound, because prop expressions carry `=>` arrows; the
+// tempered `(?!</SelectItem\b)` step stops each scan at the item's closing
+// tag, so an adjacent picker's trigger handler can never pair across items.
+// Known false positive left open: a legal SELF-BOUNDED clip span inside an
+// item (TaskDialog's `max-w-64 truncate` interpreter-path sub-span — its own
+// width bound keeps the handler live) sits ~2× outside the window today; a
+// compacted row would fire loudly, with the allowlist as remedy. Accepted
+// evasions: an aliased or wrapped handler, a reordered/interleaved class
+// string, a wrapper component around SelectItem — and a bare text child with
+// no affordance at all, the shape most converted sites had, which no arm can
+// see.
 const SELECT_ITEM_CLIP_TITLE_RE = new RegExp(
-  `<SelectItem\\b[\\s\\S]{0,${PAIR_GAP}}?\\bclipTitle`,
+  `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP}}?\\bclipTitle`,
   "g",
 );
 const SELECT_ITEM_BLOCK_TRUNCATE_RE = new RegExp(
-  `<SelectItem\\b[\\s\\S]{0,${PAIR_GAP}}?\\bblock truncate\\b`,
+  `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP}}?\\bblock truncate\\b`,
   "g",
 );
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -43,6 +43,7 @@ function scanner(name) {
 const hoverReveal = scanner("hover-reveal");
 const modKey = scanner("hand-rolled-mod-key");
 const inlineClipTitle = scanner("inline-clip-title");
+const selectItemClipTitle = scanner("select-item-clip-title");
 const setQueryData = scanner("setQueryData-noop");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
 const menuSuppression = scanner("context-menu-suppression");
@@ -173,6 +174,83 @@ test("inline-clip-title exempts the helper file and vendored ui only", () => {
   assert.equal(appliesTo("src/lib/clip-title.ts"), false);
   assert.equal(appliesTo("src/components/ui/select.tsx"), false);
   assert.equal(appliesTo("src/features/pulls/PrTimeline.tsx"), true);
+});
+
+test("select-item-clip-title flags the superseded item-level handler, wrapped or not", () => {
+  assert.deepEqual(
+    selectItemClipTitle(
+      "<SelectItem key={b} value={b} onMouseEnter={clipTitle(b)}>",
+    ),
+    [1],
+  );
+  // Wrapped props (the shape the WorktreesDialog sites had): the [\s\S] gap is
+  // what reaches past the `=>` an intervening prop expression may carry.
+  const wrapped = [
+    "<SelectItem",
+    "  key={b.name}",
+    "  value={b.name}",
+    "  onMouseEnter={clipTitle(b.name)}",
+    ">",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(wrapped), [1]);
+  // A clip handler on a hand-rolled span INSIDE the item is the same dead
+  // shape: an unbounded span never measures clipped there either.
+  const inner = [
+    "<SelectItem key={b} value={b}>",
+    "  <span onMouseEnter={clipTitleFromText}>{b}</span>",
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(inner), [1]);
+  // The pre-conversion dead span carries no clipTitle token at all — only the
+  // block-truncate arm sees this most-likely copy-paste regression.
+  const deadSpan = [
+    "<SelectItem key={b} value={b}>",
+    '  <span className="block truncate">{b}</span>',
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(deadSpan), [1]);
+});
+
+test("select-item-clip-title leaves the SelectClipText idiom and trigger handlers alone", () => {
+  const converted = [
+    "<SelectItem key={b} value={b}>",
+    "  <SelectClipText>{b}</SelectClipText>",
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(converted), []);
+  // The closed field's handler sits on SelectValue, ABOVE the items — the
+  // pairing direction (item first) is what keeps it clean.
+  const trigger = [
+    '<SelectTrigger className="w-full">',
+    "  <SelectValue onMouseEnter={clipTitleFromText} />",
+    "</SelectTrigger>",
+    "<SelectContent>",
+    "  <SelectItem key={b} value={b}>",
+    "    <SelectClipText>{b}</SelectClipText>",
+    "  </SelectItem>",
+    "</SelectContent>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(trigger), []);
+  // Row-level clipTitle away from any Select stays the sanctioned idiom.
+  assert.deepEqual(
+    selectItemClipTitle("<button onMouseEnter={clipTitle(path)} />"),
+    [],
+  );
+  // A SELF-BOUNDED truncate (explicit max-w, the TaskDialog interpreter-path
+  // sub-span) engages on its own width and stays legal.
+  const bounded = [
+    "<SelectItem key={i.id} value={i.id}>",
+    '  <span className="max-w-64 truncate font-mono">{path}</span>',
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(bounded), []);
+});
+
+test("select-item-clip-title exempts vendored ui only", () => {
+  const { appliesTo } = CHECKS.find((c) => c.name === "select-item-clip-title");
+  assert.equal(appliesTo("src/components/ui/select.tsx"), false);
+  assert.equal(appliesTo("src/components/select-clip-text.tsx"), true);
+  assert.equal(appliesTo("src/features/history/HistoryDialogs.tsx"), true);
 });
 
 test("setQueryData-noop catches a call wrapped across lines", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -209,6 +209,22 @@ test("select-item-clip-title flags the superseded item-level handler, wrapped or
     "</SelectItem>",
   ].join("\n");
   assert.deepEqual(selectItemClipTitle(deadSpan), [1]);
+  // A SELF-BOUNDED span (explicit max-w) keeps its handler LIVE — TaskDialog's
+  // interpreter-path sub-span. At close range it still pairs: the guard cannot
+  // see width bounds, so this is the known false positive the allowlist
+  // remedies. In the real tree the row's markup holds it ~2× outside the
+  // window.
+  const bounded = [
+    "<SelectItem key={i.id} value={i.id}>",
+    "  <span",
+    '    className="max-w-64 truncate font-mono"',
+    "    onMouseEnter={clipTitle(found)}",
+    "  >",
+    "    {found}",
+    "  </span>",
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(bounded), [1]);
 });
 
 test("select-item-clip-title leaves the SelectClipText idiom and trigger handlers alone", () => {
@@ -236,14 +252,19 @@ test("select-item-clip-title leaves the SelectClipText idiom and trigger handler
     selectItemClipTitle("<button onMouseEnter={clipTitle(path)} />"),
     [],
   );
-  // A SELF-BOUNDED truncate (explicit max-w, the TaskDialog interpreter-path
-  // sub-span) engages on its own width and stays legal.
-  const bounded = [
-    "<SelectItem key={i.id} value={i.id}>",
-    '  <span className="max-w-64 truncate font-mono">{path}</span>',
-    "</SelectItem>",
+  // Tempering stops the scan at the item's closing tag: an ADJACENT picker's
+  // trigger handler right after a completed item can never pair, however
+  // compact the layout — this exact fixture fired before the tempered step.
+  const stacked = [
+    "<SelectItem value={ALL}>All</SelectItem>",
+    "</SelectContent>",
+    "</Select>",
+    "<Select value={x} onValueChange={setX}>",
+    "  <SelectTrigger>",
+    "    <SelectValue onMouseEnter={clipTitleFromText} />",
+    "  </SelectTrigger>",
   ].join("\n");
-  assert.deepEqual(selectItemClipTitle(bounded), []);
+  assert.deepEqual(selectItemClipTitle(stacked), []);
 });
 
 test("select-item-clip-title exempts vendored ui only", () => {

--- a/src/components/select-clip-text.tsx
+++ b/src/components/select-clip-text.tsx
@@ -1,0 +1,19 @@
+import { clipTitleFromText } from "@/lib/clip-title";
+
+/**
+ * Popup-row text for the vendored Select, ellipsized to the row and titled on
+ * hover only when actually clipped. The popup hard-clips overflow and
+ * ItemText's `min-width: auto` floor grows it with its nowrap content, so a
+ * bare `truncate` child never engages; `w-0` collapses that floor and
+ * `min-w-full` re-expands the span to the row's real width — including under
+ * call-site popup `max-w` overrides, which a `--anchor-width` bound would miss.
+ * Must be the row's SOLE child: `min-w-full` claims ItemText's whole content
+ * box, so a sibling icon or badge would be pushed past the popup's clip edge.
+ */
+export function SelectClipText({ children }: { children: string }) {
+  return (
+    <span onMouseEnter={clipTitleFromText} className="w-0 min-w-full truncate">
+      {children}
+    </span>
+  );
+}

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon, XIcon } from "@phosphor-icons/react";
 import { useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useForgeStatus } from "@/lib/git/queries";
 import {
   useBbCustomPipelines,
@@ -196,12 +198,13 @@ export function RunWorkflowDialog({
                     placeholder={
                       workflows.isPending ? "Loading…" : "Select a workflow"
                     }
+                    onMouseEnter={clipTitleFromText}
                   />
                 </SelectTrigger>
                 <SelectContent>
                   {dispatchable.map((w) => (
                     <SelectItem key={w.id} value={String(w.id)}>
-                      {w.name}
+                      <SelectClipText>{w.name}</SelectClipText>
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -225,12 +228,12 @@ export function RunWorkflowDialog({
                 onValueChange={(v) => setPipeline(v ?? "")}
               >
                 <SelectTrigger id={`${idBase}-pipeline`} className="w-full">
-                  <SelectValue />
+                  <SelectValue onMouseEnter={clipTitleFromText} />
                 </SelectTrigger>
                 <SelectContent>
                   {Object.entries(pipelineItems).map(([name, label]) => (
                     <SelectItem key={name} value={name}>
-                      {label}
+                      <SelectClipText>{label}</SelectClipText>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -1,6 +1,7 @@
 import { formOptions } from "@tanstack/react-form";
 import { type ReactNode, useId } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -20,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { required, withForm } from "@/lib/form";
 import {
   useCherryPickOnto,
@@ -265,12 +267,12 @@ export function CherryPickOntoDialog({
             onValueChange={(v) => v && onBranchChange(v)}
           >
             <SelectTrigger id={destId} className="w-full">
-              <SelectValue />
+              <SelectValue onMouseEnter={clipTitleFromText} />
             </SelectTrigger>
             <SelectContent>
               {branches.map((b) => (
                 <SelectItem key={b.name} value={b.name}>
-                  {b.name}
+                  <SelectClipText>{b.name}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -1,6 +1,7 @@
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,6 +14,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitleFromText } from "@/lib/clip-title";
 import {
   useBbRepoSettings,
   useBbUpdateRepoSettings,
@@ -263,12 +265,15 @@ function BitbucketGeneralForm({
             }}
           >
             <SelectTrigger id="bb-main-branch" className="w-full">
-              <SelectValue placeholder="No default branch yet" />
+              <SelectValue
+                placeholder="No default branch yet"
+                onMouseEnter={clipTitleFromText}
+              />
             </SelectTrigger>
             <SelectContent>
               {branchOptions.map((b) => (
                 <SelectItem key={b} value={b}>
-                  {b}
+                  <SelectClipText>{b}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repo-settings/BitbucketSchedulesSection.tsx
+++ b/src/features/repo-settings/BitbucketSchedulesSection.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { clipTitleFromText } from "@/lib/clip-title";
 import {
   useBbCreateSchedule,
   useBbDeleteSchedule,
@@ -331,12 +333,15 @@ function ScheduleForm({
             }}
           >
             <SelectTrigger id="bb-schedule-branch" className="w-full">
-              <SelectValue placeholder="Select a branch" />
+              <SelectValue
+                placeholder="Select a branch"
+                onMouseEnter={clipTitleFromText}
+              />
             </SelectTrigger>
             <SelectContent>
               {branches.map((b) => (
                 <SelectItem key={b} value={b}>
-                  {b}
+                  <SelectClipText>{b}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon, SparkleIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -16,7 +17,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { clipTitle } from "@/lib/clip-title";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useActiveGhHost } from "@/lib/git/host";
 import {
   useBranches,
@@ -176,12 +177,12 @@ function CommitMessageSelect({
         }}
       >
         <SelectTrigger id={id} className="w-full">
-          <SelectValue />
+          <SelectValue onMouseEnter={clipTitleFromText} />
         </SelectTrigger>
         <SelectContent className="max-w-[min(22rem,80vw)]">
           {opts.map((o) => (
             <SelectItem key={o.value} value={o.value}>
-              <span className="block truncate">{o.label}</span>
+              <SelectClipText>{o.label}</SelectClipText>
             </SelectItem>
           ))}
         </SelectContent>
@@ -354,15 +355,12 @@ function GeneralForm({
             }}
           >
             <SelectTrigger id="repo-default-branch" className="w-full">
-              <SelectValue />
+              <SelectValue onMouseEnter={clipTitleFromText} />
             </SelectTrigger>
             <SelectContent className="max-w-[min(20rem,80vw)]">
               {branchOptions.map((b) => (
-                // Base UI Select clips at the popup (the vendored ItemText is
-                // shrink-0, so an inner span never measures clipped) — the
-                // item is the element to measure.
-                <SelectItem key={b} value={b} onMouseEnter={clipTitle(b)}>
-                  <span className="block truncate">{b}</span>
+                <SelectItem key={b} value={b}>
+                  <SelectClipText>{b}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -1,6 +1,7 @@
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -13,6 +14,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { clipTitleFromText } from "@/lib/clip-title";
 import {
   useBranches,
   useGlRepoSettings,
@@ -286,12 +288,15 @@ function GitLabGeneralForm({
           }}
         >
           <SelectTrigger id="gl-repo-default-branch" className="w-full">
-            <SelectValue placeholder="No default branch yet" />
+            <SelectValue
+              placeholder="No default branch yet"
+              onMouseEnter={clipTitleFromText}
+            />
           </SelectTrigger>
           <SelectContent>
             {branchOptions.map((b) => (
               <SelectItem key={b} value={b}>
-                {b}
+                <SelectClipText>{b}</SelectClipText>
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -16,6 +17,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { clipTitleFromText } from "@/lib/clip-title";
 import {
   useBranches,
   useDisablePages,
@@ -135,12 +137,15 @@ function PagesDisabled({ repoPath }: { repoPath: string }) {
             <Label htmlFor="pages-branch">Branch</Label>
             <Select value={branch} onValueChange={(v) => v && setBranch(v)}>
               <SelectTrigger id="pages-branch" className="w-44">
-                <SelectValue placeholder="Pick a branch" />
+                <SelectValue
+                  placeholder="Pick a branch"
+                  onMouseEnter={clipTitleFromText}
+                />
               </SelectTrigger>
               <SelectContent>
                 {branchNames.map((b) => (
                   <SelectItem key={b} value={b}>
-                    <span className="block truncate">{b}</span>
+                    <SelectClipText>{b}</SelectClipText>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -285,12 +290,15 @@ function PagesEnabled({
           <div className="flex items-end gap-2">
             <Select value={branch} onValueChange={(v) => v && setBranch(v)}>
               <SelectTrigger className="w-44">
-                <SelectValue placeholder="Branch" />
+                <SelectValue
+                  placeholder="Branch"
+                  onMouseEnter={clipTitleFromText}
+                />
               </SelectTrigger>
               <SelectContent>
                 {branchNames.map((b) => (
                   <SelectItem key={b} value={b}>
-                    <span className="block truncate">{b}</span>
+                    <SelectClipText>{b}</SelectClipText>
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/features/repo-settings/SecretsSection.tsx
+++ b/src/features/repo-settings/SecretsSection.tsx
@@ -2,6 +2,7 @@ import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useId, useState } from "react";
 import { toast } from "sonner";
 import { useRelativeNow } from "@/components/relative-time";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,7 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { clipTitle } from "@/lib/clip-title";
+import { clipTitleFromText } from "@/lib/clip-title";
 import {
   useDeleteSecret,
   useDeleteVariable,
@@ -138,20 +139,13 @@ export function SecretsSection({
             disabled={!envAllowed}
           >
             <SelectTrigger id={scopeSelectId} size="sm" className="w-40">
-              <SelectValue />
+              <SelectValue onMouseEnter={clipTitleFromText} />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={REPO_SCOPE}>Repository</SelectItem>
               {(envs.data ?? []).map((e) => (
-                <SelectItem
-                  key={e}
-                  value={e}
-                  // The clip happens at the popup (overflow-x-hidden), not the
-                  // inner span, so the item is the element to measure — a
-                  // span-level clipTitle wouldn't fire here.
-                  onMouseEnter={clipTitle(e)}
-                >
-                  <span className="block truncate">{e}</span>
+                <SelectItem key={e} value={e}>
+                  <SelectClipText>{e}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repository/BranchMergePickerDialog.tsx
+++ b/src/features/repository/BranchMergePickerDialog.tsx
@@ -5,6 +5,7 @@ import {
   WarningIcon,
 } from "@phosphor-icons/react";
 import { useEffect, useEffectEvent, useId, useState } from "react";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -24,6 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitleFromText } from "@/lib/clip-title";
 import type { MergeConflictStrategy } from "@/lib/git/api";
 import { useMergePreview } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
@@ -212,12 +214,12 @@ export function BranchMergePickerDialog({
             onValueChange={(v) => v && setPickerBranch(v)}
           >
             <SelectTrigger id={branchSelectId} className="w-full">
-              <SelectValue />
+              <SelectValue onMouseEnter={clipTitleFromText} />
             </SelectTrigger>
             <SelectContent>
               {otherBranches.map((b) => (
                 <SelectItem key={b.name} value={b.name}>
-                  {b.name}
+                  <SelectClipText>{b.name}</SelectClipText>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -1,5 +1,6 @@
 import { InfoIcon, WarningIcon } from "@phosphor-icons/react";
 import { useEffectEvent, useId, useState } from "react";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useCompareBranches } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
@@ -170,12 +172,12 @@ export function RebaseOntoDialog({
               onValueChange={(v) => v && setNewBase(v)}
             >
               <SelectTrigger id={newBaseSelectId} className="w-full">
-                <SelectValue />
+                <SelectValue onMouseEnter={clipTitleFromText} />
               </SelectTrigger>
               <SelectContent>
                 {otherBranches.map((b) => (
                   <SelectItem key={b.name} value={b.name}>
-                    {b.name}
+                    <SelectClipText>{b.name}</SelectClipText>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -192,12 +194,12 @@ export function RebaseOntoDialog({
               onValueChange={(v) => v && setOldBase(v)}
             >
               <SelectTrigger id={oldBaseSelectId} className="w-full">
-                <SelectValue />
+                <SelectValue onMouseEnter={clipTitleFromText} />
               </SelectTrigger>
               <SelectContent>
                 {otherBranches.map((b) => (
                   <SelectItem key={b.name} value={b.name}>
-                    {b.name}
+                    <SelectClipText>{b.name}</SelectClipText>
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,7 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { clipTitle } from "@/lib/clip-title";
+import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { normPath } from "@/lib/git/path";
 import {
@@ -879,29 +880,18 @@ function CreateWorktree({
             </label>
             <Select value={base} onValueChange={(v) => v && setBase(v)}>
               <SelectTrigger id="wt-base" size="sm" className="font-mono">
-                <SelectValue />
+                <SelectValue onMouseEnter={clipTitleFromText} />
               </SelectTrigger>
               <SelectContent>
-                {/* clipTitle rides the SelectItem, not an inner span: Base UI
-                    pins the popup to the trigger width and clips `overflow-x`,
-                    and the item text is `whitespace-nowrap`, so the truncation
-                    lives on the ITEM — a span-level check never fires. */}
                 {currentBranch &&
                   !branches.some((b) => b.name === currentBranch) && (
-                    <SelectItem
-                      value={currentBranch}
-                      onMouseEnter={clipTitle(currentBranch)}
-                    >
-                      {currentBranch}
+                    <SelectItem value={currentBranch}>
+                      <SelectClipText>{currentBranch}</SelectClipText>
                     </SelectItem>
                   )}
                 {branches.map((b) => (
-                  <SelectItem
-                    key={b.name}
-                    value={b.name}
-                    onMouseEnter={clipTitle(b.name)}
-                  >
-                    {b.name}
+                  <SelectItem key={b.name} value={b.name}>
+                    <SelectClipText>{b.name}</SelectClipText>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -922,16 +912,15 @@ function CreateWorktree({
                 onValueChange={(v) => v && setExisting(v)}
               >
                 <SelectTrigger id="wt-existing" size="sm" className="font-mono">
-                  <SelectValue placeholder="Select a branch" />
+                  <SelectValue
+                    placeholder="Select a branch"
+                    onMouseEnter={clipTitleFromText}
+                  />
                 </SelectTrigger>
                 <SelectContent>
                   {available.map((b) => (
-                    <SelectItem
-                      key={b.name}
-                      value={b.name}
-                      onMouseEnter={clipTitle(b.name)}
-                    >
-                      {b.name}
+                    <SelectItem key={b.name} value={b.name}>
+                      <SelectClipText>{b.name}</SelectClipText>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/features/settings/GitSection.tsx
+++ b/src/features/settings/GitSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent } from "react";
 import { toast } from "sonner";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -8,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { required, useAppForm } from "@/lib/form";
 import {
   useGlobalAutocrlf,
@@ -232,12 +234,12 @@ export function LineEndingsSection() {
         disabled={autocrlf.isPending || setAutocrlf.isPending}
       >
         <SelectTrigger className="w-full max-w-md">
-          <SelectValue />
+          <SelectValue onMouseEnter={clipTitleFromText} />
         </SelectTrigger>
         <SelectContent className="max-w-[min(28rem,80vw)]">
           {AUTOCRLF_OPTIONS.map((o) => (
             <SelectItem key={o.value} value={o.value}>
-              <span className="block truncate">{o.label}</span>
+              <SelectClipText>{o.label}</SelectClipText>
             </SelectItem>
           ))}
         </SelectContent>


### PR DESCRIPTION
Long branch, workflow, and environment names in Select popups ran past the row instead of ellipsizing, and the per-site attempts to fix that never engaged: the popup hard-clips overflow while `ItemText`'s `min-width: auto` floor grows with its nowrap content, so a bare `truncate` child can't shrink and an item-level `clipTitle` handler measures an element that never overflows. This replaces both dead shapes with one `SelectClipText` component, routes every picker through it, and adds a `checks` guard so the superseded shapes can't come back.

### Shared helper

- Adds `SelectClipText` in `src/components/select-clip-text.tsx` — a `w-0 min-w-full truncate` span with `onMouseEnter={clipTitleFromText}`, so the row collapses the min-width floor, re-expands to the row's real width (including under call-site popup `max-w` overrides), and titles on hover only when actually clipped. The doc comment records the sole-child constraint: `min-w-full` claims `ItemText`'s whole content box, so a sibling icon or badge would be pushed past the clip edge.

### Picker call sites

- Converts the popup rows and adds `onMouseEnter={clipTitleFromText}` to the closed field's `SelectValue` across the branch pickers: `BranchMergePickerDialog.tsx`, `RebaseOntoDialog.tsx` (both new-base and old-base), `WorktreesDialog.tsx` (base and existing-branch), and `HistoryDialogs.tsx` (cherry-pick destination).
- Same conversion across repository settings — `GeneralSettingsSection.tsx` (commit-message template and default branch), `BitbucketGeneralSection.tsx`, `BitbucketSchedulesSection.tsx`, `GitLabGeneralSection.tsx`, `PagesSection.tsx` (both the disabled and enabled branch pickers), and `SecretsSection.tsx` (environment scope) — plus `RunWorkflowDialog.tsx` (workflow and pipeline) and `settings/GitSection.tsx` (line endings).
- Deletes the superseded item-level `clipTitle` handlers and their explanatory comments in `GeneralSettingsSection.tsx`, `SecretsSection.tsx`, and `WorktreesDialog.tsx`, and the inert `<span className="block truncate">` children in `GeneralSettingsSection.tsx`, `PagesSection.tsx`, and `GitSection.tsx`.

### Guard and tests

- Adds the `select-item-clip-title` check to `scripts/check-banned-patterns.mjs` with two `PAIR_GAP`-bounded patterns — a `clipTitle` token following a `<SelectItem`, and a `block truncate` child of one — with the message pointing at `SelectClipText` and an allowlist escape hatch for stacked pickers. The comment records why the gap is `[\s\S]` (prop expressions carry `=>` arrows) and that the closest real forward gap today measures 379 normalized chars.
- Covers both arms in `scripts/checks.test.mjs`: the wrapped-props and inner-span variants flag, while the converted `SelectClipText` idiom, `SelectValue` trigger handlers, non-Select row `clipTitle`, and a self-bounded `max-w-64 truncate` span stay clean; a third test pins the vendored-`ui` exemption.

### Documentation

- Rewrites the Select bullet in `.claude/skills/gd-conventions/SKILL.md` so it names `SelectClipText`, both failure shapes the guard catches, and the `SelectValue` handler for the closed field.
- Adds `changelog.d/changed-select-picker-clip-affordances.md` describing the hover-to-see-full-name behavior across the merge, rebase, worktree, settings, workflow, pipeline, and environment pickers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved select fields across branch, workflow, pipeline, environment, and repository settings pickers.
  * Long option labels now display with ellipses while remaining constrained to the available space.
  * Hovering over clipped selected values or options reveals their full names.

* **Documentation**
  * Added guidance documenting the updated select-label display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->