### PR TITLE
fix(window): remove fixed minimum width

### DIFF
--- a/changelog.d/changed-narrower-window-width.md
+++ b/changelog.d/changed-narrower-window-width.md
@@ -1,0 +1,1 @@
+- GitDesktop windows can now be resized below the previous fixed width limit for split-screen layouts.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,6 @@
         "title": "GitDesktop",
         "width": 1280,
         "height": 800,
-        "minWidth": 960,
         "minHeight": 600
       }
     ],


### PR DESCRIPTION
## Summary

GitDesktop currently sets a fixed 960px minimum window width in the Tauri configuration. This prevents the app from being used comfortably in split-screen and tiled layouts where the available width is smaller than that floor.

This removes the global `minWidth` constraint and leaves window sizing to the operating system and window manager. The change does not add app-specific or window-manager-specific behavior. The existing 600px minimum height is unchanged.

Closes #275

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other (please describe)

## Screenshots / recording

Not applicable. This changes the native window sizing constraint.

## AI assistance disclosure

Codex helped inspect the repository and draft this change. I reviewed the diff and ran the listed checks.

## Checklist

- [x] My PR title follows the Conventional Commit format.
- [x] I ran `pnpm build`.
- [x] I ran the repository checks.
- [x] I added a changelog fragment under `changelog.d/`.
- [x] I did not add secrets or private data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitDesktop windows can now be resized to narrower widths, making split-screen layouts more convenient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->