### PR TITLE
docs(readme,site): correct forge coverage and drop "honest" framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ priority, labels, and original/remaining estimates.
   allow simply don't appear.
 - **Linked in**: issue keys (e.g. `PROJ-123`) spotted in your branch name,
   commits, and PR titles surface as a **referenced Jira issues** row that
-  jumps to the issue; a **local issue** can be promoted to Jira (comments
+  jumps to the issue; a **local issue** can be published to Jira (comments
   carry over, with a back-link).
 
 </details>

--- a/README.md
+++ b/README.md
@@ -274,13 +274,13 @@ The full pull-request loop on GitHub, GitLab & Bitbucket, plus **local
 PRs**: the same workflow against any two branches with no remote at all,
 promotable to a real GitHub or GitLab PR (comments and all) in one click.
 
-- **Open, edit, merge**: review, comment, approve, edit, and merge
-  (merge/squash/rebase) without the browser. Labels and assignees on GitHub &
-  GitLab (set them when you open a PR/MR or any time after), request
-  reviewers across GitHub, GitLab & Bitbucket, see, link, and unlink an
-  open PR's **GitHub Projects** in its header, flip a PR
-  between **draft and ready for review** either way on all three, and
-  **create new PRs as drafts by default** (Settings → General).
+- **Open, edit, merge**: review, comment, approve, edit, and merge (merge &
+  squash on all three; rebase on GitHub, fast-forward on Bitbucket) without
+  the browser. Labels and assignees on GitHub & GitLab (set them when you
+  open a PR/MR or any time after), request reviewers across GitHub, GitLab &
+  Bitbucket, see, link, and unlink an open PR's **GitHub Projects** in its
+  header, flip a PR between **draft and ready for review** either way on all
+  three, and **create new PRs as drafts by default** (Settings → General).
 - **Linked issues**: link related issues when you open *or* edit a PR, as
   chips **auto-detected** from your branch name and commits (a `fix/123-…`
   branch seeds `#123`) or picked by hand. Each chip toggles between
@@ -464,14 +464,14 @@ close the window.
 A dedicated tab for GitHub & GitLab issues and private **local to-dos** (no
 remote needed; publishable to GitHub, GitLab, or linked Jira in one click).
 Browse, create, and edit (drafting with AI from your repo's issue
-templates), react with emoji, and manage the full metadata: labels,
-assignees, milestones, **projects** (GitHub Projects, repo and owner level),
-issue type, sub-issues, dependencies (blocked-by / blocking), and
-development links (linked and closing PRs and branches, plus
-create-a-branch) on GitHub, and related issues on GitLab. Close or reopen
-with a comment you've drafted posted alongside; duplicate, transfer (move,
-on GitLab), pin/unpin (GitHub), lock/unlock, or delete. On a **fork**, the
-same **Fork | Upstream** lens as the PR tab browses the parent repository's
+templates), react with emoji, and manage the shared metadata: labels,
+assignees, and milestones. On GitHub, add **projects** (GitHub Projects,
+repo and owner level), issue type, sub-issues, dependencies (blocked-by /
+blocking), and development links (linked and closing PRs and branches, plus
+create-a-branch); on GitLab, related issues. Close or reopen with a comment
+you've drafted posted alongside; duplicate, transfer (move, on GitLab),
+pin/unpin (GitHub), lock/unlock, or delete. On a **fork**, the same
+**Fork | Upstream** lens as the PR tab browses the parent repository's
 issues (creating one under the Upstream lens opens it **on the parent**),
 and a fork with issues turned off offers a one-click switch to Upstream
 instead of a dead end.
@@ -777,13 +777,13 @@ touches your checkout.
   criteria, and verify plan, with cited paths validated against your tree so
   hallucinations are flagged. If the plan leaves decisions open, answer them
   in an inline panel (pick a suggestion or write your own) and **refine**
-  the plan with your choices. Then file it as a local or GitHub issue, or
-  hand it **straight to a write-capable agent session** to implement.
-  Nothing is changed during planning; it never writes.
-- **From issue to implementation**: an **Implement** button on any local or
-  GitHub issue (and on a finished plan) seeds the agent composer with the
-  spec, so you pick the agent and confirm; then it builds it in an isolated
-  worktree.
+  the plan with your choices. Then file it as a local, GitHub, or GitLab
+  issue, or hand it **straight to a write-capable agent session** to
+  implement. Nothing is changed during planning; it never writes.
+- **From issue to implementation**: a **Solve with agent** button on any
+  local, GitHub, or GitLab issue (and **Implement** on a finished plan)
+  seeds the agent composer with the spec, so you pick the agent and
+  confirm; then it builds it in an isolated worktree.
 
 ### MCP servers
 

--- a/README.md
+++ b/README.md
@@ -469,9 +469,9 @@ assignees, and milestones. On GitHub, add **projects** (GitHub Projects,
 repo and owner level), issue type, sub-issues, dependencies (blocked-by /
 blocking), and development links (linked and closing PRs and branches, plus
 create-a-branch); on GitLab, related issues. Close or reopen with a comment
-you've drafted posted alongside; duplicate, transfer (move, on GitLab),
-pin/unpin (GitHub), lock/unlock, or delete. On a **fork**, the same
-**Fork | Upstream** lens as the PR tab browses the parent repository's
+you've drafted posted alongside; duplicate, transfer (called *move* on
+GitLab), pin/unpin (GitHub), lock/unlock, or delete. On a **fork**, the
+same **Fork | Upstream** lens as the PR tab browses the parent repository's
 issues (creating one under the Upstream lens opens it **on the parent**),
 and a fork with issues turned off offers a one-click switch to Upstream
 instead of a dead end.

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ pushing and pulling stay manual.
 
 ### Pull requests
 
-Full read + write for GitHub PRs, plus **local PRs**: the same workflow
-against any two branches with no remote at all, promotable to a real GitHub
-PR (comments and all) in one click.
+Full read + write for GitHub, GitLab & Bitbucket PRs, plus **local PRs**:
+the same workflow against any two branches with no remote at all, promotable
+to a real GitHub or GitLab PR (comments and all) in one click.
 
 - **Open, edit, merge**: review, comment, label, **assign**, **request
   reviewers**, approve, edit, and merge (merge/squash/rebase) without the
@@ -461,13 +461,14 @@ close the window.
 
 ### Issues and to-dos
 
-A dedicated tab for GitHub issues and private **local to-dos** (no remote
-needed; publishable to GitHub in one click). Browse, create, and edit
-(drafting with AI from your repo's issue templates), react with emoji, and
-manage the full metadata: labels, assignees, milestones, **projects**
-(GitHub Projects, repo and owner level), issue type, sub-issues,
-dependencies (blocked-by / blocking), and development links (linked and
-closing PRs and branches, plus create-a-branch). Close or
+A dedicated tab for GitHub & GitLab issues and private **local to-dos** (no
+remote needed; publishable to GitHub, GitLab, or linked Jira in one click).
+Browse, create, and edit (drafting with AI from your repo's issue
+templates), react with emoji, and manage the full metadata: labels,
+assignees, milestones, **projects** (GitHub Projects, repo and owner level),
+issue type, sub-issues, and dependencies (blocked-by / blocking) on GitHub,
+related issues on GitLab, and development links (linked and closing PRs and
+branches, plus create-a-branch). Close or
 reopen with a comment you've drafted posted alongside; duplicate, transfer,
 pin/unpin, lock/unlock, or delete. On a **fork**, the same
 **Fork | Upstream** lens as the PR tab browses the parent repository's
@@ -496,8 +497,8 @@ them by file, and lets you filter by text/path or marker. Select one for a
 syntax-highlighted excerpt with blame attribution (who wrote the line, and
 how long ago); then **open it in your editor**, **copy its `path:line`**, or
 **promote it to a local issue**, pre-filled with the comment and a
-`path:line` reference, from where it's publishable to GitHub or Jira like
-any other local issue.
+`path:line` reference, from where it's publishable to GitHub, GitLab, or
+Jira like any other local issue.
 
 ### Discussions
 

--- a/README.md
+++ b/README.md
@@ -270,15 +270,15 @@ pushing and pulling stay manual.
 
 ### Pull requests
 
-Full read + write for GitHub, GitLab & Bitbucket PRs, plus **local PRs**:
-the same workflow against any two branches with no remote at all, promotable
-to a real GitHub or GitLab PR (comments and all) in one click.
+The full pull-request loop on GitHub, GitLab & Bitbucket, plus **local
+PRs**: the same workflow against any two branches with no remote at all,
+promotable to a real GitHub or GitLab PR (comments and all) in one click.
 
-- **Open, edit, merge**: review, comment, label, **assign**, **request
-  reviewers**, approve, edit, and merge (merge/squash/rebase) without the
-  browser. Set labels and assignees right when you open a PR/MR (GitHub &
-  GitLab), request reviewers across GitHub, GitLab & Bitbucket, see, link,
-  and unlink an open PR's **GitHub Projects** in its header, flip a PR
+- **Open, edit, merge**: review, comment, approve, edit, and merge
+  (merge/squash/rebase) without the browser. Labels and assignees on GitHub &
+  GitLab (set them when you open a PR/MR or any time after), request
+  reviewers across GitHub, GitLab & Bitbucket, see, link, and unlink an
+  open PR's **GitHub Projects** in its header, flip a PR
   between **draft and ready for review** either way on all three, and
   **create new PRs as drafts by default** (Settings → General).
 - **Linked issues**: link related issues when you open *or* edit a PR, as
@@ -466,12 +466,12 @@ remote needed; publishable to GitHub, GitLab, or linked Jira in one click).
 Browse, create, and edit (drafting with AI from your repo's issue
 templates), react with emoji, and manage the full metadata: labels,
 assignees, milestones, **projects** (GitHub Projects, repo and owner level),
-issue type, sub-issues, and dependencies (blocked-by / blocking) on GitHub,
-related issues on GitLab, and development links (linked and closing PRs and
-branches, plus create-a-branch). Close or
-reopen with a comment you've drafted posted alongside; duplicate, transfer,
-pin/unpin, lock/unlock, or delete. On a **fork**, the same
-**Fork | Upstream** lens as the PR tab browses the parent repository's
+issue type, sub-issues, dependencies (blocked-by / blocking), and
+development links (linked and closing PRs and branches, plus
+create-a-branch) on GitHub, and related issues on GitLab. Close or reopen
+with a comment you've drafted posted alongside; duplicate, transfer (move,
+on GitLab), pin/unpin (GitHub), lock/unlock, or delete. On a **fork**, the
+same **Fork | Upstream** lens as the PR tab browses the parent repository's
 issues (creating one under the Upstream lens opens it **on the parent**),
 and a fork with issues turned off offers a one-click switch to Upstream
 instead of a dead end.

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -51,7 +51,7 @@ Only the optional layer disappears.
 
 ## Agency matters
 
-I think AI is genuinely useful. I also think people should decide when it
+I think AI is useful. I also think people should decide when it
 belongs in their workflow. So GitDesktop never calls a model on its own. The
 only thing that runs automatically is an automation you turned on yourself.
 

--- a/site/src/content/blog/the-ai-off-switch.md
+++ b/site/src/content/blog/the-ai-off-switch.md
@@ -51,9 +51,9 @@ Only the optional layer disappears.
 
 ## Agency matters
 
-I think AI is useful. I also think people should decide when it
-belongs in their workflow. So GitDesktop never calls a model on its own. The
-only thing that runs automatically is an automation you turned on yourself.
+I think AI is useful. I also think people should decide when it belongs in
+their workflow. So GitDesktop never calls a model on its own. The only thing
+that runs automatically is an automation you turned on yourself.
 
 When you do use it, you choose where the requests go. Bring your own API
 key. Run Ollama locally, so the calls never leave your machine. Or don't

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -314,7 +314,7 @@ export const capabilities: Capability[] = [
   {
     group: "CI, tags & releases",
     label:
-      "GitLab & Bitbucket Pipelines — runs in-app, re-run, cancel & trigger; job logs on GitLab",
+      "GitLab & Bitbucket pipelines — runs, job logs, re-run, cancel & trigger, in-app",
   },
   {
     group: "CI, tags & releases",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -156,7 +156,7 @@ export const capabilities: Capability[] = [
   // — Pull requests & review —
   {
     group: "Pull requests & review",
-    label: "GitHub PRs + private, offline local PRs",
+    label: "PRs on GitHub, GitLab & Bitbucket + private, offline local PRs",
     highlight: true,
   },
   {
@@ -273,7 +273,7 @@ export const capabilities: Capability[] = [
   // — Issues & discussions —
   {
     group: "Issues & discussions",
-    label: "GitHub issues & private local to-dos",
+    label: "GitHub & GitLab issues, plus private local to-dos",
   },
   {
     group: "Issues & discussions",
@@ -283,7 +283,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Issues & discussions",
-    label: "Issue types, sub-issues & dependencies",
+    label:
+      "Issue types, sub-issues & dependencies on GitHub; related issues on GitLab",
   },
   {
     group: "Issues & discussions",
@@ -318,7 +319,7 @@ export const capabilities: Capability[] = [
   {
     group: "CI, tags & releases",
     label:
-      "Tags, releases & cross-platform assets — edit notes, sync the updater manifest",
+      "Tags, releases & cross-platform assets — edit notes, sync the updater manifest (GitHub & GitLab)",
   },
   {
     group: "CI, tags & releases",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -314,6 +314,11 @@ export const capabilities: Capability[] = [
   {
     group: "CI, tags & releases",
     label:
+      "GitLab & Bitbucket Pipelines — runs in-app, re-run, cancel & trigger; job logs on GitLab",
+  },
+  {
+    group: "CI, tags & releases",
+    label:
       "CI checks rollup — pass/fail/pending/skipped, live step progress on running Actions checks",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -319,7 +319,7 @@ export const capabilities: Capability[] = [
   {
     group: "CI, tags & releases",
     label:
-      "Tags, releases & cross-platform assets — edit notes, sync the updater manifest (GitHub & GitLab)",
+      "Tags, releases & cross-platform assets — edit notes (GitHub & GitLab), sync the updater manifest (GitHub)",
   },
   {
     group: "CI, tags & releases",

--- a/site/src/pages/bitbucket-issues-sunset.astro
+++ b/site/src/pages/bitbucket-issues-sunset.astro
@@ -30,7 +30,7 @@ const options = [
   {
     label: "Keep a tracker next to your code",
     detail:
-      "If the browser round-trip is what you're trying to avoid, put the tracker inside your Git client. The section below is the honest pitch for that.",
+      "If the browser round-trip is what you're trying to avoid, put the tracker inside your Git client. The section below is the pitch for that.",
   },
 ];
 

--- a/site/src/pages/bitbucket-issues-sunset.astro
+++ b/site/src/pages/bitbucket-issues-sunset.astro
@@ -38,7 +38,7 @@ const jiraPoints = [
   "Link a Jira Cloud site and project to any repository, and its Issues tab gains a Jira section: browse, filter, and read status, priority, assignee, description, and comments",
   "Create, comment, assign, set due dates, change priority, and close or reopen along the project's own workflow, with every action gated on your Jira permissions",
   "Issue keys in your branch names, commit messages, and PR titles are spotted and linked straight back to the issue",
-  "A local issue can be promoted to Jira when the work goes public",
+  "A local issue can be published to Jira when the work goes public",
 ];
 ---
 

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -252,10 +252,10 @@ const faqs = [
 ---
 
 <SiteLayout
-  title="GitDesktop vs GitHub Desktop — an honest comparison"
+  title="GitDesktop vs GitHub Desktop — a verified comparison"
   description="GitDesktop vs GitHub Desktop, verified August 2026: forges, the PR loop, CI, issues, recovery, and optional AI — plus what GitHub Desktop still does better."
   ogTitle="GitDesktop vs GitHub Desktop"
-  ogDescription="Forges, the PR loop, CI, issues, recovery tooling, and optional AI — an honest, dated comparison."
+  ogDescription="Forges, the PR loop, CI, issues, recovery tooling, and optional AI — a verified, dated comparison."
   breadcrumbs={[{ name: "GitDesktop vs GitHub Desktop", path: "/compare/github-desktop/" }]}
 >
   <section class="border-b border-line">

--- a/site/src/pages/compare/gitkraken.astro
+++ b/site/src/pages/compare/gitkraken.astro
@@ -336,7 +336,7 @@ const faqs = [
         class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg"
       >
         GitDesktop is a free, open-source GitKraken alternative built for the
-        <span class="text-ink">private repositories</span> GitKraken's free
+        <span class="text-ink">private repositories</span> that GitKraken's free
         plan locks out. No vendor account, no per-seat plan, no AI credit
         meter. The pull-request loop (review, approve, merge, CI) stays in the
         app across <span class="text-ink">GitHub, GitLab, and Bitbucket</span>,

--- a/site/src/pages/compare/gitkraken.astro
+++ b/site/src/pages/compare/gitkraken.astro
@@ -313,10 +313,10 @@ const faqs = [
 ---
 
 <SiteLayout
-  title="GitDesktop vs GitKraken — an honest comparison"
+  title="GitDesktop vs GitKraken — a verified comparison"
   description="GitDesktop vs GitKraken, verified August 2026: private repos on the free plan, the PR review loop in-app, unmetered AI on your own keys, sandboxed agents — plus what GitKraken still does better."
   ogTitle="GitDesktop vs GitKraken"
-  ogDescription="Free on private repos, review in-app, AI without a meter — an honest, dated comparison."
+  ogDescription="Free on private repos, review in-app, AI without a meter — a verified, dated comparison."
   breadcrumbs={[{ name: "GitDesktop vs GitKraken", path: "/compare/gitkraken/" }]}
 >
   <section class="border-b border-line">
@@ -336,13 +336,12 @@ const faqs = [
         class="mt-6 max-w-[62ch] text-base leading-relaxed text-body sm:text-lg"
       >
         GitDesktop is a free, open-source GitKraken alternative built for the
-        repositories GitKraken's free plan doesn't cover:
-        <span class="text-ink">private repositories</span>. No vendor account,
-        no per-seat plan, no AI credit meter. The pull-request loop (review,
-        approve, merge, CI) stays in the app across
-        <span class="text-ink">GitHub, GitLab, and Bitbucket</span>, and AI runs
-        on your own keys, your own subscriptions, or your own hardware. Or stays
-        hidden.
+        <span class="text-ink">private repositories</span> GitKraken's free
+        plan locks out. No vendor account, no per-seat plan, no AI credit
+        meter. The pull-request loop (review, approve, merge, CI) stays in the
+        app across <span class="text-ink">GitHub, GitLab, and Bitbucket</span>,
+        and AI runs on your own keys, your own subscriptions, or your own
+        hardware — or stays hidden entirely.
       </p>
       <p data-reveal style="transition-delay:180ms" class="mt-5 max-w-[66ch] text-sm text-muted">
         Verified against GitKraken Desktop {GK_VERSION} (current release, dated

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -245,7 +245,7 @@ const groups: Group[] = [
 const faqs = [
   {
     q: "Is GitDesktop a good Sourcetree alternative?",
-    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for (staging by file, hunk, or line, interactive rebase, stashes, submodules) and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs (with GitHub and GitLab step logs in-app), and issues, across GitHub, GitLab, and Bitbucket. On Bitbucket, issues go through a linked Jira project. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those. The table above is honest about it.",
+    a: "For Git work, yes. GitDesktop covers the fundamentals Sourcetree is loved for (staging by file, hunk, or line, interactive rebase, stashes, submodules) and adds what Sourcetree hands to the browser: creating, reviewing, and merging pull requests, CI runs (with GitHub and GitLab step logs in-app), and issues, across GitHub, GitLab, and Bitbucket. On Bitbucket, issues go through a linked Jira project. It's free, open source (Apache-2.0), and needs no vendor account. If you rely on Mercurial or git-flow, Sourcetree keeps those, and the table above says so.",
   },
   {
     q: "Is there a Sourcetree for Linux?",
@@ -263,10 +263,10 @@ const faqs = [
 ---
 
 <SiteLayout
-  title="GitDesktop vs Sourcetree — an honest comparison"
+  title="GitDesktop vs Sourcetree — a verified comparison"
   description="GitDesktop vs Sourcetree, verified August 2026: Linux support, the in-app PR loop, CI, issues, optional AI, and no vendor account — plus what Sourcetree still does better."
   ogTitle="GitDesktop vs Sourcetree"
-  ogDescription="Linux support, the in-app PR loop, CI, issues, optional AI, and no vendor account — an honest, dated comparison."
+  ogDescription="Linux support, the in-app PR loop, CI, issues, optional AI, and no vendor account — a verified, dated comparison."
   breadcrumbs={[{ name: "GitDesktop vs Sourcetree", path: "/compare/sourcetree/" }]}
 >
   <section class="border-b border-line">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -514,7 +514,7 @@ const forges = [
     <p class="text-muted">
       A local-PR merge pre-shows whether it will conflict, and if it does you resolve
       it in an isolated worktree that never touches your branch, then Finish or Abort.
-      Promote a local PR to a real GitHub PR, comments and all, in one click.
+      Promote a local PR to a real GitHub or GitLab PR, comments and all, in one click.
     </p>
   </FeatureRow>
 
@@ -549,8 +549,9 @@ const forges = [
   >
     <p>
       Browse, open, and edit GitHub and GitLab issues without the tab-switch. Labels,
-      assignees, milestones, GitHub Projects, issue type, sub-issues, dependencies, and
-      the pull requests and branches that close them all sit in one panel. The
+      assignees, and milestones sit in one panel, joined on GitHub by Projects, issue
+      type, sub-issues, dependencies, and the pull requests and branches that close
+      them, and on GitLab by related issues. The
       conversation reads as one date-sorted activity feed, with label, assignment,
       milestone, mention, and state-change events interleaved between the comments.
     </p>
@@ -562,8 +563,8 @@ const forges = [
     </p>
     <p class="text-muted">
       Working privately? Keep plain <span class="text-ink">local to-dos</span> that need
-      no remote, then publish them to GitHub or promote them to Jira when the work goes
-      public.
+      no remote, then publish them to GitHub or GitLab, or promote them to Jira, when
+      the work goes public.
     </p>
   </FeatureRow>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -551,9 +551,9 @@ const forges = [
       Browse, open, and edit GitHub and GitLab issues without the tab-switch. Labels,
       assignees, and milestones sit in one panel, joined on GitHub by Projects, issue
       type, sub-issues, dependencies, and the pull requests and branches that close
-      them, and on GitLab by related issues. The
-      conversation reads as one date-sorted activity feed, with label, assignment,
-      milestone, mention, and state-change events interleaved between the comments.
+      them, and on GitLab by related issues. The conversation reads as one date-sorted
+      activity feed, with label, assignment, milestone, mention, and state-change
+      events interleaved between the comments.
     </p>
     <p class="text-muted">
       A <span class="text-ink">Code TODOs</span> tab scans your working tree for
@@ -562,9 +562,9 @@ const forges = [
       introduced it, and turns any one into a local issue.
     </p>
     <p class="text-muted">
-      Working privately? Keep plain <span class="text-ink">local to-dos</span> that need
-      no remote; when the work goes public, publish them to GitHub, GitLab, or
-      Jira.
+      Working privately? Keep plain <span class="text-ink">local to-dos</span> that
+      need no remote; when the work goes public, publish them to GitHub, GitLab,
+      or Jira.
     </p>
   </FeatureRow>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -563,8 +563,8 @@ const forges = [
     </p>
     <p class="text-muted">
       Working privately? Keep plain <span class="text-ink">local to-dos</span> that need
-      no remote, then publish them to GitHub or GitLab, or promote them to Jira, when
-      the work goes public.
+      no remote; when the work goes public, publish them to GitHub, GitLab, or
+      Jira.
     </p>
   </FeatureRow>
 

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -78,7 +78,7 @@ const jiraFeatures = [
   description="GitDesktop works with GitHub, GitLab, and Bitbucket: the full PR loop, CI, issues, and releases, plus linked Jira Cloud issues, each on its own identity."
   breadcrumbs={[{ name: "Integrations", path: "/integrations/" }]}
   ogTitle="GitDesktop integrations — GitHub, GitLab, Bitbucket & Jira"
-  ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The full loop for each, with the honest per-platform differences."
+  ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The full loop for each, with the per-platform differences spelled out."
 >
   <!-- Hero -->
   <section class="border-b border-line">

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -75,7 +75,7 @@ const jiraFeatures = [
 <SiteLayout
   active="integrations"
   title="Integrations — GitHub, GitLab, Bitbucket & Jira | GitDesktop"
-  description="GitDesktop works with GitHub, GitLab, and Bitbucket: the full PR loop, CI, issues, and releases, plus linked Jira Cloud issues, each on its own identity."
+  description="GitDesktop works with GitHub, GitLab, and Bitbucket: the PR loop and CI on all three, issues and releases on GitHub & GitLab, plus linked Jira Cloud issues, each on its own identity."
   breadcrumbs={[{ name: "Integrations", path: "/integrations/" }]}
   ogTitle="GitDesktop integrations — GitHub, GitLab, Bitbucket & Jira"
   ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The full loop for each, with the per-platform differences spelled out."

--- a/site/src/pages/integrations.astro
+++ b/site/src/pages/integrations.astro
@@ -68,7 +68,7 @@ const jiraFeatures = [
   "Create, comment in Markdown, assign, set a due date, change priority, edit labels, and close/reopen along the project's own workflow",
   "Time tracking, when the project has it on — log work with Jira's duration grammar (2d 4h 30m), set the original and remaining estimates, and edit or delete your own worklog entries",
   "Edit or delete your own comments, with every action gated on your Jira permissions, so what you can't do simply doesn't appear",
-  "Issue keys in your branch, commits, and PR titles are linked back to the Issues tab; a local issue can be promoted to Jira",
+  "Issue keys in your branch, commits, and PR titles are linked back to the Issues tab; a local issue can be published to Jira",
 ];
 ---
 
@@ -78,7 +78,7 @@ const jiraFeatures = [
   description="GitDesktop works with GitHub, GitLab, and Bitbucket: the PR loop and CI on all three, issues and releases on GitHub & GitLab, plus linked Jira Cloud issues, each on its own identity."
   breadcrumbs={[{ name: "Integrations", path: "/integrations/" }]}
   ogTitle="GitDesktop integrations — GitHub, GitLab, Bitbucket & Jira"
-  ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The full loop for each, with the per-platform differences spelled out."
+  ogDescription="One calm client across GitHub, GitLab, and Bitbucket, with linked Jira Cloud issues. The PR loop and CI on all three, issues and releases on GitHub & GitLab, differences spelled out."
 >
   <!-- Hero -->
   <section class="border-b border-line">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -119,7 +119,8 @@ export default defineConfig(async () => ({
         "**/.claude/**",
         "**/.agents/**",
         "**/.impeccable/**",
-        "**/.vscode/**"
+        "**/.vscode/**",
+        "**/*.md",
       ],
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,11 +108,13 @@ export default defineConfig(async () => ({
         }
       : undefined,
     watch: {
-      // 3. tell Vite to ignore watching `src-tauri` & `site` since we don't want to trigger reloads when those files change
+      // 3. ignore src-tauri & site (their own toolchains), tool dirs, and
+      //    doc/config globs — no reloads for files the bundle doesn't use.
+      //    **/*.md covers CHANGELOG.md (imported ?raw by WhatsNew): accepted,
+      //    it's edited at release time, not during dev.
       ignored: [
         "**/src-tauri/**",
         "**/site/**",
-        "*.md",
         "*.yml",
         "*.yaml",
         "**/.github/**",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,9 +109,9 @@ export default defineConfig(async () => ({
       : undefined,
     watch: {
       // 3. ignore src-tauri & site (their own toolchains), tool dirs, and
-      //    doc/config globs — no reloads for files the bundle doesn't use.
-      //    **/*.md covers CHANGELOG.md (imported ?raw by WhatsNew): accepted,
-      //    it's edited at release time, not during dev.
+      //    doc/config globs the dev server shouldn't restart on. **/*.md
+      //    knowingly covers CHANGELOG.md (imported ?raw by WhatsNew) —
+      //    accepted: it's edited at release time, not during dev.
       ignored: [
         "**/src-tauri/**",
         "**/site/**",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,7 +109,7 @@ export default defineConfig(async () => ({
       : undefined,
     watch: {
       // 3. ignore src-tauri & site (their own toolchains), tool dirs, and
-      //    doc/config globs the dev server shouldn't restart on. **/*.md
+      //    doc/config globs the dev server shouldn't reload on. **/*.md
       //    knowingly covers CHANGELOG.md (imported ?raw by WhatsNew) —
       //    accepted: it's edited at release time, not during dev.
       ignored: [
@@ -117,12 +117,12 @@ export default defineConfig(async () => ({
         "**/site/**",
         "*.yml",
         "*.yaml",
+        "**/*.md",
         "**/.github/**",
         "**/.claude/**",
         "**/.agents/**",
         "**/.impeccable/**",
         "**/.vscode/**",
-        "**/*.md",
       ],
     },
   },


### PR DESCRIPTION
The README and marketing site still described PRs, issues, and releases as GitHub-only, understating the GitLab and Bitbucket support the app actually ships. This corrects that coverage across both surfaces and replaces the "honest comparison" framing on the comparison pages with wording that points at the dated verification instead of asserting sincerity.

### Forge coverage

- Rewrites the *Pull requests* section in `README.md` to cover GitHub, GitLab & Bitbucket PRs, with local PRs promotable to a real GitHub or GitLab PR.
- Rewrites the *Issues and to-dos* section in `README.md` for GitHub & GitLab issues, publishable to GitHub, GitLab, or linked Jira, and splits the metadata claim: issue types, sub-issues, and dependencies on GitHub, related issues on GitLab.
- Updates the code-comment promotion path in `README.md` so promoted local issues publish to GitHub, GitLab, or Jira.
- Updates five entries in `site/src/data/capabilities.ts`: the PR highlight, the issues label, the issue-types/dependencies label (now split by forge), the tags/releases label (now scoped to GitHub & GitLab), and a new "GitLab & Bitbucket pipelines" entry so the catalog's CI coverage matches the per-forge scoping elsewhere in this PR.

### Site copy

- Retitles the three comparison pages (`site/src/pages/compare/github-desktop.astro`, `gitkraken.astro`, `sourcetree.astro`) from "an honest comparison" to "a verified comparison", including their `ogDescription` strings.
- Recasts the "the table above is honest about it" line in the Sourcetree FAQ answer to "and the table above says so".
- Reworks the GitKraken hero paragraph in `site/src/pages/compare/gitkraken.astro` so the private-repositories emphasis reads in one clause and the AI sentence closes with "or stays hidden entirely".
- Drops "honest" from the option detail in `site/src/pages/bitbucket-issues-sunset.astro` and from the `ogDescription` in `site/src/pages/integrations.astro`, where per-platform differences are now "spelled out" — and drops "genuinely" from the one blog line that carried the same register.

### Ride-along

- `vite.config.ts`: ignore `**/*.md` in the dev-server watcher, so editing these docs alongside a running app no longer triggers a reload; the superseded bare `*.md` entry is dropped in the same change. This is dev-server watching only — no `src/` or `src-tauri/` paths, so the `fragment` check's path rules are unaffected. The trade-off that `**/*.md` also covers `CHANGELOG.md` (imported `?raw` by the What's New panel, so changelog edits stop hot-updating during dev) is accepted and recorded in the comment above the ignore list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated product documentation to reflect broader pull request, issue, to-do, and code TODO support across GitHub, GitLab, Bitbucket, and Jira.
  - Clarified that local pull requests and to-dos can be published to supported services.
  - Updated capability listings and integration descriptions, including GitLab support.

- **Content Updates**
  - Refreshed comparison pages and Bitbucket sunset messaging with clearer, verified language.
  - Improved homepage and integrations-page descriptions for current platform capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->