### PR TITLE
fix(a11y,repository,pulls,git,ci): patch six cross-area defects

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -71,7 +71,10 @@ leave them, don't re-flag them). Never convey meaning by color alone (WCAG AA).
 
 **Keyboard-first.** Every new selectable list gets arrow-key navigation in
 the same change (`listKeyboardNav` in `src/lib/list-keyboard-nav.ts`) — an
-invariant, not polish. Destructive paths stay behind confirmation via the
+invariant, not polish. A list container that co-hosts a text editor (inline
+edit field, reply box) passes `ignoreTextEntry` so arrows keep moving the
+caret; leave it off where arrows deliberately drive nav from a filter input.
+Destructive paths stay behind confirmation via the
 shared `useConfirm`/`ConfirmDialogHost` primitive (`src/lib/stores/confirm.ts`,
 host in `src/components/confirm-dialog-host.tsx`) — never a bespoke confirm
 dialog. Commit-level destructive prompts (checkout, revert, cherry-pick, undo)
@@ -146,6 +149,9 @@ words the user reads on screen — the palette matcher is a plain substring, so
   not a silent gap.
 - Never degrade a surface to dodge machinery: no plain `<pre>` where the app
   highlights, no spinner where skeletons exist.
+- A lazy panel's `Suspense` fallback is `LazyPanelFallback`
+  (`src/components/lazy-panel-fallback.tsx`) — never `fallback={null}`: a blank
+  region has no aria-busy and announces nothing to assistive tech.
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.
@@ -246,7 +252,9 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
 - **User input → git refspecs/argv** routes through the existing chokepoints:
   `validate_ref_name` (git/branches.rs), `validate_tag_name` (git/ops.rs),
   pushes via `build_push_args` (git/remote.rs) — never construct an inline
-  refspec or re-derive the validation.
+  refspec or re-derive the validation. Refs reaching a compare-endpoint
+  basehead route through `forge::validate_compare_branch`
+  (guard: check-rust-invariants check E).
 - **Rust tests never read the real settings store** — use the
   `TEST_STORE_DIR` seam in `app_store.rs` (arm 0 of `store_path`). The other
   app-data modules carry their own seams with the opposite arm order

--- a/.github/workflows/appimage-check.yml
+++ b/.github/workflows/appimage-check.yml
@@ -33,6 +33,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Validate the FORMAT of every pending fragment (finished "- " bullet,
       # 2-space wrapped-line indent, consumable filename), not just presence —
       # a malformed fragment otherwise only surfaces when `pnpm release` trips

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -24,6 +24,8 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
+      # Credentials stay persisted (no `persist-credentials: false` here): the
+      # bump step's `git push` authenticates with this checkout's stored token.
       - name: Checkout tap
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
       body: ${{ steps.extract.outputs.body }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Extract release notes from CHANGELOG
         id: extract
         shell: bash
@@ -59,6 +61,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -96,6 +96,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Decide whether the matrix must run
         id: decide
@@ -305,6 +306,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/changelog.d/fixed-changes-kind-screen-reader.md
+++ b/changelog.d/fixed-changes-kind-screen-reader.md
@@ -1,2 +1,2 @@
-- Screen readers now announce each file's change kind in file lists (Modified,
-  Added, Deleted, …) instead of a bare status letter.
+- Screen readers announce each file's change kind in file lists (Modified,
+  Added, Deleted, …).

--- a/changelog.d/fixed-changes-kind-screen-reader.md
+++ b/changelog.d/fixed-changes-kind-screen-reader.md
@@ -1,0 +1,2 @@
+- Screen readers now announce each file's change kind in file lists (Modified,
+  Added, Deleted, …) instead of a bare status letter.

--- a/changelog.d/fixed-lazy-panel-loading-placeholders.md
+++ b/changelog.d/fixed-lazy-panel-loading-placeholders.md
@@ -1,0 +1,2 @@
+- Slow-loading panels (Insights, Agent sessions, syntax settings) show loading
+  placeholders instead of a blank area.

--- a/changelog.d/fixed-lazy-panel-loading-placeholders.md
+++ b/changelog.d/fixed-lazy-panel-loading-placeholders.md
@@ -1,2 +1,2 @@
-- Slow-loading panels (Insights, Agent sessions, syntax settings) show loading
-  placeholders instead of a blank area.
+- Panels that load on demand (the diff, Insights, Agent sessions, the
+  terminal, syntax settings) show loading placeholders.

--- a/changelog.d/fixed-list-arrows-while-typing.md
+++ b/changelog.d/fixed-list-arrows-while-typing.md
@@ -1,2 +1,1 @@
-- Arrow keys while typing in a task or review editor move the caret again
-  instead of jumping focus to the list.
+- Arrow keys move the caret while typing in task and review editors.

--- a/changelog.d/fixed-list-arrows-while-typing.md
+++ b/changelog.d/fixed-list-arrows-while-typing.md
@@ -1,0 +1,2 @@
+- Arrow keys while typing in a task or review editor move the caret again
+  instead of jumping focus to the list.

--- a/changelog.d/fixed-pr-divergence-ref-validation.md
+++ b/changelog.d/fixed-pr-divergence-ref-validation.md
@@ -1,2 +1,2 @@
-- Fork branch names with special characters can no longer skew a PR's
-  divergence check.
+- A PR's divergence count comes from an exact base…head comparison; a fork
+  head that can't be addressed exactly reads as unknown.

--- a/changelog.d/fixed-pr-divergence-ref-validation.md
+++ b/changelog.d/fixed-pr-divergence-ref-validation.md
@@ -1,0 +1,2 @@
+- Fork branch names with special characters can no longer skew a PR's
+  divergence check.

--- a/changelog.d/fixed-repo-settings-open-polish.md
+++ b/changelog.d/fixed-repo-settings-open-polish.md
@@ -1,0 +1,2 @@
+- Repository settings opens with a single smooth backdrop fade, and keyboard
+  shortcuts stay inside the dialog while it loads.

--- a/changelog.d/fixed-resolve-worktree-long-paths.md
+++ b/changelog.d/fixed-resolve-worktree-long-paths.md
@@ -1,2 +1,3 @@
-- Conflict resolution now works in deeply nested repositories on Windows, and
-  path-length errors explain how to enable long paths for other tools.
+- Git operations run with Windows long-path support, so deeply nested
+  repositories work (including conflict resolution), and path-length errors
+  explain how to enable long paths for other tools.

--- a/changelog.d/fixed-resolve-worktree-long-paths.md
+++ b/changelog.d/fixed-resolve-worktree-long-paths.md
@@ -1,0 +1,2 @@
+- Conflict resolution now works in deeply nested repositories on Windows, and
+  path-length errors explain how to enable long paths for other tools.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -298,6 +298,15 @@ const DIFF_STAT_PAIR_RE = new RegExp(
 // comment stripping is what keeps the many prose mentions of `<Activity>` clean.
 const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
 
+// A `fallback` prop whose value is the literal `null`, on any component — the
+// converted sites were all Suspense, but an ErrorBoundary-style host trips it
+// too; allowlist deliberate cases. Run over the whole-file view because a
+// formatter puts the prop on its own line. Two blind spots, zero instances
+// today: a fallback naming a BINDING that holds null is invisible
+// (DiffSurfaceLazy forwards a `fallback` prop), and so is one built by a
+// conditional — the bare literal is the shape every converted site had.
+const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
+
 export const CHECKS = [
   {
     name: "hover-reveal",
@@ -475,6 +484,14 @@ export const CHECKS = [
     allowlist: ["src/features/repository/RepositoryView.tsx"],
     message:
       "a tab panel's <Activity> must be paired with PanelPortalBoundary and PanelActivityBoundary, or its dialogs and popups strand over the wrong tab — render TabPanel (RepositoryView.tsx) rather than a second <Activity>, or extend the allowlist deliberately for a non-tab Activity",
+  },
+  {
+    name: "null-suspense-fallback",
+    appliesTo: notVendoredUi,
+    scan: perFile(NULL_FALLBACK_RE),
+    allowlist: [],
+    message:
+      "`fallback={null}` blanks the region while the boundary is active, with no aria-busy and nothing announced to assistive tech — lazy panels use LazyPanelFallback (src/components/lazy-panel-fallback.tsx); any other fallback-taking host, or a boundary whose absence is genuinely invisible, needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -301,10 +301,10 @@ const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
 // A `fallback` prop whose value is the literal `null`, on any component — the
 // converted sites were all Suspense, but an ErrorBoundary-style host trips it
 // too; allowlist deliberate cases. Run over the whole-file view because a
-// formatter puts the prop on its own line. Two blind spots, zero instances
-// today: a fallback naming a BINDING that holds null is invisible
-// (DiffSurfaceLazy forwards a `fallback` prop), and so is one built by a
-// conditional — the bare literal is the shape every converted site had.
+// formatter puts the prop on its own line. Two blind spots, no in-repo
+// instances: a fallback naming a BINDING that holds null is invisible, and so
+// is one built by a conditional — the bare literal is the shape every
+// converted site had.
 const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 
 export const CHECKS = [

--- a/scripts/check-dead-surface.mjs
+++ b/scripts/check-dead-surface.mjs
@@ -20,6 +20,12 @@ const SRC = join(root, "src");
 // (2) a call site that builds the command name as a computed string, which the
 // literal-only scan below cannot see. Neither exists now — every call site in
 // the tree passes a bare string literal.
+//
+// RATCHET RULE: the list only shrinks by default. Adding an entry is a reviewed
+// change needing a rationale for which of those two classes it falls in, and an
+// entry that suppresses nothing fails as stale (`staleAllowlistEntries`
+// below) — so a leftover can never pre-authorize whatever takes that name
+// next.
 const ALLOWLIST = [];
 
 /** Registered set: the final `::` segment of every entry in the

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Static gate for four Rust invariants that have each cost this repo a fix
+// Static gate for five Rust invariants that have each cost this repo a fix
 // round. Text-level checks over `src-tauri/src/**/*.rs` — no compiler, no deps,
 // Node built-ins only — so they run anywhere `node` does:
 //
@@ -17,6 +17,11 @@
 //      `GitOutput::full_failure_text()` is the shaping that carries both halves.
 //      Scoped to `AppError::Git` constructions on purpose: the `Gh`/`Glab`
 //      variants are tuple-shaped and their CLIs do not split a report this way.
+//   E. compare basehead — a forge-sourced ref interpolated into a
+//      `…/compare/<base>...<head>` path. `gh api` expands `{…}` as its own
+//      placeholders and a URL parser truncates at `#`/`?`, so an unvalidated
+//      segment answers 200 for the WRONG refs; fork head refs and owners are
+//      attacker-chosen. `forge::validate_compare_branch` is the chokepoint.
 //
 // Each check carries an ALLOWLIST of `{ file, fn, rationale }` records. RATCHET
 // RULE: the lists only shrink by default. Adding an entry is a reviewed change —
@@ -259,6 +264,24 @@ const STDERR_ONLY_ALLOWLIST = [
   },
 ];
 
+// Check E. Both sites route every interpolated segment — base, head, and the
+// cross-repo owner sharing the head's path segment — through
+// `forge::validate_compare_branch`, verified by reading each one.
+const COMPARE_ENDPOINT_ALLOWLIST = [
+  {
+    file: "forge/github.rs",
+    fn: "fork_divergence",
+    rationale:
+      "its only caller (forge::forge_fork_divergence) validates base_branch and fork_branch with validate_compare_branch, and the owner via fork_owner_from_full_name, before dispatch",
+  },
+  {
+    file: "github/pr.rs",
+    fn: "build_divergence_compare_path",
+    rationale:
+      "validates base, head and the cross-repository owner with validate_compare_branch at fn entry",
+  },
+];
+
 // ------------------------------------------------------------------- helpers
 
 /** Every `.rs` file under `src-tauri/src`, as absolute paths. */
@@ -326,6 +349,35 @@ export function checkRefspecTemplates(file, src, lines, hits) {
       fn,
       allowlisted: allowed(REFSPEC_ALLOWLIST, file, fn),
       fix: REFSPEC_FIX,
+    });
+  }
+}
+
+// A `format!` template whose `…/compare/…` path interpolates ANYTHING after
+// the `/compare/` marker — that tail is the basehead, the only part a
+// forge-sourced ref reaches. A fully literal compare path is not a hit
+// (nothing to inject), and, like check A, a path built by `push_str`/`+` is
+// invisible here by construction — that is what the allowlist is for.
+const COMPARE_MARKER = "/compare/";
+const COMPARE_FIX =
+  "refs reaching a compare basehead route through " +
+  "forge::validate_compare_branch (gh expands `{…}` as placeholders; `#`/`?` " +
+  "truncate the path) — validate, or allowlist with rationale";
+
+export function checkCompareEndpoints(file, src, lines, hits) {
+  FORMAT_RE.lastIndex = 0;
+  for (let m = FORMAT_RE.exec(src); m; m = FORMAT_RE.exec(src)) {
+    const at = m[1].indexOf(COMPARE_MARKER);
+    if (at < 0) continue;
+    if (!m[1].slice(at + COMPARE_MARKER.length).includes("{")) continue;
+    const line = src.slice(0, m.index).split("\n").length;
+    const fn = enclosingFn(lines, line - 1);
+    hits.push({
+      file,
+      line,
+      fn,
+      allowlisted: allowed(COMPARE_ENDPOINT_ALLOWLIST, file, fn),
+      fix: COMPARE_FIX,
     });
   }
 }
@@ -679,6 +731,12 @@ function main() {
       name: "D. stderr-only AppError::Git",
       run: checkStderrOnlyGitError,
       allowlist: STDERR_ONLY_ALLOWLIST,
+      hits: [],
+    },
+    {
+      name: "E. compare basehead",
+      run: checkCompareEndpoints,
+      allowlist: COMPARE_ENDPOINT_ALLOWLIST,
       hits: [],
     },
   ];

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -23,6 +23,7 @@ import {
   staleAllowlistEntries as staleCommandEntries,
 } from "./check-dead-surface.mjs";
 import {
+  checkCompareEndpoints,
   checkRefspecTemplates,
   checkSecretArgv,
   checkStderrOnlyGitError,
@@ -50,6 +51,7 @@ const menuSuppression = scanner("context-menu-suppression");
 const loneActivity = scanner("lone-activity-boundary");
 const seedOnOpen = scanner("seed-effect-on-open");
 const diffStatPair = scanner("hand-rolled-diff-stat");
+const nullFallback = scanner("null-suspense-fallback");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -589,6 +591,31 @@ test("hand-rolled-diff-stat exempts the component file and vendored ui only", ()
   assert.equal(appliesTo("src/features/repository/FileRow.tsx"), true);
 });
 
+test("null-suspense-fallback flags the literal on one line or wrapped", () => {
+  assert.deepEqual(nullFallback("<Suspense fallback={null}>{kids}</Suspense>"), [
+    1,
+  ]);
+  // The formatter's shape: the prop on its own line, with inner spacing.
+  const wrapped = [
+    "<Suspense",
+    "  fallback={ null }",
+    ">",
+    "  <InsightsBoard />",
+    "</Suspense>",
+  ].join("\n");
+  assert.deepEqual(nullFallback(wrapped), [2]);
+});
+
+test("null-suspense-fallback leaves a real fallback and a forwarded prop alone", () => {
+  for (const source of [
+    '<Suspense fallback={<LazyPanelFallback name="Insights" />}>{kids}</Suspense>',
+    // DiffSurfaceLazy forwards its own `fallback` prop — a binding, not a literal.
+    "<Suspense fallback={fallback}>{kids}</Suspense>",
+    "<Suspense fallback={compact ? null : <Skeleton />}>{kids}</Suspense>",
+  ])
+    assert.deepEqual(nullFallback(source), [], `should ignore ${source}`);
+});
+
 test("an allowlist entry whose file no longer has the pattern is stale", () => {
   // Allowlisted files are scanned, not skipped: a live entry suppresses its hit
   // and stays; an entry with nothing left to suppress is reported so the ratchet
@@ -693,6 +720,39 @@ test("refspec-template check ignores format! templates with no ref marker", () =
   const hits = [];
   checkRefspecTemplates("fixture.rs", src, src.split("\n"), hits);
   assert.deepEqual(hits, []);
+});
+
+test("compare-endpoint check flags an interpolated basehead, either side", () => {
+  for (const template of [
+    "repos/{slug}/compare/{base}...{head}",
+    // Only the head interpolates — still the injectable half.
+    "repos/{slug}/compare/main...{head}",
+    "repos/{slug}/compare/{base}...{owner}:{branch}?per_page=1",
+  ]) {
+    const src = ["fn build() -> String {", `    format!("${template}")`, "}"].join(
+      "\n",
+    );
+    const hits = [];
+    checkCompareEndpoints("fixture.rs", src, src.split("\n"), hits);
+    assert.equal(hits.length, 1, `should flag ${template}`);
+    assert.equal(hits[0].fn, "build");
+    assert.equal(hits[0].allowlisted, false);
+  }
+});
+
+test("compare-endpoint check ignores a fully literal path and the slug alone", () => {
+  for (const template of [
+    // Nothing after the marker interpolates — no segment an attacker reaches.
+    "repos/{slug}/compare/main...dev",
+    "repos/{slug}/pulls/{number}",
+  ]) {
+    const src = ["fn build() -> String {", `    format!("${template}")`, "}"].join(
+      "\n",
+    );
+    const hits = [];
+    checkCompareEndpoints("fixture.rs", src, src.split("\n"), hits);
+    assert.deepEqual(hits, [], `should ignore ${template}`);
+  }
 });
 
 test("secret-shaped argv is caught next to a -f-family flag", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -609,7 +609,7 @@ test("null-suspense-fallback flags the literal on one line or wrapped", () => {
 test("null-suspense-fallback leaves a real fallback and a forwarded prop alone", () => {
   for (const source of [
     '<Suspense fallback={<LazyPanelFallback name="Insights" />}>{kids}</Suspense>',
-    // DiffSurfaceLazy forwards its own `fallback` prop — a binding, not a literal.
+    // A fallback naming a binding, not a literal — outside the check's shape.
     "<Suspense fallback={fallback}>{kids}</Suspense>",
     "<Suspense fallback={compact ? null : <Skeleton />}>{kids}</Suspense>",
   ])

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -7675,10 +7675,10 @@ fn map_protected_branch(pb: GlabProtectedBranch) -> GitLabProtectedBranch {
 
 /// A protection's `name` must survive as a single path segment (`update`/`delete`
 /// address it in the URL) and can't be blank.
-fn validate_branch_name(name: &str) -> AppResult<()> {
+fn validate_protection_name(name: &str) -> AppResult<()> {
     if name.trim().is_empty() {
         return Err(AppError::InvalidArgument(
-            "branch name can't be empty".into(),
+            "protection name can't be empty".into(),
         ));
     }
     Ok(())
@@ -7723,7 +7723,7 @@ pub async fn create_protected_branch(
     merge_access_level: u8,
     allow_force_push: bool,
 ) -> AppResult<()> {
-    validate_branch_name(name)?;
+    validate_protection_name(name)?;
     validate_protected_access_level(push_access_level)?;
     validate_protected_access_level(merge_access_level)?;
     let enc = encode_project(&project_path(repo_path).await?);
@@ -7751,7 +7751,7 @@ pub async fn update_protected_branch(
     name: &str,
     allow_force_push: bool,
 ) -> AppResult<()> {
-    validate_branch_name(name)?;
+    validate_protection_name(name)?;
     let enc = encode_project(&project_path(repo_path).await?);
     // The name rides the URL as a single path segment — percent-encode it so
     // wildcards (`*`) and `/` in wildcard names survive.
@@ -7770,7 +7770,7 @@ pub async fn update_protected_branch(
 }
 
 pub async fn delete_protected_branch(repo_path: &str, name: &str) -> AppResult<()> {
-    validate_branch_name(name)?;
+    validate_protection_name(name)?;
     let enc = encode_project(&project_path(repo_path).await?);
     let endpoint = format!(
         "projects/{enc}/protected_branches/{}",

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -7678,7 +7678,7 @@ fn map_protected_branch(pb: GlabProtectedBranch) -> GitLabProtectedBranch {
 fn validate_protection_name(name: &str) -> AppResult<()> {
     if name.trim().is_empty() {
         return Err(AppError::InvalidArgument(
-            "protection name can't be empty".into(),
+            "a branch name or wildcard pattern is required".into(),
         ));
     }
     Ok(())

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -2990,7 +2990,7 @@ fn fork_owner_from_full_name(full_name: &str) -> AppResult<String> {
 /// `{branch}`-style placeholders in the endpoint to local repo values. Any of these
 /// would make the API answer 200 for the WRONG branch, which renders as a
 /// confident number.
-fn validate_compare_branch(branch: &str) -> AppResult<()> {
+pub(crate) fn validate_compare_branch(branch: &str) -> AppResult<()> {
     if branch.is_empty()
         || branch.starts_with('-')
         || branch.contains("..")

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -1389,7 +1389,10 @@ mod tests {
         let err = git_merge_autostash_core(&state, repo.clone(), "feat".into())
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::InvalidArgument(_)), "{err:?}");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("conflict is in progress")),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]
@@ -1415,7 +1418,10 @@ mod tests {
         let err = git_merge_autostash_core(&state, repo.clone(), "feat".into())
             .await
             .unwrap_err();
-        assert!(matches!(err, AppError::InvalidArgument(_)), "{err:?}");
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("merge, rebase, cherry-pick or revert is in progress")),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1251,9 +1251,10 @@ fn unique_suffix() -> String {
 mod tests {
     use super::{
         branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args,
-        divergence_out_of_range, git_branches, git_create_branch_core, git_default_branch,
-        git_rename_branch_core, parse_cherry_counts, parse_upstream_track, update_branch_from,
-        validate_branch_name, validate_ref_name, BranchRewriteStatus,
+        divergence_out_of_range, git_branch_merge_states, git_branches, git_create_branch_core,
+        git_default_branch, git_rename_branch_core, parse_cherry_counts, parse_upstream_track,
+        update_branch_from, validate_branch_name, validate_ref_name, BranchRewriteStatus,
+        MergePair,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -2294,6 +2295,118 @@ mod tests {
                 divergence_out_of_range(bad, 200, 1000),
                 "{bad:?} is unreadable and must gate out"
             );
+        }
+    }
+
+    /// `git_branch_merge_states` answers a SHAPE, never an error: a name the branch
+    /// gate refuses reads as `merged: false, head_exists: false`. The rows that
+    /// discriminate are the ones `rev-parse --verify refs/heads/<name>` RESOLVES
+    /// (`feature~1`, `<base>^`, `feature^{commit}`) — ungated, those report a live
+    /// branch and an ancestor-merged verdict for a ref no branch is at.
+    #[tokio::test]
+    async fn branch_merge_states_refuse_rev_expressions_as_unmerged_and_absent() {
+        let (_base, base_dir) = temp_base("merge-states-revs");
+        let repo = base_dir.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "a.txt").await;
+
+        // Two commits on the base branch, so `<base>^` resolves; `landed` sits at
+        // that tip (merged), `feature` one commit past it (not merged).
+        let base = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+        std::fs::write(repo.join("a.txt"), "second\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "second"]).await;
+        run(&repo_s, &["branch", "landed"]).await;
+        run(&repo_s, &["switch", "-qc", "feature"]).await;
+        std::fs::write(repo.join("a.txt"), "feature\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "feature edit"]).await;
+        run(&repo_s, &["switch", "-q", &base]).await;
+
+        let pair = |b: &str, h: &str| MergePair {
+            base: b.to_string(),
+            head: h.to_string(),
+        };
+        // The probe itself works: a merged branch and an unmerged one, both live.
+        let states = git_branch_merge_states(
+            repo_s.clone(),
+            vec![pair(&base, "landed"), pair(&base, "feature")],
+        )
+        .await
+        .expect("real pairs resolve");
+        assert_eq!((states[0].merged, states[0].head_exists), (true, true));
+        assert_eq!((states[1].merged, states[1].head_exists), (false, true));
+
+        // HEAD side: every rev shape and refspec metacharacter reads absent.
+        for head in [
+            "feature~1",
+            &format!("{base}^"),
+            "feature^{commit}",
+            "HEAD@{1}",
+            &format!("{base}..feature"),
+            "@",
+            "a*b",
+            "a:b",
+        ] {
+            let states = git_branch_merge_states(repo_s.clone(), vec![pair(&base, head)])
+                .await
+                .expect("a refused name is a shape, not an error");
+            assert_eq!(
+                (states[0].merged, states[0].head_exists),
+                (false, false),
+                "head {head:?}"
+            );
+        }
+
+        // BASE side: the head stays live, but nothing may be reported merged INTO a
+        // rev expression. `feature~1` and `feature^{commit}` both have `landed` as
+        // an ancestor, so an ungated base flips `merged` to true.
+        for bad_base in ["feature~1", "feature^{commit}", "@", "a*b"] {
+            let states = git_branch_merge_states(repo_s.clone(), vec![pair(bad_base, "landed")])
+                .await
+                .expect("a refused base is a shape, not an error");
+            assert_eq!(
+                (states[0].merged, states[0].head_exists),
+                (false, true),
+                "base {bad_base:?}"
+            );
+        }
+    }
+
+    /// `update_branch_from` merges into `refs/heads/<branch>` and merges `<base>`,
+    /// so both must name a BRANCH: a rev expression would resolve and merge an
+    /// ancestor. Asserts the gate's MESSAGE — the function raises `InvalidArgument`
+    /// for a self-update too, which a variant-only match could not tell apart.
+    #[tokio::test]
+    async fn update_branch_from_rejects_rev_expressions_on_both_sides() {
+        let (_base, base_dir) = temp_base("update-from-revs");
+        let repo = base_dir.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "a.txt").await;
+        run(&repo_s, &["branch", "feature"]).await;
+
+        let state = AppState::default();
+        for bad in [
+            "feature~1",
+            "main^",
+            "HEAD@{1}",
+            "main..other",
+            "a^{commit}",
+            "@",
+            "a*b",
+        ] {
+            for (branch, base) in [(bad, "feature"), ("feature", bad)] {
+                let err = update_branch_from(&state, &repo_s, branch, base)
+                    .await
+                    .unwrap_err();
+                assert!(
+                    matches!(&err, AppError::InvalidArgument(m) if m.contains("invalid branch name")),
+                    "{branch:?} from {base:?} got: {err:?}"
+                );
+            }
         }
     }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2500,7 +2500,7 @@ pub(crate) fn parse_worktree_paths(porcelain: &str) -> Vec<String> {
 
 /// Whether a worktree path is one of our resolve worktrees — its final path
 /// segment starts with `gd-resolve-`. The basename is the reliable signal:
-/// `git_merge_local_pr` names them `gd-resolve-<uuid>`, and porcelain may
+/// `git_merge_local_pr` names them `gd-resolve-<id>`, and porcelain may
 /// normalize the leading path so an app-data-root prefix check is less robust.
 fn is_resolve_worktree_path(path: &str) -> bool {
     std::path::Path::new(path)
@@ -2516,7 +2516,9 @@ fn is_resolve_worktree_path(path: &str) -> bool {
 /// A collision at 48 random bits stays unreachable, and would be refused rather
 /// than reused: `worktree add` fails on a registered or non-empty path.
 fn new_resolve_worktree_id() -> String {
-    uuid::Uuid::new_v4().simple().to_string()[..12].to_string()
+    let mut id = uuid::Uuid::new_v4().simple().to_string();
+    id.truncate(12);
+    id
 }
 
 /// Pure decision for [`git_cleanup_orphaned_resolve_worktrees`]: from all
@@ -3110,7 +3112,7 @@ pub async fn git_abort_local_pr_merge(
     Ok(())
 }
 
-/// Sweeps orphaned resolve worktrees (`gd-resolve-<uuid>`) left under the app-data
+/// Sweeps orphaned resolve worktrees (`gd-resolve-<id>`) left under the app-data
 /// root by a paused local-PR merge. The only live handle to one is a local PR's
 /// `pendingMerge`, so a crash mid-resolve (or a lost PR) orphans it with no UI path
 /// to remove it — being detached, the user-facing worktree manager excludes it. The

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2510,6 +2510,15 @@ fn is_resolve_worktree_path(path: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// A fresh resolve-worktree id: the first 12 hex chars of a v4 uuid. Short
+/// deliberately — every path in the checkout is measured from this directory, and
+/// a full 36-char uuid spent much of Windows' 260-char budget on the name alone.
+/// A collision at 48 random bits stays unreachable, and would be refused rather
+/// than reused: `worktree add` fails on a registered or non-empty path.
+fn new_resolve_worktree_id() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..12].to_string()
+}
+
 /// Pure decision for [`git_cleanup_orphaned_resolve_worktrees`]: from all
 /// worktree paths, pick the resolve worktrees (basename `gd-resolve-*`) whose
 /// normalized path is NOT among `keep`. Normalization matches how the app
@@ -2767,7 +2776,7 @@ pub(crate) async fn merge_local_pr(
     .await;
 
     // Create the isolated DETACHED resolve worktree at base's tip.
-    let worktree_id = uuid::Uuid::new_v4().to_string();
+    let worktree_id = new_resolve_worktree_id();
     let worktree_path = root.join(format!("gd-resolve-{worktree_id}"));
     let worktree_path = worktree_path.to_string_lossy().into_owned();
     if let Err(e) = std::fs::create_dir_all(root) {
@@ -7102,6 +7111,26 @@ detached
         assert_eq!(all_orphans.len(), 2);
     }
 
+    /// The directory name is a Windows MAX_PATH budget item — every path inside
+    /// the checkout is measured from it — and it is also what the orphan sweep
+    /// recognizes, so both the length and the prefix are pinned here.
+    #[test]
+    fn resolve_worktree_id_is_12_hex_under_the_gd_resolve_prefix() {
+        let id = super::new_resolve_worktree_id();
+        assert_eq!(id.len(), 12, "id was {id}");
+        assert!(
+            id.bytes().all(|b| b.is_ascii_hexdigit()),
+            "id must be bare hex (no dashes, no braces): {id}"
+        );
+        assert_ne!(id, super::new_resolve_worktree_id());
+
+        let name = format!("gd-resolve-{id}");
+        assert_eq!(name.len(), 23, "name was {name}");
+        assert!(is_resolve_worktree_path(&format!(
+            "C:/data/worktrees/h/{name}"
+        )));
+    }
+
     #[test]
     fn repo_hash_is_case_insensitive_and_16_hex() {
         // Mirrors worktree.rs::repo_hash's contract: case-insensitive (Windows
@@ -8616,12 +8645,14 @@ detached
             .await
             .unwrap_err();
         assert!(err.to_string().contains("upstream"), "got: {err}");
-        // An unknown lens never reaches git at all.
+        // An unknown lens never reaches git at all. The MESSAGE again: a known lens
+        // whose remote is missing raises `InvalidArgument` too, so a variant-only
+        // assertion here passes whether the lens set or the remote lookup refused.
         let err = merge_remote_pr(&state, &repo, 5, "main", "feature", None, Some("fork"), &root)
             .await
             .unwrap_err();
         assert!(
-            matches!(err, AppError::InvalidArgument(_)),
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("unknown remote lens")),
             "got: {err:?}"
         );
 
@@ -8630,6 +8661,54 @@ detached
         let wts = git(&repo, &["worktree", "list", "--porcelain"]).await;
         assert!(!wts.contains("gd-pr-resolve-"), "{wts}");
         assert!(dir.path().join("a.txt").exists(), "the tree is untouched");
+    }
+
+    /// Finishing a resolve pushes to `refs/heads/<head>` on the lens remote, so the
+    /// head must name a BRANCH: a rev expression would resolve locally and push the
+    /// wrong commit. The gate runs before the remote lookup, and the assertion is on
+    /// its MESSAGE — this clone has no remotes, so `resolve_pr_remote` raises
+    /// `InvalidArgument` for every input and a variant-only match would be vacuous
+    /// (proven by the valid-head row below).
+    #[tokio::test]
+    async fn finish_remote_pr_resolve_rejects_rev_expressions_in_the_head() {
+        let (_dir, repo) = setup_repo("frpr-validate").await;
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let wt = root.join("gd-pr-resolve-origin-5-abcdef").to_string_lossy().into_owned();
+        let state = AppState::default();
+
+        for bad in [
+            "feature~1",
+            "main^",
+            "HEAD@{1}",
+            "main..other",
+            "a^{commit}",
+            "@",
+            "a*b",
+            "a:b",
+        ] {
+            let err = finish_remote_pr_resolve(
+                &state, &repo, bad, &wt, "abcdef", None, None, &root,
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                matches!(&err, AppError::InvalidArgument(m) if m.contains("invalid branch name")),
+                "{bad:?} got: {err:?}"
+            );
+        }
+
+        // The confounder, live: a VALID head gets the same variant from the remote
+        // lookup instead — only the message tells the two gates apart.
+        let err = finish_remote_pr_resolve(
+            &state, &repo, "feature", &wt, "abcdef", None, None, &root,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArgument(m) if m.contains("remote does not exist")),
+            "got: {err:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -1848,6 +1848,9 @@ mod tests {
     /// A destination branch name is meaningless without both an explicit branch and
     /// an explicit remote, so those combinations are refused rather than silently
     /// dropping the destination. Guarded before any git call — no repo needed.
+    /// The MESSAGE is the assertion: the remote-without-branch row would ALSO be
+    /// satisfied by the next guard's "remote requires an explicit branch", so a
+    /// variant-only match cannot tell which one refused it.
     #[tokio::test]
     async fn remote_branch_requires_both_branch_and_remote() {
         let state = AppState::default();
@@ -1868,7 +1871,7 @@ mod tests {
             .await
             .expect_err("a lone remote_branch is refused");
             assert!(
-                matches!(err, AppError::InvalidArgument(_)),
+                matches!(&err, AppError::InvalidArgument(m) if m.contains("remote branch requires")),
                 "branch={branch:?} remote={remote:?} → {err:?}"
             );
         }

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -228,7 +228,17 @@ pub async fn run_git_raw_input(
     let mut cmd = Command::new(&git);
     // Also covers the credential helpers git spawns in turn.
     crate::agent::sanitize_child_env(&mut cmd);
-    cmd.args(["-c", "core.quotePath=false", "-c", "color.ui=false"]);
+    // Git for Windows gates long-path support on core.longpaths — the OS
+    // LongPathsEnabled flag alone is not enough (probe-proven). Per-invocation so
+    // the user's own git config is never mutated; other platforms ignore the key.
+    cmd.args([
+        "-c",
+        "core.quotePath=false",
+        "-c",
+        "color.ui=false",
+        "-c",
+        "core.longpaths=true",
+    ]);
     cmd.args(args);
     if let Some(repo) = repo_path {
         cmd.current_dir(repo);
@@ -524,6 +534,41 @@ mod stdin_tests {
             assert_eq!(tokens[i * 4 + 1], b"1");
             assert_eq!(tokens[i * 4 + 2], b"*");
             assert_eq!(tokens[i * 4 + 3], path.as_bytes(), "record {i}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    /// The per-invocation `-c` block is a behavior contract, not a preference:
+    /// `core.longpaths` is what lets Git for Windows write past 260 chars, and
+    /// the parse/color settings are what every output parser in the app assumes.
+    /// Read back through git so the assertion covers the value REACHING the
+    /// child, not merely the argv we build.
+    #[tokio::test]
+    async fn injected_config_reaches_git() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-runner-config-")
+            .tempdir()
+            .expect("create temp dir");
+        let repo = dir.path().to_string_lossy().into_owned();
+        run_git(Some(&repo), &["init", "-q"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+
+        // `-c` is the command-line scope, which outranks the machine's own
+        // system/global/local config — so this holds on any dev box.
+        for (key, want) in [
+            ("core.longpaths", "true"),
+            ("core.quotepath", "false"),
+            ("color.ui", "false"),
+        ] {
+            let out = run_git(Some(&repo), &["config", "--get", key], DEFAULT_TIMEOUT)
+                .await
+                .unwrap_or_else(|e| panic!("read {key}: {e}"));
+            assert_eq!(out.stdout_lossy().trim(), want, "{key}");
         }
     }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1133,8 +1133,8 @@ struct RawDivergenceRefs {
     head_repository_owner: Option<RawLogin>,
 }
 
-/// The compare endpoint for a PR's base…head. Every interpolated segment goes
-/// through the shared basehead grammar first: all three arrive from `gh pr view`
+/// The compare endpoint for a PR's base…head. Every basehead segment goes
+/// through the shared grammar first: all three arrive from `gh pr view`
 /// and a fork's head ref and owner are attacker-chosen, while `gh api` expands
 /// `{…}` placeholders and a URL parser truncates at `#`/`?` — either would answer
 /// 200 for the WRONG refs. The owner rides the same validator because it occupies

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AppError, AppResult};
 use crate::forge::gitlab::null_to_default;
 use crate::forge::model::{ForgeTimelineEventOut, ForgeUserRef};
+use crate::forge::validate_compare_branch;
 use crate::git::runner::{run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
 use crate::github::issue::{map_reaction_groups, repo_owner_name, IssueReactions};
 use crate::github::runner::{run_gh, run_gh_input, run_gh_raw, GH_NETWORK_TIMEOUT, GH_TIMEOUT};
@@ -1132,6 +1133,40 @@ struct RawDivergenceRefs {
     head_repository_owner: Option<RawLogin>,
 }
 
+/// The compare endpoint for a PR's base…head. Every interpolated segment goes
+/// through the shared basehead grammar first: all three arrive from `gh pr view`
+/// and a fork's head ref and owner are attacker-chosen, while `gh api` expands
+/// `{…}` placeholders and a URL parser truncates at `#`/`?` — either would answer
+/// 200 for the WRONG refs. The owner rides the same validator because it occupies
+/// the same path segment; one chokepoint keeps the class closed.
+fn build_divergence_compare_path(slug: &str, refs: &RawDivergenceRefs) -> AppResult<String> {
+    validate_compare_branch(&refs.base_ref_name)?;
+    validate_compare_branch(&refs.head_ref_name)?;
+    // A fork PR's head lives in another repo, so the compare must address it as
+    // `owner:branch` — a bare branch name would resolve against the BASE repo and
+    // compare the wrong (or a nonexistent) ref.
+    let head = match refs
+        .head_repository_owner
+        .as_ref()
+        .map(|o| o.login.as_str())
+        .filter(|_| refs.is_cross_repository)
+        .filter(|s| !s.is_empty())
+    {
+        Some(owner) => {
+            validate_compare_branch(owner)?;
+            format!("{owner}:{}", refs.head_ref_name)
+        }
+        None => refs.head_ref_name.clone(),
+    };
+    // Branch names ride the basehead unencoded: GitHub's capture is greedy and a
+    // git ref name can never contain `..`, so the `...` separator stays
+    // unambiguous even for slashed names (probed live 2026-08-11).
+    Ok(format!(
+        "repos/{slug}/compare/{}...{head}",
+        refs.base_ref_name
+    ))
+}
+
 /// `ahead_by`/`behind_by` from the REST compare payload (snake_case on the wire,
 /// unlike the GraphQL surfaces gh's `--json` projections expose).
 #[derive(Deserialize)]
@@ -1173,22 +1208,9 @@ pub async fn gh_pr_base_divergence(
             "GitHub reported no base/head refs for #{number}"
         )));
     }
-    // A fork PR's head lives in another repo, so the compare must address it as
-    // `owner:branch` — a bare branch name would resolve against the BASE repo and
-    // compare the wrong (or a nonexistent) ref.
-    let head = match refs
-        .head_repository_owner
-        .map(|o| o.login)
-        .filter(|_| refs.is_cross_repository)
-        .filter(|s| !s.is_empty())
-    {
-        Some(owner) => format!("{owner}:{}", refs.head_ref_name),
-        None => refs.head_ref_name.clone(),
-    };
-    // Branch names ride the basehead unencoded: GitHub's capture is greedy and a
-    // git ref name can never contain `..`, so the `...` separator stays
-    // unambiguous even for slashed names (probed live 2026-08-11).
-    let endpoint = format!("repos/{slug}/compare/{}...{head}", refs.base_ref_name);
+    // Validated before the compare dispatch: the refs are API-sourced, so this is
+    // the first point they can be checked.
+    let endpoint = build_divergence_compare_path(&slug, &refs)?;
     let out = run_gh(Some(&repo_path), &["api", &endpoint], GH_NETWORK_TIMEOUT).await?;
     let compare: RawCompare = serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse compare: {e}")))?;
@@ -5778,8 +5800,9 @@ mod tests {
         GhStackEntry, MergeAsyncOutcome, MergeAsyncStatus, PrDetails, PrInfo, PrMergeOutcome,
         GhMergeabilityRow, PrMergeability, PrPollInfo, PrStackInfo, PrStackMember,
         ForgeTimelineEventOut,
-        batch_check_present, oid_outside_origin_graph, select_fork_pr_match, validate_branch,
-        ForkPrMatch, RawForkPr, RawLogin, RawPr,
+        batch_check_present, build_divergence_compare_path, oid_outside_origin_graph,
+        select_fork_pr_match, validate_branch,
+        ForkPrMatch, RawDivergenceRefs, RawForkPr, RawLogin, RawPr,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -6524,6 +6547,96 @@ mod tests {
                 "headRepository":{"name":"proj"}}"#,
         ] {
             assert_eq!(fork_head_identity(&parse(json)), None, "json: {json}");
+        }
+    }
+
+    /// Values that must never reach a compare basehead: `..` breaks the `...`
+    /// separator, a leading `-` reads as a flag, `#`/`?`/`%` are URL-parser hazards,
+    /// `{`/`}` expand as `gh api` placeholders, whitespace/control can't reach argv,
+    /// and an empty segment addresses the wrong ref.
+    const HOSTILE_COMPARE_REFS: [&str; 11] = [
+        "",
+        "-flag",
+        "a..b",
+        "feat#1",
+        "a?b",
+        "feat%2Fx",
+        "{branch}",
+        "a}b",
+        "has space",
+        "has\ttab",
+        "has\nnewline",
+    ];
+
+    fn divergence_refs(base: &str, head: &str, owner: Option<&str>) -> RawDivergenceRefs {
+        RawDivergenceRefs {
+            base_ref_name: base.to_string(),
+            head_ref_name: head.to_string(),
+            is_cross_repository: owner.is_some(),
+            head_repository_owner: owner.map(|login| RawLogin {
+                login: login.to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn divergence_compare_path_pins_same_repo_and_fork_basehead() {
+        assert_eq!(
+            build_divergence_compare_path("octo/proj", &divergence_refs("main", "feature/x", None))
+                .expect("valid refs"),
+            "repos/octo/proj/compare/main...feature/x"
+        );
+        // Cross-repo: the head carries its owner, or it would resolve against the base.
+        assert_eq!(
+            build_divergence_compare_path(
+                "octo/proj",
+                &divergence_refs("main", "feature/x", Some("contrib"))
+            )
+            .expect("valid refs"),
+            "repos/octo/proj/compare/main...contrib:feature/x"
+        );
+        // An owner GitHub reports empty is not an error — it degrades to the bare head,
+        // which is what an absent owner already means.
+        assert_eq!(
+            build_divergence_compare_path("octo/proj", &divergence_refs("main", "dev", Some("")))
+                .expect("valid refs"),
+            "repos/octo/proj/compare/main...dev"
+        );
+        // Same-repo PRs report an owner too; only the cross-repo flag qualifies it.
+        let mut same_repo = divergence_refs("main", "dev", Some("contrib"));
+        same_repo.is_cross_repository = false;
+        assert_eq!(
+            build_divergence_compare_path("octo/proj", &same_repo).expect("valid refs"),
+            "repos/octo/proj/compare/main...dev"
+        );
+    }
+
+    #[test]
+    fn divergence_compare_path_refuses_hostile_refs_in_every_field() {
+        let refuses = |refs: RawDivergenceRefs, label: String| {
+            let err = build_divergence_compare_path("octo/proj", &refs).expect_err(&label);
+            assert!(
+                matches!(&err, AppError::InvalidArgument(m) if m.contains("invalid branch name")),
+                "{label}: {err:?}"
+            );
+        };
+        for hostile in HOSTILE_COMPARE_REFS {
+            refuses(
+                divergence_refs(hostile, "feature/x", None),
+                format!("base {hostile:?}"),
+            );
+            refuses(
+                divergence_refs("main", hostile, None),
+                format!("head {hostile:?}"),
+            );
+            // Empty is the owner's one non-error value (see the happy-path test), so the
+            // rest of the table is what applies to it.
+            if !hostile.is_empty() {
+                refuses(
+                    divergence_refs("main", "feature/x", Some(hostile)),
+                    format!("owner {hostile:?}"),
+                );
+            }
         }
     }
 

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1144,19 +1144,22 @@ fn build_divergence_compare_path(slug: &str, refs: &RawDivergenceRefs) -> AppRes
     validate_compare_branch(&refs.head_ref_name)?;
     // A fork PR's head lives in another repo, so the compare must address it as
     // `owner:branch` — a bare branch name would resolve against the BASE repo and
-    // compare the wrong (or a nonexistent) ref.
-    let head = match refs
-        .head_repository_owner
-        .as_ref()
-        .map(|o| o.login.as_str())
-        .filter(|_| refs.is_cross_repository)
-        .filter(|s| !s.is_empty())
-    {
-        Some(owner) => {
-            validate_compare_branch(owner)?;
-            format!("{owner}:{}", refs.head_ref_name)
-        }
-        None => refs.head_ref_name.clone(),
+    // silently count divergence against a same-named branch there. An absent or
+    // empty owner on a cross-repo PR therefore refuses (the probe degrades to
+    // "unknown") instead of falling back to the bare-head shape.
+    let head = if refs.is_cross_repository {
+        let owner = refs
+            .head_repository_owner
+            .as_ref()
+            .map(|o| o.login.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                AppError::InvalidArgument("cross-repository PR carries no head owner".into())
+            })?;
+        validate_compare_branch(owner)?;
+        format!("{owner}:{}", refs.head_ref_name)
+    } else {
+        refs.head_ref_name.clone()
     };
     // Branch names ride the basehead unencoded: GitHub's capture is greedy and a
     // git ref name can never contain `..`, so the `...` separator stays
@@ -6595,13 +6598,19 @@ mod tests {
             .expect("valid refs"),
             "repos/octo/proj/compare/main...contrib:feature/x"
         );
-        // An owner GitHub reports empty is not an error — it degrades to the bare head,
-        // which is what an absent owner already means.
-        assert_eq!(
-            build_divergence_compare_path("octo/proj", &divergence_refs("main", "dev", Some("")))
-                .expect("valid refs"),
-            "repos/octo/proj/compare/main...dev"
-        );
+        // A cross-repo PR with an absent or empty owner refuses: a bare head would
+        // resolve against the BASE repo and count divergence against a same-named
+        // branch there.
+        let mut ownerless = divergence_refs("main", "dev", None);
+        ownerless.is_cross_repository = true;
+        for refs in [ownerless, divergence_refs("main", "dev", Some(""))] {
+            let err = build_divergence_compare_path("octo/proj", &refs)
+                .expect_err("cross-repo without owner");
+            assert!(
+                matches!(&err, AppError::InvalidArgument(m) if m.contains("no head owner")),
+                "{err:?}"
+            );
+        }
         // Same-repo PRs report an owner too; only the cross-repo flag qualifies it.
         let mut same_repo = divergence_refs("main", "dev", Some("contrib"));
         same_repo.is_cross_repository = false;
@@ -6629,8 +6638,8 @@ mod tests {
                 divergence_refs("main", hostile, None),
                 format!("head {hostile:?}"),
             );
-            // Empty is the owner's one non-error value (see the happy-path test), so the
-            // rest of the table is what applies to it.
+            // The empty owner errors with its own message (pinned above), so only the
+            // grammar table's non-empty rows apply to the owner field.
             if !hostile.is_empty() {
                 refuses(
                     divergence_refs("main", "feature/x", Some(hostile)),

--- a/src/components/lazy-panel-fallback.tsx
+++ b/src/components/lazy-panel-fallback.tsx
@@ -26,9 +26,11 @@ export function LazyPanelFallback({
       aria-busy
       className={cn("flex h-full min-h-0 flex-col gap-2 p-2", className)}
     >
-      {/* aria-busy alone announces nothing outside a live region, so the state
-          gets words a screen reader will actually read. */}
-      <span className="sr-only">Loading {name}…</span>
+      {/* aria-busy alone announces nothing outside a live region; role="status"
+          makes the label a polite live region the reader speaks on mount. */}
+      <span role="status" className="sr-only">
+        Loading {name}…
+      </span>
       {/* Index key: the rows are static and never reorder, and two rows may
           share the same size classes. */}
       {rows.map((row, i) => (

--- a/src/components/lazy-panel-fallback.tsx
+++ b/src/components/lazy-panel-fallback.tsx
@@ -26,8 +26,8 @@ export function LazyPanelFallback({
       aria-busy
       className={cn("flex h-full min-h-0 flex-col gap-2 p-2", className)}
     >
-      {/* aria-busy alone announces nothing outside a live region; role="status"
-          makes the label a polite live region the reader speaks on mount. */}
+      {/* aria-busy alone has no text; role="status" gives the busy region words
+          for readers that announce it. */}
       <span role="status" className="sr-only">
         Loading {name}…
       </span>

--- a/src/components/lazy-panel-fallback.tsx
+++ b/src/components/lazy-panel-fallback.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/** Fill for a surface with no distinctive loading shape. */
+const DEFAULT_ROWS = ["h-8 w-full", "h-8 w-full", "h-8 w-2/3"];
+
+/**
+ * What a lazily-loaded panel shows while its chunk arrives, so the region keeps
+ * a shape instead of going blank and the wait reaches a screen reader. Callers
+ * pass their own geometry so the swap to the loaded panel doesn't shift layout.
+ */
+export function LazyPanelFallback({
+  name,
+  className,
+  rows = DEFAULT_ROWS,
+}: {
+  /** Names this surface as a screen reader reads it — "Loading insights…". */
+  name: string;
+  /** Lays the rows out; a `grid` class replaces the default column. */
+  className?: string;
+  /** One Skeleton per entry, the entry being its size classes. */
+  rows?: readonly string[];
+}) {
+  return (
+    <div
+      aria-busy
+      className={cn("flex h-full min-h-0 flex-col gap-2 p-2", className)}
+    >
+      {/* aria-busy alone announces nothing outside a live region, so the state
+          gets words a screen reader will actually read. */}
+      <span className="sr-only">Loading {name}…</span>
+      {/* Index key: the rows are static and never reorder, and two rows may
+          share the same size classes. */}
+      {rows.map((row, i) => (
+        <Skeleton key={i} className={row} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -55,7 +55,12 @@ float over the new tab.
 - **`dialog.tsx`** — every delta `sheet.tsx` carries (both are Base UI
   `Dialog.Root` underneath), plus `DialogContent` re-homing focus into the
   popup when its panel returns to view, and composing the caller's `ref`
-  with its own rather than replacing it.
+  with its own rather than replacing it. It also takes an `overlayClassName`
+  prop forwarded to the backdrop it renders internally, so a caller can style
+  a backdrop it has no other handle on. That one carries no panel-portal
+  marker, so the grep above misses it — check it separately with
+  `grep -n overlayClassName src/components/ui/dialog.tsx`, which must show
+  the prop, its type, and its forward to `<DialogOverlay/>`.
 
 Deliberately unmodified: `menubar.tsx` inherits the container default by
 delegating to `DropdownMenuPortal`, so regenerating it into a direct

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -72,12 +72,16 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ref,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
+  /** Reaches the backdrop this popup renders, which callers cannot otherwise
+   *  address — a dialog that swaps roots mid-open needs to subdue its fade. */
+  overlayClassName?: string;
 }) {
   const panelActive = usePanelActive();
   // Re-homing focus after a conceal needs the popup element, so this tracks it
@@ -113,7 +117,7 @@ function DialogContent({
 
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         // App defaults layered on the vendored primitive (deliberate, kept in

--- a/src/features/diff/DiffSurfaceLazy.tsx
+++ b/src/features/diff/DiffSurfaceLazy.tsx
@@ -1,5 +1,7 @@
 import { type ComponentProps, lazy, Suspense } from "react";
 
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
+
 // @git-diff-view (and DiffSurface's render graph — Shiki wiring, the
 // multi-select workaround, DiffFile building) is heavy and only needed once a
 // diff is actually shown. Loading the real module lazily keeps that whole
@@ -31,11 +33,10 @@ export type {
 } from "./DiffSurface";
 
 // The diff panes these render into already show their own placeholders /
-// skeletons before data arrives (DiffContent itself renders nothing while
-// pending), and the chunk loads in tens of ms — so the least-flashy neutral
-// fallback (nothing) is correct here; a spinner would flash where the app
-// otherwise renders no intermediate state.
-const fallback = null;
+// skeletons before data arrives, and the chunk loads in tens of ms — so the
+// fallback paints nothing (rows={[]}) while still marking the region busy and
+// naming the wait for assistive tech.
+const fallback = <LazyPanelFallback name="the diff" rows={[]} />;
 
 const DiffSurfaceLazyImpl = lazy(() =>
   import("./DiffSurface").then((m) => ({ default: m.DiffSurface })),

--- a/src/features/hooks/HooksDialog.tsx
+++ b/src/features/hooks/HooksDialog.tsx
@@ -1,6 +1,7 @@
 import { CaretDownIcon } from "@phosphor-icons/react";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -307,7 +308,13 @@ export function HooksDialog({
                   <div className="relative min-h-0 flex-1">
                     <div className="absolute inset-0">
                       <Suspense
-                        fallback={<Skeleton className="h-full w-full" />}
+                        fallback={
+                          <LazyPanelFallback
+                            name="the hook editor"
+                            className="p-0"
+                            rows={["h-full w-full"]}
+                          />
+                        }
                       >
                         <CodeEditor value={draft} onChange={setDraft} />
                       </Suspense>

--- a/src/features/pulls/PrTasksSection.tsx
+++ b/src/features/pulls/PrTasksSection.tsx
@@ -358,6 +358,7 @@ export function PrTasksSection({
     onActivate: (t) => setFocusedId(t.id),
     rowKey: (t) => t.id,
     rowAttr: "data-row",
+    ignoreTextEntry: true,
   });
 
   return (

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -92,6 +92,7 @@ export function ReviewHistory({
     activeIndex,
     onActivate: (_item, to) => setActiveIndex(to),
     rowKey: (r) => r.id,
+    ignoreTextEntry: true,
   });
 
   return (

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -986,16 +986,14 @@ export function ReviewThreadList({
         }
       }
     }
-    // Arrow keys inside the reply textarea move the cursor — don't hijack them
-    // for list nav (listKeyboardNav preventDefault()s and steals focus).
-    const target = e.target as HTMLElement;
-    if (target.closest("input, textarea, [contenteditable=true]")) return;
     listKeyboardNav({
       items: navThreads,
       activeIndex,
       onActivate: (_item, to) => setActiveIndex(to),
       rowKey: (t) => t.id,
       rowAttr: "data-thread-id",
+      // Arrow keys inside the reply textarea move the cursor.
+      ignoreTextEntry: true,
     })(e);
   };
 

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -375,6 +375,12 @@ export function RepoSettingsDialog({
           // rather than on which rule the stylesheet happens to emit last.
           subdueEntrance && "data-open:animate-none!",
         )}
+        // The loading frame this replaces is its own Dialog root, so its
+        // backdrop already faded in; a second fade would re-darken the screen
+        // mid-open.
+        overlayClassName={
+          subdueEntrance ? "data-open:animate-none!" : undefined
+        }
         onKeyDown={generateChord.onKeyDown}
       >
         <DialogHeader>

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -5,15 +5,22 @@ import { Button } from "@/components/ui/button";
 import type { ChangeKind, DiffStatEntry, FileEntry } from "@/lib/git/types";
 import { cn } from "@/lib/utils";
 
-const KIND_BADGE: Record<ChangeKind, { letter: string; className: string }> = {
-  added: { letter: "A", className: "text-success" },
-  untracked: { letter: "U", className: "text-success" },
-  modified: { letter: "M", className: "text-warning" },
-  typechange: { letter: "T", className: "text-warning" },
-  deleted: { letter: "D", className: "text-destructive" },
-  renamed: { letter: "R", className: "text-info" },
-  copied: { letter: "C", className: "text-info" },
-  conflicted: { letter: "!", className: "text-destructive" },
+const KIND_BADGE: Record<
+  ChangeKind,
+  { letter: string; label: string; className: string }
+> = {
+  added: { letter: "A", label: "Added", className: "text-success" },
+  untracked: { letter: "U", label: "Untracked", className: "text-success" },
+  modified: { letter: "M", label: "Modified", className: "text-warning" },
+  typechange: { letter: "T", label: "Type changed", className: "text-warning" },
+  deleted: { letter: "D", label: "Deleted", className: "text-destructive" },
+  renamed: { letter: "R", label: "Renamed", className: "text-info" },
+  copied: { letter: "C", label: "Copied", className: "text-info" },
+  conflicted: {
+    letter: "!",
+    label: "Conflicted",
+    className: "text-destructive",
+  },
 };
 
 /**
@@ -84,9 +91,17 @@ export const FileRow = memo(function FileRow({
       aria-selected={selected}
       tabIndex={0}
     >
-      <span className={cn("w-3 shrink-0 font-semibold", badge.className)}>
+      <span
+        aria-hidden
+        className={cn("w-3 shrink-0 font-semibold", badge.className)}
+      >
         {badge.letter}
       </span>
+      {/* The status letter carries no meaning for assistive tech; the name span
+          sits ahead of the path so the kind is announced first, and `sr-only`
+          is absolutely positioned so it never becomes a flex item here. The
+          trailing space keeps the name from fusing with the path text. */}
+      <span className="sr-only">{badge.label} </span>
       <span className="min-w-0 flex-1 truncate" title={label}>
         {label}
       </span>

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -58,9 +58,8 @@ export function RepoSettingsDialogFallback({
             aria-busy
             className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1"
           >
-            {/* aria-busy alone announces nothing outside a live region;
-                role="status" makes the label a polite live region the reader
-                speaks on mount. */}
+            {/* aria-busy alone has no text; role="status" gives the busy
+                region words for readers that announce it. */}
             <span role="status" className="sr-only">
               Loading repository settings…
             </span>

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -5,6 +5,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { cn } from "@/lib/utils";
 
 /** Six rows: the shortest provider rail (GitLab) offers six sections, and the
@@ -23,11 +24,22 @@ export function RepoSettingsDialogFallback({
 }: {
   onOpenChange: (open: boolean) => void;
 }) {
+  // The chord must not reach the Changes-tab generator behind this frame. A
+  // defined `run` is what arms the hook's swallow at all; `enabled: false` is
+  // what keeps it from generating before the real dialog owns the chord.
+  const generateChord = useGenerateChord({
+    enabled: false,
+    run: () => undefined,
+  });
+
   return (
     <Dialog open onOpenChange={onOpenChange}>
       {/* Frame classes mirror RepoSettingsDialog's DialogContent: the swap to
           the loaded dialog must not resize or reposition the box. */}
-      <DialogContent className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl">
+      <DialogContent
+        className="flex h-150 max-h-[85vh] flex-col sm:max-w-3xl"
+        onKeyDown={generateChord.onKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>Repository settings</DialogTitle>
           <Skeleton className="h-4 w-2/3" />

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -58,9 +58,12 @@ export function RepoSettingsDialogFallback({
             aria-busy
             className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1"
           >
-            {/* aria-busy alone announces nothing outside a live region, so the
-                state gets words a screen reader will actually read. */}
-            <span className="sr-only">Loading repository settings…</span>
+            {/* aria-busy alone announces nothing outside a live region;
+                role="status" makes the label a polite live region the reader
+                speaks on mount. */}
+            <span role="status" className="sr-only">
+              Loading repository settings…
+            </span>
             {/* The General section's own loading shape, so fallback → dialog →
                 section reads as one progressive fill, not three layouts. */}
             <div className="min-w-0 space-y-3">

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -21,6 +21,7 @@ import {
   useState,
   useTransition,
 } from "react";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import {
   PanelActivityBoundary,
   PanelPortalBoundary,
@@ -537,7 +538,21 @@ export function RepositoryView() {
           {aiEnabled && (
             <TabPanel active={repoTab === "agent"}>
               {agentSeen && (
-                <Suspense fallback={null}>
+                <Suspense
+                  fallback={
+                    <LazyPanelFallback
+                      name="agent sessions"
+                      className="min-h-0 flex-1 gap-1.5"
+                      rows={[
+                        "h-7 w-20",
+                        "h-8 w-full",
+                        "h-14 w-full",
+                        "h-14 w-full",
+                        "h-14 w-full",
+                      ]}
+                    />
+                  }
+                >
                   <SessionList repoPath={repoPath} />
                 </Suspense>
               )}
@@ -546,7 +561,7 @@ export function RepositoryView() {
         </aside>
         <main className="min-w-0 flex-1">
           <TabPanel active={repoTab === "changes"}>
-            <Suspense fallback={null}>
+            <Suspense fallback={<LazyPanelFallback name="the diff" />}>
               <DiffViewer repoPath={repoPath} />
             </Suspense>
           </TabPanel>
@@ -680,7 +695,20 @@ export function RepositoryView() {
           </TabPanel>
           <TabPanel active={repoTab === "insights"}>
             {insightsSeen && (
-              <Suspense fallback={null}>
+              <Suspense
+                fallback={
+                  <LazyPanelFallback
+                    name="insights"
+                    className="grid auto-rows-min grid-cols-1 gap-4 overflow-hidden p-4 xl:grid-cols-2"
+                    rows={[
+                      "h-6 w-24 xl:col-span-2",
+                      "h-52 w-full",
+                      "h-52 w-full",
+                      "h-52 w-full xl:col-span-2",
+                    ]}
+                  />
+                }
+              >
                 <InsightsBoard
                   repoPath={repoPath}
                   active={repoTab === "insights"}
@@ -691,7 +719,15 @@ export function RepositoryView() {
           {aiEnabled && (
             <TabPanel active={repoTab === "agent"}>
               {agentSeen && (
-                <Suspense fallback={null}>
+                <Suspense
+                  fallback={
+                    <LazyPanelFallback
+                      name="the agent session"
+                      className="gap-3 p-3"
+                      rows={["h-7 w-40", "h-24 w-full", "h-40 w-full"]}
+                    />
+                  }
+                >
                   <SessionView repoPath={repoPath} />
                 </Suspense>
               )}

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -561,7 +561,12 @@ export function RepositoryView() {
         </aside>
         <main className="min-w-0 flex-1">
           <TabPanel active={repoTab === "changes"}>
-            <Suspense fallback={<LazyPanelFallback name="the diff" />}>
+            {/* rows={[]}: this boundary is on the boot path and DiffViewer's
+                resting state is a centered placeholder — skeleton bars would
+                flash where the app otherwise paints nothing. */}
+            <Suspense
+              fallback={<LazyPanelFallback name="the diff" rows={[]} />}
+            >
               <DiffViewer repoPath={repoPath} />
             </Suspense>
           </TabPanel>

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -2,6 +2,7 @@ import { PlusIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,7 +20,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { clipTitle } from "@/lib/clip-title";
@@ -550,7 +550,15 @@ export function TaskDialog({
             )}
 
             <div className="h-48 overflow-hidden rounded-md border">
-              <Suspense fallback={<Skeleton className="h-full w-full" />}>
+              <Suspense
+                fallback={
+                  <LazyPanelFallback
+                    name="the script editor"
+                    className="p-0"
+                    rows={["h-full w-full"]}
+                  />
+                }
+              >
                 <CodeEditor value={body} onChange={setBody} />
               </Suspense>
             </div>

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -8,6 +8,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { lazy, Suspense } from "react";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { Button } from "@/components/ui/button";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { clipTitle } from "@/lib/clip-title";
@@ -126,7 +127,14 @@ export function TaskRunView() {
         )}
       </div>
 
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <LazyPanelFallback
+            name="the task output"
+            className="min-h-0 flex-1 p-1"
+          />
+        }
+      >
         <Terminal
           key={ptyId}
           ptyId={ptyId}

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -47,9 +47,8 @@ import { UpdatesSection } from "./UpdatesSection";
 // Loading it lazily keeps that whole chunk off the boot path — its render is
 // already gated on `activePanel === "syntax"`, so the import fires on first
 // visit, not on launch. `lazy` on the named export preserves the `form` prop's
-// full type. The fallback is null: the panel renders instantly once loaded (tens
-// of ms from local disk) and, like the other panels, shows no intermediate
-// state before its data — a spinner would flash where nothing otherwise does.
+// full type. The fallback mirrors the section's field geometry so the swap to
+// the loaded panel doesn't shift layout.
 const SyntaxSection = lazy(() =>
   import("./SyntaxSection").then((m) => ({ default: m.SyntaxSection })),
 );

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { NavRail } from "@/components/NavRail";
 import { Button } from "@/components/ui/button";
 import {
@@ -291,7 +292,21 @@ export function SettingsScreen() {
                 </>
               )}
               {activePanel === "syntax" && (
-                <Suspense fallback={null}>
+                <Suspense
+                  fallback={
+                    <LazyPanelFallback
+                      name="syntax settings"
+                      className="gap-4 p-0"
+                      rows={[
+                        "h-5 w-36",
+                        "h-4 w-2/3",
+                        "h-9 w-full",
+                        "h-9 w-full",
+                        "h-24 w-full",
+                      ]}
+                    />
+                  }
+                >
                   <SyntaxSection form={form} />
                 </Suspense>
               )}

--- a/src/features/terminal/TerminalDock.tsx
+++ b/src/features/terminal/TerminalDock.tsx
@@ -4,6 +4,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { lazy, Suspense, useState } from "react";
+import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { Button } from "@/components/ui/button";
 import type { AgentSession } from "@/features/sessions/store";
 
@@ -140,7 +141,14 @@ export function TerminalDock({
           <XIcon />
         </Button>
       </div>
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <LazyPanelFallback
+            name="the terminal"
+            className="min-h-0 flex-1 p-1"
+          />
+        }
+      >
         <Terminal
           key={termKey}
           ptyId={termKey}

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -180,6 +180,26 @@ function pushRejectionSummary(text: string): string | null {
   return PUSH_REJECTION_SUMMARIES.find(([m]) => m.test(text))?.[1] ?? null;
 }
 
+/** Windows MAX_PATH refusals. git prints its reason as the TAIL of a diagnostic
+ *  (`fatal: cannot create directory at '<path>': Filename too long`, measured on
+ *  git 2.51.1.windows.1), so the marker is end-anchored like `: needs merge`
+ *  above — the same blob echoes paths and commit subjects, which an unanchored
+ *  phrase would match. glibc spells the same errno "File name too long", which
+ *  this deliberately does not match: the remedy below is Windows-only. */
+const LONG_PATH_MARKERS = [/: Filename too long\s*$/m];
+
+/** The app's own git calls already pass `-c core.longpaths=true` (git/runner.rs),
+ *  so a path this long fails only where that flag can't reach — hence the remedy
+ *  is aimed at the user's other tools rather than at GitDesktop. */
+const LONG_PATH_SUMMARY =
+  "Paths in this repository are longer than Windows normally allows. GitDesktop enables long paths for its own Git commands — to use this repository with other tools, turn on Windows long paths and set git config --global core.longpaths true.";
+
+/** The humanized line for a path-length refusal, or null when the text carries
+ *  none. */
+function longPathSummary(text: string): string | null {
+  return LONG_PATH_MARKERS.some((m) => m.test(text)) ? LONG_PATH_SUMMARY : null;
+}
+
 /** The `git` kind is the only one carrying a stderr blob distinct from its
  *  message; every other kind folds its detail into `message` itself. */
 function gitStderr(e: AppError): string {
@@ -331,10 +351,14 @@ export function presentError(e: unknown): ErrorPresentation {
       !rolledBack && CONFLICT_MARKERS.some((m) => m.test(combined));
     // A rejection reason is read from the COMBINED text: it rides the `stderr`
     // blob, which the fall-through below deliberately never reads.
-    const summary = isConflict
-      ? conflictSummary(combined)
-      : (pushRejectionSummary(combined) ??
-        (firstMeaningfulLine(message) || label));
+    // A path-length failure outranks conflict framing: git could not write the
+    // tree, so no conflict flow is actually waiting to be resolved.
+    const summary =
+      longPathSummary(combined) ??
+      (isConflict
+        ? conflictSummary(combined)
+        : (pushRejectionSummary(combined) ??
+          (firstMeaningfulLine(message) || label)));
 
     const distinctStderr = stderr !== "" && !message.includes(stderr);
     const long =

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -192,7 +192,7 @@ const LONG_PATH_MARKERS = [/: Filename too long\s*$/m];
  *  so a path this long fails only where that flag can't reach — hence the remedy
  *  is aimed at the user's other tools rather than at GitDesktop. */
 const LONG_PATH_SUMMARY =
-  "Paths in this repository are longer than Windows normally allows. GitDesktop enables long paths for its own Git commands — to use this repository with other tools, turn on Windows long paths and set git config --global core.longpaths true.";
+  "Paths in this repository are longer than Windows allows by default. GitDesktop's own Git commands handle them; other tools need Windows long paths and git config --global core.longpaths true.";
 
 /** The humanized line for a path-length refusal, or null when the text carries
  *  none. */

--- a/src/lib/list-keyboard-nav.ts
+++ b/src/lib/list-keyboard-nav.ts
@@ -11,6 +11,11 @@ export interface ListKeyboardNavOptions<T> {
   rowKey?: (item: T) => string;
   /** Attribute that carries `rowKey` on each row element. */
   rowAttr?: string;
+  /**
+   * Leave arrows to a text editor inside the list (caret nav wins). Opt-in:
+   * several callers deliberately drive nav from a filter input.
+   */
+  ignoreTextEntry?: boolean;
 }
 
 /**
@@ -26,10 +31,19 @@ export function listKeyboardNav<T>({
   onActivate,
   rowKey,
   rowAttr = "data-row",
+  ignoreTextEntry = false,
 }: ListKeyboardNavOptions<T>) {
   return (e: KeyboardEvent) => {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
     if (items.length === 0) return;
+    // Ancestor walk, not the target alone: a keydown can bubble from a wrapper
+    // inside an editor.
+    if (
+      ignoreTextEntry &&
+      e.target instanceof Element &&
+      e.target.closest("input, textarea, [contenteditable=true]")
+    )
+      return;
     // Move the selection, not the scrollbar.
     e.preventDefault();
     const to =

--- a/src/lib/list-keyboard-nav.ts
+++ b/src/lib/list-keyboard-nav.ts
@@ -36,12 +36,14 @@ export function listKeyboardNav<T>({
   return (e: KeyboardEvent) => {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
     if (items.length === 0) return;
-    // Ancestor walk, not the target alone: a keydown can bubble from a wrapper
-    // inside an editor.
+    // Ancestor walk for the form controls (a keydown can bubble from a wrapper
+    // inside an editor); isContentEditable covers every editable state — true,
+    // empty, plaintext-only — and inherits from an enclosing editing host.
     if (
       ignoreTextEntry &&
-      e.target instanceof Element &&
-      e.target.closest("input, textarea, [contenteditable=true]")
+      e.target instanceof HTMLElement &&
+      (e.target.closest("input, textarea") !== null ||
+        e.target.isContentEditable)
     )
       return;
     // Move the selection, not the scrollbar.


### PR DESCRIPTION
Batches six unrelated defect fixes found across the app, each with its own changelog fragment: screen readers announcing bare status letters, blank regions behind lazy panels, arrow keys stealing focus while typing, PR divergence trusting unvalidated fork refs, conflict resolution failing on deep Windows paths, and a double backdrop fade when repository settings opens. Each fix that closes a class ships its guard in the same change (a banned-pattern scan, a Rust invariant check, or a pinning test).

### Accessibility

- Adds a `label` to every entry in `KIND_BADGE` in `src/features/repository/FileRow.tsx`, hides the status letter with `aria-hidden`, and emits an `sr-only` name span ahead of the path so the change kind ("Modified", "Deleted", …) is announced first.
- Adds `src/components/lazy-panel-fallback.tsx` — an `aria-busy` skeleton region with an `sr-only` "Loading …" line and caller-supplied `rows`/`className` geometry so the swap to the loaded panel doesn't shift layout.
- Replaces `fallback={null}` at every lazy panel: two `Suspense` boundaries in `src/features/repository/RepositoryView.tsx` (agent sessions, insights, plus the diff and session views), `src/features/settings/SettingsScreen.tsx` (syntax), `src/features/scripts/TaskRunView.tsx`, and `src/features/terminal/TerminalDock.tsx`.
- Adds the `null-suspense-fallback` check to `scripts/check-banned-patterns.mjs` with an empty allowlist, plus positive and negative cases in `scripts/checks.test.mjs` covering the wrapped-prop formatting and forwarded/conditional fallbacks.

### Keyboard navigation

- Adds an opt-in `ignoreTextEntry` option to `listKeyboardNav` in `src/lib/list-keyboard-nav.ts` that walks ancestors from `e.target` and bails when the key came from an `input`, `textarea`, or `contenteditable` — deliberately opt-in, since some callers drive nav from a filter input.
- Enables it in `src/features/pulls/PrTasksSection.tsx` and `src/features/pulls/ReviewHistory.tsx`, and moves `src/features/pulls/ReviewThreads.tsx` off its hand-rolled `target.closest(…)` guard onto the shared option.
- Records the rule in `.claude/skills/gd-conventions/SKILL.md` alongside the keyboard-first invariant.

### PR divergence ref validation

- Extracts `build_divergence_compare_path` in `src-tauri/src/github/pr.rs`, routing the base ref, head ref, and cross-repository owner through `forge::validate_compare_branch` before the compare dispatch — `gh api` expands `{…}` as placeholders and URL parsers truncate at `#`/`?`, so an unvalidated fork ref could answer 200 for the wrong refs.
- Promotes `validate_compare_branch` to `pub(crate)` in `src-tauri/src/forge/mod.rs`.
- Adds check E ("compare basehead") to `scripts/check-rust-invariants.mjs`: flags any `format!` whose `/compare/` tail interpolates, with a two-entry allowlist carrying per-site rationale, plus fixture tests in `scripts/checks.test.mjs`.
- Adds unit tests pinning the same-repo, fork, empty-owner, and same-repo-with-owner baseheads, and a `HOSTILE_COMPARE_REFS` table exercised against every field.

### Windows long paths

- Injects `-c core.longpaths=true` per invocation in `run_git_raw_input` (`src-tauri/src/git/runner.rs`) — the OS `LongPathsEnabled` flag alone doesn't cover Git for Windows — never touching the user's config, with a `config_tests` module reading all three injected keys back through git.
- Shortens the resolve-worktree directory name via `new_resolve_worktree_id` in `src-tauri/src/git/ops.rs` (12 hex chars instead of a full uuid), reclaiming most of the `MAX_PATH` budget the name was spending, with a test pinning the length, charset, and `gd-resolve-` prefix.
- Adds `LONG_PATH_MARKERS` and `longPathSummary` to `src/lib/error-summary.ts`, which outranks conflict framing and tells the user how to enable long paths for their other tools.

### Repository settings dialog

- Threads an `overlayClassName` prop through `DialogContent` to `DialogOverlay` in `src/components/ui/dialog.tsx` (a sanctioned local delta, documented in `src/components/ui/README.md` with the grep that finds it), and uses it in `src/features/repo-settings/RepoSettingsDialog.tsx` to suppress the second backdrop fade when the loading frame swaps roots.
- Arms a disabled `useGenerateChord` in `src/features/repository/RepoSettingsDialogFallback.tsx` so the chord is swallowed rather than reaching the Changes-tab generator behind the loading frame.

### CI and test hardening

- Sets `persist-credentials: false` on `actions/checkout` across `appimage-check.yml`, `changelog.yml`, `frontend.yml`, `release.yml`, `rust-tests.yml`, and `site.yml`; `homebrew.yml` keeps credentials with a comment explaining that its bump step's `git push` needs them.
- Tightens variant-only `InvalidArgument` assertions into message assertions in `src-tauri/src/git/autostash.rs`, `src-tauri/src/git/remote.rs`, and `src-tauri/src/git/ops.rs`, where a neighbouring guard raises the same variant and would make the match vacuous.
- Adds rev-expression rejection tests for `git_branch_merge_states` and `update_branch_from` in `src-tauri/src/git/branches.rs`, and for `finish_remote_pr_resolve` in `src-tauri/src/git/ops.rs`.
- Renames GitLab's `validate_branch_name` to `validate_protection_name` in `src-tauri/src/forge/gitlab.rs` (with a matching error message) so it isn't confused with the branch-name chokepoint.
- Documents the ratchet rule on the now-empty `ALLOWLIST` in `scripts/check-dead-surface.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arrow keys in task and review editors now move the text cursor instead of changing list selection.
  * Screen readers announce full file change types.
  * Pull request divergence checks handle special-character branch names correctly.
  * Conflict resolution supports deeply nested Windows repositories and explains long-path errors.
  * Repository settings open with a smoother transition and keep shortcuts contained while loading.

* **New Features**
  * Loading placeholders now appear while panels, terminals, task output, and settings load.
  * Dialog backdrops can now be styled for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->