### PR TITLE
feat(repository,diff): show per-file line counts on the changes list

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -97,6 +97,11 @@ words the user reads on screen — the palette matcher is a plain substring, so
   suppresses a titled ancestor's tooltip, and the `inline-clip-title` guard
   in `pnpm run checks` fails on rewrites. Base UI Select clips at the
   POPUP — put the handler on the `SelectItem`, not the span.
+- Per-file `+added -deleted` counts render through `DiffStat`
+  (`src/components/diff-stat.tsx`) — plain numbers in, optional `isBinary`
+  (a muted `bin`) and `format` (Insights abbreviates via `fmt`); never
+  hand-rolled, and the `hand-rolled-diff-stat` guard in `pnpm run checks`
+  fails on a new pair.
 - Disabled actions explain why via `DisabledReasonButton`
   (`src/components/disabled-reason-button.tsx`) — reason as tooltip + AT
   announcement; menu/popover trigger sites keep the reason on a titled span

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ delete), and deep links to the settings GitHub keeps browser-only.
 ### Changes and commits
 
 A unified or split diff with syntax highlighting, collapsible surrounding
-context, and image diffing. Filter the changes list by path or category. The
+context, and image diffing. Filter the changes list by path or category, and
+read a file's `+added -deleted` line counts without opening it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to
 add to a selection, so one selection can mix added and removed lines across

--- a/changelog.d/added-changes-file-line-counts.md
+++ b/changelog.d/added-changes-file-line-counts.md
@@ -1,0 +1,6 @@
+- **Line counts on the changes list.** File rows in the Changes tab now show
+  how many lines they add and remove, so you can size a change before opening
+  its diff. The Staged and Changes rows count separately: a file you staged and
+  then edited again shows what's staged for the commit on one row and what's
+  still outside it on the other. Binary files read `bin`, and untracked files
+  show no counts (git has nothing to compare them against yet).

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -246,6 +246,28 @@ const notVendoredUi = (file) => !file.startsWith("src/components/ui/");
 const SEED_ON_OPEN_RE =
   /use(?:Layout)?Effect\(\(\)\s*=>\s*\{\s*if\s*\(!?open\b/g;
 
+// A hand-rolled diff-stat pair: a `text-success` element whose own content opens
+// with an interpolated `+` count, within PAIR_GAP of a `text-destructive` one
+// opening with a `-` count. Both minus spellings match — the ASCII hyphen the
+// canonical sites use and the U+2212 the Insights pair used.
+// Unlike the class-name checks above, the two tokens are matched as bare
+// substrings rather than through `token()`: the boundary guard would drop
+// `text-success/70` and `group-hover:text-destructive`, which are the same idiom
+// in a different Tailwind spelling. Requiring each element's own `>` is what
+// bounds the false positives instead — a class named far from any count can't
+// pair. The run to that `>` is 200 chars because a realistic `cn(...)` list with
+// conditional utilities measures 95 (probed while sizing this check); the old
+// 60 missed it.
+// Three deliberate bounds, zero instances today: the deleted-then-added order is
+// not matched, nor is a count rendered through a helper call rather than a brace
+// interpolation (`>+{fmt(n)}` matches; `>{plus(n)}` does not), nor one built in a
+// template literal (`>{`+${n}`}` — no `+` precedes the brace).
+const DIFF_STAT_PAIR_RE = new RegExp(
+  `text-success[\\s\\S]{0,200}?>\\s*\\+\\s*\\{[\\s\\S]{0,${PAIR_GAP}}?` +
+    `text-destructive[\\s\\S]{0,200}?>\\s*[-−]\\s*\\{`,
+  "g",
+);
+
 // `<Activity` as a JSX open tag. The lookahead is what separates it from the
 // app's own `<ActivityDock>`/`<ActivityBell>`/`<ActivityStrip>` components, and
 // comment stripping is what keeps the many prose mentions of `<Activity>` clean.
@@ -395,6 +417,16 @@ export const CHECKS = [
     ],
     message:
       "an open-transition reset must ride useSeedOnOpen (src/lib/use-seed-on-open.ts) — a hidden <Activity> tab re-mounts its effects on show, so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires and wipes the user's draft; a data-arrival or otherwise idempotent seed needs an allowlist entry with rationale",
+  },
+  {
+    name: "hand-rolled-diff-stat",
+    // The component IS the idiom; everything else routes through it.
+    appliesTo: (file) =>
+      file !== "src/components/diff-stat.tsx" && notVendoredUi(file),
+    scan: perFile(DIFF_STAT_PAIR_RE),
+    allowlist: [],
+    message:
+      "`+added -deleted` counts render through DiffStat (src/components/diff-stat.tsx) — a hand-rolled pair drifts from the canonical spacing, minus glyph, and tabular digits one site at a time; a site the component genuinely can't express needs an allowlist entry with rationale",
   },
   {
     name: "lone-activity-boundary",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -48,6 +48,7 @@ const bareMutate = scanner("bare-mutate-in-converted-trees");
 const menuSuppression = scanner("context-menu-suppression");
 const loneActivity = scanner("lone-activity-boundary");
 const seedOnOpen = scanner("seed-effect-on-open");
+const diffStatPair = scanner("hand-rolled-diff-stat");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -423,6 +424,70 @@ test("lone-activity-boundary ignores same-prefixed components and prose", () => 
     loneActivity("// a hidden <Activity> subtree still fetches"),
     [],
   );
+});
+
+test("hand-rolled-diff-stat flags both minus glyphs and a wrapped class list", () => {
+  const ascii = [
+    '<span className="shrink-0 tabular-nums">',
+    '  <span className="text-success">+{file.added}</span>{" "}',
+    '  <span className="text-destructive">-{file.deleted}</span>',
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(diffStatPair(ascii), [2]);
+  // The Insights spelling: U+2212, and counts routed through a formatter.
+  const unicode = [
+    '<span className="text-success">+{fmt(c.additions)}</span>{" "}',
+    '<span className="text-destructive">−{fmt(c.deletions)}</span>',
+  ].join("\n");
+  assert.deepEqual(diffStatPair(unicode), [1]);
+  // A cn()-wrapped class list, each count on its own wrapped line.
+  const wrapped = [
+    '<span className={cn("text-success", PLACEHOLDER_FADE, staleDim)}>',
+    "  +{totalAdded}",
+    "</span>",
+    '<span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim)}>',
+    "  -{totalDeleted}",
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(diffStatPair(wrapped), [1]);
+  // The boundary the 200-char class run exists for: a cn() list carrying
+  // conditional utilities puts 95 chars between the class name and its `>`.
+  const longList = [
+    '<span className={cn("text-success", PLACEHOLDER_FADE, staleDim,',
+    '  isActive && "font-medium", compact ? "text-[10px]" : "text-xs")}>',
+    "  +{a}",
+    "</span>",
+    '<span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim,',
+    '  isActive && "font-medium", compact ? "text-[10px]" : "text-xs")}>',
+    "  -{d}",
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(diffStatPair(longList), [1]);
+});
+
+test("hand-rolled-diff-stat leaves the component route and lone tokens alone", () => {
+  assert.deepEqual(
+    diffStatPair("<DiffStat added={file.added} deleted={file.deleted} />"),
+    [],
+  );
+  // A success/destructive pair with no counts between them — the ordinary use.
+  const statuses = [
+    '<span className="text-success">Passing</span>',
+    '<span className="text-destructive">{failed} failed</span>',
+  ].join("\n");
+  assert.deepEqual(diffStatPair(statuses), []);
+  // Half the idiom is not the idiom.
+  assert.deepEqual(
+    diffStatPair('<span className="text-success">+{added}</span>'),
+    [],
+  );
+});
+
+test("hand-rolled-diff-stat exempts the component file and vendored ui only", () => {
+  const { appliesTo } = CHECKS.find((c) => c.name === "hand-rolled-diff-stat");
+  assert.equal(appliesTo("src/components/diff-stat.tsx"), false);
+  assert.equal(appliesTo("src/components/ui/badge.tsx"), false);
+  assert.equal(appliesTo("src/features/repository/FileRow.tsx"), true);
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -59,6 +59,10 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Diffs & staging",
+    label: "Per-file added/deleted line counts on the changes list",
+  },
+  {
+    group: "Diffs & staging",
     label: "Commit with co-authors suggested from history; amend, undo, revert",
   },
   { group: "Diffs & staging", label: "Recoverable, recycle-bin discards" },

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -433,6 +433,41 @@ pub async fn git_staged_diff(
     })
 }
 
+/// Per-file line counts for the working tree, one list per diff side.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkingLineStats {
+    /// Index vs HEAD — what the Staged section's rows show.
+    pub staged: Vec<DiffStatEntry>,
+    /// Working tree vs index — what the Changes section's rows show.
+    pub unstaged: Vec<DiffStatEntry>,
+}
+
+/// Line counts for the Changes panel's file rows, split by side so a file that
+/// is BOTH staged and re-edited reports each row's own numbers (never one
+/// shared or summed count). Read-only and lock-free like `status_core`, so it
+/// can ride the same 5s poll. Untracked paths appear on neither side: numstat
+/// only reports tracked changes, and those rows deliberately show no counts.
+#[tauri::command]
+pub async fn git_working_line_stats(repo_path: String) -> AppResult<WorkingLineStats> {
+    let (staged, unstaged) = tokio::try_join!(
+        run_git(
+            Some(&repo_path),
+            &["diff", "--cached", "--numstat", "-z"],
+            DEFAULT_TIMEOUT,
+        ),
+        run_git(
+            Some(&repo_path),
+            &["diff", "--numstat", "-z"],
+            DEFAULT_TIMEOUT,
+        )
+    )?;
+    Ok(WorkingLineStats {
+        staged: parse_numstat_z(&staged.stdout_lossy()),
+        unstaged: parse_numstat_z(&unstaged.stdout_lossy()),
+    })
+}
+
 pub fn truncate_at_char_boundary(text: String, max: usize) -> (String, bool) {
     if text.len() <= max {
         return (text, false);
@@ -656,6 +691,96 @@ mod tests {
         .unwrap();
         assert_eq!(noop.files.len(), 3);
         assert_eq!(noop.excluded_files, 0);
+    }
+
+    /// Sets up a temp git repo with a deterministic identity. `core.autocrlf` is
+    /// pinned because these tests count LINES — an inherited global setting must
+    /// not reshape the fixture.
+    async fn init_line_stats_repo(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf, String) {
+        let tmp = tempfile::Builder::new()
+            .prefix(prefix)
+            .tempdir()
+            .expect("create temp dir");
+        let dir = tmp.path().to_path_buf();
+        let repo = dir.to_string_lossy().into_owned();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            vec!["config", "core.autocrlf", "false"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        (tmp, dir, repo)
+    }
+
+    /// The panel's core invariant: a file that is staged AND re-edited reports
+    /// DIFFERENT counts per side — staged is index vs HEAD, unstaged is working
+    /// tree vs index. Untracked files appear on neither side.
+    #[tokio::test]
+    async fn working_line_stats_splits_sides_and_skips_untracked() {
+        let (_tmp, dir, repo) = init_line_stats_repo("gd-line-stats-test-").await;
+
+        std::fs::write(dir.join("file.txt"), "a\nb\nc\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        run_git(Some(&repo), &["commit", "-qm", "seed"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // Stage a 2-line append (index vs HEAD = +2 -0)...
+        std::fs::write(dir.join("file.txt"), "a\nb\nc\nd\ne\n").unwrap();
+        run_git(Some(&repo), &["add", "file.txt"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        // ...then edit further in the worktree (worktree vs index = +3 -1).
+        std::fs::write(dir.join("file.txt"), "a\nb\nc\nd\nE\nf\ng\n").unwrap();
+        std::fs::write(dir.join("untracked.txt"), "x\ny\n").unwrap();
+
+        let stats = git_working_line_stats(repo).await.unwrap();
+
+        let staged = stats
+            .staged
+            .iter()
+            .find(|e| e.path == "file.txt")
+            .expect("staged side reports the file");
+        assert_eq!((staged.added, staged.deleted), (2, 0));
+        let unstaged = stats
+            .unstaged
+            .iter()
+            .find(|e| e.path == "file.txt")
+            .expect("unstaged side reports the file");
+        assert_eq!((unstaged.added, unstaged.deleted), (3, 1));
+
+        for side in [&stats.staged, &stats.unstaged] {
+            assert!(
+                !side.iter().any(|e| e.path == "untracked.txt"),
+                "numstat never reports untracked paths"
+            );
+        }
+    }
+
+    /// A brand-new repo with no commits still reports its staged counts — `git
+    /// diff --cached` falls back to the empty tree, so the command needs no
+    /// unborn-HEAD special case.
+    #[tokio::test]
+    async fn working_line_stats_handles_unborn_head() {
+        let (_tmp, dir, repo) = init_line_stats_repo("gd-line-stats-unborn-test-").await;
+
+        std::fs::write(dir.join("new.txt"), "one\ntwo\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        let stats = git_working_line_stats(repo).await.unwrap();
+        let staged = stats
+            .staged
+            .iter()
+            .find(|e| e.path == "new.txt")
+            .expect("staged side reports the file");
+        assert_eq!((staged.added, staged.deleted), (2, 0));
+        assert!(stats.unstaged.is_empty());
     }
 
     const FILE_HEADER: &str = "diff --git a/f.txt b/f.txt\nindex 000..111 100644\n--- a/f.txt\n+++ b/f.txt\n";

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -786,8 +786,8 @@ mod tests {
     /// The premise behind the Changes panel's conflicted-row gate: numstat emits
     /// MORE THAN ONE unstaged row for an unmerged path (measured: a zero-count
     /// row plus the content diff), so a `.get(path)` lookup would surface an
-    /// arbitrary one of them. Pinned here
-    /// because the gate reads as unmotivated once the shape is out of view.
+    /// arbitrary one of them. Pinned here because the gate reads as unmotivated
+    /// once the shape is out of view.
     #[tokio::test]
     async fn working_line_stats_reports_duplicate_rows_for_a_conflict() {
         let (_tmp, dir, repo) = init_line_stats_repo("gd-line-stats-conflict-test-").await;

--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -783,6 +783,74 @@ mod tests {
         assert!(stats.unstaged.is_empty());
     }
 
+    /// The premise behind the Changes panel's conflicted-row gate: numstat emits
+    /// MORE THAN ONE unstaged row for an unmerged path (measured: a zero-count
+    /// row plus the content diff), so a `.get(path)` lookup would surface an
+    /// arbitrary one of them. Pinned here
+    /// because the gate reads as unmotivated once the shape is out of view.
+    #[tokio::test]
+    async fn working_line_stats_reports_duplicate_rows_for_a_conflict() {
+        let (_tmp, dir, repo) = init_line_stats_repo("gd-line-stats-conflict-test-").await;
+
+        std::fs::write(dir.join("file.txt"), "a\nb\nc\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        run_git(Some(&repo), &["commit", "-qm", "seed"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // Both branches are created by name off the seed commit, so the test
+        // never depends on what `git init` called the default branch.
+        for args in [
+            vec!["checkout", "-q", "-b", "mine"],
+            vec!["checkout", "-q", "-b", "other", "mine"],
+        ] {
+            run_git(Some(&repo), &args, DEFAULT_TIMEOUT).await.unwrap();
+        }
+        std::fs::write(dir.join("file.txt"), "a\nOTHER\nc\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        run_git(Some(&repo), &["commit", "-qm", "other"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        run_git(Some(&repo), &["checkout", "-q", "mine"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        std::fs::write(dir.join("file.txt"), "a\nMINE\nc\n").unwrap();
+        run_git(Some(&repo), &["add", "-A"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        run_git(Some(&repo), &["commit", "-qm", "mine"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // The conflicting merge exits non-zero, which `run_git` would turn into
+        // an error — this one spawn takes the raw runner. `--no-edit` so an
+        // unexpectedly clean merge can't block on an editor.
+        let merge = run_git_raw(
+            Some(&repo),
+            &["merge", "--no-edit", "other"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(merge.code, 0, "the merge must actually conflict");
+
+        let stats = git_working_line_stats(repo).await.unwrap();
+        let rows = stats
+            .unstaged
+            .iter()
+            .filter(|e| e.path == "file.txt")
+            .count();
+        assert!(
+            rows > 1,
+            "an unmerged path yields duplicate unstaged rows, got {rows}"
+        );
+    }
+
     const FILE_HEADER: &str = "diff --git a/f.txt b/f.txt\nindex 000..111 100644\n--- a/f.txt\n+++ b/f.txt\n";
 
     fn sel(side: Side, line: u32) -> SelectedLine {

--- a/src-tauri/src/git/submodule.rs
+++ b/src-tauri/src/git/submodule.rs
@@ -638,9 +638,13 @@ mod tests {
     fn allow_file_submodules() {
         static ONCE: std::sync::Once = std::sync::Once::new();
         ONCE.call_once(|| {
-            std::env::set_var("GIT_CONFIG_COUNT", "1");
+            // COUNT lands LAST: git parses the pairs only once COUNT is set, so a
+            // parallel test's git spawn snapshotting the env mid-triple sees either
+            // nothing or a complete set. COUNT-first left a torn `COUNT=1, no KEY_0`
+            // window that 128'd a concurrent spawn (seen live, ubuntu matrix).
             std::env::set_var("GIT_CONFIG_KEY_0", "protocol.file.allow");
             std::env::set_var("GIT_CONFIG_VALUE_0", "always");
+            std::env::set_var("GIT_CONFIG_COUNT", "1");
         });
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,6 +145,7 @@ pub fn run() {
             git::diff::git_diff_file,
             git::diff::git_session_file_diff,
             git::diff::git_staged_diff,
+            git::diff::git_working_line_stats,
             git::diff::git_apply_patch,
             git::diff::git_apply_partial,
             git::diff::git_file_base64,

--- a/src/components/diff-stat.tsx
+++ b/src/components/diff-stat.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The app's one `+added -deleted` line-count span. The `+`/`-` glyphs carry the
+ * meaning on their own, so the success/destructive colors stay decorative
+ * (WCAG AA: never color alone). Callers own size and spacing via `className`;
+ * this component has no opinion beyond `shrink-0` and tabular digits.
+ */
+export function DiffStat({
+  added,
+  deleted,
+  isBinary,
+  format = String,
+  className,
+}: {
+  added: number;
+  deleted: number;
+  isBinary?: boolean;
+  /** Number formatter for sites that abbreviate (Insights uses `fmt`). */
+  format?: (n: number) => string;
+  className?: string;
+}) {
+  if (isBinary) {
+    return (
+      <span className={cn("shrink-0 text-muted-foreground", className)}>
+        bin
+      </span>
+    );
+  }
+  return (
+    <span className={cn("shrink-0 tabular-nums", className)}>
+      <span className="text-success">+{format(added)}</span>{" "}
+      <span className="text-destructive">-{format(deleted)}</span>
+    </span>
+  );
+}

--- a/src/components/diff-stat.tsx
+++ b/src/components/diff-stat.tsx
@@ -29,7 +29,10 @@ export function DiffStat({
   }
   return (
     <span className={cn("shrink-0 tabular-nums", className)}>
-      <span className="text-success">+{format(added)}</span>{" "}
+      <span className="text-success">+{format(added)}</span>
+      {/* Separator for inline callers (a canonical text space). Flex callers
+          bring their own gap and never see it: a whitespace-only anonymous flex
+          item is not rendered (CSS Flexbox §4). */}{" "}
       <span className="text-destructive">-{format(deleted)}</span>
     </span>
   );

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -1,4 +1,5 @@
 import { useDeferredValue, useState } from "react";
+import { DiffStat } from "@/components/diff-stat";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -108,12 +109,11 @@ export function BranchDiffView({
         >
           {files.data.length} file{files.data.length === 1 ? "" : "s"}
         </span>
-        <span className={cn("text-success", PLACEHOLDER_FADE, staleDim)}>
-          +{totalAdded}
-        </span>
-        <span className={cn("text-destructive", PLACEHOLDER_FADE, staleDim)}>
-          -{totalDeleted}
-        </span>
+        <DiffStat
+          added={totalAdded}
+          deleted={totalDeleted}
+          className={cn("flex items-center gap-2", PLACEHOLDER_FADE, staleDim)}
+        />
       </header>
 
       <div className="flex min-h-0 flex-1">
@@ -153,14 +153,11 @@ export function BranchDiffView({
                   <span className="min-w-0 flex-1 truncate font-mono">
                     {file.path}
                   </span>
-                  {file.isBinary ? (
-                    <span className="shrink-0 text-muted-foreground">bin</span>
-                  ) : (
-                    <span className="shrink-0 tabular-nums">
-                      <span className="text-success">+{file.added}</span>{" "}
-                      <span className="text-destructive">-{file.deleted}</span>
-                    </span>
-                  )}
+                  <DiffStat
+                    added={file.added}
+                    deleted={file.deleted}
+                    isBinary={file.isBinary}
+                  />
                 </button>
               ))}
             </FileRowActions>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -367,6 +367,11 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 
 - Click a file to see its diff. Toggle **unified / split** at the top of the diff.
 - Stage or unstage a file with the **+ / −** button on its row, or **Stage all**.
+- File rows show their own **+added -deleted** line counts, left of that button. They
+  count per side, so a file you staged and then edited again shows what's staged on
+  its Staged row and what's still outside it on its Changes row. Binary files read
+  \`bin\`; untracked files show no counts until they're staged, and conflicted rows
+  show none while the conflict is unresolved.
 - **Hunk-level staging** — in a file's diff, each hunk has its own Stage / Unstage /
   Discard buttons.
 - **Line-level staging** — drag across the line-number gutter to select specific lines,

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -2,6 +2,7 @@ import { CopyIcon, DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import { useDeferredValue, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
+import { DiffStat } from "@/components/diff-stat";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -342,16 +343,15 @@ export function CommitDetailView({
             <CopyIcon className="size-3" />
           </button>
           <span className="flex-1" />
-          <span
+          <DiffStat
+            added={totalAdded}
+            deleted={totalDeleted}
             className={cn(
               "flex items-center gap-2",
               PLACEHOLDER_FADE,
               staleDim,
             )}
-          >
-            <span className="text-success">+{totalAdded}</span>
-            <span className="text-destructive">-{totalDeleted}</span>
-          </span>
+          />
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -440,14 +440,11 @@ export function CommitDetailView({
                   <span className="min-w-0 flex-1 truncate font-mono">
                     {file.path}
                   </span>
-                  {file.isBinary ? (
-                    <span className="shrink-0 text-muted-foreground">bin</span>
-                  ) : (
-                    <span className="shrink-0 tabular-nums">
-                      <span className="text-success">+{file.added}</span>{" "}
-                      <span className="text-destructive">-{file.deleted}</span>
-                    </span>
-                  )}
+                  <DiffStat
+                    added={file.added}
+                    deleted={file.deleted}
+                    isBinary={file.isBinary}
+                  />
                 </button>
               ))}
             </FileRowActions>

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -1,5 +1,6 @@
 import { CopyIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
+import { DiffStat } from "@/components/diff-stat";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -238,18 +239,11 @@ export function PrCommitDetail({
                     <span className="min-w-0 flex-1 truncate font-mono">
                       {file.path}
                     </span>
-                    {file.isBinary ? (
-                      <span className="shrink-0 text-muted-foreground">
-                        bin
-                      </span>
-                    ) : (
-                      <span className="shrink-0 tabular-nums">
-                        <span className="text-success">+{file.added}</span>{" "}
-                        <span className="text-destructive">
-                          -{file.deleted}
-                        </span>
-                      </span>
-                    )}
+                    <DiffStat
+                      added={file.added}
+                      deleted={file.deleted}
+                      isBinary={file.isBinary}
+                    />
                   </button>
                 ))}
               </FileRowActions>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -28,6 +28,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DiffStat } from "@/components/diff-stat";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { SelectControl } from "@/components/form/fields";
@@ -2358,8 +2359,11 @@ export function RemotePrView({
           <span className="font-mono">{pr.headRefName}</span>
           <span>→</span>
           <span className="font-mono">{pr.baseRefName}</span>
-          <span className="text-success">+{pr.additions}</span>
-          <span className="text-destructive">-{pr.deletions}</span>
+          <DiffStat
+            added={pr.additions}
+            deleted={pr.deletions}
+            className="flex items-center gap-2"
+          />
         </div>
         {/* Entity-keyed pickers — labels, assignees, projects, reviewers: each
             seeds a draft on open, commits it on close against LIVE props, and a

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -1,5 +1,6 @@
 import { ClockIcon } from "@phosphor-icons/react";
 import { type ComponentProps, useMemo, useState } from "react";
+import { DiffStat } from "@/components/diff-stat";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -264,10 +265,7 @@ export function PrFilesPane({
       title={file.path}
     >
       <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
-      <span className="shrink-0 tabular-nums">
-        <span className="text-success">+{file.additions}</span>{" "}
-        <span className="text-destructive">-{file.deletions}</span>
-      </span>
+      <DiffStat added={file.additions} deleted={file.deletions} />
     </button>
   ));
 

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -41,6 +41,7 @@ import {
   useStashPaths,
   useUnstage,
   useUntrack,
+  useWorkingLineStats,
 } from "@/lib/git/queries";
 import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
@@ -111,7 +112,15 @@ type FlatRow =
   | { type: "header"; section: "staged" | "unstaged"; count: number }
   | { type: "file"; entry: FileEntry; staged: boolean };
 
-export function ChangesPanel({ repoPath }: { repoPath: string }) {
+export function ChangesPanel({
+  repoPath,
+  active,
+}: {
+  repoPath: string;
+  /** The Changes tab is the visible one. A `<TabPanel>`-hidden panel still
+   *  renders, so the line-count poll is gated on this rather than on mounting. */
+  active: boolean;
+}) {
   const status = useRepoStatus(repoPath);
   const stage = useStage(repoPath);
   const unstage = useUnstage(repoPath);
@@ -164,6 +173,24 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
     .map((e) => e.path);
   const canResolveConflicts =
     aiEnabled && reviewConfigured && conflictedPaths.length > 0;
+
+  const lineStats = useWorkingLineStats(repoPath, active && entries.length > 0);
+  const stagedStats = new Map(
+    (lineStats.data?.staged ?? []).map((e) => [e.path, e]),
+  );
+  const unstagedStats = new Map(
+    (lineStats.data?.unstaged ?? []).map((e) => [e.path, e]),
+  );
+  // Each row reads its OWN side, never a shared or summed number: a file staged
+  // and then re-edited shows index-vs-HEAD counts on its Staged row and
+  // worktree-vs-index counts on its Changes row. The kind gate lives here alone —
+  // numstat can't see untracked paths, and emits duplicate noise rows for
+  // conflicted ones, so both render a blank slot.
+  function statFor(entry: FileEntry, staged: boolean) {
+    const kind = staged ? entry.staged : entry.unstaged;
+    if (kind === "untracked" || kind === "conflicted") return undefined;
+    return (staged ? stagedStats : unstagedStats).get(entry.path);
+  }
 
   // Empty-state suggestions: a published repo offers "View on GitHub"; a
   // branch with commits the default branch doesn't have offers a PR. The
@@ -935,6 +962,7 @@ export function ChangesPanel({ repoPath }: { repoPath: string }) {
                             }
                             staged={row.staged}
                             disabled={mutating}
+                            stat={statFor(row.entry, row.staged)}
                             selected={selectedKeys.has(
                               keyOf(row.entry.path, row.staged),
                             )}

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -1,7 +1,8 @@
 import { MinusIcon, PlusIcon } from "@phosphor-icons/react";
 import { memo } from "react";
+import { DiffStat } from "@/components/diff-stat";
 import { Button } from "@/components/ui/button";
-import type { ChangeKind, FileEntry } from "@/lib/git/types";
+import type { ChangeKind, DiffStatEntry, FileEntry } from "@/lib/git/types";
 import { cn } from "@/lib/utils";
 
 const KIND_BADGE: Record<ChangeKind, { letter: string; className: string }> = {
@@ -29,6 +30,7 @@ export const FileRow = memo(function FileRow({
   selected,
   active,
   disabled,
+  stat,
   onSelect,
   onToggle,
 }: {
@@ -40,6 +42,9 @@ export const FileRow = memo(function FileRow({
   /** The active row whose diff is shown (keeps its toggle button visible). */
   active: boolean;
   disabled: boolean;
+  /** This row's OWN side of the diff (staged rows: index vs HEAD; unstaged:
+   *  working tree vs index). Absent = no counts to show. */
+  stat?: DiffStatEntry;
   onSelect: (
     entry: FileEntry,
     staged: boolean,
@@ -85,6 +90,14 @@ export const FileRow = memo(function FileRow({
       <span className="min-w-0 flex-1 truncate" title={label}>
         {label}
       </span>
+      {stat ? (
+        <DiffStat
+          added={stat.added}
+          deleted={stat.deleted}
+          isBinary={stat.isBinary}
+          className="text-[11px]"
+        />
+      ) : null}
       <Button
         variant="ghost"
         size="icon-xs"

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -486,7 +486,7 @@ export function RepositoryView() {
             </TabsList>
           </Tabs>
           <TabPanel active={repoTab === "changes"}>
-            <ChangesPanel repoPath={repoPath} />
+            <ChangesPanel repoPath={repoPath} active={repoTab === "changes"} />
             <CommitBox repoPath={repoPath} />
           </TabPanel>
           <TabPanel active={repoTab === "history"}>

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -418,6 +418,9 @@ export function RepositoryView() {
 
   const secondaryTabs = SECONDARY_TABS.filter((t) => aiEnabled || !t.ai);
   const activeSecondary = secondaryTabs.find((t) => t.tab === repoTab);
+  // One source for panel visibility: ChangesPanel gates its line-count poll on
+  // the same flag that shows the panel, so the two can't drift apart.
+  const changesActive = repoTab === "changes";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -485,8 +488,8 @@ export function RepositoryView() {
               </DropdownMenu>
             </TabsList>
           </Tabs>
-          <TabPanel active={repoTab === "changes"}>
-            <ChangesPanel repoPath={repoPath} active={repoTab === "changes"} />
+          <TabPanel active={changesActive}>
+            <ChangesPanel repoPath={repoPath} active={changesActive} />
             <CommitBox repoPath={repoPath} />
           </TabPanel>
           <TabPanel active={repoTab === "history"}>

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -2,6 +2,7 @@ import { TrashIcon } from "@phosphor-icons/react";
 import { useDeferredValue, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DiffStat } from "@/components/diff-stat";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -573,14 +574,11 @@ function StashFiles({
                 <span className="min-w-0 flex-1 truncate font-mono">
                   {file.path}
                 </span>
-                {file.isBinary ? (
-                  <span className="shrink-0 text-muted-foreground">bin</span>
-                ) : (
-                  <span className="shrink-0 tabular-nums">
-                    <span className="text-success">+{file.added}</span>{" "}
-                    <span className="text-destructive">-{file.deleted}</span>
-                  </span>
-                )}
+                <DiffStat
+                  added={file.added}
+                  deleted={file.deleted}
+                  isBinary={file.isBinary}
+                />
               </button>
             ))}
           </div>

--- a/src/features/repository/insights/InsightsBoard.tsx
+++ b/src/features/repository/insights/InsightsBoard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { DiffStat } from "@/components/diff-stat";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -57,8 +58,11 @@ function ContributorsList({ data }: { data: ContributorChurn[] }) {
             </span>
             <span className="shrink-0 tabular-nums text-muted-foreground">
               {fmt(c.commits)} {c.commits === 1 ? "commit" : "commits"} ·{" "}
-              <span className="text-success">+{fmt(c.additions)}</span>{" "}
-              <span className="text-destructive">−{fmt(c.deletions)}</span>
+              <DiffStat
+                added={c.additions}
+                deleted={c.deletions}
+                format={fmt}
+              />
             </span>
           </div>
           <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">

--- a/src/features/repository/insights/InsightsPanel.tsx
+++ b/src/features/repository/insights/InsightsPanel.tsx
@@ -1,3 +1,4 @@
+import { DiffStat } from "@/components/diff-stat";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   useBranchStats,
@@ -144,12 +145,11 @@ export function InsightsPanel({
                       {fmt(branchStats.data.filesChanged)}
                     </Stat>
                     <Stat label="Lines changed">
-                      <span className="text-success">
-                        +{fmt(branchStats.data.additions)}
-                      </span>{" "}
-                      <span className="text-destructive">
-                        −{fmt(branchStats.data.deletions)}
-                      </span>
+                      <DiffStat
+                        added={branchStats.data.additions}
+                        deleted={branchStats.data.deletions}
+                        format={fmt}
+                      />
                     </Stat>
                     <Stat label="First branch commit">
                       <DateValue date={branchStats.data.firstCommitDate} />

--- a/src/features/repository/insights/charts.tsx
+++ b/src/features/repository/insights/charts.tsx
@@ -124,7 +124,7 @@ export function CodeFrequencyChart({ data }: { data: CodeFreqPoint[] }) {
   const dels = data.reduce((n, d) => n + d.deletions, 0);
   return (
     <ChartFigure
-      caption={`+${fmt(adds)} / −${fmt(dels)} lines across ${data.length} active week${data.length === 1 ? "" : "s"} (deletions shown below the line).`}
+      caption={`+${fmt(adds)} / -${fmt(dels)} lines across ${data.length} active week${data.length === 1 ? "" : "s"} (deletions shown below the line).`}
       table={
         <DataTable
           headers={["Week", "Additions", "Deletions"]}

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -145,6 +145,7 @@ import type {
   Webhook,
   WebhookInput,
   WeekCount,
+  WorkingLineStats,
 } from "./types";
 
 export const checkGitInstalled = () => invoke<GitInfo>("check_git_installed");
@@ -180,6 +181,11 @@ export const createRepo = (options: CreateRepoOptions) =>
 
 export const gitStatus = (repoPath: string) =>
   invoke<RepoStatus>("git_status", { repoPath });
+
+/** Per-file `+added -deleted` counts for the Changes panel's rows, split by
+ *  diff side (`git_status` runs porcelain v2, which carries no line data). */
+export const gitWorkingLineStats = (repoPath: string) =>
+  invoke<WorkingLineStats>("git_working_line_stats", { repoPath });
 
 /** Count of commits on HEAD not on any remote-tracking ref — the "unpublished"
  *  count for a branch with no upstream (where `branch.ahead` is undefined). */

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -228,6 +228,21 @@ export function useRepoStatus(repo: string) {
   });
 }
 
+/** Per-file line counts for the Changes panel's rows. The key MUST stay a child
+ *  of {@link repoKeys.status} — {@link workingTreeKeys} invalidates that key as a
+ *  PREFIX, so every staging-class mutation already refreshes these counts with no
+ *  extra wiring. `enabled` gates it on the Changes tab being active and the tree
+ *  being dirty; a `<TabPanel>`-hidden panel still renders and would otherwise poll. */
+export function useWorkingLineStats(repo: string, enabled: boolean) {
+  return useQuery({
+    queryKey: [...repoKeys.status(repo), "line-stats"],
+    queryFn: () => api.gitWorkingLineStats(repo),
+    enabled,
+    refetchInterval: 5000,
+    refetchIntervalInBackground: false,
+  });
+}
+
 export function useBranches(repo: string) {
   return useQuery({
     queryKey: repoKeys.branches(repo),

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -168,6 +168,15 @@ export interface DiffStatEntry {
   isBinary: boolean;
 }
 
+/** Per-file line counts for the working tree, one list per diff side. Untracked
+ *  paths appear on neither side — numstat only reports tracked changes. */
+export interface WorkingLineStats {
+  /** Index vs HEAD — what the Staged section's rows show. */
+  staged: DiffStatEntry[];
+  /** Working tree vs index — what the Changes section's rows show. */
+  unstaged: DiffStatEntry[];
+}
+
 export interface StagedDiff {
   text: string;
   truncated: boolean;


### PR DESCRIPTION
Adds `+added -deleted` line counts to the file rows in the Changes tab, so you can size a file's change before opening its diff. The counts are computed per diff side, which means a file that is staged and then edited again reports index-vs-HEAD numbers on its Staged row and worktree-vs-index numbers on its Changes row. Along the way, the six existing hand-rolled copies of the `+n -n` span are consolidated into one `DiffStat` component with a repo check that keeps it that way.

### Backend

- Adds the `git_working_line_stats` command in `src-tauri/src/git/diff.rs`, returning a `WorkingLineStats { staged, unstaged }` pair by running `git diff --cached --numstat -z` and `git diff --numstat -z` concurrently via `tokio::try_join!`. It's read-only and lock-free like `status_core`, so it can ride the same 5s poll.
- Registers the command in `src-tauri/src/lib.rs`.
- Adds two tokio tests in `diff.rs`: one proving a staged-then-re-edited file reports different counts per side and that untracked paths appear on neither, and one covering an unborn HEAD (where `git diff --cached` falls back to the empty tree, so no special case is needed). A shared `init_line_stats_repo` helper pins `core.autocrlf` so an inherited global setting can't reshape a line-counting fixture.

### Frontend wiring

- Adds `gitWorkingLineStats` in `src/lib/git/api.ts` and the `WorkingLineStats` type in `src/lib/git/types.ts`.
- Adds `useWorkingLineStats` in `src/lib/git/queries.ts`, keyed as a child of `repoKeys.status` so the existing `workingTreeKeys` prefix invalidation refreshes counts on every staging mutation with no extra wiring. It polls at 5s, not in the background, and is gated by an `enabled` flag.
- `src/features/repository/ChangesPanel.tsx` builds per-side lookup maps and a `statFor` helper that suppresses counts for `untracked` and `conflicted` kinds (numstat can't see the former and emits duplicate noise rows for the latter). The panel takes a new `active` prop — a `<TabPanel>`-hidden panel still renders, so the poll is gated on tab visibility rather than mounting — passed from `src/features/repository/RepositoryView.tsx`.
- `src/features/repository/FileRow.tsx` accepts an optional `stat` and renders it left of the stage/unstage button.

### `DiffStat` component and consolidation

- New `src/components/diff-stat.tsx`: one span for `+added -deleted`, with optional `isBinary` (a muted `bin`) and a `format` hook for sites that abbreviate. The `+`/`-` glyphs carry the meaning so color stays decorative (WCAG AA).
- Replaces the hand-rolled pairs in `BranchDiffView.tsx`, `CommitDetailView.tsx`, `PrCommitDetail.tsx`, `RemotePrView.tsx`, `RemotePrViewParts.tsx`, `StashesDialog.tsx`, `insights/InsightsBoard.tsx`, and `insights/InsightsPanel.tsx` — the last two also normalizing their U+2212 minus onto the canonical glyph via the `format={fmt}` route.
- Adds a `hand-rolled-diff-stat` check to `scripts/check-banned-patterns.mjs` that flags a `text-success` `+{n}` element paired with a nearby `text-destructive` `-{n}` one, matching both minus spellings and allowing a 200-char run to the element's `>` so a realistic `cn(...)` list still pairs. Its bounds and zero-instance exemptions are documented inline.
- Adds four tests in `scripts/checks.test.mjs` covering both minus glyphs, wrapped and long `cn()` class lists, the `DiffStat` route and lone tokens staying clean, and the `appliesTo` exemptions.

### Documentation

- `README.md` — extends the *Changes and commits* paragraph with reading line counts without opening a file.
- `site/src/data/capabilities.ts` — adds "Per-file added/deleted line counts on the changes list" under *Diffs & staging*.
- `src/features/help/content.ts` — documents the per-side counts, the `bin` reading for binaries, and the blank slots for untracked and conflicted rows.
- `changelog.d/added-changes-file-line-counts.md` — the Keep a Changelog bullet.
- `.claude/skills/gd-conventions/SKILL.md` — records `DiffStat` as the one route for these counts and names the new guard.

Relates to #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-file added and deleted line counts to the Changes list.
  * Clearly distinguishes staged and unstaged changes.
  * Displays `bin` for binary files and omits counts for untracked or conflicted files.
  * Standardized diff statistics across commits, branches, pull requests, stashes, and insights.
* **Documentation**
  * Updated documentation and changelog to describe per-file line-count indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->