### PR TITLE
feat(actions,hotkeys): add run context menu and dispatch-trigger probe

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -152,6 +152,12 @@ words the user reads on screen — the palette matcher is a plain substring, so
 - Shared-ContextMenu suppression for non-target right-clicks goes through
   `suppressContextMenu` (`src/lib/context-menu.ts`) — `preventDefault` alone
   still opens Base UI's menu as an empty popup.
+- CI copy comes from `src/features/actions/status.tsx`, never hand-spelled: the
+  provider's noun via `ciRunNoun` (labels and toasts derive from it, so no
+  surface says "run" beside another's "pipeline"), the gitlab-or-bitbucket test
+  via `isPipelineProvider`, and the re-run offers, titles, and cancel wording
+  via `rerunOffers`/`RERUN_TITLES`/`cancelLabel` — shared so the runs list and
+  the run detail view can't drift.
 
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -81,13 +81,18 @@ route to one of those ops imports the existing prompt, never re-spells it.
 **Command palette.** Any new tab/surface/action needs an ACTIONS entry in
 `src/lib/hotkeys/registry.ts` + `useHotkeyAction` wiring in the same change
 (`defaultBinding: null` = palette-only). Missed twice before. Labels use the
-words the user reads on screen. The matcher (`CommandPalette.tsx`) AND-s the
-query's whitespace-separated tokens over label + category with hyphens stripped
-from both sides, so word order, gaps, and hyphenation cost nothing ("cancel
-pipeline" finds "Cancel workflow run/pipeline", "rerun" finds "Re-run…", and
-#255's "ai excluded" against a tab labeled "AI excluded" would match today).
-Each token still has to be a literal substring of what remains, so a label built
-from different words than the surface shows stays unfindable.
+words the user reads on screen. Action-text search lives in
+`src/lib/hotkeys/search.ts` (`queryTokens` + `matchesActionText`), shared by the
+palette and Settings → Keyboard so a query can't hit in one and miss in the
+other — a new surface searching ACTIONS imports it rather than re-spelling the
+match. It AND-s the query's whitespace-separated tokens over label + category
+with hyphens stripped from both sides, so word order, gaps, and hyphenation cost
+nothing ("cancel pipeline" finds "Cancel workflow run/pipeline", "rerun" finds
+"Re-run…", and #255's "ai excluded" against a tab labeled "AI excluded" would
+match today). Each token still has to be a literal substring of what remains, so
+a label built from different words than the surface shows stays unfindable.
+Keyboard's binding arms deliberately stay literal — key text means its
+separators.
 
 **Mod-key display.** Shortcut hints render via `isMac` / `formatBinding` from
 `@/lib/hotkeys/binding` — never a literal ⌘ or "Ctrl+"; only labels branch.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -81,9 +81,13 @@ route to one of those ops imports the existing prompt, never re-spells it.
 **Command palette.** Any new tab/surface/action needs an ACTIONS entry in
 `src/lib/hotkeys/registry.ts` + `useHotkeyAction` wiring in the same change
 (`defaultBinding: null` = palette-only). Missed twice before. Labels use the
-words the user reads on screen — the palette matcher is a plain substring, so
-"AI-excluded files" missed a user typing "ai excluded" off the tab labeled
-"AI excluded" (live-caught, #255); no hyphens the UI itself doesn't show.
+words the user reads on screen. The matcher (`CommandPalette.tsx`) AND-s the
+query's whitespace-separated tokens over label + category with hyphens stripped
+from both sides, so word order, gaps, and hyphenation cost nothing ("cancel
+pipeline" finds "Cancel workflow run/pipeline", "rerun" finds "Re-run…", and
+#255's "ai excluded" against a tab labeled "AI excluded" would match today).
+Each token still has to be a literal substring of what remains, so a label built
+from different words than the surface shows stays unfindable.
 
 **Mod-key display.** Shortcut hints render via `isMac` / `formatBinding` from
 `@/lib/hotkeys/binding` — never a literal ⌘ or "Ctrl+"; only labels branch.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ instead, see [Development](#development).
   settings in the same panels; [issues in-app](#issues-and-to-dos) on GitHub
   and GitLab, or via [Jira](#jira-cloud-issues) on Bitbucket.
 - **A [GitHub Actions cockpit](#github-actions)**: runs, jobs, steps,
-  re-run / cancel / dispatch, failed-step logs, and AI debugging.
+  re-run / cancel / dispatch (from the run or a right-click on its row),
+  failed-step logs, and AI debugging.
 - **[Coding agents](#coding-agent-sessions) with guardrails**: hand tasks to
   Claude Code, Codex, Copilot, or opencode in isolated worktrees or
   containers, watch every edit, and keep the result as a branch or local PR.
@@ -509,7 +510,12 @@ with a comment you've drafted posted alongside.
 A dedicated tab with live run status, run detail, re-run (all or failed),
 cancel, manual dispatch, and inline failed-step logs (none of which GitHub
 Desktop does), plus a current-branch CI badge in the header and
-run-completion notifications.
+run-completion notifications. Right-click any run in the list to re-run or
+cancel it, run its workflow again with the picker already on that workflow,
+open it on the forge, or copy its link; those actions are in the command
+palette too. The Run workflow picker marks the workflows that can't be
+started by hand on the chosen ref, so a dispatch that would be rejected is
+visible before you run it.
 
 - **Debug failed CI with AI**: turn a failed job's logs into a streamed
   root-cause + fix, ending with a ready-to-paste prompt for a coding agent.

--- a/changelog.d/added-actions-run-context-menu.md
+++ b/changelog.d/added-actions-run-context-menu.md
@@ -1,0 +1,3 @@
+- Actions tab: run rows now have a context menu — re-run or cancel the run, run its
+  workflow again with the picker already on that workflow, open it on the forge, or
+  copy its link; the same re-run, cancel, and run actions are in the command palette.

--- a/changelog.d/changed-command-palette-search.md
+++ b/changelog.d/changed-command-palette-search.md
@@ -1,0 +1,5 @@
+- **Command search finds what you mean.** Both the command palette and the filter
+  in **Settings → Keyboard** now match your words in any order and ignore hyphens,
+  so `cancel pipeline` reaches **Cancel workflow run/pipeline** and `rerun` reaches
+  **Re-run workflow run/pipeline**. Searching by shortcut in Settings works exactly
+  as before.

--- a/changelog.d/fixed-run-workflow-dispatch-triggers.md
+++ b/changelog.d/fixed-run-workflow-dispatch-triggers.md
@@ -1,0 +1,3 @@
+- The Run workflow picker shows which workflows can be started manually on the
+  chosen branch or tag: ones without a `workflow_dispatch` trigger are marked,
+  and the dialog says so in plain language before you run anything.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -419,7 +419,8 @@ export const CHECKS = [
     allowlist: [
       // Seeds the category once the async list arrives; `if (!categoryId)`.
       "src/features/discussions/CreateDiscussionDialog.tsx",
-      // Defaults the workflow once `dispatchable` arrives; `!workflow`.
+      // Defaults the workflow once `dispatchable` arrives; the caller's
+      // preselect rides a consume-once ref, the fallback keeps `!workflow`.
       "src/features/actions/RunWorkflowDialog.tsx",
       // Seeds the Bitbucket workspace once workspaces load; empty-field only.
       "src/features/repository/PublishDialog.tsx",

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -1861,6 +1861,8 @@ fn from_bb_pipeline(p: BbPipeline, ws: &str, slug: &str) -> WorkflowRun {
         status,
         conclusion,
         workflow_name: friendly_trigger(&trigger),
+        // Bitbucket has no per-workflow entity; pipelines are re-run by build number.
+        workflow_database_id: 0,
         head_branch: ref_name.unwrap_or_default(),
         event: trigger.to_ascii_lowercase(),
         created_at: p.created_on.clone(),

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -5832,6 +5832,8 @@ fn from_glab_pipeline(p: GlabPipeline) -> WorkflowRun {
         status,
         conclusion,
         workflow_name,
+        // GitLab has no per-workflow entity; pipelines are re-run by their own id.
+        workflow_database_id: 0,
         head_branch: p.git_ref,
         event: p.source,
         // GitLab's LIST payload has no per-run start time (only the detail

--- a/src-tauri/src/github/actions.rs
+++ b/src-tauri/src/github/actions.rs
@@ -44,6 +44,11 @@ pub struct WorkflowRun {
     pub conclusion: String,
     #[serde(default)]
     pub workflow_name: String,
+    /// The workflow this run belongs to, so a run row can re-dispatch its own
+    /// workflow without a name lookup. 0 on providers with no per-workflow
+    /// concept (GitLab pipelines, Bitbucket pipelines).
+    #[serde(default)]
+    pub workflow_database_id: u64,
     #[serde(default)]
     pub head_branch: String,
     #[serde(default)]
@@ -153,7 +158,7 @@ pub struct Workflow {
     pub state: String,
 }
 
-const RUN_LIST_FIELDS: &str = "databaseId,number,displayTitle,status,conclusion,workflowName,headBranch,event,createdAt,startedAt,updatedAt,url,headSha";
+const RUN_LIST_FIELDS: &str = "databaseId,number,displayTitle,status,conclusion,workflowName,workflowDatabaseId,headBranch,event,createdAt,startedAt,updatedAt,url,headSha";
 const RUN_VIEW_FIELDS: &str = "databaseId,number,displayTitle,status,conclusion,workflowName,headBranch,event,createdAt,url,headSha,jobs";
 /// Failed-step logs can run to many MB; keep the tail (failures land at the end).
 const RUN_LOG_CAP: usize = 200_000;
@@ -314,17 +319,14 @@ pub async fn gh_job_logs(repo_path: String, job_id: u64) -> AppResult<String> {
     Ok(text)
 }
 
-/// The repo's workflows, for the manual-dispatch picker.
-#[tauri::command]
-pub async fn gh_workflow_list(repo_path: String) -> AppResult<Vec<Workflow>> {
-    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+async fn fetch_workflows(repo_path: &str, slug: &str) -> AppResult<Vec<Workflow>> {
     let out = run_gh(
-        Some(&repo_path),
+        Some(repo_path),
         &[
             "workflow",
             "list",
             "-R",
-            &slug,
+            slug,
             "--all",
             "--json",
             "id,name,path,state",
@@ -334,6 +336,147 @@ pub async fn gh_workflow_list(repo_path: String) -> AppResult<Vec<Workflow>> {
     .await?;
     serde_json::from_str(&out.stdout_lossy())
         .map_err(|e| AppError::Gh(format!("could not parse gh workflow list: {e}")))
+}
+
+/// The repo's workflows, for the manual-dispatch picker.
+#[tauri::command]
+pub async fn gh_workflow_list(repo_path: String) -> AppResult<Vec<Workflow>> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    fetch_workflows(&repo_path, &slug).await
+}
+
+/// Whether a workflow's file can be addressed safely as a `gh api` endpoint
+/// segment: gh expands `{…}` in an endpoint as an owner/repo placeholder, splits
+/// the endpoint on `?` and `#` as query/fragment delimiters (all three retarget
+/// the request), and reads a leading `-` as a flag.
+fn is_probeable_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('-')
+        && !path.contains('{')
+        && !path.contains('}')
+        && !path.contains('?')
+        && !path.contains('#')
+}
+
+/// Real workflow files live here; `gh workflow list` also reports GitHub's dynamic
+/// pseudo-workflows (Dependabot, the Copilot reviewer) under other prefixes.
+const WORKFLOW_DIR: &str = ".github/workflows/";
+
+/// What the probe can decide about one workflow from its path alone.
+#[derive(Debug, PartialEq, Eq)]
+enum PathVerdict {
+    /// No user-authored file exists, so no trigger can be declared — a definite
+    /// `false`, not the 404 that fetching would produce and that reads as unknown.
+    NotDispatchable,
+    /// Unaddressable as an endpoint segment; stays unknown so it keeps being offered.
+    Unknown,
+    Fetch,
+}
+
+fn classify_workflow_path(path: &str) -> PathVerdict {
+    if !path.starts_with(WORKFLOW_DIR) {
+        PathVerdict::NotDispatchable
+    } else if is_probeable_path(path) {
+        PathVerdict::Fetch
+    } else {
+        PathVerdict::Unknown
+    }
+}
+
+/// Substring test rather than a YAML parse: every spelling of the trigger
+/// (scalar, sequence item, mapping key, quoted) carries the literal token. A
+/// mention in a comment therefore reads as `true` — the accepted false positive,
+/// since that direction keeps the workflow offered and the humanized 422 backstops it.
+fn yaml_declares_workflow_dispatch(content: &str) -> bool {
+    content.contains("workflow_dispatch")
+}
+
+/// One gh process per workflow file. The gate is PROCESS-WIDE, not per call: each
+/// settled keystroke in the ref field mints another probe, so a per-invocation cap
+/// would still let K stale invocations fork 4K processes at once. Stale probes are
+/// not cancelled, they just finish slowly.
+const DISPATCH_PROBE_CONCURRENCY: usize = 4;
+static DISPATCH_PROBE_GATE: tokio::sync::Semaphore =
+    tokio::sync::Semaphore::const_new(DISPATCH_PROBE_CONCURRENCY);
+
+/// Which active workflows declare a `workflow_dispatch` trigger at `git_ref`.
+/// Keyed by stringified workflow id. A workflow ABSENT from the map is unknown
+/// (probe failed) — callers fail open and keep it offered.
+#[tauri::command]
+pub async fn gh_workflow_dispatchable(
+    repo_path: String,
+    git_ref: String,
+) -> AppResult<HashMap<String, bool>> {
+    validate_ref(&git_ref)?;
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    // Listed server-side: a frontend-supplied path would aim the contents fetch
+    // at a file of the caller's choosing.
+    let workflows = fetch_workflows(&repo_path, &slug).await?;
+    let ref_field = format!("ref={git_ref}");
+    let mut map = HashMap::new();
+    let mut probes: Vec<&Workflow> = Vec::new();
+    for w in workflows.iter().filter(|w| w.state == "active") {
+        match classify_workflow_path(&w.path) {
+            PathVerdict::NotDispatchable => {
+                map.insert(w.id.to_string(), false);
+            }
+            PathVerdict::Unknown => {}
+            PathVerdict::Fetch => probes.push(w),
+        }
+    }
+
+    let results = crate::forge::futures_join_all(probes.iter().map(|w| {
+        let endpoint = format!("repos/{slug}/contents/{}", w.path);
+        let repo_path = repo_path.as_str();
+        let ref_field = ref_field.as_str();
+        async move {
+            let _permit = DISPATCH_PROBE_GATE.acquire().await.ok();
+            // `--method GET` is mandatory: `gh api` with `-f` fields present
+            // defaults to POST, and only under GET do they become query
+            // params. `-f` never `-F` — `-F`'s leading-`@` magic reads host files.
+            let res = run_gh(
+                Some(repo_path),
+                &[
+                    "api",
+                    "--method",
+                    "GET",
+                    &endpoint,
+                    "-H",
+                    "Accept: application/vnd.github.raw",
+                    "-f",
+                    ref_field,
+                ],
+                GH_NETWORK_TIMEOUT,
+            )
+            .await;
+            (w.id, res)
+        }
+    }))
+    .await;
+    for (id, res) in results {
+        // A failed fetch leaves the key ABSENT — "unknown" must not read as
+        // "not dispatchable", which would hide a runnable workflow.
+        if let Ok(out) = res {
+            map.insert(
+                id.to_string(),
+                yaml_declares_workflow_dispatch(&out.stdout_lossy()),
+            );
+        }
+    }
+    Ok(map)
+}
+
+/// GitHub's 422 for a workflow without the trigger reaches the user as gh's raw
+/// HTTP line, API URL included. Lead with a plain sentence — the toast shows only
+/// the first line — and keep the raw text below it for the details view.
+fn humanize_dispatch_error(raw: &str, git_ref: &str) -> String {
+    let lower = raw.to_lowercase();
+    if lower.contains("workflow does not have") && lower.contains("workflow_dispatch") {
+        return format!(
+            "This workflow can't be run manually: it has no workflow_dispatch trigger on \"{git_ref}\".\n\n{raw}"
+        );
+    }
+    raw.to_string()
 }
 
 /// Manually dispatches a workflow (`workflow_dispatch`) on a ref, with inputs.
@@ -358,7 +501,7 @@ pub async fn gh_workflow_run(
         slug,
         workflow,
         "--ref".into(),
-        git_ref,
+        git_ref.clone(),
     ];
     for (k, v) in &inputs {
         if k.is_empty() || k.starts_with('-') {
@@ -368,7 +511,12 @@ pub async fn gh_workflow_run(
         args.push(format!("{k}={v}"));
     }
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_gh(Some(&repo_path), &arg_refs, GH_NETWORK_TIMEOUT).await?;
+    run_gh(Some(&repo_path), &arg_refs, GH_NETWORK_TIMEOUT)
+        .await
+        .map_err(|e| match e {
+            AppError::Gh(msg) => AppError::Gh(humanize_dispatch_error(&msg, &git_ref)),
+            other => other,
+        })?;
     Ok(())
 }
 
@@ -390,6 +538,7 @@ mod tests {
             status: "completed".to_string(),
             conclusion: "success".to_string(),
             workflow_name: "rust-tests".to_string(),
+            workflow_database_id: 334_643_035,
             head_branch: "refactor/hygiene".to_string(),
             event: "pull_request".to_string(),
             created_at: "2026-08-13T09:00:00Z".to_string(),
@@ -407,6 +556,7 @@ mod tests {
                 "status": "completed",
                 "conclusion": "success",
                 "workflowName": "rust-tests",
+                "workflowDatabaseId": 334_643_035u64,
                 "headBranch": "refactor/hygiene",
                 "event": "pull_request",
                 "createdAt": "2026-08-13T09:00:00Z",
@@ -526,5 +676,78 @@ mod tests {
                 value["id"]
             );
         }
+    }
+
+    #[test]
+    fn detects_every_workflow_dispatch_spelling() {
+        assert!(yaml_declares_workflow_dispatch(
+            "name: ci\non: workflow_dispatch\njobs: {}\n"
+        ));
+        assert!(yaml_declares_workflow_dispatch(
+            "on: [push, workflow_dispatch]\n"
+        ));
+        assert!(yaml_declares_workflow_dispatch(
+            "on:\n  workflow_dispatch:\n    inputs:\n      level:\n        type: choice\n"
+        ));
+        assert!(yaml_declares_workflow_dispatch(
+            "on:\n  \"workflow_dispatch\":\n"
+        ));
+        assert!(!yaml_declares_workflow_dispatch(
+            "name: ci\non:\n  push:\n    branches: [master]\n  pull_request:\n"
+        ));
+    }
+
+    #[test]
+    fn skips_paths_gh_would_misread_as_endpoint_syntax() {
+        assert!(is_probeable_path(".github/workflows/ci.yml"));
+        assert!(!is_probeable_path("dynamic/{owner}/thing"));
+        assert!(!is_probeable_path(".github/workflows/a}b.yml"));
+        assert!(!is_probeable_path(".github/workflows/a?b.yml"));
+        assert!(!is_probeable_path(".github/workflows/a#b.yml"));
+        assert!(!is_probeable_path("-oops.yml"));
+        assert!(!is_probeable_path(""));
+    }
+
+    #[test]
+    fn pseudo_workflows_are_a_definite_no() {
+        // GitHub's dynamic entries have no file to fetch; a 404 would read as
+        // unknown and keep them offered, so they are decided from the path.
+        assert_eq!(
+            classify_workflow_path("dynamic/dependabot/dependabot-updates"),
+            PathVerdict::NotDispatchable
+        );
+        assert_eq!(
+            classify_workflow_path("dynamic/agents/copilot-pull-request-reviewer"),
+            PathVerdict::NotDispatchable
+        );
+        assert_eq!(
+            classify_workflow_path(".github/workflows/ci.yml"),
+            PathVerdict::Fetch
+        );
+        assert_eq!(
+            classify_workflow_path(".github/workflows/a?b.yml"),
+            PathVerdict::Unknown
+        );
+    }
+
+    #[test]
+    fn humanizes_only_the_missing_trigger_error() {
+        let raw = "HTTP 422: Workflow does not have 'workflow_dispatch' trigger (https://api.github.com/repos/o/r/actions/workflows/98765432/dispatches)";
+        let out = humanize_dispatch_error(raw, "master");
+        assert_eq!(
+            out.lines().next().unwrap(),
+            "This workflow can't be run manually: it has no workflow_dispatch trigger on \"master\"."
+        );
+        assert!(out.ends_with(raw), "raw text must survive verbatim: {out}");
+
+        // Case-insensitive: gh/GitHub casing is not a contract.
+        assert!(humanize_dispatch_error(
+            "http 422: workflow does not have 'WORKFLOW_DISPATCH' trigger",
+            "main"
+        )
+        .starts_with("This workflow can't be run manually"));
+
+        let unrelated = "HTTP 404: Not Found (https://api.github.com/repos/o/r/actions/workflows/1/dispatches)";
+        assert_eq!(humanize_dispatch_error(unrelated, "master"), unrelated);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -608,6 +608,7 @@ pub fn run() {
             github::release::gh_release_download_asset,
             github::pr::gh_branch_protections,
             github::actions::gh_workflow_list,
+            github::actions::gh_workflow_dispatchable,
             fsops::append_to_gitignore,
             fsops::read_text_file,
             fsops::delete_repo_folder,

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -44,7 +44,13 @@ import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { RunContextMenuItems } from "./RunContextMenu";
 import { RunWorkflowDialog } from "./RunWorkflowDialog";
-import { rerunSuccessMessage, StatusIcon, statusLabel } from "./status";
+import {
+  cancelStartedMessage,
+  isPipelineProvider,
+  rerunSuccessMessage,
+  StatusIcon,
+  statusLabel,
+} from "./status";
 
 export function ActionsPanel({
   repoPath,
@@ -63,8 +69,8 @@ export function ActionsPanel({
   const provider = forge.data?.provider;
   const isGitLab = provider === "gitlab";
   // GitLab and Bitbucket both call CI "pipelines"; only GitHub says "workflow".
-  const isPipelines = provider === "gitlab" || provider === "bitbucket";
-  const canWrite = provider !== "gitlab" && provider !== "bitbucket";
+  const isPipelines = isPipelineProvider(provider);
+  const canWrite = !isPipelines;
   const canDispatch = canWrite || forgeFeatureReady(forge.data, "ciDispatch");
   // Re-run and cancel are shared writes too — same `canWrite || …` shape, read
   // here so the row context menu offers exactly what the run detail view does.
@@ -127,7 +133,7 @@ export function ActionsPanel({
   async function doCancel(runId: number) {
     try {
       await cancel.mutateAsync(runId);
-      toast.success("Cancelling run…");
+      toast.success(cancelStartedMessage(provider));
     } catch (e) {
       toastError(e);
     }

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -68,7 +68,6 @@ export function ActionsPanel({
   const ghReady = forgeFeatureReady(forge.data, "ci");
   const provider = forge.data?.provider;
   const isGitLab = provider === "gitlab";
-  // GitLab and Bitbucket both call CI "pipelines"; only GitHub says "workflow".
   const isPipelines = isPipelineProvider(provider);
   const canWrite = !isPipelines;
   const canDispatch = canWrite || forgeFeatureReady(forge.data, "ciDispatch");

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -1,9 +1,15 @@
 import { ArrowClockwiseIcon, PlayIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useRef, useState } from "react";
+import { type MouseEvent, useRef, useState } from "react";
+import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   Empty,
   EmptyContent,
@@ -16,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
+import { suppressContextMenu } from "@/lib/context-menu";
 import {
   forgeFeatureReady,
   useForgeStatus,
@@ -23,14 +30,21 @@ import {
   useRepoWriteAccess,
   writeAccessReason,
 } from "@/lib/git/queries";
-import { useWorkflowRuns } from "@/lib/github/actions";
+import type { WorkflowRun } from "@/lib/github/actions";
+import {
+  useCancelRun,
+  useRerunRun,
+  useWorkflowRuns,
+} from "@/lib/github/actions";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
+import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+import { RunContextMenuItems } from "./RunContextMenu";
 import { RunWorkflowDialog } from "./RunWorkflowDialog";
-import { StatusIcon, statusLabel } from "./status";
+import { rerunSuccessMessage, StatusIcon, statusLabel } from "./status";
 
 export function ActionsPanel({
   repoPath,
@@ -52,6 +66,10 @@ export function ActionsPanel({
   const isPipelines = provider === "gitlab" || provider === "bitbucket";
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
   const canDispatch = canWrite || forgeFeatureReady(forge.data, "ciDispatch");
+  // Re-run and cancel are shared writes too — same `canWrite || …` shape, read
+  // here so the row context menu offers exactly what the run detail view does.
+  const canRerun = canWrite || forgeFeatureReady(forge.data, "ciRerun");
+  const canCancel = canWrite || forgeFeatureReady(forge.data, "ciCancel");
   // Starting a run is a repo write: an explicitly read-only viewer keeps the
   // control (with the reason) rather than losing it. CI is repo-wide, so the
   // probe takes no lens; an Activity-hidden tab still renders, so it also gates
@@ -77,7 +95,14 @@ export function ActionsPanel({
   const [branchOnly, setBranchOnly] = useState(false);
   const [filterText, setFilterText] = useState("");
   const [runOpen, setRunOpen] = useState(false);
+  // The workflow the dialog opens preselected on, when a caller asked for one
+  // ("Run workflow again…"); null is the plain "pick a workflow" open.
+  const [dialogWorkflow, setDialogWorkflow] = useState<string | null>(null);
+  // The run the one shared context menu acts on, set on right-click.
+  const [menuRun, setMenuRun] = useState<WorkflowRun | null>(null);
   const filterRef = useRef<HTMLInputElement>(null);
+  const rerun = useRerunRun(repoPath);
+  const cancel = useCancelRun(repoPath);
 
   const runs = useWorkflowRuns(
     repoPath,
@@ -88,7 +113,37 @@ export function ActionsPanel({
   const selectedRunId = useUiStore((s) => s.selectedRunId);
   const selectRun = useUiStore((s) => s.selectRun);
 
+  // Awaited continuations, not per-call callbacks: react-query drops those once
+  // the observer has no listeners, and this panel unmounts with its tab.
+  async function doRerun(runId: number, failedOnly: boolean) {
+    try {
+      await rerun.mutateAsync({ runId, failed: failedOnly });
+      toast.success(rerunSuccessMessage(provider, failedOnly));
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function doCancel(runId: number) {
+    try {
+      await cancel.mutateAsync(runId);
+      toast.success("Cancelling run…");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  function runAgain(workflowId: number | null) {
+    setDialogWorkflow(workflowId === null ? null : String(workflowId));
+    setRunOpen(true);
+  }
+
   useHotkeyAction("focus-filter", () => filterRef.current?.focus());
+  useHotkeyAction(
+    "run-workflow",
+    () => runAgain(null),
+    active && canDispatch && ghReady && !writeBlocked,
+  );
 
   const query = filterText.trim().toLowerCase();
   const allRuns = runs.data ?? [];
@@ -106,6 +161,24 @@ export function ActionsPanel({
     onActivate: (run) => selectRun(run.id),
     rowKey: (run) => String(run.id),
   });
+
+  // One shared context menu for the whole list (capture phase, so it records the
+  // right-clicked row before Base UI's trigger opens the menu). Right-clicking a
+  // run selects it — standard desktop behavior — so the menu and the detail pane
+  // always describe the same run; blank space gets no menu.
+  function handleContextMenu(e: MouseEvent) {
+    const id = (e.target as HTMLElement)
+      .closest("[data-row]")
+      ?.getAttribute("data-row");
+    const run = id ? visible.find((r) => String(r.id) === id) : undefined;
+    if (!run) {
+      setMenuRun(null);
+      suppressContextMenu(e);
+      return;
+    }
+    selectRun(run.id);
+    setMenuRun(run);
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -131,7 +204,7 @@ export function ActionsPanel({
               disabled={!ghReady || writeBlocked}
               reason={runHint}
               title={runHint}
-              onClick={() => setRunOpen(true)}
+              onClick={() => runAgain(null)}
             >
               <PlayIcon data-icon="inline-start" />
               Run {runNoun}…
@@ -226,7 +299,7 @@ export function ActionsPanel({
                     size="sm"
                     disabled={writeBlocked}
                     reason={writeReason}
-                    onClick={() => setRunOpen(true)}
+                    onClick={() => runAgain(null)}
                   >
                     <PlayIcon data-icon="inline-start" />
                     Run {runNoun}…
@@ -236,55 +309,89 @@ export function ActionsPanel({
             </Empty>
           )
         ) : (
-          <div onKeyDown={onListKeyDown}>
-            {visible.map((run) => {
-              const active = run.id === selectedRunId;
-              return (
-                <button
-                  type="button"
-                  key={run.id}
-                  data-row={String(run.id)}
-                  className={cn(
-                    "block w-full border-b px-3 py-2 text-left",
-                    active
-                      ? "bg-accent text-accent-foreground"
-                      : "hover:bg-muted/60",
-                  )}
-                  onClick={() => selectRun(run.id)}
-                  onDoubleClick={() => run.url && openUrl(run.url)}
-                >
-                  <p className="flex items-center gap-1.5 text-xs font-medium">
-                    <StatusIcon
-                      status={run.status}
-                      conclusion={run.conclusion}
-                      className="size-3.5"
-                    />
-                    <span className="truncate" title={run.displayTitle}>
-                      {run.displayTitle}
-                    </span>
-                  </p>
-                  <p className="mt-0.5 truncate pl-5 text-[11px] text-muted-foreground">
-                    {run.workflowName} · {run.headBranch} ·{" "}
-                    {statusLabel(run.status, run.conclusion)}
-                    {parseableDate(run.updatedAt) && (
-                      <>
-                        {" · "}
-                        <RelativeTime date={run.updatedAt} />
-                      </>
+          <ContextMenu>
+            <ContextMenuTrigger
+              render={
+                <div
+                  onKeyDown={onListKeyDown}
+                  onContextMenuCapture={handleContextMenu}
+                />
+              }
+            >
+              {visible.map((run) => {
+                const active = run.id === selectedRunId;
+                return (
+                  <button
+                    type="button"
+                    key={run.id}
+                    data-row={String(run.id)}
+                    className={cn(
+                      "block w-full border-b px-3 py-2 text-left",
+                      active
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted/60",
                     )}
-                  </p>
-                </button>
-              );
-            })}
-          </div>
+                    onClick={() => selectRun(run.id)}
+                    onDoubleClick={() => run.url && openUrl(run.url)}
+                  >
+                    <p className="flex items-center gap-1.5 text-xs font-medium">
+                      <StatusIcon
+                        status={run.status}
+                        conclusion={run.conclusion}
+                        className="size-3.5"
+                      />
+                      <span className="truncate" title={run.displayTitle}>
+                        {run.displayTitle}
+                      </span>
+                    </p>
+                    <p className="mt-0.5 truncate pl-5 text-[11px] text-muted-foreground">
+                      {run.workflowName} · {run.headBranch} ·{" "}
+                      {statusLabel(run.status, run.conclusion)}
+                      {parseableDate(run.updatedAt) && (
+                        <>
+                          {" · "}
+                          <RelativeTime date={run.updatedAt} />
+                        </>
+                      )}
+                    </p>
+                  </button>
+                );
+              })}
+            </ContextMenuTrigger>
+            <ContextMenuContent className="min-w-60">
+              {menuRun && (
+                <RunContextMenuItems
+                  run={menuRun}
+                  provider={provider}
+                  canRerun={canRerun}
+                  canCancel={canCancel}
+                  canRunAgain={canDispatch && ghReady}
+                  writeBlocked={writeBlocked}
+                  writeReason={writeReason}
+                  actions={{
+                    rerun: (runId, failedOnly) =>
+                      void doRerun(runId, failedOnly),
+                    cancel: (runId) => void doCancel(runId),
+                    runAgain,
+                  }}
+                />
+              )}
+            </ContextMenuContent>
+          </ContextMenu>
         )}
       </ScrollArea>
 
       <RunWorkflowDialog
         repoPath={repoPath}
         open={runOpen}
-        onOpenChange={setRunOpen}
+        onOpenChange={(open) => {
+          setRunOpen(open);
+          // Drop the preselect on close so the next plain open keeps whatever
+          // the picker last had, rather than re-forcing this workflow.
+          if (!open) setDialogWorkflow(null);
+        }}
         defaultRef={currentBranch ?? ""}
+        initialWorkflow={dialogWorkflow ?? undefined}
       />
     </div>
   );

--- a/src/features/actions/RunContextMenu.tsx
+++ b/src/features/actions/RunContextMenu.tsx
@@ -7,11 +7,21 @@ import { copyText } from "@/lib/clipboard";
 import { type ForgeProvider, providerLabel } from "@/lib/git/types";
 import type { WorkflowRun } from "@/lib/github/actions";
 import {
+  type CiRunNoun,
   cancelLabel,
   cancelOffered,
+  ciRunNoun,
+  isPipelineProvider,
   RERUN_TITLES,
   rerunOffers,
 } from "./status";
+
+/** Sentence-initial noun for the copy toast; the item's own label carries it
+ *  mid-sentence, where `ciRunNoun` is used directly. */
+const COPIED_URL_TOAST: Record<CiRunNoun, string> = {
+  run: "Run URL copied",
+  pipeline: "Pipeline URL copied",
+};
 
 /** Callbacks the menu items invoke — owned by the runs panel, which holds the
  *  mutations, toasts, and dialog state so this stays presentational. */
@@ -58,7 +68,8 @@ export function RunContextMenuItems({
     : [];
   const showCancel =
     canCancel && cancelOffered(provider, run.status, run.conclusion);
-  const isPipelines = provider === "gitlab" || provider === "bitbucket";
+  const isPipelines = isPipelineProvider(provider);
+  const noun = ciRunNoun(provider);
   // GitHub re-dispatches THIS run's workflow, so the item needs its database id;
   // GitLab and Bitbucket have nothing to preselect.
   const showRunAgain =
@@ -113,8 +124,10 @@ export function RunContextMenuItems({
           <ContextMenuItem onClick={() => openUrl(run.url)}>
             View on {providerLabel(provider)}
           </ContextMenuItem>
-          <ContextMenuItem onClick={() => copyText(run.url, "Run URL copied")}>
-            Copy run URL
+          <ContextMenuItem
+            onClick={() => copyText(run.url, COPIED_URL_TOAST[noun])}
+          >
+            Copy {noun} URL
           </ContextMenuItem>
         </>
       )}

--- a/src/features/actions/RunContextMenu.tsx
+++ b/src/features/actions/RunContextMenu.tsx
@@ -1,0 +1,123 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from "@/components/ui/context-menu";
+import { copyText } from "@/lib/clipboard";
+import { type ForgeProvider, providerLabel } from "@/lib/git/types";
+import type { WorkflowRun } from "@/lib/github/actions";
+import {
+  cancelLabel,
+  cancelOffered,
+  RERUN_TITLES,
+  rerunOffers,
+} from "./status";
+
+/** Callbacks the menu items invoke — owned by the runs panel, which holds the
+ *  mutations, toasts, and dialog state so this stays presentational. */
+export interface RunMenuActions {
+  rerun: (runId: number, failedOnly: boolean) => void;
+  cancel: (runId: number) => void;
+  /** Open the run dialog. A workflow id preselects that workflow (GitHub);
+   *  null just opens it — the pipeline forges have one config per project. */
+  runAgain: (workflowId: number | null) => void;
+}
+
+/**
+ * The runs-list right-click actions. Which re-runs are offered, and what they're
+ * called, come from the shared helpers in `status.tsx`, so this menu and the run
+ * detail view can't drift. Actions a provider can't perform are absent; ones the
+ * viewer lacks push access for stay visible and disabled, with the reason riding
+ * the label (a disabled menu item can't carry a tooltip).
+ */
+export function RunContextMenuItems({
+  run,
+  provider,
+  actions,
+  canRerun,
+  canCancel,
+  canRunAgain,
+  writeBlocked,
+  writeReason,
+}: {
+  run: WorkflowRun;
+  provider: ForgeProvider | null | undefined;
+  actions: RunMenuActions;
+  /** Forge capability, not permission: false hides the group entirely. */
+  canRerun: boolean;
+  canCancel: boolean;
+  canRunAgain: boolean;
+  writeBlocked: boolean;
+  writeReason?: string;
+}) {
+  // Destructured so each callback closes over a const binding rather than a
+  // property read off the actions object.
+  const { rerun, cancel, runAgain } = actions;
+  const offers = canRerun
+    ? rerunOffers(provider, run.status, run.conclusion)
+    : [];
+  const showCancel =
+    canCancel && cancelOffered(provider, run.status, run.conclusion);
+  const isPipelines = provider === "gitlab" || provider === "bitbucket";
+  // GitHub re-dispatches THIS run's workflow, so the item needs its database id;
+  // GitLab and Bitbucket have nothing to preselect.
+  const showRunAgain =
+    canRunAgain && (isPipelines || run.workflowDatabaseId > 0);
+  const hasWriteItems = offers.length > 0 || showCancel || showRunAgain;
+  const blockedHint = writeBlocked && writeReason ? ` (${writeReason})` : "";
+
+  return (
+    <>
+      {offers.map((offer) => (
+        <ContextMenuItem
+          key={offer.kind}
+          disabled={writeBlocked}
+          // A disabled item's tooltip never shows, so a blocked item explains
+          // itself through the label parenthetical instead.
+          title={writeBlocked ? undefined : RERUN_TITLES[offer.kind]}
+          onClick={() => rerun(run.id, offer.kind === "failed")}
+        >
+          {offer.label}
+          {blockedHint}
+        </ContextMenuItem>
+      ))}
+      {showCancel && (
+        <>
+          {offers.length > 0 && <ContextMenuSeparator />}
+          <ContextMenuItem
+            disabled={writeBlocked}
+            onClick={() => cancel(run.id)}
+          >
+            {cancelLabel(provider)}
+            {blockedHint}
+          </ContextMenuItem>
+        </>
+      )}
+      {showRunAgain && (
+        <>
+          {(offers.length > 0 || showCancel) && <ContextMenuSeparator />}
+          <ContextMenuItem
+            disabled={writeBlocked}
+            onClick={() =>
+              runAgain(isPipelines ? null : run.workflowDatabaseId)
+            }
+          >
+            {isPipelines ? "Run pipeline…" : "Run workflow again…"}
+            {blockedHint}
+          </ContextMenuItem>
+        </>
+      )}
+      {run.url && (
+        <>
+          {hasWriteItems && <ContextMenuSeparator />}
+          <ContextMenuItem onClick={() => openUrl(run.url)}>
+            View on {providerLabel(provider)}
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => copyText(run.url, "Run URL copied")}>
+            Copy run URL
+          </ContextMenuItem>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -47,7 +47,9 @@ import { DebugJobDialog } from "./DebugJobDialog";
 import {
   cancelLabel,
   cancelOffered,
+  cancelStartedMessage,
   isFailureConclusion,
+  isPipelineProvider,
   RERUN_TITLES,
   rerunOffers,
   rerunSuccessMessage,
@@ -316,7 +318,7 @@ export function RunDetailView({
   // `rerunOffers`; these flags only decide whether the group renders at all.
   const forge = useForgeStatus(repoPath);
   const provider = forge.data?.provider;
-  const canWrite = provider !== "gitlab" && provider !== "bitbucket";
+  const canWrite = !isPipelineProvider(provider);
   const canRerun = canWrite || forgeFeatureReady(forge.data, "ciRerun");
   const canCancel = canWrite || forgeFeatureReady(forge.data, "ciCancel");
   // Playing a manual job is GitLab-only (no GitHub analogue here), so the flag
@@ -335,7 +337,7 @@ export function RunDetailView({
   const remoteLabel = providerLabel(provider);
   // GitLab pipelines and Bitbucket steps carry no per-job step list; only GitHub
   // jobs do — so the steps placeholder is suppressed for both.
-  const stepsExpected = provider !== "gitlab" && provider !== "bitbucket";
+  const stepsExpected = !isPipelineProvider(provider);
   const [debugJob, setDebugJob] = useState<RunJob | null>(null);
   // Dialog visibility is tracked separately from the debug session so closing
   // the dialog just hides it (the run keeps streaming) and reopening resumes.
@@ -380,7 +382,7 @@ export function RunDetailView({
   async function doCancel() {
     try {
       await cancel.mutateAsync(runId);
-      toast.success("Cancelling run…");
+      toast.success(cancelStartedMessage(provider));
     } catch (e) {
       toastError(e);
     }

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -414,12 +414,16 @@ export function RunDetailView({
   useHotkeyAction(
     "rerun-run",
     () => void doRerun(false),
-    tabActive && !writeBlocked && canRerun && rerunChoices.length > 0,
+    tabActive &&
+      !writeBlocked &&
+      canRerun &&
+      rerunChoices.length > 0 &&
+      !rerun.isPending,
   );
   useHotkeyAction(
     "cancel-run",
     () => void doCancel(),
-    tabActive && !writeBlocked && canCancel && showCancel,
+    tabActive && !writeBlocked && canCancel && showCancel && !cancel.isPending,
   );
 
   // A manual GitLab job arrives as completed + action_required; with the flag

--- a/src/features/actions/RunDetailView.tsx
+++ b/src/features/actions/RunDetailView.tsx
@@ -44,7 +44,16 @@ import { useConfirm } from "@/lib/stores/confirm";
 import { formatDurationBetween, parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { DebugJobDialog } from "./DebugJobDialog";
-import { isFailureConclusion, StatusIcon, statusLabel } from "./status";
+import {
+  cancelLabel,
+  cancelOffered,
+  isFailureConclusion,
+  RERUN_TITLES,
+  rerunOffers,
+  rerunSuccessMessage,
+  StatusIcon,
+  statusLabel,
+} from "./status";
 
 /** `gh` writes a short "still in progress" line to the log when a job's archive
  *  isn't ready yet (it briefly races a just-finished job). Detect it so we show
@@ -303,10 +312,8 @@ export function RunDetailView({
   const aiEnabled = useAiEnabled();
   // Re-run and cancel are SHARED writes (GitHub + GitLab): `canWrite || …` keeps
   // GitHub's controls up while forge-status is pending and positively enables a
-  // ready GitLab repo. GitLab's retry restarts failed+canceled jobs only, so it
-  // gets a single "Retry pipeline" button — "Re-run all jobs" has no GitLab
-  // analogue and stays on `canWrite` (GitHub-only). GitLab pipelines also have no
-  // per-job steps, so the steps placeholder is suppressed for them.
+  // ready GitLab repo. Which re-runs each provider offers comes from
+  // `rerunOffers`; these flags only decide whether the group renders at all.
   const forge = useForgeStatus(repoPath);
   const provider = forge.data?.provider;
   const canWrite = provider !== "gitlab" && provider !== "bitbucket";
@@ -339,18 +346,15 @@ export function RunDetailView({
   const run = detail.data;
   const active = run ? isRunActive(run.status) : false;
   const failed = run ? isFailureConclusion(run.conclusion) : false;
-  // GitLab's retry also covers a canceled pipeline (its retry restarts
-  // failed + canceled jobs), so the Retry button shows for both conclusions.
-  const retryable = failed || run?.conclusion === "cancelled";
-  // Bitbucket has no rerun endpoint — "rerun" re-triggers the branch pipeline (a
-  // fresh run), which makes sense on ANY finished pipeline (success too). Show it
-  // once the run is no longer in flight (a conclusion has been recorded).
-  const bitbucketRerunnable =
-    provider === "bitbucket" && !active && !!run?.conclusion;
-  // A manual/blocked GitLab pipeline maps to completed/action_required, but
-  // GitLab's cancel endpoint does cancel it — keep Cancel available there.
-  const gitlabBlocked =
-    provider === "gitlab" && run?.conclusion === "action_required";
+  // Which re-runs this provider offers for this run, and whether Cancel applies
+  // — shared with the runs-list context menu so the offers and their wording
+  // stay identical on both surfaces.
+  const rerunChoices = run
+    ? rerunOffers(provider, run.status, run.conclusion)
+    : [];
+  const showCancel = run
+    ? cancelOffered(provider, run.status, run.conclusion)
+    : false;
   // GitHub holds a first-time contributor's fork-PR run until a maintainer
   // approves it. Which field carries that state is unverified, so accept it on
   // either — a run that never reports it simply never shows the strip.
@@ -367,19 +371,7 @@ export function RunDetailView({
   async function doRerun(failedOnly: boolean) {
     try {
       await rerun.mutateAsync({ runId, failed: failedOnly });
-      const message = (() => {
-        switch (true) {
-          case provider === "gitlab":
-            return "Retrying pipeline";
-          case provider === "bitbucket":
-            return "Triggering a new pipeline";
-          case failedOnly:
-            return "Re-running failed jobs";
-          default:
-            return "Re-running workflow";
-        }
-      })();
-      toast.success(message);
+      toast.success(rerunSuccessMessage(provider, failedOnly));
     } catch (e) {
       toastError(e);
     }
@@ -415,6 +407,18 @@ export function RunDetailView({
   }
 
   useHotkeyAction("approve-workflow-run", () => void doApprove(), canApprove);
+  // Palette routes to the primary offer: a full re-run (GitHub) or the single
+  // retry/rerun the pipeline forges expose, which ignore the failed-only flag.
+  useHotkeyAction(
+    "rerun-run",
+    () => void doRerun(false),
+    tabActive && !writeBlocked && canRerun && rerunChoices.length > 0,
+  );
+  useHotkeyAction(
+    "cancel-run",
+    () => void doCancel(),
+    tabActive && !writeBlocked && canCancel && showCancel,
+  );
 
   // A manual GitLab job arrives as completed + action_required; with the flag
   // gate GitHub never matches (its manual approvals work differently).
@@ -469,7 +473,7 @@ export function RunDetailView({
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-2">
-          {active || gitlabBlocked
+          {showCancel
             ? canCancel && (
                 <DisabledReasonButton
                   variant="outline"
@@ -483,65 +487,24 @@ export function RunDetailView({
                   ) : (
                     <ProhibitIcon data-icon="inline-start" />
                   )}
-                  Cancel run
+                  {cancelLabel(provider)}
                 </DisabledReasonButton>
               )
-            : provider === "gitlab"
-              ? canRerun &&
-                retryable && (
-                  <DisabledReasonButton
-                    variant="outline"
-                    size="sm"
-                    disabled={rerun.isPending || writeBlocked}
-                    reason={writeReason}
-                    title="Restart this pipeline's failed and canceled jobs"
-                    onClick={() => doRerun(true)}
-                  >
-                    <ArrowClockwiseIcon data-icon="inline-start" />
-                    Retry pipeline
-                  </DisabledReasonButton>
-                )
-              : provider === "bitbucket"
-                ? canRerun &&
-                  bitbucketRerunnable && (
-                    <DisabledReasonButton
-                      variant="outline"
-                      size="sm"
-                      disabled={rerun.isPending || writeBlocked}
-                      reason={writeReason}
-                      title="Trigger this pipeline's branch again"
-                      onClick={() => doRerun(true)}
-                    >
-                      <ArrowClockwiseIcon data-icon="inline-start" />
-                      Rerun pipeline
-                    </DisabledReasonButton>
-                  )
-                : canWrite && (
-                    <>
-                      <DisabledReasonButton
-                        variant="outline"
-                        size="sm"
-                        disabled={rerun.isPending || writeBlocked}
-                        reason={writeReason}
-                        onClick={() => doRerun(false)}
-                      >
-                        <ArrowClockwiseIcon data-icon="inline-start" />
-                        Re-run all jobs
-                      </DisabledReasonButton>
-                      {failed && (
-                        <DisabledReasonButton
-                          variant="outline"
-                          size="sm"
-                          disabled={rerun.isPending || writeBlocked}
-                          reason={writeReason}
-                          onClick={() => doRerun(true)}
-                        >
-                          <ArrowClockwiseIcon data-icon="inline-start" />
-                          Re-run failed jobs
-                        </DisabledReasonButton>
-                      )}
-                    </>
-                  )}
+            : canRerun &&
+              rerunChoices.map((offer) => (
+                <DisabledReasonButton
+                  key={offer.kind}
+                  variant="outline"
+                  size="sm"
+                  disabled={rerun.isPending || writeBlocked}
+                  reason={writeReason}
+                  title={RERUN_TITLES[offer.kind]}
+                  onClick={() => doRerun(offer.kind === "failed")}
+                >
+                  <ArrowClockwiseIcon data-icon="inline-start" />
+                  {offer.label}
+                </DisabledReasonButton>
+              ))}
           <DisabledReasonButton
             variant="ghost"
             size="sm"

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -31,6 +31,7 @@ import {
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
+import { isPipelineProvider } from "./status";
 
 /** Only an explicit false refuses a workflow: a missing key — probe pending,
  *  errored, or unable to tell — keeps it offered, so a failed probe never hides
@@ -63,9 +64,9 @@ export function RunWorkflowDialog({
   // its GitHub-only `gh workflow list` query never fires), and "inputs" become
   // CI/CD variables on the new pipeline.
   const provider = useForgeStatus(repoPath).data?.provider;
-  const isPipelineProvider = provider === "gitlab" || provider === "bitbucket";
+  const isPipelines = isPipelineProvider(provider);
   const isBitbucket = provider === "bitbucket";
-  const workflows = useWorkflows(repoPath, open && !isPipelineProvider);
+  const workflows = useWorkflows(repoPath, open && !isPipelines);
   // Bitbucket custom-pipeline selectors (from the working-tree
   // `bitbucket-pipelines.yml`). When present, they're offered above the ref
   // alongside "Default" (the branch pipeline). Other providers never fetch.
@@ -165,7 +166,7 @@ export function RunWorkflowDialog({
   const dispatchProbe = useWorkflowDispatchable(
     repoPath,
     debouncedRef,
-    open && !isPipelineProvider,
+    open && !isPipelines,
   );
   const probed = dispatchProbe.data;
 
@@ -227,7 +228,7 @@ export function RunWorkflowDialog({
   // this panel, and react-query drops per-call callbacks once the observer has no
   // listeners.
   async function submit() {
-    if ((!isPipelineProvider && !workflow) || !gitRef.trim()) return;
+    if ((!isPipelines && !workflow) || !gitRef.trim()) return;
     const record: Record<string, string> = {};
     for (const { key, value } of inputs) {
       const k = key.trim();
@@ -241,7 +242,7 @@ export function RunWorkflowDialog({
       switch (true) {
         case isBitbucket:
           return pipeline;
-        case isPipelineProvider:
+        case isPipelines:
           return "";
         default:
           return workflow;
@@ -253,12 +254,9 @@ export function RunWorkflowDialog({
         gitRef: gitRef.trim(),
         inputs: record,
       });
-      toast.success(
-        isPipelineProvider ? "Pipeline started" : "Workflow dispatched",
-        {
-          description: "It may take a few seconds to appear in the runs list.",
-        },
-      );
+      toast.success(isPipelines ? "Pipeline started" : "Workflow dispatched", {
+        description: "It may take a few seconds to appear in the runs list.",
+      });
       // The toast reports the dispatch wherever the user went; the navigation only
       // applies to the dialog they are still in, so it is gated on the session that
       // started it — a close, a reopen, or a tab switch mid-dispatch would
@@ -274,21 +272,19 @@ export function RunWorkflowDialog({
   }
 
   const noneDispatchable =
-    !isPipelineProvider && !workflows.isPending && dispatchable.length === 0;
+    !isPipelines && !workflows.isPending && dispatchable.length === 0;
   const selectedNoTrigger =
-    !isPipelineProvider &&
-    workflow !== "" &&
-    hasNoManualTrigger(probed, workflow);
+    !isPipelines && workflow !== "" && hasNoManualTrigger(probed, workflow);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            {isPipelineProvider ? "Run pipeline" : "Run workflow"}
+            {isPipelines ? "Run pipeline" : "Run workflow"}
           </DialogTitle>
           <DialogDescription>
-            {isPipelineProvider ? (
+            {isPipelines ? (
               "Run a new pipeline on a branch or tag."
             ) : (
               <>
@@ -301,7 +297,7 @@ export function RunWorkflowDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          {!isPipelineProvider && (
+          {!isPipelines && (
             <div className="space-y-2">
               <Label htmlFor={`${idBase}-workflow`}>Workflow</Label>
               <Select
@@ -403,7 +399,7 @@ export function RunWorkflowDialog({
           >
             <div className="flex items-center justify-between">
               <Label id={`${idBase}-inputs-label`}>
-                {isPipelineProvider ? "Variables" : "Inputs"}{" "}
+                {isPipelines ? "Variables" : "Inputs"}{" "}
                 <span className="font-normal text-muted-foreground">
                   (optional)
                 </span>
@@ -420,12 +416,12 @@ export function RunWorkflowDialog({
                 }
               >
                 <PlusIcon data-icon="inline-start" />
-                {isPipelineProvider ? "Add variable" : "Add input"}
+                {isPipelines ? "Add variable" : "Add input"}
               </Button>
             </div>
             {inputs.length === 0 ? (
               <p className="text-xs text-muted-foreground">
-                {isPipelineProvider
+                {isPipelines
                   ? "Add CI/CD variables to pass to the pipeline."
                   : "Add key/value pairs if the workflow defines inputs."}
               </p>
@@ -466,7 +462,7 @@ export function RunWorkflowDialog({
                       variant="ghost"
                       size="icon-xs"
                       aria-label={
-                        isPipelineProvider ? "Remove variable" : "Remove input"
+                        isPipelines ? "Remove variable" : "Remove input"
                       }
                       onClick={() =>
                         setInputs((prev) => prev.filter((r) => r.id !== row.id))
@@ -487,14 +483,14 @@ export function RunWorkflowDialog({
           </Button>
           <Button
             disabled={
-              (!isPipelineProvider && !workflow) ||
+              (!isPipelines && !workflow) ||
               selectedNoTrigger ||
               !gitRef.trim() ||
               runWorkflow.isPending
             }
             onClick={submit}
           >
-            {isPipelineProvider ? "Run pipeline" : "Run workflow"}
+            {isPipelines ? "Run pipeline" : "Run workflow"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -168,7 +168,11 @@ export function RunWorkflowDialog({
     debouncedRef,
     open && !isPipelines,
   );
-  const probed = dispatchProbe.data;
+  // Verdicts are ref-scoped, and the debounce lets the input run ahead of the ref
+  // they were probed for: a mid-debounce mismatch reads as no-verdict, never as
+  // refusal. Gated at the one read, so every consumer below fails open together.
+  const probeCurrent = gitRef.trim() === debouncedRef;
+  const probed = probeCurrent ? dispatchProbe.data : undefined;
 
   useEffect(() => {
     // Only a landed list can judge an id. While the query is pending or errored

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -116,6 +116,14 @@ export function RunWorkflowDialog({
   // value string for anything the `items` map doesn't carry, and a since-disabled
   // workflow never joins that map at all.
   const pendingInitial = useRef<string | null>(null);
+  // Whether the current selection was chosen by the preselect rather than by a
+  // person. On a cold list the workflow query resolves before the slower
+  // per-workflow probe, so that first pick is made trigger-blind; only a pick marked
+  // here may be revised once the probe lands.
+  const autoPicked = useRef(false);
+  // The ref the standing selection was made under. The seed writes it too, so the
+  // open's own seeded ref never reads as a change.
+  const pickedUnderRef = useRef(defaultRef.trim());
   // Stable row ids keep input focus/state correct when rows are removed.
   const nextId = useRef(0);
   const [inputs, setInputs] = useState<
@@ -134,12 +142,23 @@ export function RunWorkflowDialog({
     // observer stays mounted, so only a new repo key or a gcTime eviction lands here;
     // a valid pick survives every ordinary reopen.
     if (!workflows.data) setWorkflow("");
+    pickedUnderRef.current = defaultRef.trim();
     // Armed here, consumed by the preselect effect below (which runs later in this
     // same commit) once the workflow list can vouch for the id.
     pendingInitial.current = initialWorkflow ?? null;
   });
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedRef(gitRef.trim()), 400);
+    const t = setTimeout(() => {
+      const next = gitRef.trim();
+      setDebouncedRef(next);
+      if (next === pickedUnderRef.current) return;
+      pickedUnderRef.current = next;
+      // An auto-pick is only defensible for the ref it was made under, and the seeded
+      // ref at open is not a change: a LATER ref whose probe refuses the standing
+      // selection shows the hint instead of silently swapping the picker, so toggling
+      // the ref can't flip-flop what is selected.
+      autoPicked.current = false;
+    }, 400);
     return () => clearTimeout(t);
   }, [gitRef]);
 
@@ -166,23 +185,34 @@ export function RunWorkflowDialog({
     pendingInitial.current = null;
     if (wanted && offered(wanted)) {
       // Replacing a carried-over selection is the point — the caller asked for this
-      // workflow, and nothing in this open has been touched yet.
+      // workflow, and nothing in this open has been touched yet. Named intent counts
+      // as a person's pick, so the probe may not revise it.
+      autoPicked.current = false;
       setWorkflow(wanted);
       return;
     }
-    // The selection outlives repo switches, so an id can belong to another repo (or
-    // to a workflow disabled/deleted since): left standing it renders raw in the
-    // closed trigger and dispatches an id gh can't resolve. Unoffered means unset.
-    if (workflow && offered(workflow)) return;
+    // Keep the selection only while it is still offered AND is either a person's pick
+    // or an auto-pick the probe hasn't refused. The selection outlives repo switches,
+    // so an unoffered id (another repo's, or disabled/deleted since) renders raw in
+    // the closed trigger and dispatches an id gh can't resolve.
+    if (
+      workflow &&
+      offered(workflow) &&
+      !(autoPicked.current && hasNoManualTrigger(probed, workflow))
+    ) {
+      return;
+    }
     if (dispatchable.length === 0) {
       setWorkflow("");
       return;
     }
     // Prefer a runnable workflow; with every one refused, the first still gets
-    // picked so the picker shows what it refuses (the Run button stays disabled).
+    // picked so the picker shows what it refuses (the Run button stays disabled) —
+    // and re-picking the same id bails out of setState, so this can't loop.
     const pick =
       dispatchable.find((w) => !hasNoManualTrigger(probed, String(w.id))) ??
       dispatchable[0];
+    autoPicked.current = true;
     setWorkflow(String(pick.id));
   }, [
     open,
@@ -277,7 +307,13 @@ export function RunWorkflowDialog({
               <Select
                 items={workflowItems}
                 value={workflow}
-                onValueChange={(v) => v && setWorkflow(v)}
+                onValueChange={(v) => {
+                  if (!v) return;
+                  // A hand-picked workflow is final: the probe landing later may
+                  // disable the Run button but never re-picks for the user.
+                  autoPicked.current = false;
+                  setWorkflow(v);
+                }}
                 disabled={dispatchable.length === 0}
               >
                 <SelectTrigger id={`${idBase}-workflow`} className="w-full">

--- a/src/features/actions/RunWorkflowDialog.tsx
+++ b/src/features/actions/RunWorkflowDialog.tsx
@@ -25,22 +25,36 @@ import { useForgeStatus } from "@/lib/git/queries";
 import {
   useBbCustomPipelines,
   useRunWorkflow,
+  useWorkflowDispatchable,
   useWorkflows,
 } from "@/lib/github/actions";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
+/** Only an explicit false refuses a workflow: a missing key — probe pending,
+ *  errored, or unable to tell — keeps it offered, so a failed probe never hides
+ *  a workflow the user could in fact run. */
+const hasNoManualTrigger = (
+  probed: Record<string, boolean> | undefined,
+  id: string,
+) => probed?.[id] === false;
+
 export function RunWorkflowDialog({
   repoPath,
   open,
   onOpenChange,
   defaultRef,
+  initialWorkflow,
 }: {
   repoPath: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   defaultRef: string;
+  /** Preselect this workflow (a stringified workflow id) on each open, once the
+   *  workflow list confirms it's still offered — GitHub only. Omitted, the picker
+   *  keeps its previous selection. */
+  initialWorkflow?: string;
 }) {
   // Per-mount base for the field ids (label↔control association).
   const idBase = useId();
@@ -92,6 +106,16 @@ export function RunWorkflowDialog({
   // "" = the branch's default pipeline; a name = a custom selector. Bitbucket only.
   const [pipeline, setPipeline] = useState("");
   const [gitRef, setGitRef] = useState(defaultRef);
+  // The ref the dispatch probe runs against. Debounced locally rather than via
+  // useDebouncedValue: the dialog stays mounted across open/close, so the seed
+  // below must re-point it SYNCHRONOUSLY — the default ref has to probe on open
+  // instead of waiting out a timer.
+  const [debouncedRef, setDebouncedRef] = useState(defaultRef.trim());
+  // The caller's preselect, held until the workflow list lands. Applying it in the
+  // open seed would put a raw id in the closed trigger: SelectValue renders the
+  // value string for anything the `items` map doesn't carry, and a since-disabled
+  // workflow never joins that map at all.
+  const pendingInitial = useRef<string | null>(null);
   // Stable row ids keep input focus/state correct when rows are removed.
   const nextId = useRef(0);
   const [inputs, setInputs] = useState<
@@ -101,14 +125,73 @@ export function RunWorkflowDialog({
   // Reset the form each time the dialog opens.
   useSeedOnOpen(open, () => {
     setGitRef(defaultRef);
+    setDebouncedRef(defaultRef.trim());
     setInputs([]);
     setPipeline("");
+    // No list for this repo yet means a carried-over selection can't be vouched for,
+    // and the closed trigger renders an unknown value as its raw id — clear it so the
+    // "Loading…" placeholder shows instead. A disabled query keeps its cache while the
+    // observer stays mounted, so only a new repo key or a gcTime eviction lands here;
+    // a valid pick survives every ordinary reopen.
+    if (!workflows.data) setWorkflow("");
+    // Armed here, consumed by the preselect effect below (which runs later in this
+    // same commit) once the workflow list can vouch for the id.
+    pendingInitial.current = initialWorkflow ?? null;
   });
   useEffect(() => {
-    if (open && !workflow && dispatchable.length > 0) {
-      setWorkflow(String(dispatchable[0].id));
+    const t = setTimeout(() => setDebouncedRef(gitRef.trim()), 400);
+    return () => clearTimeout(t);
+  }, [gitRef]);
+
+  const dispatchProbe = useWorkflowDispatchable(
+    repoPath,
+    debouncedRef,
+    open && !isPipelineProvider,
+  );
+  const probed = dispatchProbe.data;
+
+  useEffect(() => {
+    // Only a landed list can judge an id. While the query is pending or errored
+    // (including the never-enabled pipeline-provider case) nothing is touched, so a
+    // valid selection survives every open.
+    if (!open || workflows.isPending || !workflows.data) return;
+    const offered = (id: string) =>
+      dispatchable.some((w) => String(w.id) === id);
+
+    // Consumed once per open, whether or not it resolves: a refetch must never
+    // re-apply it over a selection the user has since made. A preselect the loaded
+    // list doesn't offer (workflow disabled or deleted since the run) is dropped
+    // for the ordinary default rather than shown as an unrunnable id.
+    const wanted = pendingInitial.current;
+    pendingInitial.current = null;
+    if (wanted && offered(wanted)) {
+      // Replacing a carried-over selection is the point — the caller asked for this
+      // workflow, and nothing in this open has been touched yet.
+      setWorkflow(wanted);
+      return;
     }
-  }, [open, workflow, dispatchable]);
+    // The selection outlives repo switches, so an id can belong to another repo (or
+    // to a workflow disabled/deleted since): left standing it renders raw in the
+    // closed trigger and dispatches an id gh can't resolve. Unoffered means unset.
+    if (workflow && offered(workflow)) return;
+    if (dispatchable.length === 0) {
+      setWorkflow("");
+      return;
+    }
+    // Prefer a runnable workflow; with every one refused, the first still gets
+    // picked so the picker shows what it refuses (the Run button stays disabled).
+    const pick =
+      dispatchable.find((w) => !hasNoManualTrigger(probed, String(w.id))) ??
+      dispatchable[0];
+    setWorkflow(String(pick.id));
+  }, [
+    open,
+    workflow,
+    dispatchable,
+    probed,
+    workflows.isPending,
+    workflows.data,
+  ]);
 
   // Awaited, not per-call callbacks: leaving the repo view mid-dispatch unmounts
   // this panel, and react-query drops per-call callbacks once the observer has no
@@ -162,6 +245,10 @@ export function RunWorkflowDialog({
 
   const noneDispatchable =
     !isPipelineProvider && !workflows.isPending && dispatchable.length === 0;
+  const selectedNoTrigger =
+    !isPipelineProvider &&
+    workflow !== "" &&
+    hasNoManualTrigger(probed, workflow);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -202,11 +289,24 @@ export function RunWorkflowDialog({
                   />
                 </SelectTrigger>
                 <SelectContent>
-                  {dispatchable.map((w) => (
-                    <SelectItem key={w.id} value={String(w.id)}>
-                      <SelectClipText>{w.name}</SelectClipText>
-                    </SelectItem>
-                  ))}
+                  {dispatchable.map((w) => {
+                    const refused = hasNoManualTrigger(probed, String(w.id));
+                    return (
+                      <SelectItem
+                        key={w.id}
+                        value={String(w.id)}
+                        disabled={refused}
+                      >
+                        {/* The reason rides inside the SOLE SelectClipText child:
+                            a sibling span would be pushed past the popup's clip
+                            edge. The `items` map keeps the plain name, which a
+                            disabled row can never reach anyway. */}
+                        <SelectClipText>
+                          {refused ? `${w.name} (no manual trigger)` : w.name}
+                        </SelectClipText>
+                      </SelectItem>
+                    );
+                  })}
                 </SelectContent>
               </Select>
               {noneDispatchable && (
@@ -214,6 +314,14 @@ export function RunWorkflowDialog({
                   No active workflows found. A workflow needs a{" "}
                   <code className="font-mono">workflow_dispatch</code> trigger
                   to be run manually.
+                </p>
+              )}
+              {/* At most one hint shows; an empty picker outranks a refused pick. */}
+              {selectedNoTrigger && !noneDispatchable && (
+                <p className="text-xs text-muted-foreground">
+                  This workflow can't be run manually: it has no{" "}
+                  <code className="font-mono">workflow_dispatch</code> trigger
+                  on the chosen branch or tag.
                 </p>
               )}
             </div>
@@ -344,6 +452,7 @@ export function RunWorkflowDialog({
           <Button
             disabled={
               (!isPipelineProvider && !workflow) ||
+              selectedNoTrigger ||
               !gitRef.trim() ||
               runWorkflow.isPending
             }

--- a/src/features/actions/status.tsx
+++ b/src/features/actions/status.tsx
@@ -8,6 +8,7 @@ import {
   WarningIcon,
   XCircleIcon,
 } from "@phosphor-icons/react";
+import type { ForgeProvider } from "@/lib/git/types";
 import { isRunActive } from "@/lib/github/actions";
 import { cn } from "@/lib/utils";
 
@@ -18,6 +19,24 @@ export function isFailureConclusion(conclusion: string): boolean {
     conclusion === "timed_out" ||
     conclusion === "startup_failure"
   );
+}
+
+/** Whether the provider calls its CI unit a pipeline rather than a workflow
+ *  run. An unrecognized host routes through `gh`, so it reads as GitHub. */
+export function isPipelineProvider(
+  provider: ForgeProvider | null | undefined,
+): boolean {
+  return provider === "gitlab" || provider === "bitbucket";
+}
+
+/** What this provider calls one CI unit. Every run-facing label and toast is
+ *  built from this, so one surface can never say "run" beside another's
+ *  "pipeline". */
+export type CiRunNoun = "run" | "pipeline";
+export function ciRunNoun(
+  provider: ForgeProvider | null | undefined,
+): CiRunNoun {
+  return isPipelineProvider(provider) ? "pipeline" : "run";
 }
 
 /** One re-run the provider offers for a run: the label users read, plus the
@@ -34,7 +53,7 @@ export type RerunOffer = {
  * Cancel is its only action.
  */
 export function rerunOffers(
-  provider: string | null | undefined,
+  provider: ForgeProvider | null | undefined,
   status: string,
   conclusion: string,
 ): RerunOffer[] {
@@ -73,7 +92,7 @@ export const RERUN_TITLES: Record<RerunOffer["kind"], string | undefined> = {
 /** The toast a started re-run shows, in the words of the provider's own
  *  operation. */
 export function rerunSuccessMessage(
-  provider: string | null | undefined,
+  provider: ForgeProvider | null | undefined,
   failedOnly: boolean,
 ): string {
   switch (true) {
@@ -91,7 +110,7 @@ export function rerunSuccessMessage(
 /** Whether Cancel applies to a run. A manual/blocked GitLab pipeline reports
  *  completed + action_required, but GitLab's cancel endpoint does cancel it. */
 export function cancelOffered(
-  provider: string | null | undefined,
+  provider: ForgeProvider | null | undefined,
   status: string,
   conclusion: string,
 ): boolean {
@@ -103,11 +122,17 @@ export function cancelOffered(
 
 /** What Cancel is called, in the provider's own noun. */
 export function cancelLabel(
-  provider: string | null | undefined,
+  provider: ForgeProvider | null | undefined,
 ): "Cancel run" | "Cancel pipeline" {
-  return provider === "gitlab" || provider === "bitbucket"
-    ? "Cancel pipeline"
-    : "Cancel run";
+  return `Cancel ${ciRunNoun(provider)}`;
+}
+
+/** The toast an accepted cancel shows — same noun as the control the user
+ *  clicked. */
+export function cancelStartedMessage(
+  provider: ForgeProvider | null | undefined,
+): string {
+  return `Cancelling ${ciRunNoun(provider)}…`;
 }
 
 /** Human label for a run/job/step's combined status + conclusion. */

--- a/src/features/actions/status.tsx
+++ b/src/features/actions/status.tsx
@@ -20,6 +20,96 @@ export function isFailureConclusion(conclusion: string): boolean {
   );
 }
 
+/** One re-run the provider offers for a run: the label users read, plus the
+ *  kind the caller dispatches. */
+export type RerunOffer = {
+  kind: "all" | "failed" | "retry" | "bb-rerun";
+  label: string;
+};
+
+/**
+ * The re-run offers for a run, in render order. Shared by the run detail view
+ * and the runs-list context menu so the two can't drift on which offers a
+ * provider makes or what they're called. An in-flight run offers none of them:
+ * Cancel is its only action.
+ */
+export function rerunOffers(
+  provider: string | null | undefined,
+  status: string,
+  conclusion: string,
+): RerunOffer[] {
+  // GitLab's retry restarts a pipeline's failed AND canceled jobs, so it covers
+  // both conclusions and has no "all jobs" analogue.
+  if (provider === "gitlab") {
+    return isFailureConclusion(conclusion) || conclusion === "cancelled"
+      ? [{ kind: "retry", label: "Retry pipeline" }]
+      : [];
+  }
+  // Bitbucket has no rerun endpoint — its "rerun" re-triggers the branch
+  // pipeline, which makes sense on any finished run (success included).
+  if (provider === "bitbucket") {
+    return !isRunActive(status) && conclusion !== ""
+      ? [{ kind: "bb-rerun", label: "Rerun pipeline" }]
+      : [];
+  }
+  if (isRunActive(status)) return [];
+  const offers: RerunOffer[] = [{ kind: "all", label: "Re-run all jobs" }];
+  if (isFailureConclusion(conclusion)) {
+    offers.push({ kind: "failed", label: "Re-run failed jobs" });
+  }
+  return offers;
+}
+
+/** Hover copy per re-run offer, for the two whose label doesn't say what the
+ *  provider actually restarts. Shared with the offers themselves so a surface
+ *  can't show one without the other. */
+export const RERUN_TITLES: Record<RerunOffer["kind"], string | undefined> = {
+  all: undefined,
+  failed: undefined,
+  retry: "Restart this pipeline's failed and canceled jobs",
+  "bb-rerun": "Trigger this pipeline's branch again",
+};
+
+/** The toast a started re-run shows, in the words of the provider's own
+ *  operation. */
+export function rerunSuccessMessage(
+  provider: string | null | undefined,
+  failedOnly: boolean,
+): string {
+  switch (true) {
+    case provider === "gitlab":
+      return "Retrying pipeline";
+    case provider === "bitbucket":
+      return "Triggering a new pipeline";
+    case failedOnly:
+      return "Re-running failed jobs";
+    default:
+      return "Re-running workflow";
+  }
+}
+
+/** Whether Cancel applies to a run. A manual/blocked GitLab pipeline reports
+ *  completed + action_required, but GitLab's cancel endpoint does cancel it. */
+export function cancelOffered(
+  provider: string | null | undefined,
+  status: string,
+  conclusion: string,
+): boolean {
+  return (
+    isRunActive(status) ||
+    (provider === "gitlab" && conclusion === "action_required")
+  );
+}
+
+/** What Cancel is called, in the provider's own noun. */
+export function cancelLabel(
+  provider: string | null | undefined,
+): "Cancel run" | "Cancel pipeline" {
+  return provider === "gitlab" || provider === "bitbucket"
+    ? "Cancel pipeline"
+    : "Cancel run";
+}
+
 /** Human label for a run/job/step's combined status + conclusion. */
 export function statusLabel(status: string, conclusion: string): string {
   if (status !== "completed") {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1607,6 +1607,13 @@ Actions workflow runs (needs \`gh\` + a GitHub remote). **GitLab pipelines** sho
 - Click a run to see its **jobs and steps** with status and durations — a job or step
   that's still running counts its elapsed time up live.
 - **Re-run all jobs**, **Re-run failed jobs**, or **Cancel** an in-progress run.
+- {{Secondaryclick}} a run in the list to act on it without opening it: the same
+  **re-run** and **cancel** offers, **Run workflow again…** (the Run dialog opens with
+  that run's workflow already picked), **View on GitHub**, and **Copy run URL**. Only
+  what applies to that run appears; if your sign-in can't push, the write actions stay
+  visible and disabled with the reason. The command palette carries these too, with no
+  default shortcut: **Run workflow/pipeline…** from anywhere in the tab, and re-run or
+  cancel for whichever run you have open.
 - A run GitHub is **holding for approval** — its gate on a first-time contributor's
   fork pull request — says so in the run, and **Approve and run** (it confirms first)
   releases it. The same offer appears above the pull request's checks list,
@@ -1614,7 +1621,10 @@ Actions workflow runs (needs \`gh\` + a GitHub remote). **GitLab pipelines** sho
   so GitDesktop offers it there only — there's no approval action on GitLab or Bitbucket
   pipelines.
 - **Run workflow…** manually dispatches a workflow (one with a \`workflow_dispatch\`
-  trigger) on a branch you choose, including any **input parameters** it defines.
+  trigger) on a branch you choose, including any **input parameters** it defines. The
+  picker marks a workflow that has no \`workflow_dispatch\` trigger on the ref you picked
+  as **(no manual trigger)** and won't let you choose it; if the workflow you already had
+  selected turns out not to have one there, a line under the picker says so.
 - Expand any job for its **logs** — or a failed run's **failed-step logs** — inline, and
   **copy** them with the button in the log's top-right corner.
 
@@ -1626,7 +1636,8 @@ latest one. Open a pipeline to see its **jobs** (status + durations, counting up
 a job runs); expand a job for its **log** (copyable from its corner). The pipeline actions
 work here too: **Cancel** a running pipeline, **Retry** a failed or canceled one (GitLab
 restarts its failed jobs), and **Run pipeline…** starts a fresh pipeline on a branch or tag,
-with optional **CI/CD variables**. A **manual job** — one that waits for a manual trigger —
+with optional **CI/CD variables**. The row {{secondaryclick}} menu carries the same
+offers, named for pipelines. A **manual job** — one that waits for a manual trigger —
 shows a **Run job** button that plays it.
 {{ai}}
 ## Debug with AI

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1607,13 +1607,14 @@ Actions workflow runs (needs \`gh\` + a GitHub remote). **GitLab pipelines** sho
 - Click a run to see its **jobs and steps** with status and durations — a job or step
   that's still running counts its elapsed time up live.
 - **Re-run all jobs**, **Re-run failed jobs**, or **Cancel** an in-progress run.
-- {{Secondaryclick}} a run in the list to act on it without opening it: the same
-  **re-run** and **cancel** offers, **Run workflow again…** (the Run dialog opens with
-  that run's workflow already picked), **View on GitHub**, and **Copy run URL**. Only
-  what applies to that run appears; if your sign-in can't push, the write actions stay
-  visible and disabled with the reason. The command palette carries these too, with no
-  default shortcut: **Run workflow/pipeline…** from anywhere in the tab, and re-run or
-  cancel for whichever run you have open.
+- {{Secondaryclick}} a run in the list for its actions without leaving the list — the
+  run is selected, so the detail pane follows. You get the same **re-run** and **cancel**
+  offers, **Run workflow again…** (the Run dialog opens with that run's workflow already
+  picked), **View on GitHub**, and **Copy run URL**. Only what applies to that run
+  appears; if your sign-in can't push, the write actions stay visible and disabled with
+  the reason. The command palette carries these too, with no default shortcut:
+  **Run workflow/pipeline…** from anywhere in the tab, and re-run or cancel for whichever
+  run you have open.
 - A run GitHub is **holding for approval** — its gate on a first-time contributor's
   fork pull request — says so in the run, and **Approve and run** (it confirms first)
   releases it. The same offer appears above the pull request's checks list,
@@ -1786,11 +1787,10 @@ Once connected:
   a running pipeline. The row {{secondaryclick}} menu carries the same actions, named for
   pipelines: **Rerun pipeline** on a finished one, **Cancel pipeline** on a running one,
   **Run pipeline…**, **View on Bitbucket**, and **Copy pipeline URL**. They're in the
-  command palette too, with no default shortcut. When the repo's
-  \`bitbucket-pipelines.yml\` defines **custom
-  pipelines** (\`pipelines.custom.*\`), the **Run pipeline** dialog adds a **Pipeline**
-  picker — run the branch's **Default** pipeline or a named custom one, with the same
-  variables.
+  command palette too, with no default shortcut. When the repo's \`bitbucket-pipelines.yml\`
+  defines **custom pipelines** (\`pipelines.custom.*\`), the **Run pipeline** dialog adds a
+  **Pipeline** picker — run the branch's **Default** pipeline or a named custom one, with
+  the same variables.
 - **Insights** — the **Insights** tab works on Bitbucket repos: the local-git charts
   (commit activity, code frequency, contributors, punch card), a **Pipelines** duration
   and success-rate chart, a **Fork activity** card listing the repo's recently active

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1783,7 +1783,11 @@ Once connected:
 - **Pipelines** — the **Actions** tab lists Bitbucket **Pipelines**; open one to see its
   **steps** with their **logs**. You can **rerun** a finished pipeline (re-triggers its
   branch), **trigger** a new one on a branch or tag (with optional variables), and **stop**
-  a running pipeline. When the repo's \`bitbucket-pipelines.yml\` defines **custom
+  a running pipeline. The row {{secondaryclick}} menu carries the same actions, named for
+  pipelines: **Rerun pipeline** on a finished one, **Cancel pipeline** on a running one,
+  **Run pipeline…**, **View on Bitbucket**, and **Copy pipeline URL**. They're in the
+  command palette too, with no default shortcut. When the repo's
+  \`bitbucket-pipelines.yml\` defines **custom
   pipelines** (\`pipelines.custom.*\`), the **Run pipeline** dialog adds a **Pipeline**
   picker — run the branch's **Default** pipeline or a named custom one, with the same
   variables.

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -11,6 +11,7 @@ import {
   type ActionDef,
   CATEGORY_ORDER,
 } from "@/lib/hotkeys/registry";
+import { matchesActionText, queryTokens } from "@/lib/hotkeys/search";
 import { cn } from "@/lib/utils";
 import { settingsFormOpts } from "./settings-form";
 
@@ -109,16 +110,20 @@ export const KeyboardSection = withForm({
     }, [recordingId]);
 
     const query = filter.trim().toLowerCase();
+    const tokens = queryTokens(filter);
 
-    /** Substring match over what the row shows: its label, its category, and
-     *  the binding in both display ("Ctrl+Shift+P") and canonical
-     *  ("mod+shift+p") form. "unbound" is the word for the empty binding —
-     *  from three characters on, so typing toward it narrows instead of
-     *  flashing the empty state ("un" still means the Unstage/Undo labels). */
+    /** Match over what the row shows, two ways. Label and category go through
+     *  the shared action-text search (every word present, any order, hyphens
+     *  ignored) so this list finds what the command palette finds. The binding
+     *  arms stay literal substrings of the raw query, in both display
+     *  ("Ctrl+Shift+P") and canonical ("mod+shift+p") form — tokenizing key
+     *  text would match across separators that mean something here. "unbound"
+     *  is the word for the empty binding, from three characters on, so typing
+     *  toward it narrows instead of flashing the empty state ("un" still means
+     *  the Unstage/Undo labels). */
     function matchesQuery(action: ActionDef): boolean {
       if (query === "") return true;
-      if (action.label.toLowerCase().includes(query)) return true;
-      if (action.category.toLowerCase().includes(query)) return true;
+      if (matchesActionText(tokens, action.label, action.category)) return true;
       const binding = effective(action.id);
       if (binding === null)
         return query.length >= 3 && "unbound".startsWith(query);

--- a/src/features/shortcuts/CommandPalette.tsx
+++ b/src/features/shortcuts/CommandPalette.tsx
@@ -35,15 +35,21 @@ export function CommandPalette({
     setHighlight(0);
   });
 
-  const q = query.trim().toLowerCase();
-  const items = ACTIONS.filter(
-    (a) =>
-      a.id !== "command-palette" &&
-      available.has(a.id) &&
-      (!q ||
-        a.label.toLowerCase().includes(q) ||
-        a.category.toLowerCase().includes(q)),
-  );
+  // Every whitespace-separated token must appear somewhere in the label +
+  // category, so a query can name words the label separates ("cancel pipeline"
+  // finds "Cancel workflow run/pipeline") instead of having to match one
+  // contiguous run of it. Hyphens drop from both sides, so a label's spelling
+  // of a compound word can't hide it from the other ("rerun" finds "Re-run…").
+  const norm = (s: string) => s.toLowerCase().replaceAll("-", "");
+  // Filter AFTER normalizing: an all-hyphen token normalizes to "", which every
+  // haystack "contains" — dropping it keeps the no-constraint path the only one.
+  const tokens = query.trim().split(/\s+/).map(norm).filter(Boolean);
+  const items = ACTIONS.filter((a) => {
+    if (a.id === "command-palette" || !available.has(a.id)) return false;
+    if (tokens.length === 0) return true;
+    const hay = norm(`${a.label} ${a.category}`);
+    return tokens.every((t) => hay.includes(t));
+  });
   const highlighted = items[Math.min(highlight, items.length - 1)];
 
   // Keep the highlighted row in view while arrowing through.

--- a/src/features/shortcuts/CommandPalette.tsx
+++ b/src/features/shortcuts/CommandPalette.tsx
@@ -8,6 +8,7 @@ import {
   useEffectiveBindings,
 } from "@/lib/hotkeys/hotkeys";
 import { ACTIONS, type ActionId } from "@/lib/hotkeys/registry";
+import { matchesActionText, queryTokens } from "@/lib/hotkeys/search";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
@@ -35,20 +36,10 @@ export function CommandPalette({
     setHighlight(0);
   });
 
-  // Every whitespace-separated token must appear somewhere in the label +
-  // category, so a query can name words the label separates ("cancel pipeline"
-  // finds "Cancel workflow run/pipeline") instead of having to match one
-  // contiguous run of it. Hyphens drop from both sides, so a label's spelling
-  // of a compound word can't hide it from the other ("rerun" finds "Re-run…").
-  const norm = (s: string) => s.toLowerCase().replaceAll("-", "");
-  // Filter AFTER normalizing: an all-hyphen token normalizes to "", which every
-  // haystack "contains" — dropping it keeps the no-constraint path the only one.
-  const tokens = query.trim().split(/\s+/).map(norm).filter(Boolean);
+  const tokens = queryTokens(query);
   const items = ACTIONS.filter((a) => {
     if (a.id === "command-palette" || !available.has(a.id)) return false;
-    if (tokens.length === 0) return true;
-    const hay = norm(`${a.label} ${a.category}`);
-    return tokens.every((t) => hay.includes(t));
+    return matchesActionText(tokens, a.label, a.category);
   });
   const highlighted = items[Math.min(highlight, items.length - 1)];
 

--- a/src/lib/github/actions.ts
+++ b/src/lib/github/actions.ts
@@ -20,6 +20,10 @@ export interface WorkflowRun {
   updatedAt: string;
   url: string;
   headSha: string;
+  /** The workflow this run belongs to, as its own database id — the handle a
+   *  re-dispatch needs. 0 on GitLab/Bitbucket rows: neither forge has a
+   *  per-workflow concept (one pipeline config per project). */
+  workflowDatabaseId: number;
 }
 
 export interface RunStep {
@@ -156,6 +160,14 @@ export const forgeGlCiPlayJob = (repoPath: string, jobId: number) =>
 export const ghWorkflowList = (repoPath: string) =>
   invoke<Workflow[]>("gh_workflow_list", { repoPath });
 
+/** Per-workflow workflow_dispatch presence at a ref, keyed by String(workflow.id).
+ *  A MISSING key means the probe couldn't tell — callers fail open (keep offering). */
+export const ghWorkflowDispatchable = (repoPath: string, gitRef: string) =>
+  invoke<Record<string, boolean>>("gh_workflow_dispatchable", {
+    repoPath,
+    gitRef,
+  });
+
 /** Start a run: GitHub dispatches `workflow` on the ref with `inputs`; GitLab runs
  *  a new pipeline on the ref with `inputs` as variables (send `workflow` empty);
  *  Bitbucket triggers the branch pipeline, or a named CUSTOM pipeline when `workflow`
@@ -237,6 +249,24 @@ export function useWorkflows(repo: string, enabled: boolean) {
     queryFn: () => ghWorkflowList(repo),
     enabled,
     staleTime: 5 * 60_000,
+  });
+}
+
+/** Which workflows accept a manual dispatch at `gitRef` (GitHub-only). The probe
+ *  fans out one `gh` process per workflow, so it never retries — a storm on every
+ *  keystroke of a bad ref would cost more than the affordance is worth — and an
+ *  empty ref isn't probed at all. */
+export function useWorkflowDispatchable(
+  repo: string,
+  gitRef: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "actions", "dispatchable", gitRef] as const,
+    queryFn: () => ghWorkflowDispatchable(repo, gitRef),
+    enabled: enabled && gitRef !== "",
+    staleTime: 5 * 60_000,
+    retry: false,
   });
 }
 

--- a/src/lib/github/actions.ts
+++ b/src/lib/github/actions.ts
@@ -262,7 +262,10 @@ export function useWorkflowDispatchable(
   enabled: boolean,
 ) {
   return useQuery({
-    queryKey: ["repo", repo, "actions", "dispatchable", gitRef] as const,
+    // Deliberately OUTSIDE the `["repo", repo, "actions"]` subtree the Actions
+    // mutations invalidate: dispatch/re-run/cancel can't change a workflow's trigger
+    // declarations, and a refetch here re-runs the whole per-workflow fan-out.
+    queryKey: ["repo", repo, "actions-dispatchable", gitRef] as const,
     queryFn: () => ghWorkflowDispatchable(repo, gitRef),
     enabled: enabled && gitRef !== "",
     staleTime: 5 * 60_000,

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -15,7 +15,8 @@ export type ActionCategory =
   | "Branches & stash"
   | "Changes"
   | "Agent"
-  | "Pull requests";
+  | "Pull requests"
+  | "Actions";
 
 export interface ActionDef {
   id: string;
@@ -799,10 +800,32 @@ export const ACTIONS = [
     category: "Pull requests",
     defaultBinding: null,
   },
+
+  // Actions
+  {
+    id: "run-workflow",
+    // Registry labels are static (no provider context here) — one label covers
+    // GitHub workflows and GitLab/Bitbucket pipelines alike.
+    label: "Run workflow/pipeline…",
+    category: "Actions",
+    defaultBinding: null,
+  },
+  {
+    id: "rerun-run",
+    label: "Re-run workflow run/pipeline",
+    category: "Actions",
+    defaultBinding: null,
+  },
+  {
+    id: "cancel-run",
+    label: "Cancel workflow run/pipeline",
+    category: "Actions",
+    defaultBinding: null,
+  },
   {
     id: "approve-workflow-run",
     label: "Approve workflow run",
-    category: "Pull requests",
+    category: "Actions",
     defaultBinding: null,
   },
 ] as const satisfies readonly ActionDef[];
@@ -817,6 +840,7 @@ export const CATEGORY_ORDER: ActionCategory[] = [
   "Changes",
   "Agent",
   "Pull requests",
+  "Actions",
 ];
 
 /**

--- a/src/lib/hotkeys/search.ts
+++ b/src/lib/hotkeys/search.ts
@@ -1,0 +1,34 @@
+/**
+ * Text search over the actions list, shared by the command palette and the
+ * Settings → Keyboard list so a query can't find an action in one and miss it
+ * in the other.
+ */
+
+const norm = (s: string) => s.toLowerCase().replaceAll("-", "");
+
+/**
+ * A query's searchable tokens: whitespace-separated, lowercased, hyphens
+ * dropped. Filtering AFTER normalizing matters — an all-hyphen token
+ * normalizes to "", which every haystack "contains", so dropping it keeps the
+ * no-constraint path the only one that matches everything.
+ */
+export function queryTokens(query: string): string[] {
+  return query.trim().split(/\s+/).map(norm).filter(Boolean);
+}
+
+/**
+ * Whether every token appears somewhere in an action's label + category, so
+ * word order and gaps cost nothing ("cancel pipeline" finds "Cancel workflow
+ * run/pipeline") and neither does hyphenation ("rerun" finds "Re-run…"). Each
+ * token still has to be a literal substring of what's left. No tokens matches
+ * everything.
+ */
+export function matchesActionText(
+  tokens: string[],
+  label: string,
+  category: string,
+): boolean {
+  if (tokens.length === 0) return true;
+  const hay = norm(`${label} ${category}`);
+  return tokens.every((t) => hay.includes(t));
+}


### PR DESCRIPTION
Right-clicking a run in the Actions list now offers the same re-run/cancel actions the detail pane has, plus "Run workflow again…", "View on GitHub", and "Copy run URL" — so acting on a run no longer requires opening it first. Alongside that, the Run workflow picker now probes each workflow's file for a `workflow_dispatch` trigger at the chosen ref, so a dispatch GitHub would reject with a raw HTTP 422 is visible (and refused) before you press Run.

### Run context menu

- Adds `src/features/actions/RunContextMenu.tsx`: a presentational `RunContextMenuItems` that renders the re-run offers, cancel, "Run workflow again…", and the open/copy pair, hiding what a provider can't do and keeping write items visible-but-disabled with the reason in the label (a disabled menu item can't carry a tooltip).
- Wires one shared `ContextMenu` around the run list in `src/features/actions/ActionsPanel.tsx`, recording the right-clicked row on the capture phase via `data-row`, selecting that run, and suppressing the menu on blank space through `suppressContextMenu`. The panel owns `doRerun` / `doCancel` (awaited continuations, since the tab unmounts) and the `runAgain` dialog handoff.
- Extracts the provider-specific behavior into `src/features/actions/status.tsx` so the menu and detail view can't drift: `rerunOffers`, `RERUN_TITLES`, `rerunSuccessMessage`, `cancelOffered`, and `cancelLabel`.
- Rewrites the button block in `src/features/actions/RunDetailView.tsx` to render from `rerunOffers` / `cancelOffered`, replacing the nested provider ternaries and the local `retryable` / `bitbucketRerunnable` / `gitlabBlocked` flags.

### Dispatch-trigger probe

- Adds the `gh_workflow_dispatchable` command in `src-tauri/src/github/actions.rs` (registered in `src-tauri/src/lib.rs`): it lists workflows server-side, classifies each path via `classify_workflow_path` (dynamic pseudo-workflows outside `.github/workflows/` are a definite no; paths carrying gh's endpoint metacharacters `{}?#` or a leading `-` stay unknown), then fetches raw contents at the ref behind a process-wide `DISPATCH_PROBE_GATE` semaphore. Failed probes leave the key absent so callers fail open.
- Adds `humanize_dispatch_error`, which prefixes GitHub's 422 with a plain first line (the toast shows only that) while keeping the raw text below for details.
- `RunWorkflowDialog.tsx` consumes the probe via the new `useWorkflowDispatchable` hook (`src/lib/github/actions.ts`, `retry: false`, 5-minute `staleTime`), locally debouncing the ref by 400ms so the open seed can re-point it synchronously. Refused workflows render as `(no manual trigger)` and are disabled; a refused current selection shows a hint and disables Run.
- Reworks the dialog's default-selection effect to validate a carried-over `workflow` id against the loaded list (stale ids from another repo previously rendered raw in the trigger and dispatched unresolvable ids), and adds `initialWorkflow` with a consume-once `pendingInitial` ref so "Run workflow again…" preselects without re-applying on refetch.
- Threads `workflowDatabaseId` end to end — new field on the Rust `WorkflowRun` and `RUN_LIST_FIELDS`, mirrored in the TS `WorkflowRun` interface, and set to `0` in `src-tauri/src/forge/gitlab.rs` and `src-tauri/src/forge/bitbucket.rs`, which have no per-workflow entity.
- Rust tests cover every `workflow_dispatch` spelling, the endpoint-syntax path rejections, pseudo-workflow classification, and the error humanizer.

### Shortcuts, docs, and hygiene

- Adds an `Actions` hotkey category in `src/lib/hotkeys/registry.ts` with `run-workflow`, `rerun-run`, and `cancel-run` (no default bindings), moves `approve-workflow-run` into it, and adds it to `CATEGORY_ORDER`; the actions are bound in `ActionsPanel.tsx` and `RunDetailView.tsx`.
- Documents the menu and the trigger marking in `README.md` and the Actions/pipelines sections of `src/features/help/content.ts` (using `{{secondaryclick}}` tokens), with `changelog.d/added-actions-run-context-menu.md` and `changelog.d/fixed-run-workflow-dispatch-triggers.md`.
- Updates the `RunWorkflowDialog.tsx` allowlist comment in `scripts/check-banned-patterns.mjs` to describe the consume-once ref alongside the `!workflow` fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click menus for workflow and pipeline runs with re-run, cancel, run again, open in forge, and copy-link actions.
  * Added matching Actions commands to the command palette, with improved token-based search.
  * Run workflow now identifies workflows unavailable for manual triggering on the selected branch or tag.
  * Added provider-aware retry, cancellation, labels, and status messages.

* **Documentation**
  * Updated in-app help, README, and changelog entries for these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->