### PR TITLE
fix(issues,clone,diff,pulls,tags): patch five cross-area defects

### DIFF
--- a/changelog.d/changed-checkout-commit-toast.md
+++ b/changelog.d/changed-checkout-commit-toast.md
@@ -1,2 +1,2 @@
-- Checking out a commit now shows a toast naming the commit and the
+- Checking out a commit or tag now shows a toast naming it and the
   detached HEAD state.

--- a/changelog.d/fixed-clone-local-backslash-path.md
+++ b/changelog.d/fixed-clone-local-backslash-path.md
@@ -1,1 +1,1 @@
-- Cloning from a local Windows path with backslashes (`C:\...`) now works.
+- Cloning from a local Windows path with backslashes (`C:\...`) works.

--- a/changelog.d/fixed-clone-local-backslash-path.md
+++ b/changelog.d/fixed-clone-local-backslash-path.md
@@ -1,0 +1,1 @@
+- Cloning from a local Windows path with backslashes (`C:\...`) now works.

--- a/changelog.d/fixed-diff-stat-screen-reader.md
+++ b/changelog.d/fixed-diff-stat-screen-reader.md
@@ -1,0 +1,2 @@
+- Screen readers now announce line counts as "N added, N deleted" (and binary
+  files as such) everywhere the app shows +/− counts.

--- a/changelog.d/fixed-diff-stat-screen-reader.md
+++ b/changelog.d/fixed-diff-stat-screen-reader.md
@@ -1,2 +1,2 @@
-- Screen readers now announce line counts as "N added, N deleted" (and binary
-  files as such) everywhere the app shows +/− counts.
+- Screen readers now announce line counts as "N lines added, N lines deleted"
+  (and binary files as such) everywhere the app shows +/− counts.

--- a/changelog.d/fixed-local-issues-mcp-refresh.md
+++ b/changelog.d/fixed-local-issues-mcp-refresh.md
@@ -1,0 +1,1 @@
+- Local issues written by MCP agents (new issues, comments, status changes) now appear when the app window regains focus, without a restart.

--- a/changelog.d/fixed-local-issues-mcp-refresh.md
+++ b/changelog.d/fixed-local-issues-mcp-refresh.md
@@ -1,1 +1,2 @@
-- Local issues written by MCP agents (new issues, comments, status changes) now appear when the app window regains focus, without a restart.
+- Local issues written by MCP agents (new issues, comments, status changes) now
+  appear when the app window regains focus, without a restart.

--- a/changelog.d/fixed-pr-task-row-keyboard.md
+++ b/changelog.d/fixed-pr-task-row-keyboard.md
@@ -1,0 +1,1 @@
+- Keyboard-activating a button inside a PR task row (view comment, task menu) now triggers that button instead of toggling the task.

--- a/changelog.d/fixed-pr-task-row-keyboard.md
+++ b/changelog.d/fixed-pr-task-row-keyboard.md
@@ -1,1 +1,2 @@
-- Keyboard-activating a button inside a PR task row (view comment, task menu) now triggers that button instead of toggling the task.
+- Keyboard-activating a button inside a PR task row (view comment, task menu)
+  now triggers that button instead of toggling the task.

--- a/src-tauri/src/git/repo.rs
+++ b/src-tauri/src/git/repo.rs
@@ -242,9 +242,12 @@ pub(crate) async fn clone_repo_core(
     Ok(cloned.to_string_lossy().into_owned())
 }
 
+// The separator set covers every source spelling git accepts — `/` for URLs,
+// `:` for scp-like `git@host:team/repo.git`, `\` for Windows local paths —
+// because the caller rejects any inferred name that still holds a separator.
 fn default_clone_dir_name(url: &str) -> Option<String> {
-    let trimmed = url.trim_end_matches('/');
-    let last = trimmed.rsplit(['/', ':']).next()?;
+    let trimmed = url.trim_end_matches(['/', '\\']);
+    let last = trimmed.rsplit(['/', '\\', ':']).next()?;
     let name = last.trim_end_matches(".git").trim();
     (!name.is_empty()).then(|| name.to_string())
 }
@@ -421,6 +424,41 @@ fn time_year() -> String {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     (1970 + secs / 31_557_600).to_string()
+}
+
+#[cfg(test)]
+mod clone_dir_tests {
+    use super::default_clone_dir_name;
+
+    #[test]
+    fn default_clone_dir_name_reads_a_windows_local_path() {
+        assert_eq!(default_clone_dir_name(r"C:\Users\dev\my-repo"), Some("my-repo".into()));
+    }
+
+    #[test]
+    fn default_clone_dir_name_ignores_a_trailing_backslash() {
+        assert_eq!(default_clone_dir_name(r"C:\Users\dev\my-repo\"), Some("my-repo".into()));
+    }
+
+    #[test]
+    fn default_clone_dir_name_reads_a_unc_path() {
+        assert_eq!(default_clone_dir_name(r"\\server\share\repo"), Some("repo".into()));
+    }
+
+    #[test]
+    fn default_clone_dir_name_reads_urls_and_scp_form() {
+        assert_eq!(default_clone_dir_name("C:/Users/dev/my-repo"), Some("my-repo".into()));
+        assert_eq!(
+            default_clone_dir_name("https://github.com/owner/repo.git"),
+            Some("repo".into())
+        );
+        assert_eq!(default_clone_dir_name("git@host:team/repo.git"), Some("repo".into()));
+    }
+
+    #[test]
+    fn default_clone_dir_name_rejects_a_bare_drive_root() {
+        assert_eq!(default_clone_dir_name(r"C:\"), None);
+    }
 }
 
 #[cfg(test)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,7 @@ import { useBackgroundPrSync } from "@/lib/automations/useBackgroundPrSync";
 import { useGitInstalled } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { useModalGateOpen } from "@/lib/hotkeys/modal-gate";
-import { reloadLocalPrs } from "@/lib/pulls/local";
-import { reloadReviewNotes } from "@/lib/review-notes/store";
+import { MCP_WRITABLE_STORES } from "@/lib/mcp-writable-stores";
 import {
   useApplyTheme,
   useSaveSettings,
@@ -209,26 +208,16 @@ function App() {
       ({ payload: focused }) => {
         if (focused) {
           queryClient.invalidateQueries({ queryKey: ["repo"] });
-          // The MCP server (with --allow-write) can mutate local-prs.json on
-          // disk while we're unfocused; reload the in-memory store from disk
-          // BEFORE invalidating so the refetch sees the external writes.
-          reloadLocalPrs()
-            .then(() =>
-              queryClient.invalidateQueries({ queryKey: ["local-prs"] }),
-            )
-            .catch(() => {
-              // Best-effort: a failed reload just leaves the last known state.
-            });
-          // Same story for review-notes.json — the MCP server can deposit a
-          // per-branch reviewer note while we're unfocused; reload the store
-          // from disk BEFORE invalidating so the refetch sees it.
-          reloadReviewNotes()
-            .then(() =>
-              queryClient.invalidateQueries({ queryKey: ["review-notes"] }),
-            )
-            .catch(() => {
-              // Best-effort: a failed reload just leaves the last known state.
-            });
+          // The MCP server (with --allow-write) can mutate these store files on
+          // disk while we're unfocused; reload each from disk BEFORE invalidating
+          // so the refetch sees the external writes. Each store is independent.
+          for (const { reload, queryKey } of MCP_WRITABLE_STORES) {
+            reload()
+              .then(() => queryClient.invalidateQueries({ queryKey }))
+              .catch(() => {
+                // Best-effort: a failed reload just leaves the last known state.
+              });
+          }
         }
       },
     );

--- a/src/components/diff-stat.tsx
+++ b/src/components/diff-stat.tsx
@@ -4,7 +4,9 @@ import { cn } from "@/lib/utils";
  * The app's one `+added -deleted` line-count span. The `+`/`-` glyphs carry the
  * meaning on their own, so the success/destructive colors stay decorative
  * (WCAG AA: never color alone). Callers own size and spacing via `className`;
- * this component has no opinion beyond `shrink-0` and tabular digits.
+ * this component has no opinion beyond `shrink-0` and tabular digits. The
+ * glyphs are `aria-hidden` behind an `sr-only` name span, which is absolutely
+ * positioned and so never becomes a flex item in a caller's layout.
  */
 export function DiffStat({
   added,
@@ -23,17 +25,27 @@ export function DiffStat({
   if (isBinary) {
     return (
       <span className={cn("shrink-0 text-muted-foreground", className)}>
-        bin
+        <span aria-hidden>bin</span>
+        <span className="sr-only">Binary file</span>
       </span>
     );
   }
   return (
     <span className={cn("shrink-0 tabular-nums", className)}>
-      <span className="text-success">+{format(added)}</span>
+      <span aria-hidden className="text-success">
+        +{format(added)}
+      </span>
       {/* Separator for inline callers (a canonical text space). Flex callers
           bring their own gap and never see it: a whitespace-only anonymous flex
           item is not rendered (CSS Flexbox §4). */}{" "}
-      <span className="text-destructive">-{format(deleted)}</span>
+      <span aria-hidden className="text-destructive">
+        -{format(deleted)}
+      </span>
+      {/* Raw counts, never `format`: an abbreviating caller (Insights) still
+          owes assistive tech the exact numbers. */}
+      <span className="sr-only">
+        {added} added, {deleted} deleted
+      </span>
     </span>
   );
 }

--- a/src/components/diff-stat.tsx
+++ b/src/components/diff-stat.tsx
@@ -44,7 +44,8 @@ export function DiffStat({
       {/* Raw counts, never `format`: an abbreviating caller (Insights) still
           owes assistive tech the exact numbers. */}
       <span className="sr-only">
-        {added} added, {deleted} deleted
+        {added} {added === 1 ? "line" : "lines"} added, {deleted}{" "}
+        {deleted === 1 ? "line" : "lines"} deleted
       </span>
     </span>
   );

--- a/src/features/history/commit-confirms.ts
+++ b/src/features/history/commit-confirms.ts
@@ -1,8 +1,9 @@
 /**
  * The one wording for each commit-level action that changes the working tree or
- * writes history. The History list, the commit detail view's ⋯ menu, and a tag's
- * Checkout all ask through these, so no route can pose a different question than
- * its twin. Prompts go through `useConfirm.getState().ask(...)`.
+ * writes history. The History list, the commit detail view's ⋯ menu, Compare's
+ * commit context menu, and a tag's Checkout all ask through these, so no route
+ * can pose a different question than its twin. Prompts go through
+ * `useConfirm.getState().ask(...)`.
  */
 
 const short = (hash: string) => hash.slice(0, 7);
@@ -20,11 +21,18 @@ export function checkoutDetachedConfirm(kind: "commit" | "tag", name: string) {
 export const checkoutCommitConfirm = (hash: string) =>
   checkoutDetachedConfirm("commit", short(hash));
 
-/** A silent checkout reads as a dead end from Compare, which flips to its
- *  detached-HEAD empty state, so every commit-checkout route reports success
- *  with this same sentence. */
+/** A silent checkout reads as a dead end (Compare flips to its detached-HEAD
+ *  empty state with no acknowledgment), so every checkout route — commit or
+ *  tag — reports success through this one template. */
+const checkedOutDetached = (name: string) =>
+  `Checked out ${name} — HEAD is detached`;
+
 export function checkoutCommitSuccessToast(hash: string) {
-  return `Checked out ${short(hash)} — HEAD is detached`;
+  return checkedOutDetached(short(hash));
+}
+
+export function checkoutTagSuccessToast(tag: string) {
+  return checkedOutDetached(tag);
 }
 
 export const revertCommitConfirm = (hash: string) => ({

--- a/src/features/pulls/PrTasksSection.tsx
+++ b/src/features/pulls/PrTasksSection.tsx
@@ -91,6 +91,9 @@ function TaskRow({
       onFocus={onFocus}
       onClick={editable ? onToggle : undefined}
       onKeyDown={(e) => {
+        // Keys from the nested action buttons pass through untouched, or the
+        // preventDefault below would cancel their native Enter/Space activation.
+        if (e.target !== e.currentTarget) return;
         if (!editable) return;
         if (e.key === " " || e.key === "Enter") {
           e.preventDefault();

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -29,7 +29,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
-import { checkoutDetachedConfirm } from "@/features/history/commit-confirms";
+import {
+  checkoutDetachedConfirm,
+  checkoutTagSuccessToast,
+} from "@/features/history/commit-confirms";
 import { formatBytes } from "@/features/repository/insights/primitives";
 import { presentError } from "@/lib/error-summary";
 import { UPDATER_MANIFEST_NAME } from "@/lib/git/api";
@@ -216,7 +219,7 @@ export function TagDetailView({
       .ask(checkoutDetachedConfirm("tag", tag));
     if (!ok) return;
     checkout.mutate(target, {
-      onSuccess: () => toast.success(`Checked out ${tag}`),
+      onSuccess: () => toast.success(checkoutTagSuccessToast(tag)),
       onError,
     });
   }

--- a/src/features/welcome/clone-utils.ts
+++ b/src/features/welcome/clone-utils.ts
@@ -9,6 +9,11 @@ export function parentDir(p: string): string {
  *  from `default_clone_dir_name` (src-tauri/src/git/repo.rs) and a submodule's
  *  from git itself — keep the separator sets in sync with that Rust twin. */
 export function nameFromUrl(url: string): string {
-  const last = url.trim().replace(/[/\\]+$/, "").split(/[/\\:]/).pop() ?? "";
+  const last =
+    url
+      .trim()
+      .replace(/[/\\]+$/, "")
+      .split(/[/\\:]/)
+      .pop() ?? "";
   return last.replace(/\.git$/, "");
 }

--- a/src/features/welcome/clone-utils.ts
+++ b/src/features/welcome/clone-utils.ts
@@ -4,8 +4,11 @@ export function parentDir(p: string): string {
   return idx > 0 ? p.slice(0, idx) : "";
 }
 
-/** Repo name inferred from a clone URL, for the "will clone into" hint. */
+/** Repo name inferred from a clone URL — the "will clone into" hint and the
+ *  submodule dialog's path placeholder, both advisory: a clone's real name comes
+ *  from `default_clone_dir_name` (src-tauri/src/git/repo.rs) and a submodule's
+ *  from git itself — keep the separator sets in sync with that Rust twin. */
 export function nameFromUrl(url: string): string {
-  const last = url.trim().replace(/\/+$/, "").split(/[/:]/).pop() ?? "";
+  const last = url.trim().replace(/[/\\]+$/, "").split(/[/\\:]/).pop() ?? "";
   return last.replace(/\.git$/, "");
 }

--- a/src/lib/issues/local.ts
+++ b/src/lib/issues/local.ts
@@ -109,10 +109,11 @@ async function writeAll(key: string, issues: LocalIssue[]): Promise<void> {
 }
 
 /** Re-read `local-issues.json` from disk into the in-memory store. The MCP server
- *  (`--allow-write`) writes it out of process (create/comment/status), so this store
- *  is registered in `@/lib/mcp-writable-stores` for the focus sweep's reload; without
- *  it the autoSave store would clobber those writes on the next GUI mutation.
- *  `ignoreDefaults` fully matches the store to disk (so external deletes drop). */
+ *  (`--allow-write`) writes it out of process (create/comment/status); without a
+ *  reload the autoSave store would clobber those writes on the next GUI mutation.
+ *  `ignoreDefaults` fully matches the store to disk (so external deletes drop).
+ *  Registered in `@/lib/mcp-writable-stores` so the focus sweep makes external
+ *  writes visible without a relaunch. */
 export async function reloadLocalIssues(): Promise<void> {
   return serialize(reloadRaw);
 }

--- a/src/lib/issues/local.ts
+++ b/src/lib/issues/local.ts
@@ -108,10 +108,11 @@ async function writeAll(key: string, issues: LocalIssue[]): Promise<void> {
   await store.save();
 }
 
-/** Re-read `local-issues.json` from disk into the in-memory store. Kept symmetric
- *  with the local-PR store's reconcile-before-mutate discipline (see reloadLocalPrs);
- *  local issues have no external writer today, but every mutation reloads first so the
- *  API is uniform and future-proof if one is ever added. */
+/** Re-read `local-issues.json` from disk into the in-memory store. The MCP server
+ *  (`--allow-write`) writes it out of process (create/comment/status), so this store
+ *  is registered in `@/lib/mcp-writable-stores` for the focus sweep's reload; without
+ *  it the autoSave store would clobber those writes on the next GUI mutation.
+ *  `ignoreDefaults` fully matches the store to disk (so external deletes drop). */
 export async function reloadLocalIssues(): Promise<void> {
   return serialize(reloadRaw);
 }

--- a/src/lib/mcp-writable-stores.ts
+++ b/src/lib/mcp-writable-stores.ts
@@ -1,0 +1,21 @@
+import { reloadLocalIssues } from "@/lib/issues/local";
+import { reloadLocalPrs } from "@/lib/pulls/local";
+import { reloadReviewNotes } from "@/lib/review-notes/store";
+
+interface McpWritableStore {
+  /** Re-read the store file from disk into the plugin store's memory cache. */
+  reload: () => Promise<void>;
+  /** Query-key prefix invalidated once the reload lands. */
+  queryKey: readonly string[];
+}
+
+/** Every app-data store the MCP server (`--allow-write`) can mutate out of process
+ *  registers here. The focus sweep reloads each from DISK before invalidating,
+ *  because tauri-plugin-store caches the file in memory — a plain
+ *  invalidate/refetch re-reads the stale snapshot forever. A store missing from
+ *  this table shows external writes only after an app relaunch. */
+export const MCP_WRITABLE_STORES: readonly McpWritableStore[] = [
+  { reload: reloadLocalPrs, queryKey: ["local-prs"] },
+  { reload: reloadReviewNotes, queryKey: ["review-notes"] },
+  { reload: reloadLocalIssues, queryKey: ["local-issues"] },
+];


### PR DESCRIPTION
A batch of five independent defect fixes, each small enough to land together but each with its own changelog fragment. They cover local issues going stale after out-of-process MCP writes, cloning from a Windows local path, screen-reader text for diff line counts, keyboard activation inside PR task rows, and the tag checkout toast wording.

### Local issues refresh on window focus

- Adds `src/lib/mcp-writable-stores.ts`, a `MCP_WRITABLE_STORES` table pairing each store the MCP server can mutate out of process with its `reload` function and the query key to invalidate afterwards. The doc comment records why a plain invalidate is not enough: `tauri-plugin-store` caches the file in memory, so a refetch re-reads the stale snapshot.
- Registers `reloadLocalIssues` alongside the existing `reloadLocalPrs` and `reloadReviewNotes` entries, which is the actual fix — local issues created or commented on by MCP agents previously needed an app relaunch to appear.
- Replaces the two hand-written reload-then-invalidate chains in the focus listener in `src/App.tsx` with a loop over the table, so a future store is one line rather than another copy of the chain.
- Rewrites the `reloadLocalIssues` doc comment in `src/lib/issues/local.ts`, which claimed local issues have no external writer today.

### Cloning from a Windows local path

- `default_clone_dir_name` in `src-tauri/src/git/repo.rs` now trims trailing `\` and splits on `\` in addition to `/` and `:`, so `C:\Users\dev\my-repo` infers `my-repo` instead of tripping the caller's separator rejection.
- Adds a `clone_dir_tests` module covering the Windows path, a trailing backslash, a UNC path, the existing URL and scp-like forms, and a bare drive root that must still return `None`.
- Mirrors the separator set in `nameFromUrl` (`src/features/welcome/clone-utils.ts`) for the "will clone into" hint and the submodule path placeholder, with a comment naming the Rust twin to keep the two in sync.

### Diff stat accessibility

- `src/components/diff-stat.tsx` marks the `+`/`-` glyphs `aria-hidden` and adds an `sr-only` span reading "N added, N deleted"; the binary case gets "Binary file" behind an `aria-hidden` `bin`.
- The screen-reader span uses the raw `added`/`deleted` values rather than `format`, so an abbreviating caller such as Insights still announces exact numbers. The component doc comment notes the `sr-only` span is absolutely positioned and so never becomes a flex item in a caller's layout.

### PR task row keyboard handling

- `TaskRow` in `src/features/pulls/PrTasksSection.tsx` returns early from `onKeyDown` when `e.target !== e.currentTarget`, so Enter/Space on a nested button (view comment, task menu) activates that button instead of being swallowed by the row's `preventDefault` and toggling the task.

### Tag checkout toast

- `src/features/history/commit-confirms.ts` factors the success sentence into a shared `checkedOutDetached` template and exports `checkoutTagSuccessToast` beside `checkoutCommitSuccessToast`.
- `src/features/tags/TagDetailView.tsx` uses it, so checking out a tag now reports the detached HEAD state the same way a commit checkout does. The module doc comment also picks up Compare's commit context menu in its list of callers.

### Changelog

- New fragments: `fixed-local-issues-mcp-refresh.md`, `fixed-clone-local-backslash-path.md`, `fixed-diff-stat-screen-reader.md`, `fixed-pr-task-row-keyboard.md`.
- `changed-checkout-commit-toast.md` is reworded to cover tags as well as commits, since the pending entry described commit-only behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local issues, comments, and status changes now appear after the app regains focus without requiring a restart.
  * Added success notifications when checking out tags.

* **Bug Fixes**
  * Improved cloning from Windows and UNC paths, including paths with trailing backslashes.
  * Screen readers now announce additions, deletions, and binary file statistics clearly.
  * Fixed keyboard activation for actions within pull request task rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->