### PR TITLE
feat(pulls,ui): lay out PR header meta fields in a two-column grid

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -178,8 +178,8 @@ separators.
   (`src/components/meta-field-cells.tsx`) — never a hand-rolled `role="group"`
   value cell or a re-spelled empty-dash placeholder. A forge user inside one of
   those cells is a `UserChip` from the same module — never a hand-rolled
-  avatar + truncating-label span — and any sibling chip with its own markup
-  wears the shared `USER_CHIP_CLASS` box so adjacent chips can't drift. The
+  avatar + truncating-label span — and any chip that shares a value cell with
+  another but keeps its own markup wears the `USER_CHIP_CLASS` box. The
   pickers emit those two cells only under their `cells` prop; unset, each still
   renders its own inline trigger+chips row. Scope is that grid alone:
   `MrTimeTracking` (GitLab-only) deliberately keeps its own full-width row below

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -176,12 +176,16 @@ separators.
 - Header meta fields (the PR header's label/value grid: labels, assignees,
   projects, reviewers) render through `MetaValueCell` / `MetaFieldLabel`
   (`src/components/meta-field-cells.tsx`) — never a hand-rolled `role="group"`
-  value cell or a re-spelled empty-dash placeholder. The pickers emit those two
-  cells only under their `cells` prop; unset, each still renders its own inline
-  trigger+chips row. Scope is that grid alone: `MrTimeTracking` (GitLab-only)
-  deliberately keeps its own full-width row below it, and form-dialog field
-  groups (CreatePrDialog / CreateIssueDialog's `Label` + `aria-labelledby`
-  wrappers) are a richer separate pattern this rule doesn't govern.
+  value cell or a re-spelled empty-dash placeholder. A forge user inside one of
+  those cells is a `UserChip` from the same module — never a hand-rolled
+  avatar + truncating-label span — and any sibling chip with its own markup
+  wears the shared `USER_CHIP_CLASS` box so adjacent chips can't drift. The
+  pickers emit those two cells only under their `cells` prop; unset, each still
+  renders its own inline trigger+chips row. Scope is that grid alone:
+  `MrTimeTracking` (GitLab-only) deliberately keeps its own full-width row below
+  it, and form-dialog field groups (CreatePrDialog / CreateIssueDialog's `Label`
+  + `aria-labelledby` wrappers) are a richer separate pattern this rule doesn't
+  govern.
 
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -178,7 +178,10 @@ separators.
   (`src/components/meta-field-cells.tsx`) — never a hand-rolled `role="group"`
   value cell or a re-spelled empty-dash placeholder. The pickers emit those two
   cells only under their `cells` prop; unset, each still renders its own inline
-  trigger+chips row.
+  trigger+chips row. Scope is that grid alone: `MrTimeTracking` (GitLab-only)
+  deliberately keeps its own full-width row below it, and form-dialog field
+  groups (CreatePrDialog / CreateIssueDialog's `Label` + `aria-labelledby`
+  wrappers) are a richer separate pattern this rule doesn't govern.
 
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -152,6 +152,12 @@ words the user reads on screen — the palette matcher is a plain substring, so
 - Shared-ContextMenu suppression for non-target right-clicks goes through
   `suppressContextMenu` (`src/lib/context-menu.ts`) — `preventDefault` alone
   still opens Base UI's menu as an empty popup.
+- Header meta fields (the PR header's label/value grid: labels, assignees,
+  projects, reviewers) render through `MetaValueCell` / `MetaFieldLabel`
+  (`src/components/meta-field-cells.tsx`) — never a hand-rolled `role="group"`
+  value cell or a re-spelled empty-dash placeholder. The pickers emit those two
+  cells only under their `cells` prop; unset, each still renders its own inline
+  trigger+chips row.
 
 **Layout gotchas.** `DialogContent` is a grid — truncating flex content needs
 `min-w-0` on the grid item; cap tall dialogs at `max-h-[85vh]`. Link-styled

--- a/changelog.d/changed-pr-header-meta-grid.md
+++ b/changelog.d/changed-pr-header-meta-grid.md
@@ -1,3 +1,3 @@
-- Pull request and merge request headers now arrange labels, assignees, projects,
-  and reviewers in a label/value grid that packs two fields per line and drops to
-  one as the panel narrows.
+- Pull request and merge request headers now arrange the meta fields your forge
+  provides (labels, assignees, projects, reviewers) in a label/value grid — two
+  fields per line where the panel has room, one where it doesn't.

--- a/changelog.d/changed-pr-header-meta-grid.md
+++ b/changelog.d/changed-pr-header-meta-grid.md
@@ -1,0 +1,3 @@
+- Pull request and merge request headers now arrange labels, assignees, projects,
+  and reviewers in a label/value grid that packs two fields per line and drops to
+  one as the panel narrows.

--- a/src/components/meta-field-cells.tsx
+++ b/src/components/meta-field-cells.tsx
@@ -57,8 +57,9 @@ export function MetaValueCell({
   );
 }
 
-/** The chip box shared by every chip that can sit in one meta value cell — a
- *  user, a bot request, a completed review — so adjacent chips can't drift. */
+/** The chip box shared by every chip that can share one value cell with
+ *  another — a user, a bot request, a completed review — so adjacent chips
+ *  can't drift. */
 export const USER_CHIP_CLASS =
   "inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground";
 

--- a/src/components/meta-field-cells.tsx
+++ b/src/components/meta-field-cells.tsx
@@ -1,11 +1,18 @@
 import type { ReactNode } from "react";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { clipTitleFromText } from "@/lib/clip-title";
+import type { ForgeUserRef } from "@/lib/git/types";
 
 /** A blank grid cell reads as a broken render, so an empty field says it has
- *  nothing instead. Decorative — the cell's own label already names the field. */
+ *  nothing instead. The dash is decorative; the word beside it is what a screen
+ *  reader hears, the cell's own label having already named the field. */
 const EMPTY_CELL = (
-  <span aria-hidden className="text-muted-foreground">
-    —
-  </span>
+  <>
+    <span aria-hidden className="text-muted-foreground">
+      —
+    </span>
+    <span className="sr-only">None</span>
+  </>
 );
 
 /**
@@ -19,21 +26,73 @@ const EMPTY_CELL = (
 export function MetaValueCell({
   label,
   empty = false,
+  busy = false,
   children,
 }: {
   label: string;
   /** The field holds nothing — render the placeholder rather than `children`. */
   empty?: boolean;
+  /** The value is still being read, so `children` is a placeholder rather than
+   *  the value — set it only when nothing real is on screen, since a refetch
+   *  over visible content isn't a busy region. */
+  busy?: boolean;
   children?: ReactNode;
 }) {
   return (
     <div
       role="group"
       aria-label={label}
+      aria-busy={busy || undefined}
       className="flex min-h-6 min-w-0 flex-wrap items-center gap-1.5"
     >
+      {/* aria-busy alone has no text; role="status" gives the busy region words
+          for readers that announce it. */}
+      {busy ? (
+        <span role="status" className="sr-only">
+          Loading {label.toLowerCase()}…
+        </span>
+      ) : null}
       {empty ? EMPTY_CELL : children}
     </div>
+  );
+}
+
+/** The chip box shared by every chip that can sit in one meta value cell — a
+ *  user, a bot request, a completed review — so adjacent chips can't drift. */
+export const USER_CHIP_CLASS =
+  "inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground";
+
+/**
+ * A forge user as a chip — the shared shape behind assignee and reviewer values,
+ * editable and read-only alike. Bounded by its container so one long name can't
+ * set a narrow column's min-content width; the clip tooltip removes its own
+ * title when nothing is cut, leaving a caller's `title` to show through.
+ */
+export function UserChip({
+  user,
+  ghHost,
+  hint,
+  title,
+}: {
+  user: ForgeUserRef;
+  /** GitHub host for login-derived avatars; `null` off GitHub. */
+  ghHost: string | null;
+  /** Disambiguator for a label another account shares (`userRefHint`). */
+  hint?: string | null;
+  /** Chip-level tooltip for callers that want one whether or not the name is
+   *  cut — the disambiguated full label, say. */
+  title?: string;
+}) {
+  return (
+    <span title={title} className={USER_CHIP_CLASS}>
+      {/* Decorative: the label beside it is the name, so an announced fallback
+          letter would just precede it. */}
+      <ForgeUserAvatar user={user} ghHost={ghHost} decorative />
+      <span className="truncate" onMouseEnter={clipTitleFromText}>
+        {user.label}
+        {hint && <span className="text-muted-foreground"> · {hint}</span>}
+      </span>
+    </span>
   );
 }
 

--- a/src/components/meta-field-cells.tsx
+++ b/src/components/meta-field-cells.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+/** A blank grid cell reads as a broken render, so an empty field says it has
+ *  nothing instead. Decorative — the cell's own label already names the field. */
+const EMPTY_CELL = (
+  <span aria-hidden className="text-muted-foreground">
+    —
+  </span>
+);
+
+/**
+ * The value half of a header meta field (labels, assignees, projects,
+ * reviewers), paired in the grid with either its picker's trigger or a
+ * `MetaFieldLabel`. role="group" plus the field name is what ties a value to
+ * its field for assistive tech, the label column being a separate cell.
+ * `min-h-6` matches the ghost xs trigger's box so short content shares the
+ * row's centerline under the grid's `items-start`.
+ */
+export function MetaValueCell({
+  label,
+  empty = false,
+  children,
+}: {
+  label: string;
+  /** The field holds nothing — render the placeholder rather than `children`. */
+  empty?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="flex min-h-6 min-w-0 flex-wrap items-center gap-1.5"
+    >
+      {empty ? EMPTY_CELL : children}
+    </div>
+  );
+}
+
+/** The label half of a meta field with no picker — a closed PR, or a provider
+ *  that lacks it. The inset matches a ghost xs trigger's own text (a 1px
+ *  transparent border + pl-1.5 + a size-3 icon + gap-1), so a column mixing
+ *  static labels with triggers shares one text edge. */
+export function MetaFieldLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex min-h-6 items-center pl-[23px] text-xs text-muted-foreground">
+      {children}
+    </span>
+  );
+}

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@base-ui/react/popover";
 import { TagIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -24,6 +25,7 @@ export function LabelsPopover({
   labels,
   lens,
   disabledReason,
+  cells = false,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -39,6 +41,10 @@ export function LabelsPopover({
    *  its action needs, or the surface is still loading the entity. The trigger
    *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
+  /** Emit the trigger and the chips as two SIBLING elements rather than one
+   *  inline row, so a caller's label/value grid can place each in its own
+   *  column. Default renders the inline row. */
+  cells?: boolean;
 }) {
   const repoLabels = useRepoLabels(repoPath, enabled, lens);
   const editLabels = useEditPrLabels(repoPath, lens);
@@ -88,77 +94,91 @@ export function LabelsPopover({
     }
   }
 
+  // Trigger first, so it never shifts as chips come and go. A natively disabled
+  // button swallows `title`, so the reason rides a wrapping span.
+  const trigger = (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      <span
+        title={disabledReason}
+        className={
+          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        }
+      >
+        <Popover.Trigger
+          disabled={!!disabledReason}
+          render={<Button variant="ghost" size="xs" aria-label="Edit labels" />}
+        >
+          {editLabels.isPending ? (
+            <Spinner data-icon="inline-start" />
+          ) : (
+            <TagIcon data-icon="inline-start" />
+          )}
+          Labels
+        </Popover.Trigger>
+      </span>
+      <Popover.Portal container={portalContainer}>
+        <Popover.Positioner
+          align="start"
+          sideOffset={4}
+          className="isolate z-50"
+        >
+          <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <p className="px-1 pb-1.5 text-xs font-medium">Labels</p>
+            {(repoLabels.data ?? []).length === 0 && (
+              <p className="px-1 py-1 text-xs text-muted-foreground">
+                {repoLabels.isPending
+                  ? "Loading labels…"
+                  : "This repository has no labels."}
+              </p>
+            )}
+            {(repoLabels.data ?? []).map((label) => (
+              <label
+                key={label.name}
+                className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
+              >
+                <Checkbox
+                  checked={draft.has(label.name)}
+                  onCheckedChange={(v) => toggleDraft(label.name, v === true)}
+                />
+                <span
+                  aria-hidden
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: `#${label.color}` }}
+                />
+                <span className="flex-1 truncate" title={label.name}>
+                  {label.name}
+                </span>
+              </label>
+            ))}
+            {(repoLabels.data ?? []).length > 0 && (
+              <p className="mt-1 border-t px-1 pt-1.5 text-[11px] text-muted-foreground">
+                Changes apply when this closes.
+              </p>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+  const chips = labels.map((label) => (
+    <LabelChip key={label.name} label={label} />
+  ));
+
+  if (cells) {
+    return (
+      <>
+        {trigger}
+        <MetaValueCell label="Labels" empty={labels.length === 0}>
+          {chips}
+        </MetaValueCell>
+      </>
+    );
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      {/* Trigger first, so it never shifts as chips come and go. A natively
-          disabled button swallows `title`, so the reason rides a wrapping span. */}
-      <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <span
-          title={disabledReason}
-          className={
-            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
-          }
-        >
-          <Popover.Trigger
-            disabled={!!disabledReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Edit labels" />
-            }
-          >
-            {editLabels.isPending ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <TagIcon data-icon="inline-start" />
-            )}
-            Labels
-          </Popover.Trigger>
-        </span>
-        <Popover.Portal container={portalContainer}>
-          <Popover.Positioner
-            align="start"
-            sideOffset={4}
-            className="isolate z-50"
-          >
-            <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
-              <p className="px-1 pb-1.5 text-xs font-medium">Labels</p>
-              {(repoLabels.data ?? []).length === 0 && (
-                <p className="px-1 py-1 text-xs text-muted-foreground">
-                  {repoLabels.isPending
-                    ? "Loading labels…"
-                    : "This repository has no labels."}
-                </p>
-              )}
-              {(repoLabels.data ?? []).map((label) => (
-                <label
-                  key={label.name}
-                  className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
-                >
-                  <Checkbox
-                    checked={draft.has(label.name)}
-                    onCheckedChange={(v) => toggleDraft(label.name, v === true)}
-                  />
-                  <span
-                    aria-hidden
-                    className="size-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: `#${label.color}` }}
-                  />
-                  <span className="flex-1 truncate" title={label.name}>
-                    {label.name}
-                  </span>
-                </label>
-              ))}
-              {(repoLabels.data ?? []).length > 0 && (
-                <p className="mt-1 border-t px-1 pt-1.5 text-[11px] text-muted-foreground">
-                  Changes apply when this closes.
-                </p>
-              )}
-            </Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>
-      {labels.map((label) => (
-        <LabelChip key={label.name} label={label} />
-      ))}
+      {trigger}
+      {chips}
     </div>
   );
 }

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -108,8 +108,10 @@ export function LabelsPopover({
           disabled={!!disabledReason}
           render={<Button variant="ghost" size="xs" aria-label="Edit labels" />}
         >
+          {/* size-3 explicitly: the Button's own icon rule skips a sized
+              element, and a 16px swap would widen the label column mid-write. */}
           {editLabels.isPending ? (
-            <Spinner data-icon="inline-start" />
+            <Spinner className="size-3" data-icon="inline-start" />
           ) : (
             <TagIcon data-icon="inline-start" />
           )}

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -2,6 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { CopyIcon, KanbanIcon } from "@phosphor-icons/react";
 import { type ReactNode, useEffect, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
+import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -60,6 +61,7 @@ export function ProjectsPopover({
   contentId,
   lens,
   disabledReason,
+  cells = false,
 }: {
   repoPath: string;
   /** Gates the reads. Both call sites pass `true`; the real gate is upstream, and
@@ -78,6 +80,10 @@ export function ProjectsPopover({
    *  its action needs, or the surface is still loading the entity. The trigger
    *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
+  /** Emit the trigger and the chips as two SIBLING elements rather than one
+   *  inline row, so a caller's label/value grid can place each in its own
+   *  column. Default renders the inline row. */
+  cells?: boolean;
 }) {
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
@@ -264,138 +270,151 @@ export function ProjectsPopover({
     }
   }
 
-  return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      {/* Trigger first, so it never shifts as chips come and go. A natively
-          disabled button swallows `title`, so the reason rides a wrapping span. */}
-      <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <span
-          title={heldReason}
-          className={
-            heldReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+  // Trigger first, so it never shifts as chips come and go. A natively disabled
+  // button swallows `title`, so the reason rides a wrapping span.
+  const trigger = (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      <span
+        title={heldReason}
+        className={
+          heldReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        }
+      >
+        <Popover.Trigger
+          disabled={!!heldReason}
+          render={
+            <Button variant="ghost" size="xs" aria-label="Edit projects" />
           }
         >
-          <Popover.Trigger
-            disabled={!!heldReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Edit projects" />
-            }
-          >
-            {editProjects.isPending ? (
-              <Spinner data-icon="inline-start" />
+          {editProjects.isPending ? (
+            <Spinner data-icon="inline-start" />
+          ) : (
+            <KanbanIcon data-icon="inline-start" />
+          )}
+          Projects
+        </Popover.Trigger>
+      </span>
+      <Popover.Portal container={portalContainer}>
+        <Popover.Positioner
+          align="start"
+          sideOffset={4}
+          className="isolate z-50"
+        >
+          <Popover.Popup className="w-80 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <p className="px-1 pb-1.5 text-xs font-medium">Projects</p>
+            {classicMissing ? (
+              <ScopeGapBlock host={host} onReconnect={reconnectForProjectScope}>
+                Projects need the <span className="font-mono">project</span>{" "}
+                scope, which your GitHub sign-in is missing.
+              </ScopeGapBlock>
             ) : (
-              <KanbanIcon data-icon="inline-start" />
-            )}
-            Projects
-          </Popover.Trigger>
-        </span>
-        <Popover.Portal container={portalContainer}>
-          <Popover.Positioner
-            align="start"
-            sideOffset={4}
-            className="isolate z-50"
-          >
-            <Popover.Popup className="w-80 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
-              <p className="px-1 pb-1.5 text-xs font-medium">Projects</p>
-              {classicMissing ? (
-                <ScopeGapBlock
-                  host={host}
-                  onReconnect={reconnectForProjectScope}
-                >
-                  Projects need the <span className="font-mono">project</span>{" "}
-                  scope, which your GitHub sign-in is missing.
-                </ScopeGapBlock>
-              ) : (
-                <>
-                  {readError !== null && (
-                    <div className="px-1 py-1 text-xs">
-                      <p className="text-muted-foreground">
-                        {presentError(readError).summary}
-                      </p>
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        className="mt-1.5"
-                        onClick={() => {
-                          memberships.refetch();
-                          available.refetch();
-                        }}
-                      >
-                        Retry
-                      </Button>
-                    </div>
-                  )}
-                  {readOnlyScope && (
-                    <div className="mb-1 border-b pb-1">
-                      <ScopeGapBlock
-                        host={host}
-                        onReconnect={reconnectForProjectScope}
-                      >
-                        Changing projects needs the{" "}
-                        <span className="font-mono">project</span> scope, which
-                        your GitHub sign-in is missing.
-                      </ScopeGapBlock>
-                    </div>
-                  )}
-                  {/* Not gated on an empty list: membership rows render from
+              <>
+                {readError !== null && (
+                  <div className="px-1 py-1 text-xs">
+                    <p className="text-muted-foreground">
+                      {presentError(readError).summary}
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="mt-1.5"
+                      onClick={() => {
+                        memberships.refetch();
+                        available.refetch();
+                      }}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                )}
+                {readOnlyScope && (
+                  <div className="mb-1 border-b pb-1">
+                    <ScopeGapBlock
+                      host={host}
+                      onReconnect={reconnectForProjectScope}
+                    >
+                      Changing projects needs the{" "}
+                      <span className="font-mono">project</span> scope, which
+                      your GitHub sign-in is missing.
+                    </ScopeGapBlock>
+                  </div>
+                )}
+                {/* Not gated on an empty list: membership rows render from
                       their own query, so the catalog can still be in flight
                       under a list that already looks complete. `canRead` keeps a
                       DISABLED query — permanently "pending" — from reading as one. */}
-                  {canRead && available.isPending && (
+                {canRead && available.isPending && (
+                  <p className="px-1 py-1 text-xs text-muted-foreground">
+                    Loading projects…
+                  </p>
+                )}
+                {rows.length === 0 &&
+                  readError === null &&
+                  !(canRead && available.isPending) && (
                     <p className="px-1 py-1 text-xs text-muted-foreground">
-                      Loading projects…
+                      No open projects in this repository or its owner.
                     </p>
                   )}
-                  {rows.length === 0 &&
-                    readError === null &&
-                    !(canRead && available.isPending) && (
-                      <p className="px-1 py-1 text-xs text-muted-foreground">
-                        No open projects in this repository or its owner.
-                      </p>
-                    )}
-                  <div
-                    className="max-h-64 overflow-y-auto"
-                    onKeyDown={onRowKeyDown}
-                  >
-                    {rows.map((project) => (
-                      <ProjectRow
-                        key={project.id}
-                        project={project}
-                        checked={draft.has(project.id)}
-                        active={activeId === project.id}
-                        rovingTab={
-                          navIndexById.get(project.id) === focusIndex ? 0 : -1
-                        }
-                        lockedReason={rowLockedReason}
-                        onToggle={(on) => toggleDraft(project.id, on)}
-                        onFocus={() => setActiveId(project.id)}
-                      />
-                    ))}
-                  </div>
-                  {/* The truncation note stands alone: a 50-cap catalog of only
+                <div
+                  className="max-h-64 overflow-y-auto"
+                  onKeyDown={onRowKeyDown}
+                >
+                  {rows.map((project) => (
+                    <ProjectRow
+                      key={project.id}
+                      project={project}
+                      checked={draft.has(project.id)}
+                      active={activeId === project.id}
+                      rovingTab={
+                        navIndexById.get(project.id) === focusIndex ? 0 : -1
+                      }
+                      lockedReason={rowLockedReason}
+                      onToggle={(on) => toggleDraft(project.id, on)}
+                      onFocus={() => setActiveId(project.id)}
+                    />
+                  ))}
+                </div>
+                {/* The truncation note stands alone: a 50-cap catalog of only
                       CLOSED boards renders zero rows, where a bare "no projects"
                       would be a lie. */}
-                  {(showApplyNote || showTruncated) && (
-                    <div className="mt-1 border-t px-1 pt-1.5 text-[11px] text-muted-foreground">
-                      {showApplyNote && <p>Changes apply when this closes.</p>}
-                      {showTruncated && <p>Some projects aren't shown.</p>}
-                    </div>
-                  )}
-                </>
-              )}
-            </Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>
-      {items.map((item) => (
-        <span
-          key={item.itemId}
-          className="inline-flex max-w-full items-center border px-1.5 py-0.5 text-[11px] text-muted-foreground"
-          title={projectLabel(item.project)}
-        >
-          <span className="truncate">{projectLabel(item.project)}</span>
-        </span>
-      ))}
+                {(showApplyNote || showTruncated) && (
+                  <div className="mt-1 border-t px-1 pt-1.5 text-[11px] text-muted-foreground">
+                    {showApplyNote && <p>Changes apply when this closes.</p>}
+                    {showTruncated && <p>Some projects aren't shown.</p>}
+                  </div>
+                )}
+              </>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+  const chips = items.map((item) => (
+    <span
+      key={item.itemId}
+      className="inline-flex max-w-full items-center border px-1.5 py-0.5 text-[11px] text-muted-foreground"
+      title={projectLabel(item.project)}
+    >
+      <span className="truncate">{projectLabel(item.project)}</span>
+    </span>
+  ));
+
+  if (cells) {
+    return (
+      <>
+        {trigger}
+        <MetaValueCell label="Projects" empty={items.length === 0}>
+          {chips}
+        </MetaValueCell>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {trigger}
+      {chips}
     </div>
   );
 }

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -404,15 +404,16 @@ export function ProjectsPopover({
   ));
 
   if (cells) {
-    // The dash is a resolved-none claim, so only a settled read may show it: a
-    // cold fetch, a failed one and the scope-gated path all leave membership
-    // unknown, and the popup is where each is explained and repaired.
+    // Keyed on the data, not the query status: a cached list outlives a failed
+    // background refetch (the popup owns the Retry), and the dash is a
+    // resolved-none claim, so only a settled empty read may show it.
     const value = (() => {
       switch (true) {
-        case memberships.isSuccess:
+        case items.length > 0:
           return chips;
         case loadingMemberships:
           return <Skeleton className="h-5 w-24" aria-hidden />;
+        // A settled empty read never renders this: `empty` on the cell takes it.
         default:
           return (
             <span className="text-[11px] text-muted-foreground">
@@ -427,6 +428,7 @@ export function ProjectsPopover({
         <MetaValueCell
           label="Projects"
           empty={memberships.isSuccess && items.length === 0}
+          busy={loadingMemberships}
         >
           {value}
         </MetaValueCell>

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -6,6 +6,7 @@ import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
@@ -286,8 +287,10 @@ export function ProjectsPopover({
             <Button variant="ghost" size="xs" aria-label="Edit projects" />
           }
         >
+          {/* size-3 explicitly: the Button's own icon rule skips a sized
+              element, and a 16px swap would widen the label column mid-write. */}
           {editProjects.isPending ? (
-            <Spinner data-icon="inline-start" />
+            <Spinner className="size-3" data-icon="inline-start" />
           ) : (
             <KanbanIcon data-icon="inline-start" />
           )}
@@ -401,11 +404,31 @@ export function ProjectsPopover({
   ));
 
   if (cells) {
+    // The dash is a resolved-none claim, so only a settled read may show it: a
+    // cold fetch, a failed one and the scope-gated path all leave membership
+    // unknown, and the popup is where each is explained and repaired.
+    const value = (() => {
+      switch (true) {
+        case memberships.isSuccess:
+          return chips;
+        case loadingMemberships:
+          return <Skeleton className="h-5 w-24" aria-hidden />;
+        default:
+          return (
+            <span className="text-[11px] text-muted-foreground">
+              unavailable
+            </span>
+          );
+      }
+    })();
     return (
       <>
         {trigger}
-        <MetaValueCell label="Projects" empty={items.length === 0}>
-          {chips}
+        <MetaValueCell
+          label="Projects"
+          empty={memberships.isSuccess && items.length === 0}
+        >
+          {value}
         </MetaValueCell>
       </>
     );

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Markdown } from "@/components/ui/markdown";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import type { MinimizeReason } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
@@ -322,15 +323,19 @@ export function Thread({
   );
 }
 
+/** A repo label as a chip. Bounded by its container so one long name can't set a
+ *  narrow column's min-content width; the tooltip appears only once cut. */
 export function LabelChip({ label }: { label: RepoLabel }) {
   return (
-    <span className="flex items-center gap-1 border px-1.5 py-0.5 text-[11px]">
+    <span className="flex max-w-full items-center gap-1 border px-1.5 py-0.5 text-[11px]">
       <span
         aria-hidden
         className="size-2 shrink-0 rounded-full"
         style={{ backgroundColor: `#${label.color}` }}
       />
-      {label.name}
+      <span className="truncate" onMouseEnter={clipTitleFromText}>
+        {label.name}
+      </span>
     </span>
   );
 }

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useForgeGhHost } from "@/lib/git/host";
 import {
   useAssignableUsers,
@@ -192,13 +193,17 @@ export function AssigneesPopover({
       </Popover.Portal>
     </Popover.Root>
   );
+  // Bounded by its container so one long name can't set a narrow column's
+  // min-content width; the tooltip appears only once the name is cut.
   const chips = value.map((user) => (
     <span
       key={user.id}
-      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
     >
       <ForgeUserAvatar user={user} ghHost={ghHost} />
-      {user.label}
+      <span className="truncate" onMouseEnter={clipTitleFromText}>
+        {user.label}
+      </span>
     </span>
   ));
 

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -7,7 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { type ComponentProps, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
-import { MetaValueCell } from "@/components/meta-field-cells";
+import { MetaValueCell, UserChip } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -17,7 +17,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { clipTitleFromText } from "@/lib/clip-title";
 import { useForgeGhHost } from "@/lib/git/host";
 import {
   useAssignableUsers,
@@ -193,18 +192,8 @@ export function AssigneesPopover({
       </Popover.Portal>
     </Popover.Root>
   );
-  // Bounded by its container so one long name can't set a narrow column's
-  // min-content width; the tooltip appears only once the name is cut.
   const chips = value.map((user) => (
-    <span
-      key={user.id}
-      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-    >
-      <ForgeUserAvatar user={user} ghHost={ghHost} />
-      <span className="truncate" onMouseEnter={clipTitleFromText}>
-        {user.label}
-      </span>
-    </span>
+    <UserChip key={user.id} user={user} ghHost={ghHost} />
   ));
 
   if (cells) {

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { type ComponentProps, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -71,6 +72,7 @@ export function AssigneesPopover({
   commitOnClose = false,
   lens,
   disabledReason,
+  cells = false,
 }: {
   repoPath: string;
   enabled: boolean;
@@ -83,6 +85,10 @@ export function AssigneesPopover({
    *  its action needs, or the surface is still loading the entity. The trigger
    *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
+  /** Emit the trigger and the chips as two SIBLING elements rather than one
+   *  inline row, so a caller's label/value grid can place each in its own
+   *  column. Default renders the inline row. */
+  cells?: boolean;
 }) {
   const users = useAssignableUsers(repoPath, enabled, lens);
   const ghHost = useForgeGhHost(repoPath);
@@ -133,68 +139,84 @@ export function AssigneesPopover({
 
   const loaded = users.data ?? [];
 
-  return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        {/* A natively disabled button swallows `title`, so the reason rides a
-            wrapping span. */}
-        <span
-          title={disabledReason}
-          className={
-            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+  const trigger = (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      {/* A natively disabled button swallows `title`, so the reason rides a
+          wrapping span. */}
+      <span
+        title={disabledReason}
+        className={
+          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        }
+      >
+        <Popover.Trigger
+          disabled={!!disabledReason}
+          render={
+            <Button variant="ghost" size="xs" aria-label="Edit assignees" />
           }
         >
-          <Popover.Trigger
-            disabled={!!disabledReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Edit assignees" />
-            }
-          >
-            <UserPlusIcon data-icon="inline-start" />
-            Assignees
-          </Popover.Trigger>
-        </span>
-        <Popover.Portal container={portalContainer}>
-          <Popover.Positioner
-            align="start"
-            sideOffset={4}
-            className="isolate z-50"
-          >
-            <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
-              <p className="px-1 pb-1.5 text-xs font-medium">Assignees</p>
-              {loaded.length === 0 && (
-                <p className="px-1 py-1 text-xs text-muted-foreground">
-                  {users.isPending ? "Loading…" : "No assignable users."}
-                </p>
-              )}
-              {loaded.map((user) => (
-                <label
-                  key={user.id}
-                  className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
-                >
-                  <Checkbox
-                    checked={checkedIds.has(user.id)}
-                    onCheckedChange={(v) => toggle(user, v === true)}
-                  />
-                  <ForgeUserAvatar user={user} ghHost={ghHost} />
-                  <span className="flex-1 truncate" title={user.label}>
-                    {user.label}
-                  </span>
-                </label>
-              ))}
-            </Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>
-      {value.map((user) => (
-        <span
-          key={user.id}
-          className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+          <UserPlusIcon data-icon="inline-start" />
+          Assignees
+        </Popover.Trigger>
+      </span>
+      <Popover.Portal container={portalContainer}>
+        <Popover.Positioner
+          align="start"
+          sideOffset={4}
+          className="isolate z-50"
         >
-          <ForgeUserAvatar user={user} ghHost={ghHost} />
-          {user.label}
-        </span>
-      ))}
+          <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <p className="px-1 pb-1.5 text-xs font-medium">Assignees</p>
+            {loaded.length === 0 && (
+              <p className="px-1 py-1 text-xs text-muted-foreground">
+                {users.isPending ? "Loading…" : "No assignable users."}
+              </p>
+            )}
+            {loaded.map((user) => (
+              <label
+                key={user.id}
+                className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
+              >
+                <Checkbox
+                  checked={checkedIds.has(user.id)}
+                  onCheckedChange={(v) => toggle(user, v === true)}
+                />
+                <ForgeUserAvatar user={user} ghHost={ghHost} />
+                <span className="flex-1 truncate" title={user.label}>
+                  {user.label}
+                </span>
+              </label>
+            ))}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+  const chips = value.map((user) => (
+    <span
+      key={user.id}
+      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+    >
+      <ForgeUserAvatar user={user} ghHost={ghHost} />
+      {user.label}
+    </span>
+  ));
+
+  if (cells) {
+    return (
+      <>
+        {trigger}
+        <MetaValueCell label="Assignees" empty={value.length === 0}>
+          {chips}
+        </MetaValueCell>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {trigger}
+      {chips}
     </div>
   );
 }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -34,7 +34,12 @@ import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { SelectControl } from "@/components/form/fields";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
-import { MetaFieldLabel, MetaValueCell } from "@/components/meta-field-cells";
+import {
+  MetaFieldLabel,
+  MetaValueCell,
+  USER_CHIP_CLASS,
+  UserChip,
+} from "@/components/meta-field-cells";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -77,7 +82,6 @@ import {
   useEffectiveBranchRules,
   useEffectiveBranchRulesSettling,
 } from "@/lib/branch-rules/queries";
-import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import {
@@ -2337,15 +2341,7 @@ export function RemotePrView({
         <MetaFieldLabel>Assignees</MetaFieldLabel>
         <MetaValueCell label="Assignees">
           {pr.assignees.map((user) => (
-            <span
-              key={user.id}
-              className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-            >
-              <ForgeUserAvatar user={user} ghHost={ghHost} />
-              <span className="truncate" onMouseEnter={clipTitleFromText}>
-                {user.label}
-              </span>
-            </span>
+            <UserChip key={user.id} user={user} ghHost={ghHost} />
           ))}
         </MetaValueCell>
       </Fragment>,
@@ -2413,19 +2409,13 @@ export function RemotePrView({
             .map((user) => {
               const hint = userRefHint(user, humanReviewers);
               return (
-                <span
+                <UserChip
                   key={user.id}
+                  user={user}
+                  ghHost={ghHost}
+                  hint={hint}
                   title={hint ? `${user.label} (${hint})` : undefined}
-                  className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-                >
-                  <ForgeUserAvatar user={user} ghHost={ghHost} />
-                  <span className="truncate" onMouseEnter={clipTitleFromText}>
-                    {user.label}
-                    {hint && (
-                      <span className="text-muted-foreground"> · {hint}</span>
-                    )}
-                  </span>
-                </span>
+                />
               );
             })}
           {botReviewers.map((user) => (
@@ -3711,11 +3701,7 @@ function CompletedReviewerChip({
   const { Icon, tone, word } = reviewStatePresentation(reviewer.state);
   const name = `${reviewer.label} — ${word}`;
   return (
-    <span
-      title={name}
-      aria-label={name}
-      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-    >
+    <span title={name} aria-label={name} className={USER_CHIP_CLASS}>
       <Icon aria-hidden className={cn("size-3 shrink-0", tone)} />
       {reviewer.isBot ? (
         <RobotIcon aria-hidden className="size-3 shrink-0" />
@@ -3748,11 +3734,7 @@ function BotReviewerChip({
 }) {
   const name = `${user.label} — review requested from a bot, managed on the forge`;
   return (
-    <span
-      title={name}
-      aria-label={name}
-      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-    >
+    <span title={name} aria-label={name} className={USER_CHIP_CLASS}>
       <ForgeUserAvatar user={user} ghHost={ghHost} decorative />
       <span className="truncate">{user.label}</span>
       <RobotIcon aria-hidden className="size-3 shrink-0" />

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -18,6 +18,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+  Fragment,
   type ReactNode,
   useEffect,
   useEffectEvent,
@@ -33,6 +34,7 @@ import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { SelectControl } from "@/components/form/fields";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
+import { MetaFieldLabel, MetaValueCell } from "@/components/meta-field-cells";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -2267,9 +2269,178 @@ export function RemotePrView({
           ? "No merge method is enabled by both this repository's settings and its branch rules"
           : `Merge this ${prNoun}`);
 
+  // The header's meta fields, row-major, as label/value pairs for the grid
+  // below: an editable field emits its trigger as the label cell and its chips
+  // as the value cell (`cells`), a read-only one a static label plus chips.
+  // Entity-keyed pickers — labels, assignees, projects, reviewers: each seeds a
+  // draft on open, commits it on close against LIVE props, and a keyboard PR
+  // switch leaves the popover open; unkeyed, the old draft lands on the new PR.
+  // Projects is the exception to the commit clause: its memberships come from a
+  // query rather than props, so its close diffs the draft against the set SEEDED
+  // at open (or at the first settle after it), never the live one — live items
+  // serve only as the item-id lookup for unlinks.
+  // Every field prefixes its key: duplicate keys in one children array make React
+  // drop the earlier duplicates' unmount, leaking stale rows.
+  const metaCells: ReactNode[] = [];
+  if (isOpen && canEditLabels) {
+    metaCells.push(
+      <LabelsPopover
+        key={`labels-${entityKey}`}
+        cells
+        repoPath={repoPath}
+        enabled
+        number={number}
+        target="mr"
+        labelableId={pr.id}
+        labels={pr.labels}
+        lens={lens}
+        disabledReason={pickerReason}
+      />,
+    );
+  } else if (pr.labels.length > 0) {
+    metaCells.push(
+      <Fragment key="labels-static">
+        <MetaFieldLabel>Labels</MetaFieldLabel>
+        <MetaValueCell label="Labels">
+          {pr.labels.map((label) => (
+            <LabelChip key={label.name} label={label} />
+          ))}
+        </MetaValueCell>
+      </Fragment>,
+    );
+  }
+  // Assignee picker (GitHub + GitLab). A closed/merged PR falls back to
+  // read-only chips, like the labels field.
+  if (isOpen && canEditAssignees) {
+    metaCells.push(
+      <AssigneesPopover
+        key={`assignees-${entityKey}`}
+        cells
+        repoPath={repoPath}
+        enabled
+        value={pr.assignees}
+        commitOnClose
+        lens={lens}
+        disabledReason={pickerReason}
+        onChange={(next) =>
+          setAssignees.mutate(
+            { number, assignees: next },
+            { onError: toastError },
+          )
+        }
+      />,
+    );
+  } else if (pr.assignees.length > 0) {
+    metaCells.push(
+      <Fragment key="assignees-static">
+        <MetaFieldLabel>Assignees</MetaFieldLabel>
+        <MetaValueCell label="Assignees">
+          {pr.assignees.map((user) => (
+            <span
+              key={user.id}
+              className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+            >
+              <ForgeUserAvatar user={user} ghHost={ghHost} />
+              {user.label}
+            </span>
+          ))}
+        </MetaValueCell>
+      </Fragment>,
+    );
+  }
+  // GitHub Projects membership (GitHub-only). Unlike labels/assignees it has no
+  // read-only fallback: its chips come from their own query rather than from
+  // `pr`, so a closed PR would pay a fetch to show them.
+  if (isOpen && providerKey === "github") {
+    metaCells.push(
+      <ProjectsPopover
+        key={`projects-${entityKey}`}
+        cells
+        repoPath={repoPath}
+        enabled
+        kind="pr"
+        number={number}
+        contentId={pr.id}
+        lens={lens}
+        disabledReason={pickerReason}
+      />,
+    );
+  }
+  // Reviewers (all three providers). A closed/merged PR falls back to read-only
+  // chips. Bot requests (e.g. Copilot) are display-only and split out here so the
+  // popover's onChange — which emits its `value` as the desired set — can never
+  // ride a bot through; they share the value cell as the picker's children.
+  if (isOpen && canEditReviewers) {
+    metaCells.push(
+      <ReviewersPopover
+        key={`reviewers-${entityKey}`}
+        cells
+        repoPath={repoPath}
+        number={number}
+        enabled
+        value={humanReviewers}
+        lens={lens}
+        disabledReason={pickerReason}
+        onChange={(next) =>
+          setReviewers.mutate(
+            { number, reviewers: next },
+            { onError: toastError },
+          )
+        }
+      >
+        {botReviewers.map((user) => (
+          <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
+        ))}
+        {completedReviewers.map((reviewer) => (
+          <CompletedReviewerChip
+            key={reviewer.login}
+            reviewer={reviewer}
+            ghHost={ghHost}
+          />
+        ))}
+      </ReviewersPopover>,
+    );
+  } else if (pr.reviewers.length > 0 || completedReviewers.length > 0) {
+    metaCells.push(
+      <Fragment key="reviewers-static">
+        <MetaFieldLabel>Reviewers</MetaFieldLabel>
+        <MetaValueCell label="Reviewers">
+          {humanReviewers
+            .filter((h) => !completedLogins.has(h.id))
+            .map((user) => {
+              const hint = userRefHint(user, humanReviewers);
+              return (
+                <span
+                  key={user.id}
+                  title={hint ? `${user.label} (${hint})` : undefined}
+                  className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+                >
+                  <ForgeUserAvatar user={user} ghHost={ghHost} />
+                  {user.label}
+                  {hint && (
+                    <span className="text-muted-foreground"> · {hint}</span>
+                  )}
+                </span>
+              );
+            })}
+          {botReviewers.map((user) => (
+            <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
+          ))}
+          {completedReviewers.map((reviewer) => (
+            <CompletedReviewerChip
+              key={reviewer.login}
+              reviewer={reviewer}
+              ghHost={ghHost}
+            />
+          ))}
+        </MetaValueCell>
+      </Fragment>,
+    );
+  }
+
   return (
     <div className="flex h-full flex-col">
-      <header className="space-y-2 border-b px-4 py-3">
+      <header className="@container space-y-2 border-b px-4 py-3">
         <div className="flex items-start gap-2">
           <h2 className="text-sm font-medium">
             {pr.title}{" "}
@@ -2365,152 +2536,15 @@ export function RemotePrView({
             className="flex items-center gap-2"
           />
         </div>
-        {/* Entity-keyed pickers — labels, assignees, projects, reviewers: each
-            seeds a draft on open, commits it on close against LIVE props, and a
-            keyboard PR switch leaves the popover open; unkeyed, the old draft
-            lands on the new PR. Projects is the exception to the commit clause:
-            its memberships come from a query rather than props, so its close
-            diffs the draft against the set SEEDED at open (or at the first settle
-            after it), never the live one — live items serve only as the item-id
-            lookup for unlinks.
-            Labels/assignees/projects prefix keys as SIBLINGS: duplicate keys in
-            one children array make React drop the earlier duplicates' unmount,
-            leaking stale rows. Reviewers' prefix is consistency: own wrapper div. */}
-        {isOpen && canEditLabels ? (
-          <LabelsPopover
-            key={`labels-${entityKey}`}
-            repoPath={repoPath}
-            enabled
-            number={number}
-            target="mr"
-            labelableId={pr.id}
-            labels={pr.labels}
-            lens={lens}
-            disabledReason={pickerReason}
-          />
-        ) : (
-          pr.labels.length > 0 && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              {pr.labels.map((label) => (
-                <LabelChip key={label.name} label={label} />
-              ))}
-            </div>
-          )
-        )}
-        {/* Assignee picker (GitHub + GitLab). A closed/merged PR falls back to
-            read-only chips, like the labels row. */}
-        {isOpen && canEditAssignees ? (
-          <AssigneesPopover
-            key={`assignees-${entityKey}`}
-            repoPath={repoPath}
-            enabled
-            value={pr.assignees}
-            commitOnClose
-            lens={lens}
-            disabledReason={pickerReason}
-            onChange={(next) =>
-              setAssignees.mutate(
-                { number, assignees: next },
-                { onError: toastError },
-              )
-            }
-          />
-        ) : (
-          pr.assignees.length > 0 && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              {pr.assignees.map((user) => (
-                <span
-                  key={user.id}
-                  className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-                >
-                  <ForgeUserAvatar user={user} ghHost={ghHost} />
-                  {user.label}
-                </span>
-              ))}
-            </div>
-          )
-        )}
-        {/* GitHub Projects membership (GitHub-only). Unlike labels/assignees it has
-            no read-only fallback: its chips come from their own query rather than
-            from `pr`, so a closed PR would pay a fetch to show them. */}
-        {isOpen && providerKey === "github" ? (
-          <ProjectsPopover
-            key={`projects-${entityKey}`}
-            repoPath={repoPath}
-            enabled
-            kind="pr"
-            number={number}
-            contentId={pr.id}
-            lens={lens}
-            disabledReason={pickerReason}
-          />
-        ) : null}
-        {/* Reviewers picker (all three providers). A closed/merged PR falls back to
-            read-only chips. Bot requests (e.g. Copilot) are display-only and split out
-            here so the popover's onChange — which emits its `value` as the desired
-            set — can never ride a bot through. */}
-        {isOpen && canEditReviewers ? (
-          <div className="flex flex-wrap items-center gap-1.5">
-            <ReviewersPopover
-              key={`reviewers-${entityKey}`}
-              repoPath={repoPath}
-              number={number}
-              enabled
-              value={humanReviewers}
-              lens={lens}
-              disabledReason={pickerReason}
-              onChange={(next) =>
-                setReviewers.mutate(
-                  { number, reviewers: next },
-                  { onError: toastError },
-                )
-              }
-            />
-            {botReviewers.map((user) => (
-              <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
-            ))}
-            {completedReviewers.map((reviewer) => (
-              <CompletedReviewerChip
-                key={reviewer.login}
-                reviewer={reviewer}
-                ghHost={ghHost}
-              />
-            ))}
+        {/* One label/value grid for every meta field, two pairs wide until the
+            PANEL (not the viewport) is too narrow for them — the PR view's width
+            tracks its panel, so this is a container query. `minmax(0,…)` lets a
+            dense chip cell shrink instead of overflowing the header. */}
+        {metaCells.length > 0 ? (
+          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-2 text-xs @3xl:grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)]">
+            {metaCells}
           </div>
-        ) : (
-          (pr.reviewers.length > 0 || completedReviewers.length > 0) && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              {humanReviewers
-                .filter((h) => !completedLogins.has(h.id))
-                .map((user) => {
-                  const hint = userRefHint(user, humanReviewers);
-                  return (
-                    <span
-                      key={user.id}
-                      title={hint ? `${user.label} (${hint})` : undefined}
-                      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-                    >
-                      <ForgeUserAvatar user={user} ghHost={ghHost} />
-                      {user.label}
-                      {hint && (
-                        <span className="text-muted-foreground"> · {hint}</span>
-                      )}
-                    </span>
-                  );
-                })}
-              {botReviewers.map((user) => (
-                <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
-              ))}
-              {completedReviewers.map((reviewer) => (
-                <CompletedReviewerChip
-                  key={reviewer.login}
-                  reviewer={reviewer}
-                  ghHost={ghHost}
-                />
-              ))}
-            </div>
-          )
-        )}
+        ) : null}
         {/* GitLab-only time-tracking summary; a popover with estimate/add-spent
             while the MR is open, static once closed. */}
         {canTrackTime && (

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -77,6 +77,7 @@ import {
   useEffectiveBranchRules,
   useEffectiveBranchRulesSettling,
 } from "@/lib/branch-rules/queries";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { presentError } from "@/lib/error-summary";
 import {
@@ -2338,10 +2339,12 @@ export function RemotePrView({
           {pr.assignees.map((user) => (
             <span
               key={user.id}
-              className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+              className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
             >
               <ForgeUserAvatar user={user} ghHost={ghHost} />
-              {user.label}
+              <span className="truncate" onMouseEnter={clipTitleFromText}>
+                {user.label}
+              </span>
             </span>
           ))}
         </MetaValueCell>
@@ -2413,13 +2416,15 @@ export function RemotePrView({
                 <span
                   key={user.id}
                   title={hint ? `${user.label} (${hint})` : undefined}
-                  className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+                  className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
                 >
                   <ForgeUserAvatar user={user} ghHost={ghHost} />
-                  {user.label}
-                  {hint && (
-                    <span className="text-muted-foreground"> · {hint}</span>
-                  )}
+                  <span className="truncate" onMouseEnter={clipTitleFromText}>
+                    {user.label}
+                    {hint && (
+                      <span className="text-muted-foreground"> · {hint}</span>
+                    )}
+                  </span>
                 </span>
               );
             })}
@@ -2440,7 +2445,7 @@ export function RemotePrView({
 
   return (
     <div className="flex h-full flex-col">
-      <header className="@container space-y-2 border-b px-4 py-3">
+      <header className="@container/pr-header space-y-2 border-b px-4 py-3">
         <div className="flex items-start gap-2">
           <h2 className="text-sm font-medium">
             {pr.title}{" "}
@@ -2541,7 +2546,7 @@ export function RemotePrView({
             tracks its panel, so this is a container query. `minmax(0,…)` lets a
             dense chip cell shrink instead of overflowing the header. */}
         {metaCells.length > 0 ? (
-          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-2 text-xs @3xl:grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)]">
+          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-2 text-xs @3xl/pr-header:grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)]">
             {metaCells}
           </div>
         ) : null}
@@ -3709,7 +3714,7 @@ function CompletedReviewerChip({
     <span
       title={name}
       aria-label={name}
-      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
     >
       <Icon aria-hidden className={cn("size-3 shrink-0", tone)} />
       {reviewer.isBot ? (
@@ -3726,7 +3731,7 @@ function CompletedReviewerChip({
           decorative
         />
       )}
-      {reviewer.label}
+      <span className="truncate">{reviewer.label}</span>
     </span>
   );
 }
@@ -3746,10 +3751,10 @@ function BotReviewerChip({
     <span
       title={name}
       aria-label={name}
-      className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+      className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
     >
       <ForgeUserAvatar user={user} ghHost={ghHost} decorative />
-      {user.label}
+      <span className="truncate">{user.label}</span>
       <RobotIcon aria-hidden className="size-3 shrink-0" />
     </span>
   );

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -1,7 +1,8 @@
 import { Popover } from "@base-ui/react/popover";
 import { UserCheckIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { Children, type ReactNode, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -48,6 +49,8 @@ export function ReviewersPopover({
   onChange,
   lens,
   disabledReason,
+  cells = false,
+  children,
 }: {
   repoPath: string;
   number: number | null;
@@ -60,6 +63,16 @@ export function ReviewersPopover({
    *  its action needs, or the surface is still loading the entity. The trigger
    *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
+  /** Emit the trigger and the chips as two SIBLING elements rather than one
+   *  inline row, so a caller's label/value grid can place each in its own
+   *  column. Default renders the inline row. */
+  cells?: boolean;
+  /** `cells` mode only: display-only reviewer chips the caller owns (bot
+   *  requests, completed reviews), rendered after this picker's own chips so the
+   *  whole field reads as one value. Pass them as bare children, never wrapped
+   *  in a Fragment: the empty-cell test drops null/undefined/booleans but counts
+   *  a Fragment as content whatever is inside it. */
+  children?: ReactNode;
 }) {
   const candidates = useReviewerCandidates(repoPath, number, enabled, lens);
   // GitHub reviewer ids are logins (avatars served at `<host>/<login>.png`), so the
@@ -105,87 +118,109 @@ export function ReviewersPopover({
     if (changed) onChange([...draft.values()]);
   }
 
-  return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        {/* A natively disabled button swallows `title`, so the reason rides a
-            wrapping span. */}
-        <span
-          title={disabledReason}
-          className={
-            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+  const trigger = (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      {/* A natively disabled button swallows `title`, so the reason rides a
+          wrapping span. */}
+      <span
+        title={disabledReason}
+        className={
+          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        }
+      >
+        <Popover.Trigger
+          disabled={!!disabledReason}
+          render={
+            <Button variant="ghost" size="xs" aria-label="Edit reviewers" />
           }
         >
-          <Popover.Trigger
-            disabled={!!disabledReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Edit reviewers" />
-            }
-          >
-            <UserCheckIcon data-icon="inline-start" />
-            Reviewers
-          </Popover.Trigger>
-        </span>
-        <Popover.Portal container={portalContainer}>
-          <Popover.Positioner
-            align="start"
-            sideOffset={4}
-            className="isolate z-50"
-          >
-            <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
-              <p className="px-1 pb-1.5 text-xs font-medium">Reviewers</p>
-              {(candidates.data ?? []).length === 0 && (
-                <p className="px-1 py-1 text-xs text-muted-foreground">
-                  {candidates.isPending
-                    ? "Loading…"
-                    : candidates.isError
-                      ? "Couldn't load workspace members."
-                      : "No eligible reviewers — the workspace has no other members."}
-                </p>
-              )}
-              {loaded.map((user) => {
-                const hint = userRefHint(user, rowUniverse);
-                return (
-                  <label
-                    key={user.id}
-                    title={hint ? `${user.label} (${hint})` : undefined}
-                    className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
+          <UserCheckIcon data-icon="inline-start" />
+          Reviewers
+        </Popover.Trigger>
+      </span>
+      <Popover.Portal container={portalContainer}>
+        <Popover.Positioner
+          align="start"
+          sideOffset={4}
+          className="isolate z-50"
+        >
+          <Popover.Popup className="w-60 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <p className="px-1 pb-1.5 text-xs font-medium">Reviewers</p>
+            {(candidates.data ?? []).length === 0 && (
+              <p className="px-1 py-1 text-xs text-muted-foreground">
+                {candidates.isPending
+                  ? "Loading…"
+                  : candidates.isError
+                    ? "Couldn't load workspace members."
+                    : "No eligible reviewers — the workspace has no other members."}
+              </p>
+            )}
+            {loaded.map((user) => {
+              const hint = userRefHint(user, rowUniverse);
+              return (
+                <label
+                  key={user.id}
+                  title={hint ? `${user.label} (${hint})` : undefined}
+                  className="flex cursor-pointer items-center gap-2 px-1 py-1.5 text-xs hover:bg-muted/60"
+                >
+                  <Checkbox
+                    checked={draft.has(user.id)}
+                    onCheckedChange={(v) => toggle(user, v === true)}
+                  />
+                  <ForgeUserAvatar user={user} ghHost={ghHost} />
+                  <span
+                    className="flex-1 truncate"
+                    title={hint ? `${user.label} (${hint})` : user.label}
                   >
-                    <Checkbox
-                      checked={draft.has(user.id)}
-                      onCheckedChange={(v) => toggle(user, v === true)}
-                    />
-                    <ForgeUserAvatar user={user} ghHost={ghHost} />
-                    <span
-                      className="flex-1 truncate"
-                      title={hint ? `${user.label} (${hint})` : user.label}
-                    >
-                      {user.label}
-                      {hint && (
-                        <span className="text-muted-foreground"> · {hint}</span>
-                      )}
-                    </span>
-                  </label>
-                );
-              })}
-            </Popover.Popup>
-          </Popover.Positioner>
-        </Popover.Portal>
-      </Popover.Root>
-      {value.map((user) => {
-        const hint = userRefHint(user, chipUniverse);
-        return (
-          <span
-            key={user.id}
-            title={hint ? `${user.label} (${hint})` : undefined}
-            className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-          >
-            <ForgeUserAvatar user={user} ghHost={ghHost} />
-            {user.label}
-            {hint && <span className="text-muted-foreground"> · {hint}</span>}
-          </span>
-        );
-      })}
+                    {user.label}
+                    {hint && (
+                      <span className="text-muted-foreground"> · {hint}</span>
+                    )}
+                  </span>
+                </label>
+              );
+            })}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+  const chips = value.map((user) => {
+    const hint = userRefHint(user, chipUniverse);
+    return (
+      <span
+        key={user.id}
+        title={hint ? `${user.label} (${hint})` : undefined}
+        className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+      >
+        <ForgeUserAvatar user={user} ghHost={ghHost} />
+        {user.label}
+        {hint && <span className="text-muted-foreground"> · {hint}</span>}
+      </span>
+    );
+  });
+
+  if (cells) {
+    // Caller-owned chips count toward the cell being populated, so a PR whose
+    // only reviewers are bots or finished reviews shows them, not the dash.
+    // `toArray` over `count`: it drops null/undefined/booleans, so a caller's
+    // `{cond && chips}` can't report content while rendering none.
+    const empty = value.length === 0 && Children.toArray(children).length === 0;
+    return (
+      <>
+        {trigger}
+        <MetaValueCell label="Reviewers" empty={empty}>
+          {chips}
+          {children}
+        </MetaValueCell>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {trigger}
+      {chips}
     </div>
   );
 }

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -2,11 +2,10 @@ import { Popover } from "@base-ui/react/popover";
 import { UserCheckIcon } from "@phosphor-icons/react";
 import { Children, type ReactNode, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
-import { MetaValueCell } from "@/components/meta-field-cells";
+import { MetaValueCell, UserChip } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { clipTitleFromText } from "@/lib/clip-title";
 import { useForgeGhHost } from "@/lib/git/host";
 import { useReviewerCandidates } from "@/lib/git/queries";
 import type { ForgeUserRef, RemoteLens } from "@/lib/git/types";
@@ -192,23 +191,16 @@ export function ReviewersPopover({
       </Popover.Portal>
     </Popover.Root>
   );
-  // Bounded by its container so one long name can't set a narrow column's
-  // min-content width. The clip tooltip REMOVES its own title when nothing is
-  // cut, leaving the chip's disambiguating one (when it has a hint) to show.
   const chips = value.map((user) => {
     const hint = userRefHint(user, chipUniverse);
     return (
-      <span
+      <UserChip
         key={user.id}
+        user={user}
+        ghHost={ghHost}
+        hint={hint}
         title={hint ? `${user.label} (${hint})` : undefined}
-        className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
-      >
-        <ForgeUserAvatar user={user} ghHost={ghHost} />
-        <span className="truncate" onMouseEnter={clipTitleFromText}>
-          {user.label}
-          {hint && <span className="text-muted-foreground"> · {hint}</span>}
-        </span>
-      </span>
+      />
     );
   });
 

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -6,6 +6,7 @@ import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useForgeGhHost } from "@/lib/git/host";
 import { useReviewerCandidates } from "@/lib/git/queries";
 import type { ForgeUserRef, RemoteLens } from "@/lib/git/types";
@@ -63,17 +64,23 @@ export function ReviewersPopover({
    *  its action needs, or the surface is still loading the entity. The trigger
    *  stays visible but disabled and this text explains why. Absent = editable. */
   disabledReason?: string;
-  /** Emit the trigger and the chips as two SIBLING elements rather than one
-   *  inline row, so a caller's label/value grid can place each in its own
-   *  column. Default renders the inline row. */
-  cells?: boolean;
-  /** `cells` mode only: display-only reviewer chips the caller owns (bot
-   *  requests, completed reviews), rendered after this picker's own chips so the
-   *  whole field reads as one value. Pass them as bare children, never wrapped
-   *  in a Fragment: the empty-cell test drops null/undefined/booleans but counts
-   *  a Fragment as content whatever is inside it. */
-  children?: ReactNode;
-}) {
+} & (
+  | {
+      /** Emit the trigger and the chips as two SIBLING elements rather than one
+       *  inline row, so a caller's label/value grid can place each in its own
+       *  column. */
+      cells: true;
+      /** Display-only reviewer chips the caller owns (bot requests, completed
+       *  reviews), rendered after this picker's own chips so the whole field
+       *  reads as one value. Pass them as bare children, never wrapped in a
+       *  Fragment: the empty-cell test drops null/undefined/booleans but counts
+       *  a Fragment as content whatever is inside it. */
+      children?: ReactNode;
+    }
+  // Children have nowhere to render outside `cells`, so the type refuses them
+  // rather than dropping them silently.
+  | { cells?: false; children?: never }
+)) {
   const candidates = useReviewerCandidates(repoPath, number, enabled, lens);
   // GitHub reviewer ids are logins (avatars served at `<host>/<login>.png`), so the
   // avatar is login-derived there; off GitHub it's the initial fallback unless the
@@ -185,17 +192,22 @@ export function ReviewersPopover({
       </Popover.Portal>
     </Popover.Root>
   );
+  // Bounded by its container so one long name can't set a narrow column's
+  // min-content width. The clip tooltip REMOVES its own title when nothing is
+  // cut, leaving the chip's disambiguating one (when it has a hint) to show.
   const chips = value.map((user) => {
     const hint = userRefHint(user, chipUniverse);
     return (
       <span
         key={user.id}
         title={hint ? `${user.label} (${hint})` : undefined}
-        className="inline-flex items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
+        className="inline-flex max-w-full items-center gap-1 border py-0.5 pr-1.5 pl-0.5 text-[11px] text-muted-foreground"
       >
         <ForgeUserAvatar user={user} ghHost={ghHost} />
-        {user.label}
-        {hint && <span className="text-muted-foreground"> · {hint}</span>}
+        <span className="truncate" onMouseEnter={clipTitleFromText}>
+          {user.label}
+          {hint && <span className="text-muted-foreground"> · {hint}</span>}
+        </span>
       </span>
     );
   });


### PR DESCRIPTION
The PR/MR header stacked labels, assignees, projects, and reviewers as four full-width rows, so a PR with all of them pushed the description and diff well down the panel. This reshapes them into a label/value grid that packs two fields per line and collapses to one as the panel narrows, and extracts the shared cell primitives the pickers now render into.

### Shared cell primitives

- Adds `src/components/meta-field-cells.tsx` with `MetaValueCell` and `MetaFieldLabel`. `MetaValueCell` is the value half of a field: `role="group"` plus the field name ties the value to its label for assistive tech (the label lives in a separate grid cell), `min-h-6` matches the ghost xs trigger box so short content shares the row centerline, and an `empty` prop renders an `aria-hidden` em dash so a blank cell doesn't read as a broken render.
- `MetaFieldLabel` covers fields with no picker (closed PRs, providers lacking the field); its `pl-[23px]` inset is derived from a ghost xs trigger's own text offset so a column mixing static labels and triggers shares one text edge.

### Pickers opt into cell mode

- `LabelsPopover`, `AssigneesPopover` (`src/features/issues/IssueMetaPickers.tsx`), `ProjectsPopover`, and `ReviewersPopover` each gain a `cells` prop. When set, the picker returns its trigger and a `MetaValueCell` of chips as two siblings so a caller's grid can place each in its own column; unset, every picker still renders the previous inline trigger+chips row, leaving the issue-side call sites untouched.
- Each file extracts its existing `trigger` and `chips` into locals ahead of the return — most of the line count in those four files is re-indentation rather than behavior change.
- `ReviewersPopover` additionally accepts `children` for caller-owned display-only chips (bot requests, completed reviews) so they share the one value cell. Emptiness is tested with `Children.toArray(children).length` rather than `Children.count`, so a caller's `{cond && chips}` can't report content while rendering none; the prop doc warns against wrapping those children in a Fragment for the same reason.

### PR header layout

- `src/features/pulls/RemotePrView.tsx` now builds a row-major `metaCells: ReactNode[]` before the return, pushing either a picker in `cells` mode or a keyed `Fragment` of `MetaFieldLabel` + `MetaValueCell` for the read-only closed/merged fallbacks (labels, assignees, reviewers). Projects keeps its GitHub-only, open-PR-only condition with no read-only fallback.
- The `<header>` becomes an `@container` and the fields render into a single `grid-cols-[auto_minmax(0,1fr)]` grid that widens to two label/value pairs at `@3xl`. The query is on the container because the PR view's width tracks its panel rather than the viewport, and `minmax(0,…)` lets a dense chip cell shrink instead of overflowing the header.
- The entity-keyed draft/commit rationale that was spread across four JSX comments consolidates into one block above the array, and the reviewers field drops its dedicated wrapper div.

### Docs

- Adds `changelog.d/changed-pr-header-meta-grid.md` describing the new header arrangement.
- Records the convention in `.claude/skills/gd-conventions/SKILL.md`: header meta fields go through `MetaValueCell` / `MetaFieldLabel` instead of a hand-rolled `role="group"` cell or a re-spelled empty-dash placeholder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request and merge request headers now display labels, assignees, projects, and reviewers in a responsive label/value grid.
  * The grid shows one or two fields per row based on available space.
  * Empty, loading, and unavailable states are presented clearly with consistent placeholders.
  * User entries now use consistent avatars, truncation, and hover details.
* **Bug Fixes**
  * Long labels and user or project names now truncate cleanly while preserving full-text access on hover.
* **Documentation**
  * Added release documentation for the updated header metadata layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->