### PR TITLE
fix(diff,pulls,git,actions): batch diff, forge, and pull-guard fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ pushing and pulling stay manual.
 
 The full pull-request loop on GitHub, GitLab & Bitbucket, plus **local
 PRs**: the same workflow against any two branches with no remote at all,
-promotable to a real GitHub, GitLab, or Bitbucket PR (comments and all) in one click.
+promotable to a real GitHub, GitLab, or Bitbucket PR (comments and all)
+in one click.
 
 - **Open, edit, merge**: review, comment, approve, edit, and merge (merge &
   squash on all three; rebase on GitHub, fast-forward on Bitbucket) without

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ pushing and pulling stay manual.
 
 The full pull-request loop on GitHub, GitLab & Bitbucket, plus **local
 PRs**: the same workflow against any two branches with no remote at all,
-promotable to a real GitHub or GitLab PR (comments and all) in one click.
+promotable to a real GitHub, GitLab, or Bitbucket PR (comments and all) in one click.
 
 - **Open, edit, merge**: review, comment, approve, edit, and merge (merge &
   squash on all three; rebase on GitHub, fast-forward on Bitbucket) without

--- a/changelog.d/changed-diff-selection-toolbar.md
+++ b/changelog.d/changed-diff-selection-toolbar.md
@@ -1,0 +1,3 @@
+- Selecting lines in a diff keeps the diff exactly where it is. The
+  selected-line count and the **Stage** / **Unstage** / **Discard** actions now
+  appear in the file toolbar, which tints while a selection is live.

--- a/changelog.d/changed-mdx-diff-highlighting.md
+++ b/changelog.d/changed-mdx-diff-highlighting.md
@@ -1,0 +1,4 @@
+- **MDX files** now highlight in diffs, covering the `export` and JSX header,
+  the prose body, and `ts`, `js`, `tsx` and `sql` fenced code blocks. **MDX** is
+  also available in the diff language picker if you want to apply it to another
+  extension.

--- a/changelog.d/fixed-bitbucket-promote-label.md
+++ b/changelog.d/fixed-bitbucket-promote-label.md
@@ -1,4 +1,4 @@
 - Publishing a local pull request names the repository's own provider: on a
   Bitbucket repository the **Publish to Bitbucket** button, its logo, and the
   confirmation dialog all say Bitbucket. The local pull request and local issue
-  dialogs no longer mention GitHub on repositories hosted elsewhere.
+  dialogs describe the flow in provider-neutral terms.

--- a/changelog.d/fixed-bitbucket-promote-label.md
+++ b/changelog.d/fixed-bitbucket-promote-label.md
@@ -1,0 +1,4 @@
+- Publishing a local pull request names the repository's own provider: on a
+  Bitbucket repository the **Publish to Bitbucket** button, its logo, and the
+  confirmation dialog all say Bitbucket. The local pull request and local issue
+  dialogs no longer mention GitHub on repositories hosted elsewhere.

--- a/changelog.d/fixed-push-protection-rejection.md
+++ b/changelog.d/fixed-push-protection-rejection.md
@@ -1,3 +1,3 @@
 - A push that GitHub's secret push protection blocks now explains itself: the
-  secret never left your machine, and you can rewrite the commits to remove it or
-  use the unblock link GitHub printed when it's a false positive.
+  commits were not added to the repository, and you can rewrite them to remove
+  the secret or use the unblock link GitHub printed when it's a false positive.

--- a/changelog.d/fixed-push-protection-rejection.md
+++ b/changelog.d/fixed-push-protection-rejection.md
@@ -1,0 +1,3 @@
+- A push that GitHub's secret push protection blocks now explains itself: the
+  secret never left your machine, and you can rewrite the commits to remove it or
+  use the unblock link GitHub printed when it's a false positive.

--- a/site/src/pages/compare/github-desktop.astro
+++ b/site/src/pages/compare/github-desktop.astro
@@ -83,7 +83,7 @@ const groups: Group[] = [
         them: { state: "no" },
         gd: {
           state: "yes",
-          note: "review & merge offline, promote to GitHub or GitLab later",
+          note: "review & merge offline, promote to GitHub, GitLab, or Bitbucket later",
         },
       },
     ],

--- a/site/src/pages/compare/gitkraken.astro
+++ b/site/src/pages/compare/gitkraken.astro
@@ -118,7 +118,7 @@ const groups: Group[] = [
         them: { state: "no" },
         gd: {
           state: "yes",
-          note: "review & merge offline, promote to GitHub or GitLab later",
+          note: "review & merge offline, promote to GitHub, GitLab, or Bitbucket later",
         },
       },
     ],

--- a/site/src/pages/compare/sourcetree.astro
+++ b/site/src/pages/compare/sourcetree.astro
@@ -104,7 +104,7 @@ const groups: Group[] = [
         them: { state: "no" },
         gd: {
           state: "yes",
-          note: "review & merge offline, promote to GitHub or GitLab later",
+          note: "review & merge offline, promote to GitHub, GitLab, or Bitbucket later",
         },
       },
     ],

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -514,7 +514,8 @@ const forges = [
     <p class="text-muted">
       A local-PR merge pre-shows whether it will conflict, and if it does you resolve
       it in an isolated worktree that never touches your branch, then Finish or Abort.
-      Promote a local PR to a real GitHub or GitLab PR, comments and all, in one click.
+      Promote a local PR to a real GitHub, GitLab, or Bitbucket PR, comments and all,
+      in one click.
     </p>
   </FeatureRow>
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -86,9 +86,10 @@ async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
     (!dir.is_empty()).then(|| std::path::PathBuf::from(dir))
 }
 
-/// Whether `CHERRY_PICK_HEAD` is present, resolved without spawning git — for the
-/// commit path, which pays this on EVERY commit and must not grow a `rev-parse`
-/// child for it. Anything unreadable answers "no pick", never an error.
+/// The dir holding `repo`'s op markers, resolved without spawning git — for the
+/// paths that pay this on EVERY commit or while holding a lock and must not grow a
+/// `rev-parse` child for it. `None` for anything unreadable, which callers must read
+/// as "no markers", never as an error.
 ///
 /// A linked worktree or submodule replaces `.git` with a one-line `gitdir:` pointer
 /// to the dir holding ITS markers, and that path may be relative to the tree holding
@@ -96,25 +97,37 @@ async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
 /// for a worktree under `worktree.useRelativePaths` / `--relative-paths`
 /// (`gitdir: ../<main>/.git/worktrees/<name>`); measured, git 2.51.1. Joining on the
 /// repo path resolves those and leaves an absolute pointer untouched.
+fn marker_dir(repo: &str) -> Option<std::path::PathBuf> {
+    let repo_root = Path::new(repo);
+    let dot_git = repo_root.join(".git");
+    match std::fs::metadata(&dot_git) {
+        Ok(meta) if meta.is_dir() => Some(dot_git),
+        Ok(_) => std::fs::read_to_string(&dot_git)
+            .ok()?
+            .trim()
+            .strip_prefix("gitdir:")
+            .map(|dir| repo_root.join(dir.trim())),
+        Err(_) => None,
+    }
+}
+
+/// Whether `CHERRY_PICK_HEAD` is present, resolved without spawning git (see
+/// [`marker_dir`]).
 ///
 /// Narrower than [`op_state`] on purpose: it answers only "is a single-commit pick
 /// stopped here", the state `cherry-pick <hash>` leaves and `git commit` clears. The
 /// sequencer-only pick (`cherry-pick -n`, no marker) is deliberately outside it.
 pub(crate) fn cherry_pick_marker_present(repo: &str) -> bool {
-    let repo_root = Path::new(repo);
-    let dot_git = repo_root.join(".git");
-    let git_dir = match std::fs::metadata(&dot_git) {
-        Ok(meta) if meta.is_dir() => dot_git,
-        Ok(_) => match std::fs::read_to_string(&dot_git) {
-            Ok(text) => match text.trim().strip_prefix("gitdir:") {
-                Some(dir) => repo_root.join(dir.trim()),
-                None => return false,
-            },
-            Err(_) => return false,
-        },
-        Err(_) => return false,
-    };
-    git_dir.join("CHERRY_PICK_HEAD").exists()
+    marker_dir(repo).is_some_and(|dir| dir.join("CHERRY_PICK_HEAD").exists())
+}
+
+/// Whether a rebase is stopped here, resolved without spawning git (see
+/// [`marker_dir`]) — the same `rebase-merge`/`rebase-apply` pair [`op_state`] reads,
+/// for the callers that need the verdict while holding a lock.
+pub(crate) fn rebase_marker_present(repo: &str) -> bool {
+    marker_dir(repo).is_some_and(|dir| {
+        dir.join("rebase-merge").exists() || dir.join("rebase-apply").exists()
+    })
 }
 
 /// True when an interactive rebase is paused at an `edit` instruction (the last
@@ -275,14 +288,28 @@ pub(crate) async fn op_abort(state: &AppState, repo_path: &str, op: &str) -> App
             stderr: out.full_failure_text(),
         });
     }
-    // Closes the stop arm's paused record as the user's own abandonment. The verdict
-    // is only right for the record this abort actually ended: a pick concluded
-    // outside the app leaves a stale paused record until the next `git_oplog_check`
-    // that finds no pick in progress retires it via `conclude_stale_pauses` — until
-    // then, this call would close it as "aborted by user" (the accepted cost of
-    // keying on the newest paused record rather than an op id).
-    if op == "cherry-pick" {
-        crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Aborted).await;
+    // Closes the stop arm's paused record as the user's own abandonment: a cherry-pick
+    // owns a `cherry_pick_onto` record, a rebase owns a guarded pull's
+    // `pull_rebase_drop` one. Each closes only its OWN op's record, so the two can
+    // never take each other's disposition.
+    //
+    // The accepted cost, unchanged from when only picks paused but now with a second
+    // op's trigger surface: the handle is the newest paused record of that op, not an
+    // op id, so a STALE one — left by an op continued or aborted outside the app —
+    // would be closed as "aborted by user" by the next in-app abort of its kind. The
+    // rebase arm widens WHICH aborts can do that (any in-app rebase abort, not just a
+    // guarded pull's), never what it can reach: only an already-stale record, and only
+    // until the next `git_oplog_check` that finds no op of its kind in progress
+    // retires it via `conclude_stale_pauses`.
+    match op {
+        "cherry-pick" => {
+            crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Aborted).await
+        }
+        "rebase" => {
+            crate::oplog::close_paused_pull_drop(repo_path, crate::oplog::PausedOutcome::Aborted)
+                .await
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -354,11 +381,24 @@ pub(crate) async fn op_continue(state: &AppState, repo_path: &str, op: &str) -> 
     }
     // A cherry-pick that reaches here is over, so a `cherry_pick_onto` record the
     // stop arm left "paused" is closed as done. This is one of the two in-app routes
-    // that end a pick — the commit box is the other, and closes it too. A pick
-    // concluded from a terminal keeps its record paused until the next
-    // `git_oplog_check` that finds no pick in progress retires it.
-    if op == "cherry-pick" {
-        crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Continued).await;
+    // that end a pick — the commit box is the other, and closes it too.
+    //
+    // A rebase owns a guarded pull's `pull_rebase_drop` record and is the arm that
+    // needs the marker check: `--continue` can stop AGAIN at the next commit it
+    // replays, and closing then would report a pull the user is still resolving as
+    // done. Each op closes only its own record, and the same stale-handle cost
+    // `op_abort` documents applies here: an op ended outside the app keeps its record
+    // paused until the next `git_oplog_check` that finds none of its kind in progress
+    // retires it, and until then an in-app continue of that kind would close it.
+    match op {
+        "cherry-pick" => {
+            crate::oplog::close_paused_pick(repo_path, crate::oplog::PausedOutcome::Continued).await
+        }
+        "rebase" if !rebase_marker_present(repo_path) => {
+            crate::oplog::close_paused_pull_drop(repo_path, crate::oplog::PausedOutcome::Continued)
+                .await
+        }
+        _ => {}
     }
     Ok(true)
 }
@@ -3229,7 +3269,7 @@ pub struct RemotePrResolveHandle {
 }
 
 /// Whether a worktree path is one of our REMOTE-PR resolve worktrees — basename
-/// `gd-pr-resolve-<remote>-<number>-<uuid>`. Matches on the bare `gd-pr-resolve-`
+/// `gd-pr-resolve-<remote>-<number>-<id>`. Matches on the bare `gd-pr-resolve-`
 /// prefix so it covers EVERY remote/number, and deliberately does NOT match
 /// [`is_resolve_worktree_path`]'s `gd-resolve-`, keeping the local-PR orphan sweep
 /// away from a remote resolve holding the user's resolutions.
@@ -3465,7 +3505,10 @@ pub(crate) async fn merge_remote_pr(
     // worktree IS the durable resume handle (`find` rediscovers it), and the
     // oplog's interrupted-check keys on the MAIN repo's branch, which this flow
     // never touches — a paused resolve would read as interrupted forever.
-    let worktree_id = uuid::Uuid::new_v4().to_string();
+    // The local resolve mint's short id, shared deliberately: this directory name
+    // is the base every path in the checkout is measured from, and the remote
+    // prefix already spends 14 chars of Windows' 260-char budget before the id.
+    let worktree_id = new_resolve_worktree_id();
     let worktree_path = root.join(format!(
         "{}{worktree_id}",
         pr_resolve_prefix(remote, number)
@@ -3589,7 +3632,7 @@ pub(crate) async fn finish_remote_pr_resolve(
     let remote = resolve_pr_remote(repo_path, lens).await?;
     ensure_pr_resolve_worktree(root, worktree_path)?;
     // Parse the identity this module itself encodes into the directory name —
-    // `gd-pr-resolve-<remote>-<number>-<uuid>` — rather than suffix-matching the
+    // `gd-pr-resolve-<remote>-<number>-<id>` — rather than suffix-matching the
     // id: an empty id makes `ends_with` vacuously true, and a partial one matches
     // any worktree whose name happens to end that way. The remote segment is what
     // stops one lens from finishing (and pushing) another lens's resolve.
@@ -3602,8 +3645,10 @@ pub(crate) async fn finish_remote_pr_resolve(
             "this resolve worktree does not belong to the {remote} remote"
         )));
     };
-    // `<number>-<uuid>`: the number is digits, so the FIRST `-` ends it and
-    // everything after is the id (a uuid, which contains `-` itself).
+    // `<number>-<id>`: the number is digits, so the FIRST `-` ends it and
+    // everything after is the id. Taking the WHOLE tail rather than the next
+    // segment is what keeps worktrees minted before the id shortened — a full
+    // 36-char uuid, dashes and all — finishable without a migration.
     let parsed_id = rest
         .split_once('-')
         .filter(|(number, _)| !number.is_empty() && number.bytes().all(|b| b.is_ascii_digit()))
@@ -7569,6 +7614,88 @@ detached
         assert!(third.conflicts.is_empty(), "got: {:?}", third.conflicts);
     }
 
+    /// The remote-PR resolve directory is the same Windows MAX_PATH budget item
+    /// the local `gd-resolve-` mint was shortened for — every path in the checkout
+    /// is measured from it — so the minted name's length is pinned here, at the
+    /// mint itself (composing the prefix by hand would not notice a regression).
+    #[tokio::test]
+    async fn remote_pr_resolve_worktree_name_is_12_hex_under_the_pr_prefix() {
+        let (dir, _origin, repo, _bare) = setup_repo_with_origin("rpr-name").await;
+        let base = push_conflicting_pair(&repo, dir.path(), "origin").await;
+
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        let state = AppState::default();
+        let outcome = merge_remote_pr(&state, &repo, 42, &base, "feature", None, None, &root)
+            .await
+            .unwrap();
+
+        let wt = outcome.worktree_path.clone().expect("worktree path set");
+        let name = Path::new(&wt).file_name().unwrap().to_string_lossy().into_owned();
+        let prefix = pr_resolve_prefix("origin", 42);
+        let id = name
+            .strip_prefix(&prefix)
+            .unwrap_or_else(|| panic!("name {name} under prefix {prefix}"));
+        assert_eq!(id.len(), 12, "id was {id}");
+        assert!(
+            id.bytes().all(|b| b.is_ascii_hexdigit()),
+            "id must be bare hex (no dashes, no braces): {id}"
+        );
+        // `gd-pr-resolve-` (14) + `origin` (6) + `-` + a 2-digit number + `-` + 12.
+        assert_eq!(name.len(), 36, "name was {name}");
+        // The id handed to the frontend is the one in the path, or a resume would
+        // fail its match check.
+        assert_eq!(outcome.worktree_id.as_deref(), Some(id));
+    }
+
+    /// Resolve worktrees minted before the id shortened are still on disk with a
+    /// full 36-char uuid tail, and this flow ships no migration: `finish` parses
+    /// the id as the whole post-number tail, so such a name still pushes.
+    #[tokio::test]
+    async fn finish_remote_pr_resolve_still_accepts_a_legacy_uuid_name() {
+        let (dir, _origin, repo, bare) = setup_repo_with_origin("rpr-legacy").await;
+        let base = push_conflicting_pair(&repo, dir.path(), "origin").await;
+        let head_before = rev(&bare, "refs/heads/feature").await;
+        // `finish` reads the head tip from the remote-tracking ref the start step
+        // would have fetched; this fixture skips that step.
+        git(&repo, &["fetch", "origin"]).await;
+
+        let legacy_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(legacy_id.len(), 36, "the old mint's shape: {legacy_id}");
+        let root_holder = tempfile::tempdir().expect("create temp dir");
+        let root = root_holder.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        let wt = root
+            .join(format!("{}{legacy_id}", pr_resolve_prefix("origin", 8)))
+            .to_string_lossy()
+            .into_owned();
+        let head_tip = rev(&repo, "refs/remotes/origin/feature").await;
+        let base_tip = rev(&repo, &format!("refs/remotes/origin/{base}")).await;
+        git(&repo, &["worktree", "add", "--detach", &wt, &head_tip]).await;
+        let merged = run_git_raw(
+            Some(&wt),
+            &["merge", "--no-ff", "-m", "Merge base into feature", &base_tip],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_ne!(merged.code, 0, "the fixture merge conflicts as the flow's does");
+
+        std::fs::write(Path::new(&wt).join("a.txt"), "resolved\n").unwrap();
+        git(&wt, &["add", "a.txt"]).await;
+
+        let state = AppState::default();
+        let done = finish_remote_pr_resolve(
+            &state, &repo, "feature", &wt, &legacy_id, None, None, &root,
+        )
+        .await
+        .unwrap();
+        assert_eq!(done.status, "pushed");
+        let pushed = done.pushed_sha.clone().expect("pushed sha");
+        assert_ne!(pushed, head_before, "the PR head advanced");
+        assert_eq!(rev(&bare, "refs/heads/feature").await, pushed);
+    }
+
     /// Abort tears the worktree down and pushes nothing; `find` locates the live
     /// worktree by (remote, number) beforehand and reports none afterwards. The
     /// local-PR orphan sweep must NOT claim it (its `gd-resolve-` prefix
@@ -7794,7 +7921,7 @@ detached
 
         // An EMPTY id must be refused, not accepted: every path "ends with" the
         // empty string, so a suffix match would wave it through. A partial id is
-        // refused for the same reason — the id must be the whole uuid segment.
+        // refused for the same reason — the id must match the whole trailing segment.
         for bad_id in ["", &wt_id[wt_id.len() - 4..]] {
             let err = finish_remote_pr_resolve(
                 &state, &repo, "feature", &wt, bad_id, None, None, &root,

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -6227,6 +6227,82 @@ mod tests {
         );
     }
 
+    /// The probe `op_continue` consults while holding the repo lock: a rebase that
+    /// STOPPED must read true and an aborted one false, or a guarded pull's drop
+    /// record closes at the wrong moment — mid-rebase, or never. Both marker dirs
+    /// count, because the probe is an OR over the pair: the default merge backend
+    /// writes `rebase-merge`, `--apply` writes `rebase-apply`.
+    #[tokio::test]
+    async fn rebase_marker_probe_tracks_a_paused_rebase() {
+        let (dir, repo) = setup_repo("rebase-marker").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        git(&repo, &["switch", "feature"]).await;
+
+        assert!(!rebase_marker_present(&repo), "nothing is rebasing yet");
+
+        for backend in [Vec::new(), vec!["--apply"]] {
+            let mut argv = vec!["rebase"];
+            argv.extend(backend.iter().copied());
+            argv.push(&base);
+            let out = run_git_raw(Some(&repo), &argv, DEFAULT_TIMEOUT).await.unwrap();
+            assert_ne!(out.code, 0, "the rebase should conflict: {argv:?}");
+            assert!(
+                rebase_marker_present(&repo),
+                "a stopped rebase leaves its marker dir: {argv:?}"
+            );
+            git(&repo, &["rebase", "--abort"]).await;
+            assert!(
+                !rebase_marker_present(&repo),
+                "and the abort clears it: {argv:?}"
+            );
+        }
+    }
+
+    /// The rebase twin of the pick probe above: the same spawn-free lookup has to
+    /// follow a linked worktree's one-line `gitdir:` pointer, or a guarded pull
+    /// paused in a worktree would read as finished and close its record mid-rebase.
+    #[tokio::test]
+    async fn rebase_marker_probe_follows_a_worktrees_gitdir_pointer() {
+        let (dir, repo) = setup_repo("worktree-rebase-marker").await;
+        let base = head_branch(&repo).await;
+        git(&repo, &["switch", "-c", "feature"]).await;
+        commit_file(&repo, dir.path(), "a.txt", "theirs\n", "feature edit").await;
+        let feature_tip = rev(&repo, "HEAD").await;
+        git(&repo, &["switch", &base]).await;
+        commit_file(&repo, dir.path(), "a.txt", "mine\n", "base edit").await;
+        let tip = rev(&repo, "HEAD").await;
+
+        let link_dir = tempfile::Builder::new()
+            .prefix("gd-worktree-rebase-marker-")
+            .tempdir()
+            .expect("create temp dir");
+        let link = link_dir.path().join("linked").to_string_lossy().into_owned();
+        git(&repo, &["worktree", "add", "--detach", &link, &feature_tip]).await;
+        assert!(
+            !rebase_marker_present(&link),
+            "nothing is rebasing in the fresh worktree"
+        );
+
+        let out = run_git_raw(Some(&link), &["rebase", &tip], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_ne!(out.code, 0, "the rebase inside the worktree should conflict");
+        assert!(
+            rebase_marker_present(&link),
+            "the worktree's own marker must be found through its gitdir pointer"
+        );
+        assert!(
+            !rebase_marker_present(&repo),
+            "and the main checkout has no rebase of its own"
+        );
+
+        git(&repo, &["worktree", "remove", "--force", &link]).await;
+    }
+
     /// Conflicted revert / cherry-pick / rebase all split ONE report across both
     /// streams: the diagnostic on stderr, the conflicted-file list on stdout. An
     /// error carrying either alone looks populated while dropping exactly what

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -188,7 +188,8 @@ async fn submodule_recurse(repo: &str) -> bool {
 /// measured on that git: a conflicted rebase gets no submodule step, while a landed
 /// rebase gets one even when the autostash reapply conflicted (pull exits 0 and
 /// still runs it). [`fold_submodule_failure`] keeps that from costing the reapply
-/// report. Clones and fetches what a moved pointer needs, so network budget.
+/// report. `submodule update` clones and fetches what a moved pointer needs,
+/// so it runs on `NETWORK_TIMEOUT`.
 async fn update_submodules_after_rebase(repo: &str) -> AppResult<()> {
     if !submodule_recurse(repo).await {
         return Ok(());

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -157,6 +157,110 @@ async fn plain_autostash_flag(repo: &str) -> Option<&'static str> {
 /// The compounds' flag: they stash and reapply themselves, so git must not.
 const COMPOUND_AUTOSTASH: Option<&str> = Some("--no-autostash");
 
+/// Whether the user's `submodule.recurse` is on. Read through git's own `--bool`
+/// resolution, so system/global/local precedence and every spelling of true stay
+/// git's verdict rather than ours; absent, unreadable or non-boolean reads as false,
+/// which is the key's documented default ("Defaults to false", git-config).
+async fn submodule_recurse(repo: &str) -> bool {
+    let Ok(out) = run_git_raw(
+        Some(repo),
+        &["config", "--bool", "submodule.recurse"],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    else {
+        return false;
+    };
+    out.code == 0 && out.stdout_lossy().trim() == "true"
+}
+
+/// The submodule worktree update a rebase-mode `git pull` runs after its rebase, and
+/// the one thing the guard's plain `git rebase` cannot do for itself.
+///
+/// Semantics taken from git's own docs, not from the argv: `submodule.recurse` is
+/// "A boolean indicating if commands should enable the `--recurse-submodules` option
+/// by default", and its supported-command list is checkout, fetch, grep, pull, push,
+/// read-tree, reset, restore and switch — `rebase` is absent, which is why the
+/// guard's phases lose the behavior. Pull's `--recurse-submodules` "controls if new
+/// commits of populated submodules should be fetched, and if the working trees of
+/// active submodules should be updated, too … If the checkout is done via rebase,
+/// local submodule commits are rebased as well" (git-pull). The step pull runs for
+/// that second half is `git submodule update --recursive --rebase` (measured through
+/// `GIT_TRACE`, git 2.51.1.windows.1).
+///
+/// The FETCH half needs nothing here: the guard's probe fetch is a plain
+/// `git fetch` in the user's own repo, so it already inherits `submodule.recurse`
+/// exactly as pull's own flagless `git fetch` does — and forcing an explicit
+/// `--recurse-submodules` would recurse where a `fetch.recurseSubmodules=no` makes
+/// plain pull not (both measured on the same git).
+///
+/// WHEN it runs is parity too, and both directions are measured on that git rather
+/// than reasoned: a rebase that CONFLICTS gets no submodule step (pull's trace ends
+/// at `git rebase`, and the submodule stays put), while a rebase that landed gets one
+/// even if the AUTOSTASH reapply then conflicted — pull prints "Applying autostash
+/// resulted in conflicts", exits 0, and still runs the step, leaving the submodule
+/// updated beside the unmerged paths. So the gate here is "did the rebase land", not
+/// "is the tree clean"; [`fold_submodule_failure`] is what keeps that from costing
+/// the reapply report.
+///
+/// `submodule update` clones and fetches what a moved pointer needs, so it takes the
+/// network budget.
+async fn update_submodules_after_rebase(repo: &str) -> AppResult<()> {
+    if !submodule_recurse(repo).await {
+        return Ok(());
+    }
+    let out = run_git_raw(
+        Some(repo),
+        &["submodule", "update", "--recursive", "--rebase"],
+        NETWORK_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
+    Ok(())
+}
+
+/// Fold a failed submodule step into the compound's own report, so the step can run
+/// on a conflicted REAPPLY (which is parity — see
+/// [`update_submodules_after_rebase`]) without that outcome being thrown away.
+///
+/// `ReapplyConflicted` is the one outcome the user MUST still see: it names a
+/// retained stash and unmerged paths, which no `AppError` from a submodule checkout
+/// would tell them about, so the step's failure is appended to its detail instead of
+/// replacing it. Every other landed outcome carries nothing the error does not, so
+/// there the failure IS the result and is never swallowed.
+///
+/// That arm is defensive rather than common: with the index left unmerged by the
+/// conflicted pop, `git submodule update` skips the submodules it would have to CLONE
+/// and exits 0 (measured, git 2.51.1.windows.1), so it often has nothing to fail at.
+/// It can still act — and so still fail — on an already-cloned submodule whose new
+/// sha needs a fetch, which is the path pull was measured taking with unmerged paths
+/// present.
+fn fold_submodule_failure(
+    result: AppResult<AutostashOutcome>,
+    submodule: AppResult<()>,
+) -> AppResult<AutostashOutcome> {
+    let Err(failure) = submodule else {
+        return result;
+    };
+    match result {
+        Ok(AutostashOutcome::ReapplyConflicted {
+            stderr,
+            conflicted,
+        }) => Ok(AutostashOutcome::ReapplyConflicted {
+            stderr: format!("{stderr}\n{failure}"),
+            conflicted,
+        }),
+        Ok(_) => Err(failure),
+        // The step only runs on a landed rebase, so a failed one never reaches here.
+        stopped => stopped,
+    }
+}
+
 /// The current branch's short name, or `None` on a detached HEAD.
 async fn current_branch(repo: &str) -> Option<String> {
     let out = run_git_raw(
@@ -497,6 +601,9 @@ pub(crate) async fn guarded_pull(state: &AppState, repo: &str) -> AppResult<bool
         )
         .await);
     }
+    // Only after a rebase that LANDED — a conflicted pull runs no submodule step
+    // either (measured), and the tree is mid-rebase.
+    update_submodules_after_rebase(repo).await?;
     Ok(true)
 }
 
@@ -528,7 +635,15 @@ pub(crate) async fn guarded_pull_autostash(
         DEFAULT_TIMEOUT,
     )
     .await;
-    settle(repo, "rebase", stashed, true, op).await.map(Some)
+    let result = settle(repo, "rebase", stashed, true, op).await;
+    // `settled_journal_error` is exactly the "did the rebase itself land" verdict a
+    // conflicted REAPPLY still passes, which is the gate pull uses too — the stash
+    // comes back before the submodule step runs either way.
+    if settled_journal_error(&result).is_none() {
+        let submodule = update_submodules_after_rebase(repo).await;
+        return fold_submodule_failure(result, submodule).map(Some);
+    }
+    result.map(Some)
 }
 
 /// Which base the user's answer rebases from: `keep` starts below the rewritten-away
@@ -751,12 +866,26 @@ pub(crate) async fn git_pull_rebase_decided_core(
         .await),
         Ok(_) => Ok(()),
     };
-    crate::oplog::finish(
-        &repo_path,
-        &op_id,
-        result.as_ref().err().map(ToString::to_string),
-    )
-    .await;
+    // The submodule step belongs to THIS op as far as the journal is concerned, so it
+    // runs BEFORE the record closes: settling first would leave a green "done" row
+    // behind a call the caller saw fail.
+    let result = match result {
+        Ok(()) => update_submodules_after_rebase(&repo_path).await,
+        stopped => stopped,
+    };
+    // A conflict did not END the op — it handed the tree to the user, who still has
+    // to continue or abort it. The record pauses exactly as the cherry-pick stop
+    // arm's does; every other failure is a real failure.
+    if matches!(result, Err(AppError::Conflict { .. })) {
+        crate::oplog::pause(&repo_path, &op_id).await;
+    } else {
+        crate::oplog::finish(
+            &repo_path,
+            &op_id,
+            result.as_ref().err().map(ToString::to_string),
+        )
+        .await;
+    }
     result
 }
 
@@ -815,7 +944,29 @@ pub(crate) async fn git_pull_rebase_decided_autostash_core(
     let op_id =
         begin_drop_journal(&repo_path, &decided, &keep_base, &drop_base, &expected_tip).await;
     let result = decided_autostash_run(&repo_path, &decided).await;
-    crate::oplog::finish(&repo_path, &op_id, settled_journal_error(&result)).await;
+    // Submodule step first, folded into the result, so the record below closes on the
+    // SAME verdict the caller receives — a settle-then-step order journals "done" for
+    // a call that goes on to return an error.
+    let result = if settled_journal_error(&result).is_none() {
+        let submodule = update_submodules_after_rebase(&repo_path).await;
+        fold_submodule_failure(result, submodule)
+    } else {
+        result
+    };
+    // The compound's conflict shape: the rebase stopped and left itself in progress
+    // for the user to continue or abort, which the plain core reports as
+    // `AppError::Conflict`. A stash kept for any OTHER reason is a real failure.
+    if matches!(
+        result,
+        Ok(AutostashOutcome::OpFailedStashKept {
+            in_progress: true,
+            ..
+        })
+    ) {
+        crate::oplog::pause(&repo_path, &op_id).await;
+    } else {
+        crate::oplog::finish(&repo_path, &op_id, settled_journal_error(&result)).await;
+    }
     result
 }
 
@@ -1522,13 +1673,10 @@ mod tests {
         assert!(crate::git::ops::op_state(&clone).await.unwrap().rebasing);
     }
 
-    /// The destructive arm's conflict: dropping V still replays the local commit
-    /// above it, which can collide. The journal entry the drop opened has to be
-    /// closed — a record left `"pending"` would show up as an interrupted op on
-    /// the next launch, offering recovery for a rebase the user is mid-resolve on.
-    #[tokio::test]
-    async fn decided_drop_that_conflicts_pauses_a_rebase_and_closes_its_record() {
-        let (_dir, clone, shas) = colliding_fixture("drop-conflict", true).await;
+    /// Drive a decided DROP to its conflict: dropping V still replays the local
+    /// commit above it, which collides with the rewritten upstream.
+    async fn conflicted_drop(marker: &str) -> (tempfile::TempDir, String, DecisionShas) {
+        let (dir, clone, shas) = colliding_fixture(marker, true).await;
 
         let state = AppState::default();
         let err = git_pull_rebase_decided_core(
@@ -1537,8 +1685,8 @@ mod tests {
             "main".into(),
             "drop".into(),
             shas.new_tip.clone(),
-            shas.keep_base,
-            shas.drop_base,
+            shas.keep_base.clone(),
+            shas.drop_base.clone(),
             shas.expected_tip.clone(),
         )
         .await
@@ -1549,16 +1697,35 @@ mod tests {
         assert_eq!(op, "rebase");
         assert_eq!(paths, &vec!["a.txt".to_string()]);
         assert!(crate::git::ops::op_state(&clone).await.unwrap().rebasing);
+        (dir, clone, shas)
+    }
 
-        let entry = crate::oplog::git_oplog_list(clone.clone())
+    /// `repo`'s journaled drop record.
+    async fn drop_entry(repo: &str) -> crate::oplog::OpLogEntry {
+        crate::oplog::git_oplog_list(repo.to_string())
             .await
             .expect("the journal must be readable")
             .into_iter()
             .find(|e| e.op == "pull_rebase_drop")
-            .expect("a drop must be journaled even when it stops");
-        // Recorded as failed rather than paused: the paused-op distinction the
-        // sequencer commands draw is a separate question from this one.
-        assert_eq!(entry.status, "failed");
+            .expect("a drop must be journaled even when it stops")
+    }
+
+    /// The destructive arm's conflict did not END the drop — it handed the tree to
+    /// the user, who still has to continue or abort it. The record takes the same
+    /// `"paused"` disposition a stopped cherry-pick gets: neither a failure that
+    /// hasn't happened, nor a `"pending"` row offering recovery for a rebase the
+    /// user is mid-resolve on.
+    #[tokio::test]
+    async fn decided_drop_that_conflicts_pauses_a_rebase_and_its_record() {
+        let (_dir, clone, shas) = conflicted_drop("drop-conflict").await;
+
+        let entry = drop_entry(&clone).await;
+        assert_eq!(entry.status, "paused");
+        assert!(entry.finished_at.is_none(), "a paused op has not ended");
+        assert!(
+            entry.error.is_none(),
+            "the conflict lives in the banner, not in a failure line"
+        );
         assert_eq!(entry.original_sha, shas.expected_tip);
         // The rollback slot holds the PRE-op tip, never the upstream's: resetting
         // to the upstream tip would redo the very drop a recovery is undoing.
@@ -1569,16 +1736,52 @@ mod tests {
         );
         assert_ne!(entry.pre_op_tip.as_deref(), Some(shas.new_tip.as_str()));
         assert!(
-            entry.error.is_some_and(|e| e.contains("a.txt")),
-            "the record carries what stopped it"
-        );
-        assert!(
             crate::oplog::git_oplog_check(clone.clone())
                 .await
                 .unwrap()
                 .is_empty(),
-            "and it is no longer pending, so relaunch offers no recovery for it"
+            "and it is not pending, so relaunch offers no recovery for it"
         );
+        assert_eq!(
+            drop_entry(&clone).await.status,
+            "paused",
+            "a check must not retire the handle of a rebase that is still live"
+        );
+    }
+
+    /// Continuing the paused rebase in-app ends the drop, so `op_continue`'s rebase
+    /// arm closes its record done — the mirror of the route a pick already has.
+    #[tokio::test]
+    async fn continuing_a_paused_drop_closes_its_record() {
+        let (dir, clone, _shas) = conflicted_drop("drop-continue").await;
+        std::fs::write(dir.path().join("clone").join("a.txt"), "resolved\n").unwrap();
+        git(&clone, &["add", "a.txt"]).await;
+
+        let state = AppState::default();
+        assert!(crate::git::ops::op_continue(&state, &clone, "rebase")
+            .await
+            .expect("the resolved rebase continues to completion"));
+        assert!(!crate::git::ops::op_state(&clone).await.unwrap().rebasing);
+        assert_eq!(drop_entry(&clone).await.status, "done");
+    }
+
+    /// Aborting it abandons the drop, journaled the way every user-abandoned op is.
+    #[tokio::test]
+    async fn aborting_a_paused_drop_closes_its_record() {
+        let (_dir, clone, shas) = conflicted_drop("drop-abort").await;
+
+        let state = AppState::default();
+        crate::git::ops::op_abort(&state, &clone, "rebase")
+            .await
+            .expect("the paused rebase aborts");
+        assert_eq!(
+            rev(&clone, "HEAD").await,
+            shas.expected_tip,
+            "the abort restored the branch"
+        );
+        let entry = drop_entry(&clone).await;
+        assert_eq!(entry.status, "failed");
+        assert_eq!(entry.error.as_deref(), Some("aborted by user"));
     }
 
     /// The autostash variant stashes the dirty tree across the rebase and puts it
@@ -1612,5 +1815,307 @@ mod tests {
             "dirty\n"
         );
         assert!(git(&clone, &["stash", "list"]).await.trim().is_empty());
+    }
+
+    // ---- submodule parity ---------------------------------------------------
+
+    /// The gate is git's own boolean resolution, so every spelling of true counts
+    /// and anything non-boolean reads as the key's documented default, false.
+    #[tokio::test]
+    async fn submodule_recurse_reads_gits_own_boolean() {
+        let (_dir, clone, _shas) = decided_fixture("submodule-config").await;
+
+        assert!(!submodule_recurse(&clone).await, "unset defaults to false");
+        git(&clone, &["config", "submodule.recurse", "yes"]).await;
+        assert!(submodule_recurse(&clone).await);
+        git(&clone, &["config", "submodule.recurse", "false"]).await;
+        assert!(!submodule_recurse(&clone).await);
+        git(&clone, &["config", "submodule.recurse", "sometimes"]).await;
+        assert!(!submodule_recurse(&clone).await);
+    }
+
+    /// git refuses `file://` transport for submodule CLONE, and a repo-local
+    /// `protocol.file.allow` does not lift it — only a command-line `-c` does
+    /// (measured, git 2.51.1.windows.1). The fixture's own setup commands carry it;
+    /// nothing under test needs it, because the clone already holds every object the
+    /// parity step checks out.
+    const ALLOW_FILE_SUBMODULE: &str = "protocol.file.allow=always";
+
+    /// A superproject carrying one submodule, cloned so the clone is the repo under
+    /// test: it has a local commit (so the guard has something to rebase) while
+    /// upstream has moved the pointer to a second submodule commit. Returns the
+    /// fixture guard, the clone, and that second submodule sha.
+    ///
+    /// Both submodule commits are pushed BEFORE anything clones, so the clone's
+    /// submodule object store already holds the one the bump records.
+    async fn submodule_fixture(marker: &str) -> (tempfile::TempDir, String, String) {
+        let dir = temp(marker);
+        let root = dir.path().to_string_lossy().into_owned();
+        git(&root, &["init", "-q", "--bare", "-b", "main", "sub.git"]).await;
+        git(&root, &["init", "-q", "--bare", "-b", "main", "super.git"]).await;
+        let url = |name: &str| {
+            format!(
+                "file://{}",
+                dir.path().join(name).to_string_lossy().replace('\\', "/")
+            )
+        };
+
+        // The submodule's own upstream.
+        git(&root, &["init", "-q", "-b", "main", "sub-work"]).await;
+        let sub_dir = dir.path().join("sub-work");
+        let sub = sub_dir.to_string_lossy().into_owned();
+        configure(&sub).await;
+        std::fs::write(sub_dir.join("s.txt"), "s1\n").unwrap();
+        git(&sub, &["add", "-A"]).await;
+        git(&sub, &["commit", "-qm", "s1"]).await;
+        git(&sub, &["remote", "add", "origin", &url("sub.git")]).await;
+        git(&sub, &["push", "-q", "-u", "origin", "main"]).await;
+        let s1 = rev(&sub, "HEAD").await;
+        std::fs::write(sub_dir.join("s.txt"), "s2\n").unwrap();
+        git(&sub, &["commit", "-qam", "s2"]).await;
+        git(&sub, &["push", "-q"]).await;
+        let s2 = rev(&sub, "HEAD").await;
+
+        // The superproject, recording the submodule at s1.
+        git(&root, &["init", "-q", "-b", "main", "super-work"]).await;
+        let work_dir = dir.path().join("super-work");
+        let work = work_dir.to_string_lossy().into_owned();
+        configure(&work).await;
+        std::fs::write(work_dir.join("a.txt"), "base\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "base"]).await;
+        git(
+            &work,
+            &[
+                "-c",
+                ALLOW_FILE_SUBMODULE,
+                "submodule",
+                "add",
+                "-q",
+                &url("sub.git"),
+                "sub",
+            ],
+        )
+        .await;
+        let work_sub = work_dir.join("sub").to_string_lossy().into_owned();
+        git(&work_sub, &["checkout", "-q", &s1]).await;
+        git(&work, &["add", "sub"]).await;
+        git(&work, &["commit", "-qm", "add the submodule"]).await;
+        git(&work, &["remote", "add", "origin", &url("super.git")]).await;
+        git(&work, &["push", "-q", "-u", "origin", "main"]).await;
+
+        // The clone under test, plus a local commit so the guard has a rebase to run.
+        git(
+            &root,
+            &[
+                "-c",
+                "core.autocrlf=false",
+                "-c",
+                ALLOW_FILE_SUBMODULE,
+                "clone",
+                "-q",
+                "--recurse-submodules",
+                &url("super.git"),
+                "clone",
+            ],
+        )
+        .await;
+        let clone_dir = dir.path().join("clone");
+        let clone = clone_dir.to_string_lossy().into_owned();
+        configure(&clone).await;
+        std::fs::write(clone_dir.join("mine.txt"), "mine\n").unwrap();
+        git(&clone, &["add", "-A"]).await;
+        git(&clone, &["commit", "-qm", "local commit"]).await;
+
+        // Upstream moves the pointer to s2, leaving the clone's worktree behind.
+        git(&work_sub, &["checkout", "-q", &s2]).await;
+        git(&work, &["add", "sub"]).await;
+        git(&work, &["commit", "-qm", "bump the submodule"]).await;
+        git(&work, &["push", "-q"]).await;
+
+        (dir, clone, s2)
+    }
+
+    /// `submodule.recurse=true` asks git to keep submodule worktrees in step with
+    /// the pointer, which the guard's plain `git rebase` cannot do — `rebase` is not
+    /// one of the commands that key enables `--recurse-submodules` for. The parity
+    /// step is what moves the submodule after the superproject records it.
+    #[tokio::test]
+    async fn a_guarded_pull_updates_submodules_when_the_user_asked_for_it() {
+        let (dir, clone, s2) = submodule_fixture("submodule-recurse").await;
+        git(&clone, &["config", "submodule.recurse", "true"]).await;
+        let sub = dir
+            .path()
+            .join("clone")
+            .join("sub")
+            .to_string_lossy()
+            .into_owned();
+        let before = rev(&sub, "HEAD").await;
+        assert_ne!(before, s2, "the fixture must leave the submodule behind");
+
+        let state = AppState::default();
+        assert!(
+            guarded_pull(&state, &clone)
+                .await
+                .expect("the guarded pull rebases cleanly"),
+            "the guard must engage, or this test proves nothing"
+        );
+
+        assert_eq!(
+            rev(&clone, "HEAD:sub").await,
+            s2,
+            "the superproject records the new submodule commit"
+        );
+        assert_eq!(
+            rev(&sub, "HEAD").await,
+            s2,
+            "and the submodule worktree is checked out at it"
+        );
+    }
+
+    /// Commit a submodule that can never be checked out — a gitlink whose object is
+    /// absent and a URL git will not use — and register it, so the parity step fails
+    /// deterministically and offline. `update-index --cacheinfo` accepts a gitlink
+    /// with no local object, and the entry survives a `rebase --onto` (both measured,
+    /// git 2.51.1.windows.1), which is what lets the failure land AFTER the rebase.
+    ///
+    /// Returns the new tip, since the extra commit moves HEAD past the one a decision
+    /// fixture pinned.
+    async fn commit_a_broken_submodule(repo: &str, dir: &std::path::Path) -> String {
+        std::fs::write(
+            dir.join(".gitmodules"),
+            "[submodule \"brk\"]\n\tpath = brk\n\turl = file:///gd-no-such-submodule\n",
+        )
+        .unwrap();
+        git(
+            repo,
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "160000,0123456789012345678901234567890123456789,brk",
+            ],
+        )
+        .await;
+        git(repo, &["add", ".gitmodules"]).await;
+        git(repo, &["commit", "-qm", "a submodule that cannot resolve"]).await;
+        git(repo, &["submodule", "init"]).await;
+        git(repo, &["config", "submodule.recurse", "true"]).await;
+        rev(repo, "HEAD").await
+    }
+
+    /// The journal row and the returned result must never disagree. The rebase lands,
+    /// the parity step then fails, and the record has to close on THAT verdict — a
+    /// record settled before the step would show a green Done row for a call the
+    /// caller saw fail.
+    #[tokio::test]
+    async fn a_submodule_failure_after_a_landed_rebase_journals_the_failure() {
+        let (dir, clone, shas) = decided_fixture("submodule-step-fails").await;
+        let expected_tip =
+            commit_a_broken_submodule(&clone, &dir.path().join("clone")).await;
+
+        let state = AppState::default();
+        let err = git_pull_rebase_decided_core(
+            &state,
+            clone.clone(),
+            "main".into(),
+            "drop".into(),
+            shas.new_tip,
+            shas.keep_base,
+            shas.drop_base,
+            expected_tip,
+        )
+        .await
+        .expect_err("the submodule step cannot resolve its gitlink");
+        assert!(
+            matches!(&err, AppError::Git { .. }),
+            "the step's own failure reaches the caller: {err:?}"
+        );
+
+        // The rebase itself landed — this is a failure AFTER it, not instead of it.
+        assert_eq!(
+            log_subjects(&clone).await.get(1).map(String::as_str),
+            Some("teammate rewrite"),
+            "the drop replayed onto the rewritten upstream"
+        );
+        let entry = drop_entry(&clone).await;
+        assert_eq!(entry.status, "failed", "the row agrees with the result");
+        assert!(
+            entry.error.is_some_and(|e| e.contains("brk")),
+            "and it carries what actually stopped it"
+        );
+    }
+
+    /// The fold's contract, driven directly. An integration fixture cannot reach it
+    /// reliably: the conflicted pop leaves the index unmerged, and `git submodule
+    /// update` then skips the submodules it would have to clone and exits 0
+    /// (measured) — so the fixture version of this test passed without the fold ever
+    /// running, which its negative control is what caught.
+    #[test]
+    fn a_submodule_failure_never_replaces_a_conflicted_reapply() {
+        let boom = || AppError::Command("submodule brk exploded".into());
+
+        let folded = fold_submodule_failure(
+            Ok(AutostashOutcome::ReapplyConflicted {
+                stderr: "pop conflicted on a.txt".into(),
+                conflicted: true,
+            }),
+            Err(boom()),
+        )
+        .expect("the reapply report survives the failing step");
+        let AutostashOutcome::ReapplyConflicted { stderr, conflicted } = folded else {
+            panic!("the outcome must keep its variant");
+        };
+        assert!(conflicted, "and its discriminant");
+        assert!(stderr.contains("pop conflicted on a.txt"), "{stderr}");
+        assert!(stderr.contains("submodule brk exploded"), "{stderr}");
+
+        // An outcome carrying nothing the error does not: the failure IS the result,
+        // so it can never be swallowed.
+        for outcome in [
+            AutostashOutcome::Reapplied,
+            AutostashOutcome::NothingStashed,
+        ] {
+            let err = fold_submodule_failure(Ok(outcome), Err(boom()))
+                .expect_err("a failure with nothing to preserve is never swallowed");
+            assert!(err.to_string().contains("submodule brk exploded"), "{err}");
+        }
+
+        // A clean step changes nothing.
+        assert!(matches!(
+            fold_submodule_failure(Ok(AutostashOutcome::Reapplied), Ok(())),
+            Ok(AutostashOutcome::Reapplied)
+        ));
+    }
+
+    /// The flip side: with `submodule.recurse` unset the guard must leave submodule
+    /// worktrees where the user left them — a bare `git pull` does not recurse
+    /// either, and that default is the whole reason the step is gated.
+    #[tokio::test]
+    async fn a_guarded_pull_leaves_submodules_alone_by_default() {
+        let (dir, clone, s2) = submodule_fixture("submodule-default").await;
+        let sub = dir
+            .path()
+            .join("clone")
+            .join("sub")
+            .to_string_lossy()
+            .into_owned();
+        let before = rev(&sub, "HEAD").await;
+
+        let state = AppState::default();
+        assert!(guarded_pull(&state, &clone)
+            .await
+            .expect("the guarded pull rebases cleanly"));
+
+        assert_eq!(
+            rev(&clone, "HEAD:sub").await,
+            s2,
+            "the pointer still moves — that is the rebase's own work"
+        );
+        assert_eq!(
+            rev(&sub, "HEAD").await,
+            before,
+            "the worktree stays where the user left it"
+        );
     }
 }

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -174,37 +174,21 @@ async fn submodule_recurse(repo: &str) -> bool {
     out.code == 0 && out.stdout_lossy().trim() == "true"
 }
 
-/// The submodule worktree update a rebase-mode `git pull` runs after its rebase, and
-/// the one thing the guard's plain `git rebase` cannot do for itself.
+/// The submodule worktree update a rebase-mode `git pull` runs after its rebase —
+/// the one thing the guard's plain `git rebase` cannot do for itself:
+/// `submodule.recurse`'s supported-command list (git-config) omits `rebase`, and
+/// the step pull runs for it is `git submodule update --recursive --rebase`
+/// (measured via GIT_TRACE, git 2.51.1.windows.1).
 ///
-/// Semantics taken from git's own docs, not from the argv: `submodule.recurse` is
-/// "A boolean indicating if commands should enable the `--recurse-submodules` option
-/// by default", and its supported-command list is checkout, fetch, grep, pull, push,
-/// read-tree, reset, restore and switch — `rebase` is absent, which is why the
-/// guard's phases lose the behavior. Pull's `--recurse-submodules` "controls if new
-/// commits of populated submodules should be fetched, and if the working trees of
-/// active submodules should be updated, too … If the checkout is done via rebase,
-/// local submodule commits are rebased as well" (git-pull). The step pull runs for
-/// that second half is `git submodule update --recursive --rebase` (measured through
-/// `GIT_TRACE`, git 2.51.1.windows.1).
+/// The fetch half needs nothing: the guard's plain `git fetch` inherits
+/// `submodule.recurse` like pull's own, and forcing `--recurse-submodules` would
+/// recurse where `fetch.recurseSubmodules=no` makes plain pull not (measured).
 ///
-/// The FETCH half needs nothing here: the guard's probe fetch is a plain
-/// `git fetch` in the user's own repo, so it already inherits `submodule.recurse`
-/// exactly as pull's own flagless `git fetch` does — and forcing an explicit
-/// `--recurse-submodules` would recurse where a `fetch.recurseSubmodules=no` makes
-/// plain pull not (both measured on the same git).
-///
-/// WHEN it runs is parity too, and both directions are measured on that git rather
-/// than reasoned: a rebase that CONFLICTS gets no submodule step (pull's trace ends
-/// at `git rebase`, and the submodule stays put), while a rebase that landed gets one
-/// even if the AUTOSTASH reapply then conflicted — pull prints "Applying autostash
-/// resulted in conflicts", exits 0, and still runs the step, leaving the submodule
-/// updated beside the unmerged paths. So the gate here is "did the rebase land", not
-/// "is the tree clean"; [`fold_submodule_failure`] is what keeps that from costing
-/// the reapply report.
-///
-/// `submodule update` clones and fetches what a moved pointer needs, so it takes the
-/// network budget.
+/// The gate is "did the rebase land", not "is the tree clean" — both directions
+/// measured on that git: a conflicted rebase gets no submodule step, while a landed
+/// rebase gets one even when the autostash reapply conflicted (pull exits 0 and
+/// still runs it). [`fold_submodule_failure`] keeps that from costing the reapply
+/// report. Clones and fetches what a moved pointer needs, so network budget.
 async fn update_submodules_after_rebase(repo: &str) -> AppResult<()> {
     if !submodule_recurse(repo).await {
         return Ok(());
@@ -247,6 +231,8 @@ fn fold_submodule_failure(
     let Err(failure) = submodule else {
         return result;
     };
+    // Every arm is spelled out, with no `Ok(_)` catch-all: a new outcome variant must
+    // then come here for a decision rather than defaulting into the discarding arm.
     match result {
         Ok(AutostashOutcome::ReapplyConflicted {
             stderr,
@@ -255,9 +241,22 @@ fn fold_submodule_failure(
             stderr: format!("{stderr}\n{failure}"),
             conflicted,
         }),
-        Ok(_) => Err(failure),
-        // The step only runs on a landed rebase, so a failed one never reaches here.
-        stopped => stopped,
+        // The landed outcomes that carry nothing the error does not, so the failure IS
+        // the result. `StashedOnly` is landed too and belongs here even though neither
+        // caller can produce it (both settle with `reapply: true`) — listing it keeps
+        // the arm about what the outcome MEANS, not about which callers exist.
+        Ok(
+            AutostashOutcome::Reapplied
+            | AutostashOutcome::NothingStashed
+            | AutostashOutcome::StashedOnly,
+        ) => Err(failure),
+        // Not landed: both carry the stderr naming a retained stash or a paused
+        // rebase, which no submodule error would tell the user about. Unreachable
+        // while both callers gate the step on the rebase having landed — matched
+        // explicitly so that guarantee is the compiler's, not the caller's.
+        stopped @ (Ok(AutostashOutcome::OpFailedRestored { .. })
+        | Ok(AutostashOutcome::OpFailedStashKept { .. })
+        | Err(_)) => stopped,
     }
 }
 
@@ -788,6 +787,25 @@ fn settled_journal_error(result: &AppResult<AutostashOutcome>) -> Option<String>
     }
 }
 
+/// Whether a settled compound HANDED the tree to the user rather than ending — the
+/// journal's pause condition, and the compound's answer to the plain core's
+/// `AppError::Conflict`.
+///
+/// `in_progress` is the whole discrimination, not decoration: it is true only when
+/// the rebase stopped and left itself for the user to continue or abort. The same
+/// variant with `in_progress: false` means the op is OVER and the stash was kept
+/// because the RESTORE-pop failed — a real failure with nothing waiting on the user,
+/// which must journal as one.
+fn settled_paused(result: &AppResult<AutostashOutcome>) -> bool {
+    matches!(
+        result,
+        Ok(AutostashOutcome::OpFailedStashKept {
+            in_progress: true,
+            ..
+        })
+    )
+}
+
 /// Phase B: rebase onto the SHAs the user decided on, keeping or dropping the
 /// commits the fork-point verdict would have rewritten away. `branch` is the one
 /// the refusal named — the decision only means anything on that ref.
@@ -953,16 +971,9 @@ pub(crate) async fn git_pull_rebase_decided_autostash_core(
     } else {
         result
     };
-    // The compound's conflict shape: the rebase stopped and left itself in progress
-    // for the user to continue or abort, which the plain core reports as
-    // `AppError::Conflict`. A stash kept for any OTHER reason is a real failure.
-    if matches!(
-        result,
-        Ok(AutostashOutcome::OpFailedStashKept {
-            in_progress: true,
-            ..
-        })
-    ) {
+    // The compound's conflict shape — see [`settled_paused`]. A stash kept for any
+    // OTHER reason is a real failure.
+    if settled_paused(&result) {
         crate::oplog::pause(&repo_path, &op_id).await;
     } else {
         crate::oplog::finish(&repo_path, &op_id, settled_journal_error(&result)).await;
@@ -1206,6 +1217,40 @@ mod tests {
             settled_journal_error(&Ok(AutostashOutcome::NothingStashed)),
             None
         );
+    }
+
+    /// `in_progress` is the whole pause discrimination: the SAME variant with it
+    /// false means the op ended and the stash was kept because the restore-pop
+    /// failed, which is a failure to journal, not a hand-off to the user. An
+    /// integration fixture cannot pin that half — a conflicted rebase always leaves
+    /// itself in progress — so the predicate is pinned here instead.
+    #[test]
+    fn settled_paused_is_only_a_rebase_left_in_progress() {
+        assert!(settled_paused(&Ok(AutostashOutcome::OpFailedStashKept {
+            stderr: "conflict".into(),
+            in_progress: true
+        })));
+        assert!(
+            !settled_paused(&Ok(AutostashOutcome::OpFailedStashKept {
+                stderr: "the restore-pop failed".into(),
+                in_progress: false
+            })),
+            "the op is over — nothing is waiting on the user"
+        );
+        // No other settled shape is a pause, failed or landed.
+        assert!(!settled_paused(&Ok(AutostashOutcome::OpFailedRestored {
+            stderr: "restored".into()
+        })));
+        assert!(
+            !settled_paused(&Ok(AutostashOutcome::ReapplyConflicted {
+                stderr: "pop".into(),
+                conflicted: true
+            }))
+        );
+        assert!(!settled_paused(&Ok(AutostashOutcome::Reapplied)));
+        assert!(!settled_paused(&Ok(AutostashOutcome::NothingStashed)));
+        assert!(!settled_paused(&Ok(AutostashOutcome::StashedOnly)));
+        assert!(!settled_paused(&Err(AppError::Command("boom".into()))));
     }
 
     #[test]
@@ -1782,6 +1827,50 @@ mod tests {
         let entry = drop_entry(&clone).await;
         assert_eq!(entry.status, "failed");
         assert_eq!(entry.error.as_deref(), Some("aborted by user"));
+    }
+
+    /// The COMPOUND's pause predicate is a different shape from the plain core's
+    /// `AppError::Conflict`: the conflict arrives as an `Ok` outcome, and only
+    /// `in_progress` separates a rebase left for the user from a stash kept because
+    /// the restore-pop itself failed. Matching the wrong variant — or dropping that
+    /// narrowing — would journal a paused pull as "failed" with nothing to catch it.
+    #[tokio::test]
+    async fn a_conflicted_drop_under_autostash_pauses_its_record() {
+        let (dir, clone, shas) = colliding_fixture("drop-conflict-autostash", true).await;
+        // Uncommitted work, so the compound actually stashes: with a clean tree
+        // `settle` takes its no-stash path and reports the conflict as an Err instead.
+        std::fs::write(dir.path().join("clone").join("dirty.txt"), "dirty\n").unwrap();
+
+        let state = AppState::default();
+        let outcome = git_pull_rebase_decided_autostash_core(
+            &state,
+            clone.clone(),
+            "main".into(),
+            "drop".into(),
+            shas.new_tip,
+            shas.keep_base,
+            shas.drop_base,
+            shas.expected_tip.clone(),
+        )
+        .await
+        .expect("a paused rebase settles as an outcome, not an error");
+        assert!(
+            matches!(
+                outcome,
+                AutostashOutcome::OpFailedStashKept {
+                    in_progress: true,
+                    ..
+                }
+            ),
+            "the rebase stopped and left itself in progress: {outcome:?}"
+        );
+        assert!(crate::git::ops::op_state(&clone).await.unwrap().rebasing);
+
+        let entry = drop_entry(&clone).await;
+        assert_eq!(entry.status, "paused", "not a failure — it is waiting on the user");
+        assert!(entry.finished_at.is_none(), "a paused op has not ended");
+        assert!(entry.error.is_none());
+        assert_eq!(entry.original_sha, shas.expected_tip);
     }
 
     /// The autostash variant stashes the dirty tree across the rebase and puts it

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -2048,15 +2048,26 @@ hint: Updates were rejected because the tip of your current branch is behind
 ";
 
     /// Whether `report` carries a `remote:` bullet whose text opens with
-    /// `label`, mirroring `PUSH_PROTECTION_MARKERS` (src/lib/error-summary.ts)
-    /// in shape: optional indent, the `remote:` prefix, the `-` bullet,
-    /// then the text — and no end anchor, since git pads the line.
+    /// `label`, matching `PUSH_PROTECTION_MARKERS` (src/lib/error-summary.ts)
+    /// exactly: space/tab indent only, the `remote:` prefix, the `-` bullet,
+    /// the label at a word boundary — and no end anchor, since git pads the
+    /// line. Looser matching here would let the canary pass stderr the
+    /// frontend rejects, which is the one direction it must not be loose in.
     fn has_remote_bullet(report: &str, label: &str) -> bool {
+        fn eat(s: &str) -> &str {
+            s.trim_start_matches([' ', '\t'])
+        }
         report.lines().any(|l| {
-            l.trim_start()
+            eat(l)
                 .strip_prefix("remote:")
-                .and_then(|r| r.trim_start().strip_prefix('-'))
-                .is_some_and(|r| r.trim_start().starts_with(label))
+                .and_then(|r| eat(r).strip_prefix('-'))
+                .and_then(|r| eat(r).strip_prefix(label))
+                .is_some_and(|rest| {
+                    !rest
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_alphanumeric() || c == '_')
+                })
         })
     }
 
@@ -2080,6 +2091,14 @@ hint: Updates were rejected because the tip of your current branch is behind
                  own presentation"
             );
         }
+        assert!(
+            !has_remote_bullet(
+                "remote: - GITHUB PUSH PROTECTIONAL",
+                "GITHUB PUSH PROTECTION"
+            ),
+            "the label matched past its word boundary — the frontend's \\b would refuse \
+             this line, so the canary must too"
+        );
         assert!(
             PUSH_PROTECTION_STDERR
                 .lines()

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -2005,6 +2005,89 @@ mod tests {
         );
     }
 
+    /// A push GitHub's secret push protection refused, from a real GH013
+    /// rejection measured on this machine (github.com over HTTPS, 2026-08-11).
+    /// The flagged secret's own value never appears in the block, and the
+    /// unblock id is a placeholder here; two purely informational `(?)` notes
+    /// GitHub prints between the violation list and the locations are trimmed.
+    /// GitHub pads every one of these lines with trailing spaces, dropped here
+    /// because an editor would strip them back out anyway — which is the reason
+    /// the frontend markers, and `has_remote_bullet` below, never end-anchor.
+    const PUSH_PROTECTION_STDERR: &str = "\
+remote: error: GH013: Repository rule violations found for refs/heads/feat/security-findings-phase-3.
+remote:
+remote: - GITHUB PUSH PROTECTION
+remote:   —————————————————————————————————————————
+remote:     Resolve the following violations before pushing again
+remote:
+remote:     - Push cannot contain secrets
+remote:
+remote:
+remote:       —— GitLab Access Token ———————————————————————————————
+remote:        locations:
+remote:          - commit: 64a012e497764a53e38949a968553daa2d8f51a3
+remote:            path: src-tauri/src/forge/gitlab_findings.rs:1151
+remote:
+remote:        (?) To push, remove secret from commit(s) or follow this URL to allow the secret.
+remote:        https://github.com/theBGuy/GitDesktop/security/secret-scanning/unblock-secret/<id>
+remote:
+remote:
+To https://github.com/theBGuy/GitDesktop.git
+ ! [remote rejected] feat/security-findings-phase-3 -> feat/security-findings-phase-3 (push declined due to repository rule violations)
+error: failed to push some refs to 'https://github.com/theBGuy/GitDesktop.git'
+";
+
+    /// A branch simply behind its remote: the negative control for the block
+    /// above. It shares the `failed to push some refs` tail, so anything the
+    /// frontend anchors on has to come from the push-protection block itself.
+    const NON_FAST_FORWARD_STDERR: &str = "\
+To https://github.com/theBGuy/GitDesktop.git
+ ! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'https://github.com/theBGuy/GitDesktop.git'
+hint: Updates were rejected because the tip of your current branch is behind
+";
+
+    /// Whether `report` carries a `remote:` bullet whose text opens with
+    /// `label`, mirroring `PUSH_PROTECTION_MARKERS` (src/lib/error-summary.ts)
+    /// in shape: optional indent, the `remote:` prefix, the `-` bullet,
+    /// then the text — and no end anchor, since git pads the line.
+    fn has_remote_bullet(report: &str, label: &str) -> bool {
+        report.lines().any(|l| {
+            l.trim_start()
+                .strip_prefix("remote:")
+                .and_then(|r| r.trim_start().strip_prefix('-'))
+                .is_some_and(|r| r.trim_start().starts_with(label))
+        })
+    }
+
+    /// Canary for the frontend's push-protection markers: `pushProtectionSummary`
+    /// (src/lib/error-summary.ts) can only turn a blocked push into one human
+    /// line while GitHub still prints these two bullets, so the measured stderr
+    /// and the marker shapes are pinned together here. `GH013` is asserted apart
+    /// from them on purpose — it heads every repository rule violation, not just
+    /// secrets, so the frontend must never classify on it alone.
+    #[test]
+    fn push_protection_stderr_still_matches_the_frontend_markers() {
+        for label in ["GITHUB PUSH PROTECTION", "Push cannot contain secrets"] {
+            assert!(
+                has_remote_bullet(PUSH_PROTECTION_STDERR, label),
+                "the `{label}` bullet is gone — the frontend summary is now blind to a \
+                 blocked push. Actual stderr:\n{PUSH_PROTECTION_STDERR}"
+            );
+            assert!(
+                !has_remote_bullet(NON_FAST_FORWARD_STDERR, label),
+                "`{label}` matched a plain non-fast-forward rejection, which must keep its \
+                 own presentation"
+            );
+        }
+        assert!(
+            PUSH_PROTECTION_STDERR
+                .lines()
+                .any(|l| l.trim_start().starts_with("remote: error: GH013:")),
+            "the fixture no longer carries the GH013 code it was measured from"
+        );
+    }
+
     /// The wire values the TS `PushGuard` union (src/lib/git/api.ts) mirrors: the
     /// success toast keys on these exact strings, so a variant rename that skips
     /// the mirror would silently stop reporting a degraded force push.

--- a/src-tauri/src/github/actions.rs
+++ b/src-tauri/src/github/actions.rs
@@ -425,30 +425,45 @@ const DISPATCH_PROBE_TTL: ProbeTtl = ProbeTtl {
     absent: Duration::from_secs(300),
 };
 
-/// Cache map keyed by `(slug, workflow_path, git_ref)`; value is
+/// Cache map keyed by `(repo_path, slug, workflow_path, git_ref)`; value is
 /// `(probe time, declares workflow_dispatch)`.
-type DispatchProbeCache = Mutex<HashMap<(String, String, String), (Instant, bool)>>;
+type DispatchProbeCache = Mutex<HashMap<(String, String, String, String), (Instant, bool)>>;
 
-/// Per-`(slug, workflow file, ref)` cache of the last probe verdict and when it was
-/// taken. Re-probing the same key overwrites in place, but `git_ref` is a user-typed
-/// axis, so distinct refs mint entries that live for the process lifetime — slow
-/// unbounded growth, unlike the closed (repo, remote) key space of `REMOTE_URL_CACHE`
-/// this mirrors. An entry is two short strings and a bool, so no eviction machinery is
-/// warranted at this size. Only PARSED verdicts are stored: an erred fetch leaves the
-/// key absent so it re-probes and keeps failing open.
+/// Per-`(repo, slug, workflow file, ref)` cache of the last probe verdict and when it was
+/// taken. `repo_path` is in the key because the slug alone is NOT host-qualified —
+/// `gh_origin_slug` resolves through `forge::remote_path`, which strips the authority, so
+/// an Enterprise remote and a github.com remote sharing an `owner/repo` path would
+/// otherwise collide and one repo's `false` could hide the other's workflow. Re-probing
+/// the same key overwrites in place, but `git_ref` is a user-typed axis, so distinct refs
+/// mint entries that live for the process lifetime — slow unbounded growth, unlike the
+/// closed (repo, remote) key space of `REMOTE_URL_CACHE` this mirrors. An entry is a few
+/// short strings and a bool, so no eviction machinery is warranted at this size. Only
+/// PARSED verdicts are stored: an erred fetch leaves the key absent so it re-probes and
+/// keeps failing open.
 static DISPATCH_PROBE_CACHE: OnceLock<DispatchProbeCache> = OnceLock::new();
 
 fn dispatch_probe_cache() -> &'static DispatchProbeCache {
     DISPATCH_PROBE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Return the cached verdict for `(slug, path, git_ref)` only if an entry exists AND it
-/// was probed less than its direction's window ago — the stored verdict picks the window,
-/// so one cache serves both. The lock is held only long enough to read the value.
-fn probe_cache_get(slug: &str, path: &str, git_ref: &str, ttl: ProbeTtl) -> Option<bool> {
+/// Return the cached verdict for `(repo_path, slug, path, git_ref)` only if an entry
+/// exists AND it was probed less than its direction's window ago — the stored verdict
+/// picks the window, so one cache serves both. The lock is held only long enough to
+/// read the value.
+fn probe_cache_get(
+    repo_path: &str,
+    slug: &str,
+    path: &str,
+    git_ref: &str,
+    ttl: ProbeTtl,
+) -> Option<bool> {
     let guard = dispatch_probe_cache().lock().unwrap();
-    let (probed_at, verdict) =
-        guard.get(&(slug.to_string(), path.to_string(), git_ref.to_string()))?;
+    let (probed_at, verdict) = guard.get(&(
+        repo_path.to_string(),
+        slug.to_string(),
+        path.to_string(),
+        git_ref.to_string(),
+    ))?;
     let window = if *verdict { ttl.declared } else { ttl.absent };
     if probed_at.elapsed() < window {
         Some(*verdict)
@@ -457,10 +472,16 @@ fn probe_cache_get(slug: &str, path: &str, git_ref: &str, ttl: ProbeTtl) -> Opti
     }
 }
 
-/// Record `verdict` as the current answer for `(slug, path, git_ref)`, stamped now.
-fn probe_cache_put(slug: &str, path: &str, git_ref: &str, verdict: bool) {
+/// Record `verdict` as the current answer for `(repo_path, slug, path, git_ref)`,
+/// stamped now.
+fn probe_cache_put(repo_path: &str, slug: &str, path: &str, git_ref: &str, verdict: bool) {
     dispatch_probe_cache().lock().unwrap().insert(
-        (slug.to_string(), path.to_string(), git_ref.to_string()),
+        (
+            repo_path.to_string(),
+            slug.to_string(),
+            path.to_string(),
+            git_ref.to_string(),
+        ),
         (Instant::now(), verdict),
     );
 }
@@ -470,6 +491,7 @@ fn probe_cache_put(slug: &str, path: &str, git_ref: &str, verdict: bool) {
 /// never takes a [`DISPATCH_PROBE_GATE`] permit nor spawns a gh process.
 fn plan_probes<'a>(
     workflows: &'a [Workflow],
+    repo_path: &str,
     slug: &str,
     git_ref: &str,
     ttl: ProbeTtl,
@@ -482,7 +504,7 @@ fn plan_probes<'a>(
                 map.insert(w.id.to_string(), false);
             }
             PathVerdict::Unknown => {}
-            PathVerdict::Fetch => match probe_cache_get(slug, &w.path, git_ref, ttl) {
+            PathVerdict::Fetch => match probe_cache_get(repo_path, slug, &w.path, git_ref, ttl) {
                 Some(verdict) => {
                     map.insert(w.id.to_string(), verdict);
                 }
@@ -510,7 +532,8 @@ pub async fn gh_workflow_dispatchable(
     // at a file of the caller's choosing.
     let workflows = fetch_workflows(&repo_path, &slug).await?;
     let ref_field = format!("ref={git_ref}");
-    let (mut map, probes) = plan_probes(&workflows, &slug, &git_ref, DISPATCH_PROBE_TTL);
+    let (mut map, probes) =
+        plan_probes(&workflows, &repo_path, &slug, &git_ref, DISPATCH_PROBE_TTL);
 
     let results = crate::forge::futures_join_all(probes.iter().map(|w| {
         let endpoint = format!("repos/{slug}/contents/{}", w.path);
@@ -547,7 +570,7 @@ pub async fn gh_workflow_dispatchable(
         // of the cache, so the next call re-probes instead of pinning the failure.
         if let Ok(out) = res {
             let verdict = yaml_declares_workflow_dispatch(&out.stdout_lossy());
-            probe_cache_put(&slug, path, &git_ref, verdict);
+            probe_cache_put(&repo_path, &slug, path, &git_ref, verdict);
             map.insert(id.to_string(), verdict);
         }
     }
@@ -835,35 +858,40 @@ mod tests {
     };
 
     /// The cache is process-wide and shared by every test in this binary, so each test
-    /// keys its entries under its own slug.
+    /// keys its entries under its own repo path and slug.
     #[test]
     fn probe_verdicts_are_served_within_the_ttl_and_expire_after_it() {
         let ttl = DISPATCH_PROBE_TTL;
-        let (slug, path, git_ref) = ("o/ttl", ".github/workflows/ci.yml", "master");
+        let (repo, slug, path, git_ref) = (
+            "C:/repos/ttl",
+            "o/ttl",
+            ".github/workflows/ci.yml",
+            "master",
+        );
 
         // An unprobed file — the shape an erred fetch also leaves behind, since only a
         // parsed verdict is ever stored — reads as absent, i.e. unknown.
-        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), None);
+        assert_eq!(probe_cache_get(repo, slug, path, git_ref, ttl), None);
 
-        probe_cache_put(slug, path, git_ref, true);
-        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), Some(true));
-        assert_eq!(probe_cache_get(slug, path, git_ref, EXPIRED), None);
+        probe_cache_put(repo, slug, path, git_ref, true);
+        assert_eq!(probe_cache_get(repo, slug, path, git_ref, ttl), Some(true));
+        assert_eq!(probe_cache_get(repo, slug, path, git_ref, EXPIRED), None);
 
         // `false` round-trips as a hit, not as an absence.
-        probe_cache_put(slug, path, git_ref, false);
-        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), Some(false));
-        assert_eq!(probe_cache_get(slug, path, git_ref, EXPIRED), None);
+        probe_cache_put(repo, slug, path, git_ref, false);
+        assert_eq!(probe_cache_get(repo, slug, path, git_ref, ttl), Some(false));
+        assert_eq!(probe_cache_get(repo, slug, path, git_ref, EXPIRED), None);
     }
 
     #[test]
     fn a_false_verdict_expires_before_a_true_one_of_the_same_age() {
-        let slug = "o/directions";
+        let (repo, slug) = ("C:/repos/directions", "o/directions");
         let (yes, no) = (
             ".github/workflows/enabled.yml",
             ".github/workflows/disabled.yml",
         );
-        probe_cache_put(slug, yes, "master", true);
-        probe_cache_put(slug, no, "master", false);
+        probe_cache_put(repo, slug, yes, "master", true);
+        probe_cache_put(repo, slug, no, "master", false);
 
         // Both entries are the same age; only the verdict decides which window applies.
         // This window is past the `false` one and still inside the `true` one.
@@ -872,12 +900,12 @@ mod tests {
             absent: Duration::ZERO,
         };
         assert_eq!(
-            probe_cache_get(slug, yes, "master", past_the_short_window),
+            probe_cache_get(repo, slug, yes, "master", past_the_short_window),
             Some(true),
             "a true verdict still holds inside the long window"
         );
         assert_eq!(
-            probe_cache_get(slug, no, "master", past_the_short_window),
+            probe_cache_get(repo, slug, no, "master", past_the_short_window),
             None,
             "a false verdict must expire with the short window, so a workflow enabled \
              since the probe stops being hidden"
@@ -885,7 +913,7 @@ mod tests {
 
         // Inside both windows nothing has expired yet.
         assert_eq!(
-            probe_cache_get(slug, no, "master", DISPATCH_PROBE_TTL),
+            probe_cache_get(repo, slug, no, "master", DISPATCH_PROBE_TTL),
             Some(false)
         );
 
@@ -899,29 +927,38 @@ mod tests {
     #[test]
     fn every_key_axis_misses_independently() {
         let ttl = DISPATCH_PROBE_TTL;
-        probe_cache_put("o/keys", ".github/workflows/ci.yml", "master", true);
+        let (repo, slug, ci) = ("C:/repos/keys", "o/keys", ".github/workflows/ci.yml");
+        probe_cache_put(repo, slug, ci, "master", true);
 
         assert_eq!(
-            probe_cache_get("o/keys", ".github/workflows/ci.yml", "dev", ttl),
+            probe_cache_get(repo, slug, ci, "dev", ttl),
             None,
             "a different ref must re-probe"
         );
         assert_eq!(
-            probe_cache_get("o/keys", ".github/workflows/release.yml", "master", ttl),
+            probe_cache_get(repo, slug, ".github/workflows/release.yml", "master", ttl),
             None,
             "a different workflow file must re-probe"
         );
         assert_eq!(
-            probe_cache_get("other/keys", ".github/workflows/ci.yml", "master", ttl),
+            probe_cache_get(repo, "other/keys", ci, "master", ttl),
             None,
-            "a different repo must re-probe"
+            "a different slug must re-probe"
+        );
+        // The host-collision guard: `gh_origin_slug` strips the authority, so a GHE
+        // remote and a github.com remote can present the SAME slug. Two checkouts on
+        // that slug must not share a verdict.
+        assert_eq!(
+            probe_cache_get("C:/repos/keys-enterprise", slug, ci, "master", ttl),
+            None,
+            "the same slug in a different checkout must re-probe, not inherit"
         );
     }
 
     #[test]
     fn a_cached_verdict_never_reaches_the_fan_out() {
         let ttl = DISPATCH_PROBE_TTL;
-        let slug = "o/fanout";
+        let (repo, slug) = ("C:/repos/fanout", "o/fanout");
         let workflows = vec![
             workflow(1, ".github/workflows/ci.yml", "active"),
             workflow(2, ".github/workflows/release.yml", "active"),
@@ -929,7 +966,7 @@ mod tests {
             workflow(4, ".github/workflows/retired.yml", "disabled_manually"),
         ];
 
-        let (map, probes) = plan_probes(&workflows, slug, "master", ttl);
+        let (map, probes) = plan_probes(&workflows, repo, slug, "master", ttl);
         assert_eq!(
             probes.iter().map(|w| w.id).collect::<Vec<_>>(),
             vec![1, 2],
@@ -938,8 +975,8 @@ mod tests {
         assert_eq!(map.get("3"), Some(&false));
         assert_eq!(map.len(), 1, "only the path-decided workflow is in the map");
 
-        probe_cache_put(slug, ".github/workflows/ci.yml", "master", true);
-        let (map, probes) = plan_probes(&workflows, slug, "master", ttl);
+        probe_cache_put(repo, slug, ".github/workflows/ci.yml", "master", true);
+        let (map, probes) = plan_probes(&workflows, repo, slug, "master", ttl);
         assert_eq!(
             probes.iter().map(|w| w.id).collect::<Vec<_>>(),
             vec![2],
@@ -951,11 +988,26 @@ mod tests {
             "its verdict comes from the cache"
         );
 
-        let (_, probes) = plan_probes(&workflows, slug, "dev", ttl);
+        let (_, probes) = plan_probes(&workflows, repo, slug, "dev", ttl);
         assert_eq!(
             probes.iter().map(|w| w.id).collect::<Vec<_>>(),
             vec![1, 2],
             "another ref is a different key, so it fans out again"
+        );
+
+        // Same slug, different checkout — the host-collision guard, exercised through
+        // the fan-out path rather than the cache functions alone.
+        let (_, probes) = plan_probes(
+            &workflows,
+            "C:/repos/fanout-enterprise",
+            slug,
+            "master",
+            ttl,
+        );
+        assert_eq!(
+            probes.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![1, 2],
+            "a different checkout on the same slug must not inherit cached verdicts"
         );
     }
 

--- a/src-tauri/src/github/actions.rs
+++ b/src-tauri/src/github/actions.rs
@@ -4,6 +4,8 @@
 //! working directory, like the PR commands.
 
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -399,9 +401,104 @@ const DISPATCH_PROBE_CONCURRENCY: usize = 4;
 static DISPATCH_PROBE_GATE: tokio::sync::Semaphore =
     tokio::sync::Semaphore::const_new(DISPATCH_PROBE_CONCURRENCY);
 
+/// How long a probe verdict stays trusted, per direction — the two stale directions
+/// cost differently, so they get different windows.
+#[derive(Debug, Clone, Copy)]
+struct ProbeTtl {
+    /// Window for a `true` verdict (the file declares the trigger).
+    declared: Duration,
+    /// Window for a `false` verdict.
+    absent: Duration,
+}
+
+/// A workflow file's trigger block at a given ref changes on the order of releases, not
+/// keystrokes, so a generous window is what keeps a repo's whole picker off the network
+/// for a working session. The directions are asymmetric: a stale `true` merely re-offers
+/// a workflow whose dispatch then refuses with the humanized 422, while a stale `false`
+/// HIDES an action the user may have just enabled (`RunWorkflowDialog` refuses only on an
+/// explicit `false`). This window bounds the staleness a frontend refetch can RE-ADOPT:
+/// the two caches compose, since a refetch landing just inside it re-serves that verdict
+/// for another frontend staleTime. Worst-case hide is therefore `absent` + one staleTime
+/// (~600s), half of the ~900s a symmetric long window would give.
+const DISPATCH_PROBE_TTL: ProbeTtl = ProbeTtl {
+    declared: Duration::from_secs(600),
+    absent: Duration::from_secs(300),
+};
+
+/// Cache map keyed by `(slug, workflow_path, git_ref)`; value is
+/// `(probe time, declares workflow_dispatch)`.
+type DispatchProbeCache = Mutex<HashMap<(String, String, String), (Instant, bool)>>;
+
+/// Per-`(slug, workflow file, ref)` cache of the last probe verdict and when it was
+/// taken. Re-probing the same key overwrites in place, but `git_ref` is a user-typed
+/// axis, so distinct refs mint entries that live for the process lifetime — slow
+/// unbounded growth, unlike the closed (repo, remote) key space of `REMOTE_URL_CACHE`
+/// this mirrors. An entry is two short strings and a bool, so no eviction machinery is
+/// warranted at this size. Only PARSED verdicts are stored: an erred fetch leaves the
+/// key absent so it re-probes and keeps failing open.
+static DISPATCH_PROBE_CACHE: OnceLock<DispatchProbeCache> = OnceLock::new();
+
+fn dispatch_probe_cache() -> &'static DispatchProbeCache {
+    DISPATCH_PROBE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Return the cached verdict for `(slug, path, git_ref)` only if an entry exists AND it
+/// was probed less than its direction's window ago — the stored verdict picks the window,
+/// so one cache serves both. The lock is held only long enough to read the value.
+fn probe_cache_get(slug: &str, path: &str, git_ref: &str, ttl: ProbeTtl) -> Option<bool> {
+    let guard = dispatch_probe_cache().lock().unwrap();
+    let (probed_at, verdict) =
+        guard.get(&(slug.to_string(), path.to_string(), git_ref.to_string()))?;
+    let window = if *verdict { ttl.declared } else { ttl.absent };
+    if probed_at.elapsed() < window {
+        Some(*verdict)
+    } else {
+        None
+    }
+}
+
+/// Record `verdict` as the current answer for `(slug, path, git_ref)`, stamped now.
+fn probe_cache_put(slug: &str, path: &str, git_ref: &str, verdict: bool) {
+    dispatch_probe_cache().lock().unwrap().insert(
+        (slug.to_string(), path.to_string(), git_ref.to_string()),
+        (Instant::now(), verdict),
+    );
+}
+
+/// Split the active workflows into verdicts already decided and the files that still
+/// need a contents fetch. Cache hits are resolved HERE, before the fan-out, so a hit
+/// never takes a [`DISPATCH_PROBE_GATE`] permit nor spawns a gh process.
+fn plan_probes<'a>(
+    workflows: &'a [Workflow],
+    slug: &str,
+    git_ref: &str,
+    ttl: ProbeTtl,
+) -> (HashMap<String, bool>, Vec<&'a Workflow>) {
+    let mut map = HashMap::new();
+    let mut probes: Vec<&Workflow> = Vec::new();
+    for w in workflows.iter().filter(|w| w.state == "active") {
+        match classify_workflow_path(&w.path) {
+            PathVerdict::NotDispatchable => {
+                map.insert(w.id.to_string(), false);
+            }
+            PathVerdict::Unknown => {}
+            PathVerdict::Fetch => match probe_cache_get(slug, &w.path, git_ref, ttl) {
+                Some(verdict) => {
+                    map.insert(w.id.to_string(), verdict);
+                }
+                None => probes.push(w),
+            },
+        }
+    }
+    (map, probes)
+}
+
 /// Which active workflows declare a `workflow_dispatch` trigger at `git_ref`.
 /// Keyed by stringified workflow id. A workflow ABSENT from the map is unknown
-/// (probe failed) — callers fail open and keep it offered.
+/// (probe failed) — callers fail open and keep it offered. Per-file verdicts are
+/// served from [`DISPATCH_PROBE_CACHE`] within [`DISPATCH_PROBE_TTL`]'s per-direction
+/// window; the workflow LIST is always re-read, so a newly added workflow shows up
+/// immediately.
 #[tauri::command]
 pub async fn gh_workflow_dispatchable(
     repo_path: String,
@@ -413,22 +510,13 @@ pub async fn gh_workflow_dispatchable(
     // at a file of the caller's choosing.
     let workflows = fetch_workflows(&repo_path, &slug).await?;
     let ref_field = format!("ref={git_ref}");
-    let mut map = HashMap::new();
-    let mut probes: Vec<&Workflow> = Vec::new();
-    for w in workflows.iter().filter(|w| w.state == "active") {
-        match classify_workflow_path(&w.path) {
-            PathVerdict::NotDispatchable => {
-                map.insert(w.id.to_string(), false);
-            }
-            PathVerdict::Unknown => {}
-            PathVerdict::Fetch => probes.push(w),
-        }
-    }
+    let (mut map, probes) = plan_probes(&workflows, &slug, &git_ref, DISPATCH_PROBE_TTL);
 
     let results = crate::forge::futures_join_all(probes.iter().map(|w| {
         let endpoint = format!("repos/{slug}/contents/{}", w.path);
         let repo_path = repo_path.as_str();
         let ref_field = ref_field.as_str();
+        let path = w.path.as_str();
         async move {
             let _permit = DISPATCH_PROBE_GATE.acquire().await.ok();
             // `--method GET` is mandatory: `gh api` with `-f` fields present
@@ -449,18 +537,18 @@ pub async fn gh_workflow_dispatchable(
                 GH_NETWORK_TIMEOUT,
             )
             .await;
-            (w.id, res)
+            (w.id, path, res)
         }
     }))
     .await;
-    for (id, res) in results {
+    for (id, path, res) in results {
         // A failed fetch leaves the key ABSENT — "unknown" must not read as
-        // "not dispatchable", which would hide a runnable workflow.
+        // "not dispatchable", which would hide a runnable workflow — and stays out
+        // of the cache, so the next call re-probes instead of pinning the failure.
         if let Ok(out) = res {
-            map.insert(
-                id.to_string(),
-                yaml_declares_workflow_dispatch(&out.stdout_lossy()),
-            );
+            let verdict = yaml_declares_workflow_dispatch(&out.stdout_lossy());
+            probe_cache_put(&slug, path, &git_ref, verdict);
+            map.insert(id.to_string(), verdict);
         }
     }
     Ok(map)
@@ -727,6 +815,147 @@ mod tests {
         assert_eq!(
             classify_workflow_path(".github/workflows/a?b.yml"),
             PathVerdict::Unknown
+        );
+    }
+
+    fn workflow(id: u64, path: &str, state: &str) -> Workflow {
+        Workflow {
+            id,
+            name: format!("wf-{id}"),
+            path: path.to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    /// Both windows zero — every entry reads as expired whatever its verdict, which is
+    /// how these tests stand in for elapsed-past-TTL without sleeping.
+    const EXPIRED: ProbeTtl = ProbeTtl {
+        declared: Duration::ZERO,
+        absent: Duration::ZERO,
+    };
+
+    /// The cache is process-wide and shared by every test in this binary, so each test
+    /// keys its entries under its own slug.
+    #[test]
+    fn probe_verdicts_are_served_within_the_ttl_and_expire_after_it() {
+        let ttl = DISPATCH_PROBE_TTL;
+        let (slug, path, git_ref) = ("o/ttl", ".github/workflows/ci.yml", "master");
+
+        // An unprobed file — the shape an erred fetch also leaves behind, since only a
+        // parsed verdict is ever stored — reads as absent, i.e. unknown.
+        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), None);
+
+        probe_cache_put(slug, path, git_ref, true);
+        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), Some(true));
+        assert_eq!(probe_cache_get(slug, path, git_ref, EXPIRED), None);
+
+        // `false` round-trips as a hit, not as an absence.
+        probe_cache_put(slug, path, git_ref, false);
+        assert_eq!(probe_cache_get(slug, path, git_ref, ttl), Some(false));
+        assert_eq!(probe_cache_get(slug, path, git_ref, EXPIRED), None);
+    }
+
+    #[test]
+    fn a_false_verdict_expires_before_a_true_one_of_the_same_age() {
+        let slug = "o/directions";
+        let (yes, no) = (
+            ".github/workflows/enabled.yml",
+            ".github/workflows/disabled.yml",
+        );
+        probe_cache_put(slug, yes, "master", true);
+        probe_cache_put(slug, no, "master", false);
+
+        // Both entries are the same age; only the verdict decides which window applies.
+        // This window is past the `false` one and still inside the `true` one.
+        let past_the_short_window = ProbeTtl {
+            declared: Duration::from_secs(600),
+            absent: Duration::ZERO,
+        };
+        assert_eq!(
+            probe_cache_get(slug, yes, "master", past_the_short_window),
+            Some(true),
+            "a true verdict still holds inside the long window"
+        );
+        assert_eq!(
+            probe_cache_get(slug, no, "master", past_the_short_window),
+            None,
+            "a false verdict must expire with the short window, so a workflow enabled \
+             since the probe stops being hidden"
+        );
+
+        // Inside both windows nothing has expired yet.
+        assert_eq!(
+            probe_cache_get(slug, no, "master", DISPATCH_PROBE_TTL),
+            Some(false)
+        );
+
+        // The shipped windows really are asymmetric, and `absent` is pinned to one
+        // frontend staleTime (`5 * 60_000` in `useWorkflowDispatchable`) — the composed
+        // worst-case hide is that window plus one more staleTime.
+        assert!(DISPATCH_PROBE_TTL.absent < DISPATCH_PROBE_TTL.declared);
+        assert_eq!(DISPATCH_PROBE_TTL.absent, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn every_key_axis_misses_independently() {
+        let ttl = DISPATCH_PROBE_TTL;
+        probe_cache_put("o/keys", ".github/workflows/ci.yml", "master", true);
+
+        assert_eq!(
+            probe_cache_get("o/keys", ".github/workflows/ci.yml", "dev", ttl),
+            None,
+            "a different ref must re-probe"
+        );
+        assert_eq!(
+            probe_cache_get("o/keys", ".github/workflows/release.yml", "master", ttl),
+            None,
+            "a different workflow file must re-probe"
+        );
+        assert_eq!(
+            probe_cache_get("other/keys", ".github/workflows/ci.yml", "master", ttl),
+            None,
+            "a different repo must re-probe"
+        );
+    }
+
+    #[test]
+    fn a_cached_verdict_never_reaches_the_fan_out() {
+        let ttl = DISPATCH_PROBE_TTL;
+        let slug = "o/fanout";
+        let workflows = vec![
+            workflow(1, ".github/workflows/ci.yml", "active"),
+            workflow(2, ".github/workflows/release.yml", "active"),
+            workflow(3, "dynamic/dependabot/dependabot-updates", "active"),
+            workflow(4, ".github/workflows/retired.yml", "disabled_manually"),
+        ];
+
+        let (map, probes) = plan_probes(&workflows, slug, "master", ttl);
+        assert_eq!(
+            probes.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![1, 2],
+            "cold: both real files fetch"
+        );
+        assert_eq!(map.get("3"), Some(&false));
+        assert_eq!(map.len(), 1, "only the path-decided workflow is in the map");
+
+        probe_cache_put(slug, ".github/workflows/ci.yml", "master", true);
+        let (map, probes) = plan_probes(&workflows, slug, "master", ttl);
+        assert_eq!(
+            probes.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![2],
+            "warm: the cached file must not enter the fan-out at all"
+        );
+        assert_eq!(
+            map.get("1"),
+            Some(&true),
+            "its verdict comes from the cache"
+        );
+
+        let (_, probes) = plan_probes(&workflows, slug, "dev", ttl);
+        assert_eq!(
+            probes.iter().map(|w| w.id).collect::<Vec<_>>(),
+            vec![1, 2],
+            "another ref is a different key, so it fans out again"
         );
     }
 

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -66,10 +66,11 @@ pub struct OpLogEntry {
     /// Human summary, e.g. `"Squash-merge feature → main"`.
     pub label: String,
     /// `"pending"` | `"done"` | `"failed"` | `"dismissed"` | `"paused"` | `"concluded"`.
-    /// `"paused"` = handed to the user mid-op (a stopped cherry-pick), so it is
-    /// neither in-flight nor finished until they continue or abort it;
-    /// `"concluded"` = that pick ended outside the app, so the journal knows only
-    /// that it is over (see [`conclude_stale_pauses`]).
+    /// `"paused"` = handed to the user mid-op (a stopped cherry-pick or the rebase
+    /// of a decided pull drop — see [`PAUSABLE_OPS`]), so it is neither in-flight
+    /// nor finished until they continue or abort it; `"concluded"` = that op ended
+    /// outside the app, so the journal knows only that it is over (see
+    /// [`conclude_stale_pauses`]).
     pub status: String,
     /// `now_iso()` captured at [`begin`].
     pub started_at: String,
@@ -317,16 +318,61 @@ fn apply_close(obj: &mut Map<String, Value>, outcome: &PausedOutcome, now: Strin
     obj.insert("error".to_string(), error);
 }
 
-/// The id of the NEWEST `"paused"` cherry-pick entry in `entries`, if any. Sorts in
-/// place (the caller owns a store copy), so callers may pass unsorted store order.
-fn newest_paused_pick(entries: &mut [Value]) -> Option<String> {
+/// The journal op a stopped cherry-pick leaves a `"paused"` record for.
+const CHERRY_PICK_ONTO: &str = "cherry_pick_onto";
+/// The journal op a decided pull's DROP arm leaves a `"paused"` record for when its
+/// rebase stops on a conflict.
+const PULL_REBASE_DROP: &str = "pull_rebase_drop";
+
+/// Every op whose record can sit `"paused"`. Each is retired only against ITS OWN
+/// live-op signal ([`LiveOps::is_live`]): a rebase in progress says nothing about a
+/// stopped pick, and vice versa.
+const PAUSABLE_OPS: [&str; 2] = [CHERRY_PICK_ONTO, PULL_REBASE_DROP];
+
+/// What the stale-pause verdict knows about ops still in flight, one pair per
+/// [`PAUSABLE_OPS`] entry.
+///
+/// The `bool`s are the caller's earlier [`crate::git::ops::op_state`] read, already
+/// two git subprocesses old by the time the lock is held, so they may only SPARE
+/// records; the closures re-probe the marker files under the lock and are
+/// authoritative for "still live" (see [`conclude_stale_pauses`]).
+pub(crate) struct LiveOps<'a> {
+    pub cherry_picking: bool,
+    pub rebasing: bool,
+    pub pick_in_progress: &'a dyn Fn() -> bool,
+    pub rebase_in_progress: &'a dyn Fn() -> bool,
+}
+
+impl LiveOps<'_> {
+    /// Whether an op of `op`'s kind is still in flight — either signal saying yes
+    /// spares its records. An op with no probe here is never retired on a guess.
+    fn is_live(&self, op: &str) -> bool {
+        if op == CHERRY_PICK_ONTO {
+            self.cherry_picking || (self.pick_in_progress)()
+        } else if op == PULL_REBASE_DROP {
+            self.rebasing || (self.rebase_in_progress)()
+        } else {
+            true
+        }
+    }
+}
+
+/// Whether `entry` is a `"paused"` record of `op`.
+fn is_paused_op(entry: &Value, op: &str) -> bool {
+    entry.get("status").and_then(Value::as_str) == Some("paused")
+        && entry.get("op").and_then(Value::as_str) == Some(op)
+}
+
+/// The id of the NEWEST `"paused"` `op` entry in `entries`, if any. Sorts in place
+/// (the caller owns a store copy), so callers may pass unsorted store order.
+///
+/// Scoped to one op rather than to "any pause": a stale paused record of ANOTHER
+/// op would otherwise stand in as this one's close handle and take its disposition.
+fn newest_paused_op(entries: &mut [Value], op: &str) -> Option<String> {
     sort_newest_first(entries);
     entries
         .iter()
-        .find(|e| {
-            e.get("op").and_then(Value::as_str) == Some("cherry_pick_onto")
-                && e.get("status").and_then(Value::as_str) == Some("paused")
-        })
+        .find(|e| is_paused_op(e, op))
         .and_then(|e| e.get("id"))
         .and_then(Value::as_str)
         .map(str::to_string)
@@ -355,27 +401,27 @@ fn is_interrupted(
     mid_op || tree_dirty || !on_home
 }
 
-/// Conclude every STALE `"paused"` cherry-pick record in `list` — one whose pick was
-/// finished or abandoned OUTSIDE the app (a terminal `git cherry-pick
-/// --continue`/`--abort`), which otherwise leaves the record paused forever: immortal
-/// under [`cap_history`], a live handle [`close_paused_pick`] misattributes to the
-/// next in-app pick, and a permanent lie in Operation history.
+/// Conclude every STALE `"paused"` record in `list` — one whose op was finished or
+/// abandoned OUTSIDE the app (a terminal `git cherry-pick --continue`/`--abort`, a
+/// terminal `git rebase --continue`/`--abort`), which otherwise leaves the record
+/// paused forever: immortal under [`cap_history`], a live handle
+/// [`close_paused_op`] misattributes to the next in-app op of its kind, and a
+/// permanent lie in Operation history.
 ///
-/// The verdict is deliberately narrower than `mid_op`: a concurrent merge or rebase
-/// says nothing about a pick. It comes from TWO reads, and either one saying "a pick
-/// is live" spares the records. `cherry_picking` is the caller's earlier op-state
-/// read, which by the time we hold the lock is two git subprocesses old — a pick that
-/// paused in that window would have its brand-new record concluded permanently, and
-/// the user's later Continue/Abort would then find no handle to close. So
-/// `pick_in_progress` re-probes under the lock and is authoritative for that
-/// direction; it must answer whether `CHERRY_PICK_HEAD` exists for THIS repo, which
-/// is exactly the marker a paused (single-hash) pick leaves.
+/// Each op is judged against its OWN signals, never `mid_op`: a concurrent merge
+/// says nothing about a pick, and a live rebase says nothing about one either. Both
+/// signals per op come from [`LiveOps`], and either one saying "live" spares that
+/// op's records — the `bool` is the caller's earlier op-state read, two git
+/// subprocesses old by the time we hold the lock (an op that paused in that window
+/// would have its brand-new record concluded permanently, leaving the user's later
+/// Continue/Abort no handle to close), so the closure re-probes the marker files
+/// under the lock and is authoritative for that direction.
 ///
 /// Residual, accepted: git can finish an in-app continue between that probe and
-/// [`close_paused_pick`]'s own locked RMW, so a check landing in those few
+/// [`close_paused_op`]'s own locked RMW, so a check landing in those few
 /// milliseconds concludes the record first and the close then no-ops. Both run
 /// in-process and the window is order-of-ms; the cost is one history row reading
-/// "Ended outside the app" for a pick that ended inside it.
+/// "Ended outside the app" for an op that ended inside it.
 ///
 /// ALL stale records are concluded, not just the pre-newest ones — leaving any behind
 /// keeps the close-handle misattribution alive.
@@ -383,34 +429,19 @@ fn is_interrupted(
 /// Status-write ONLY: the journal never mutates git to "recover" (module contract), and
 /// `finishedAt` stays null because a reconcile observes THAT the op ended, never when.
 /// Answers whether anything changed, so a no-op check doesn't rewrite the file.
-fn conclude_stale_pauses(
-    list: &mut [Value],
-    cherry_picking: bool,
-    pick_in_progress: impl Fn() -> bool,
-) -> bool {
-    fn is_paused_pick(entry: &Value) -> bool {
-        entry.get("status").and_then(Value::as_str) == Some("paused")
-            // Every paused record is a cherry-pick today; asserting the op keeps the
-            // verdict honest if another op ever learns to pause.
-            && entry.get("op").and_then(Value::as_str) == Some("cherry_pick_onto")
-    }
-
-    // Probe only when there is something to conclude — the common check touches no
-    // filesystem beyond the store it already read.
-    if !list.iter().any(is_paused_pick) {
-        return false;
-    }
-    if cherry_picking || pick_in_progress() {
-        return false;
-    }
+fn conclude_stale_pauses(list: &mut [Value], live: &LiveOps<'_>) -> bool {
     let mut changed = false;
-    for entry in list.iter_mut() {
-        if !is_paused_pick(entry) {
+    for op in PAUSABLE_OPS {
+        // Probe only when there is something to conclude — the common check touches
+        // no filesystem beyond the store it already read.
+        if !list.iter().any(|e| is_paused_op(e, op)) || live.is_live(op) {
             continue;
         }
-        if let Some(obj) = entry.as_object_mut() {
-            obj.insert("status".to_string(), Value::String("concluded".to_string()));
-            changed = true;
+        for entry in list.iter_mut().filter(|e| is_paused_op(e, op)) {
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert("status".to_string(), Value::String("concluded".to_string()));
+                changed = true;
+            }
         }
     }
     changed
@@ -420,27 +451,18 @@ fn conclude_stale_pauses(
 /// still-`"pending"` entries newest-first (0 or 1). `mid_op` = a merge, cherry-pick,
 /// rebase or revert is currently in progress ([`RepoOpState::mid_op`]);
 /// `tree_dirty` = tracked changes are present (catches a mid-squash interrupt
-/// git_op_state can't see); `current_branch` = the branch HEAD is on now;
-/// `cherry_picking` and the `pick_in_progress` re-probe gate the stale-pause arm
-/// alone, and the probe runs INSIDE the lock (see [`conclude_stale_pauses`]).
+/// git_op_state can't see); `current_branch` = the branch HEAD is on now; `live`
+/// gates the stale-pause arm alone, and its probes run INSIDE the lock (see
+/// [`conclude_stale_pauses`]).
 /// Guarded by [`OPLOG_LOCK`] plus the cross-process store lock.
 fn reconcile(
     repo: &str,
     mid_op: bool,
     tree_dirty: bool,
     current_branch: &str,
-    cherry_picking: bool,
-    pick_in_progress: impl Fn() -> bool,
+    live: &LiveOps<'_>,
 ) -> AppResult<Vec<OpLogEntry>> {
-    reconcile_at(
-        &store_path()?,
-        repo,
-        mid_op,
-        tree_dirty,
-        current_branch,
-        cherry_picking,
-        pick_in_progress,
-    )
+    reconcile_at(&store_path()?, repo, mid_op, tree_dirty, current_branch, live)
 }
 
 /// The store logic behind [`reconcile`], taking an explicit path so a test can drive it
@@ -452,8 +474,7 @@ fn reconcile_at(
     mid_op: bool,
     tree_dirty: bool,
     current_branch: &str,
-    cherry_picking: bool,
-    pick_in_progress: impl Fn() -> bool,
+    live: &LiveOps<'_>,
 ) -> AppResult<Vec<OpLogEntry>> {
     let now = now_iso();
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -466,7 +487,7 @@ fn reconcile_at(
         return Ok(Vec::new());
     };
 
-    let mut changed = conclude_stale_pauses(list, cherry_picking, pick_in_progress);
+    let mut changed = conclude_stale_pauses(list, live);
 
     // Indices of pending entries, newest-first by startedAt. Strictly `"pending"`:
     // a live `"paused"` op was handed to the user and is owned by the conflict
@@ -597,7 +618,7 @@ pub async fn finish(repo: &str, id: &Option<String>, error: Option<String>) {
 
 /// Best-effort: if `id` is `Some`, flip that entry to `"paused"` — the op did not
 /// end, it was handed to the user to resolve, so it is neither a failure nor a
-/// recovery candidate until [`close_paused_pick`] closes it. Swallow+log like
+/// recovery candidate until [`close_paused_op`] closes it. Swallow+log like
 /// [`finish`].
 pub(crate) async fn pause(repo: &str, id: &Option<String>) {
     let Some(id) = id else {
@@ -612,16 +633,27 @@ pub(crate) async fn pause(repo: &str, id: &Option<String>) {
 }
 
 /// Best-effort: close `repo`'s newest `"paused"` cherry-pick entry now that the user
-/// has ended the pick in-app. No paused entry → no-op.
-///
-/// The handle is the newest paused record, not the specific pick, so it can only be
-/// as accurate as the store is current: [`conclude_stale_pauses`] retires the records
-/// of picks ended outside the app on the next [`git_oplog_check`] that finds no pick
-/// in progress, which is what keeps one from standing in as this op's handle.
+/// has ended the pick in-app. The named shorthand every in-app pick route calls.
 pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
+    close_paused_op(repo, CHERRY_PICK_ONTO, outcome).await;
+}
+
+/// Best-effort: close `repo`'s newest `"paused"` pull-rebase-drop entry now that the
+/// user has ended the guarded pull's rebase in-app.
+pub(crate) async fn close_paused_pull_drop(repo: &str, outcome: PausedOutcome) {
+    close_paused_op(repo, PULL_REBASE_DROP, outcome).await;
+}
+
+/// Best-effort: close `repo`'s newest `"paused"` `op` entry. No paused entry → no-op.
+///
+/// The handle is the newest paused record of that op, not the specific run, so it can
+/// only be as accurate as the store is current: [`conclude_stale_pauses`] retires the
+/// records of ops ended outside the app on the next [`git_oplog_check`] that finds
+/// none in progress, which is what keeps one from standing in as this op's handle.
+async fn close_paused_op(repo: &str, op: &'static str, outcome: PausedOutcome) {
     let (repo, now) = (repo.to_string(), now_iso());
     let result = crate::store_lock::locked_store_task(move || {
-        close_newest_paused_pick(&repo, &outcome, now)
+        close_newest_paused_op(&repo, op, &outcome, now)
     })
     .await;
     if let Err(e) = result {
@@ -633,7 +665,12 @@ pub(crate) async fn close_paused_pick(repo: &str, outcome: PausedOutcome) {
 /// them (find the handle, release, re-take to mutate) lets two concurrent closes
 /// resolve the same newest-paused id and both write it — the second overwriting the
 /// first's disposition.
-fn close_newest_paused_pick(repo: &str, outcome: &PausedOutcome, now: String) -> AppResult<()> {
+fn close_newest_paused_op(
+    repo: &str,
+    op: &str,
+    outcome: &PausedOutcome,
+    now: String,
+) -> AppResult<()> {
     let path = store_path()?;
     let _guard = oplog_lock().lock().unwrap_or_else(|p| p.into_inner());
     let _store_lock = crate::store_lock::lock_store(&path);
@@ -644,9 +681,9 @@ fn close_newest_paused_pick(repo: &str, outcome: &PausedOutcome, now: String) ->
     let Some(list) = store.get_mut(&key).and_then(Value::as_array_mut) else {
         return Ok(());
     };
-    // Resolve the handle on a copy: `newest_paused_pick` sorts what it is given, and
+    // Resolve the handle on a copy: `newest_paused_op` sorts what it is given, and
     // the stored order is the file's own (readers sort for themselves).
-    let Some(id) = newest_paused_pick(&mut list.clone()) else {
+    let Some(id) = newest_paused_op(&mut list.clone(), op) else {
         return Ok(());
     };
     let Some(obj) = list
@@ -715,11 +752,11 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     // `op_in_progress`, whose Err arm answers `true` — that would manufacture an
     // interrupt from a failed read, which the two probes below refuse to do.
     let mid_op = state.mid_op();
-    // The stale-pause verdict keys on the pick flag ALONE, not `mid_op` — see
-    // `conclude_stale_pauses`. This read goes stale across the two git subprocesses
-    // below, so `reconcile` re-probes the marker under the lock; this one only
-    // short-circuits.
-    let cherry_picking = state.cherry_picking;
+    // The stale-pause verdict keys on each op's OWN flag, not `mid_op` — see
+    // `conclude_stale_pauses`. These reads go stale across the two git subprocesses
+    // below, so `reconcile` re-probes the markers under the lock; these only
+    // short-circuit.
+    let (cherry_picking, rebasing) = (state.cherry_picking, state.rebasing);
     // A squash-merge leaves none of those markers, so git_op_state alone misses a
     // mid-squash interrupt. Corroborate with a *tracked*-dirty check (untracked is
     // allowed — mirrors ensure_clean_tree) + the current branch.
@@ -740,17 +777,23 @@ pub async fn git_oplog_check(repo_path: String) -> AppResult<Vec<OpLogEntry>> {
     .map(|o| o.stdout_lossy().trim().to_string())
     .unwrap_or_default();
     // The store RMW blocks on the cross-process lock's retry budget, so it runs off the
-    // async runtime; the marker re-probe is built inside the job, which keeps it on the
-    // same thread as the lock it must run under.
+    // async runtime; the marker re-probes are built inside the job, which keeps them on
+    // the same thread as the lock they must run under.
     crate::store_lock::locked_store_task(move || {
+        // FS-only (no subprocess), so they are cheap to run while holding the store lock.
+        let pick = || crate::git::ops::cherry_pick_marker_present(&repo_path);
+        let rebase = || crate::git::ops::rebase_marker_present(&repo_path);
         reconcile(
             &repo_path,
             mid_op,
             tree_dirty,
             &current_branch,
-            cherry_picking,
-            // FS-only (no subprocess), so it is cheap to run while holding the store lock.
-            || crate::git::ops::cherry_pick_marker_present(&repo_path),
+            &LiveOps {
+                cherry_picking,
+                rebasing,
+                pick_in_progress: &pick,
+                rebase_in_progress: &rebase,
+            },
         )
     })
     .await
@@ -776,6 +819,26 @@ mod tests {
     // These tests exercise the pure store logic against a temp file, driving the
     // SAME read/mutate/write helpers the public fns use but with an explicit path,
     // so they never touch the real app-data store.
+
+    const NOT_LIVE: &dyn Fn() -> bool = &|| false;
+    const LIVE: &dyn Fn() -> bool = &|| true;
+
+    /// A [`LiveOps`] built from plain answers: these tests pin which direction each
+    /// signal points, never a real marker probe (the arms that need one build their
+    /// own).
+    fn live_ops(
+        cherry_picking: bool,
+        pick_probe: bool,
+        rebasing: bool,
+        rebase_probe: bool,
+    ) -> LiveOps<'static> {
+        LiveOps {
+            cherry_picking,
+            rebasing,
+            pick_in_progress: if pick_probe { LIVE } else { NOT_LIVE },
+            rebase_in_progress: if rebase_probe { LIVE } else { NOT_LIVE },
+        }
+    }
 
     fn tmp_store() -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::Builder::new()
@@ -1051,6 +1114,22 @@ mod tests {
         })
     }
 
+    /// Build a wire record for a `pull_rebase_drop` entry at `status`.
+    fn drop_record(id: &str, started_at: &str, status: &str) -> Value {
+        json!({
+            "id": id,
+            "op": "pull_rebase_drop",
+            "label": "Drop 1 commit rewritten away on origin/main",
+            "status": status,
+            "startedAt": started_at,
+            "finishedAt": null,
+            "originalRef": "main",
+            "originalSha": "abc123",
+            "preOpTip": "abc123",
+            "error": null,
+        })
+    }
+
     #[test]
     fn pause_marks_the_entry_without_finishing_it() {
         let (_tmp, path) = tmp_store();
@@ -1100,7 +1179,8 @@ mod tests {
         write_store(&path, &store).unwrap();
 
         let mut entries = repo_entries(&read_store(&path).unwrap(), repo);
-        let id = newest_paused_pick(&mut entries).expect("the paused pick must be found");
+        let id = newest_paused_op(&mut entries, CHERRY_PICK_ONTO)
+            .expect("the paused pick must be found");
         assert_eq!(id, "new-paused", "a newer finished entry is not the handle");
 
         let mut s = read_store(&path).unwrap();
@@ -1157,8 +1237,8 @@ mod tests {
                 "startedAt": "2026-01-03T00:00:00.000Z",
             }),
         ];
-        assert!(newest_paused_pick(&mut entries).is_none());
-        assert!(newest_paused_pick(&mut Vec::new()).is_none());
+        assert!(newest_paused_op(&mut entries, CHERRY_PICK_ONTO).is_none());
+        assert!(newest_paused_op(&mut Vec::new(), CHERRY_PICK_ONTO).is_none());
     }
 
     #[test]
@@ -1251,7 +1331,9 @@ mod tests {
 
         // Nothing to do on either arm: a pick is in progress (so the pause stands), and
         // the pending op is genuinely interrupted (so it stays pending).
-        let returned = reconcile_at(&path, repo, true, true, "feature", true, || true).unwrap();
+        let returned =
+            reconcile_at(&path, repo, true, true, "feature", &live_ops(true, true, false, false))
+                .unwrap();
         assert_eq!(returned.len(), 1);
         assert_eq!(returned[0].id, "interrupted");
 
@@ -1416,9 +1498,19 @@ mod tests {
         );
 
         // `cherry_picking: false` is the stale pre-race read; the pick is live NOW.
-        let returned = reconcile(&repo, false, false, "target", false, || {
-            crate::git::ops::cherry_pick_marker_present(&repo)
-        })
+        let pick = || crate::git::ops::cherry_pick_marker_present(&repo);
+        let returned = reconcile(
+            &repo,
+            false,
+            false,
+            "target",
+            &LiveOps {
+                cherry_picking: false,
+                rebasing: false,
+                pick_in_progress: &pick,
+                rebase_in_progress: NOT_LIVE,
+            },
+        )
         .unwrap();
 
         assert!(returned.is_empty());
@@ -1447,7 +1539,8 @@ mod tests {
             ],
         );
 
-        let returned = reconcile(repo, false, false, "main", false, || false).unwrap();
+        let returned =
+            reconcile(repo, false, false, "main", &live_ops(false, false, false, false)).unwrap();
         assert!(returned.is_empty());
         // Sparing the newest would leave `close_paused_pick` a stale handle to
         // misattribute the user's next in-app pick to.
@@ -1471,11 +1564,96 @@ mod tests {
         // A merge is mid-flight — which is why the pause verdict reads
         // `cherry_picking` and not repo-wide `mid_op`: this merge says nothing about
         // whether a cherry-pick ended.
-        let returned = reconcile(repo, true, false, "feature", false, || false).unwrap();
+        let returned = reconcile(repo, true, false, "feature", &live_ops(false, false, false, false))
+            .unwrap();
         assert_eq!(returned.len(), 1, "{returned:?}");
         assert_eq!(returned[0].id, "interrupted-merge");
         assert_eq!(returned[0].status, "pending");
         assert_eq!(stored_entry(repo, "stale-pick")["status"], "concluded");
+    }
+
+    /// A guarded pull's DROP arm pauses too, so a rebase ended OUTSIDE the app must
+    /// retire its record exactly as a terminal cherry-pick retires a pick's —
+    /// otherwise the row is cap-immortal and a permanent lie in Operation history.
+    #[test]
+    fn a_stale_paused_pull_drop_is_concluded_by_the_next_check() {
+        let repo = r"C:\oplog\stale-pull-drop";
+        seed_entries(
+            repo,
+            vec![drop_record("stale-drop", "2026-01-01T00:00:00.000Z", "paused")],
+        );
+
+        let returned = reconcile(repo, false, false, "main", &live_ops(false, false, false, false))
+            .unwrap();
+        assert!(returned.is_empty(), "a pause is not an interrupt: {returned:?}");
+        assert_eq!(stored_entry(repo, "stale-drop")["status"], "concluded");
+    }
+
+    /// NEGATIVE CONTROL for the arm above: while the rebase the drop paused on is
+    /// still live, its record is the handle Continue/Abort needs. Either signal
+    /// alone spares it — the stale op-state flag, or the locked re-probe.
+    #[test]
+    fn a_live_paused_pull_drop_is_never_concluded() {
+        for (flag, probe) in [(true, false), (false, true)] {
+            let repo = format!(r"C:\oplog\live-pull-drop-{flag}-{probe}");
+            seed_entries(
+                &repo,
+                vec![drop_record("live-drop", "2026-01-01T00:00:00.000Z", "paused")],
+            );
+
+            let returned =
+                reconcile(&repo, true, false, "main", &live_ops(false, false, flag, probe)).unwrap();
+            assert!(returned.is_empty());
+            assert_eq!(
+                stored_entry(&repo, "live-drop")["status"],
+                "paused",
+                "flag={flag} probe={probe}"
+            );
+        }
+    }
+
+    /// Every pausable op is judged against its OWN signals. One shared verdict would
+    /// retire whichever op is not the live one — and for a drop that means
+    /// concluding the record the very check after its rebase paused.
+    #[test]
+    fn a_paused_record_is_judged_against_its_own_ops_signals() {
+        let repo = r"C:\oplog\per-op-pause-verdict";
+        let seeded = || {
+            vec![
+                pick_record("the-pick", "2026-01-01T00:00:00.000Z", "paused"),
+                drop_record("the-drop", "2026-01-02T00:00:00.000Z", "paused"),
+            ]
+        };
+
+        // A rebase is live, no pick is: only the pick's record retires.
+        seed_entries(repo, seeded());
+        reconcile(repo, true, false, "main", &live_ops(false, false, true, false)).unwrap();
+        assert_eq!(stored_entry(repo, "the-drop")["status"], "paused");
+        assert_eq!(stored_entry(repo, "the-pick")["status"], "concluded");
+
+        // And the mirror image.
+        seed_entries(repo, seeded());
+        reconcile(repo, true, false, "main", &live_ops(true, false, false, false)).unwrap();
+        assert_eq!(stored_entry(repo, "the-pick")["status"], "paused");
+        assert_eq!(stored_entry(repo, "the-drop")["status"], "concluded");
+    }
+
+    /// A close handle never crosses ops: the NEWER paused drop must not stand in for
+    /// the pick an in-app Continue/Abort just ended, or it takes that disposition.
+    #[test]
+    fn a_close_handle_never_crosses_ops() {
+        let mut entries = vec![
+            pick_record("the-pick", "2026-01-01T00:00:00.000Z", "paused"),
+            drop_record("the-drop", "2026-01-02T00:00:00.000Z", "paused"),
+        ];
+        assert_eq!(
+            newest_paused_op(&mut entries, CHERRY_PICK_ONTO).as_deref(),
+            Some("the-pick")
+        );
+        assert_eq!(
+            newest_paused_op(&mut entries, PULL_REBASE_DROP).as_deref(),
+            Some("the-drop")
+        );
     }
 
     #[test]

--- a/src-tauri/src/oplog.rs
+++ b/src-tauri/src/oplog.rs
@@ -823,20 +823,26 @@ mod tests {
     const NOT_LIVE: &dyn Fn() -> bool = &|| false;
     const LIVE: &dyn Fn() -> bool = &|| true;
 
-    /// A [`LiveOps`] built from plain answers: these tests pin which direction each
-    /// signal points, never a real marker probe (the arms that need one build their
-    /// own).
-    fn live_ops(
-        cherry_picking: bool,
-        pick_probe: bool,
-        rebasing: bool,
-        rebase_probe: bool,
-    ) -> LiveOps<'static> {
+    /// Nothing in flight — the baseline every stale-pause test starts from and names
+    /// one field of (`LiveOps { rebasing: true, ..quiet_ops() }`), so each call reads
+    /// as the signal it is flipping rather than as four positional booleans. These
+    /// tests pin which direction each signal points; the arms that need a real marker
+    /// probe build their own.
+    fn quiet_ops() -> LiveOps<'static> {
         LiveOps {
-            cherry_picking,
-            rebasing,
-            pick_in_progress: if pick_probe { LIVE } else { NOT_LIVE },
-            rebase_in_progress: if rebase_probe { LIVE } else { NOT_LIVE },
+            cherry_picking: false,
+            rebasing: false,
+            pick_in_progress: NOT_LIVE,
+            rebase_in_progress: NOT_LIVE,
+        }
+    }
+
+    /// A probe answer as a [`LiveOps`] field, for the one test that sweeps both.
+    fn probe(live: bool) -> &'static dyn Fn() -> bool {
+        if live {
+            LIVE
+        } else {
+            NOT_LIVE
         }
     }
 
@@ -1331,9 +1337,19 @@ mod tests {
 
         // Nothing to do on either arm: a pick is in progress (so the pause stands), and
         // the pending op is genuinely interrupted (so it stays pending).
-        let returned =
-            reconcile_at(&path, repo, true, true, "feature", &live_ops(true, true, false, false))
-                .unwrap();
+        let returned = reconcile_at(
+                &path,
+                repo,
+                true,
+                true,
+                "feature",
+                &LiveOps {
+                    cherry_picking: true,
+                    pick_in_progress: LIVE,
+                    ..quiet_ops()
+                },
+            )
+            .unwrap();
         assert_eq!(returned.len(), 1);
         assert_eq!(returned[0].id, "interrupted");
 
@@ -1539,8 +1555,7 @@ mod tests {
             ],
         );
 
-        let returned =
-            reconcile(repo, false, false, "main", &live_ops(false, false, false, false)).unwrap();
+        let returned = reconcile(repo, false, false, "main", &quiet_ops()).unwrap();
         assert!(returned.is_empty());
         // Sparing the newest would leave `close_paused_pick` a stale handle to
         // misattribute the user's next in-app pick to.
@@ -1564,8 +1579,7 @@ mod tests {
         // A merge is mid-flight — which is why the pause verdict reads
         // `cherry_picking` and not repo-wide `mid_op`: this merge says nothing about
         // whether a cherry-pick ended.
-        let returned = reconcile(repo, true, false, "feature", &live_ops(false, false, false, false))
-            .unwrap();
+        let returned = reconcile(repo, true, false, "feature", &quiet_ops()).unwrap();
         assert_eq!(returned.len(), 1, "{returned:?}");
         assert_eq!(returned[0].id, "interrupted-merge");
         assert_eq!(returned[0].status, "pending");
@@ -1583,8 +1597,7 @@ mod tests {
             vec![drop_record("stale-drop", "2026-01-01T00:00:00.000Z", "paused")],
         );
 
-        let returned = reconcile(repo, false, false, "main", &live_ops(false, false, false, false))
-            .unwrap();
+        let returned = reconcile(repo, false, false, "main", &quiet_ops()).unwrap();
         assert!(returned.is_empty(), "a pause is not an interrupt: {returned:?}");
         assert_eq!(stored_entry(repo, "stale-drop")["status"], "concluded");
     }
@@ -1594,20 +1607,31 @@ mod tests {
     /// alone spares it — the stale op-state flag, or the locked re-probe.
     #[test]
     fn a_live_paused_pull_drop_is_never_concluded() {
-        for (flag, probe) in [(true, false), (false, true)] {
-            let repo = format!(r"C:\oplog\live-pull-drop-{flag}-{probe}");
+        for (flag, probe_live) in [(true, false), (false, true)] {
+            let repo = format!(r"C:\oplog\live-pull-drop-{flag}-{probe_live}");
             seed_entries(
                 &repo,
                 vec![drop_record("live-drop", "2026-01-01T00:00:00.000Z", "paused")],
             );
 
             let returned =
-                reconcile(&repo, true, false, "main", &live_ops(false, false, flag, probe)).unwrap();
+                reconcile(
+                    &repo,
+                    true,
+                    false,
+                    "main",
+                    &LiveOps {
+                        rebasing: flag,
+                        rebase_in_progress: probe(probe_live),
+                        ..quiet_ops()
+                    },
+                )
+                .unwrap();
             assert!(returned.is_empty());
             assert_eq!(
                 stored_entry(&repo, "live-drop")["status"],
                 "paused",
-                "flag={flag} probe={probe}"
+                "flag={flag} probe={probe_live}"
             );
         }
     }
@@ -1627,13 +1651,33 @@ mod tests {
 
         // A rebase is live, no pick is: only the pick's record retires.
         seed_entries(repo, seeded());
-        reconcile(repo, true, false, "main", &live_ops(false, false, true, false)).unwrap();
+        reconcile(
+            repo,
+            true,
+            false,
+            "main",
+            &LiveOps {
+                rebasing: true,
+                ..quiet_ops()
+            },
+        )
+        .unwrap();
         assert_eq!(stored_entry(repo, "the-drop")["status"], "paused");
         assert_eq!(stored_entry(repo, "the-pick")["status"], "concluded");
 
         // And the mirror image.
         seed_entries(repo, seeded());
-        reconcile(repo, true, false, "main", &live_ops(true, false, false, false)).unwrap();
+        reconcile(
+            repo,
+            true,
+            false,
+            "main",
+            &LiveOps {
+                cherry_picking: true,
+                ..quiet_ops()
+            },
+        )
+        .unwrap();
         assert_eq!(stored_entry(repo, "the-pick")["status"], "paused");
         assert_eq!(stored_entry(repo, "the-drop")["status"], "concluded");
     }

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -1226,7 +1226,10 @@ export function DiffContent({
             <span className="shrink-0">(truncated — diff too large)</span>
           )}
         </span>
-        <span className="flex shrink-0 items-center gap-1.5">
+        {/* min-h-7 pins the cluster to the language picker's h-7 trigger, so an
+            extensionless file — where the picker renders nothing and only the
+            xs (h-6) mode toggle remains — doesn't shrink the row by 4px. */}
+        <span className="flex min-h-7 shrink-0 items-center gap-1.5">
           <DiffLanguagePicker filePath={filePath} />
           <DiffModeToggle />
         </span>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -52,6 +52,7 @@ import { toastError } from "@/lib/toast";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
 import { useRetained } from "@/lib/use-retained";
+import { cn } from "@/lib/utils";
 import {
   DIFF_MAX_LINE_CHARS,
   DIFF_MEGA_LINE_CHARS,
@@ -221,7 +222,7 @@ function WorkingTreeDiff({
       ? selectionState.lines
       : null;
   // One contextual chord: stage the selection on an unstaged file's diff,
-  // unstage it on a staged one — mirroring the banner's primary button. Dead
+  // unstage it on a staged one — mirroring the toolbar's primary button. Dead
   // while the Discard confirm is open (the global listener has no dialog guard)
   // and while the non-staging fallback renders.
   useHotkeyAction(
@@ -266,7 +267,7 @@ function WorkingTreeDiff({
   }
 
   const onError = (e: unknown) => toastError(e);
-  // Shortcut hints on the selection banner: `aria-keyshortcuts` keeps the chord
+  // Shortcut hints on the selection action: `aria-keyshortcuts` keeps the chord
   // off the accessible name, the title makes it discoverable. Both omitted when
   // the action is unbound.
   const selectionActionLabel = file.staged ? "Unstage" : "Stage";
@@ -278,6 +279,12 @@ function WorkingTreeDiff({
     selectionBinding === null
       ? undefined
       : bindingToAriaKeyshortcuts(selectionBinding);
+  // One source for the count: the visible copy can be truncated by a narrow
+  // pane, and the announcement must carry the full text regardless.
+  const selectionCountText =
+    selection === null
+      ? ""
+      : `${selection.length} ${selection.length === 1 ? "line" : "lines"} selected`;
 
   function applyHunk(
     hunk: DiffHunk,
@@ -329,82 +336,120 @@ function WorkingTreeDiff({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
+      {/* The selection actions take over this row rather than opening one of
+          their own: a row that mounts below the toolbar pushes the whole diff
+          down on mouseup, moving the lines the user just dragged across. */}
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 border-b px-3 py-1.5",
+          // Full-width tint marks selection mode; the count text carries the
+          // same state in words, so the cue is never colour alone.
+          selection && "bg-primary/10",
+        )}
+      >
         <span
           className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
           title={file.path}
         >
           {file.path}
         </span>
-        <span className="flex shrink-0 items-center gap-1.5">
-          <DiffLanguagePicker filePath={file.path} />
-          <DiffModeToggle />
-        </span>
-      </div>
-      {selection && (
-        <div className="flex items-center gap-2 border-b bg-primary/10 px-3 py-1 text-[11px]">
-          <span className="flex-1 font-medium">
-            {selection.length} {selection.length === 1 ? "line" : "lines"}{" "}
-            selected
-          </span>
-          {file.staged ? (
-            <Button
-              variant="secondary"
-              size="xs"
-              disabled={busy}
-              title={selectionTitle}
-              aria-keyshortcuts={selectionKeyshortcuts}
-              onClick={() => applySelection({ cached: true, reverse: true })}
-            >
-              Unstage
-            </Button>
-          ) : (
+        {/* min-h-7 pins the cluster to the language picker's h-7 trigger: the
+            xs (h-6) selection buttons — and an extensionless file, where the
+            picker renders nothing — would otherwise shrink the row by 4px.
+            The selection arm drops shrink-0 so a narrow pane takes width from
+            the count (which truncates) instead of overflowing the row; every
+            Button is shrink-0 by default, so the actions are the floor and
+            can never be squeezed or clipped. */}
+        <span
+          className={cn(
+            "flex min-h-7 items-center gap-1.5",
+            selection === null && "shrink-0",
+          )}
+        >
+          {selection ? (
             <>
-              <Button
-                variant="secondary"
-                size="xs"
-                disabled={busy}
-                title={selectionTitle}
-                aria-keyshortcuts={selectionKeyshortcuts}
-                onClick={() => applySelection({ cached: true, reverse: false })}
+              <span
+                className="min-w-0 truncate font-medium text-[11px]"
+                title={selectionCountText}
               >
-                Stage
-              </Button>
+                {selectionCountText}
+              </span>
+              {file.staged ? (
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  disabled={busy}
+                  title={selectionTitle}
+                  aria-keyshortcuts={selectionKeyshortcuts}
+                  onClick={() =>
+                    applySelection({ cached: true, reverse: true })
+                  }
+                >
+                  Unstage
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    disabled={busy}
+                    title={selectionTitle}
+                    aria-keyshortcuts={selectionKeyshortcuts}
+                    onClick={() =>
+                      applySelection({ cached: true, reverse: false })
+                    }
+                  >
+                    Stage
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="text-destructive"
+                    disabled={busy}
+                    onClick={() =>
+                      setDiscard({
+                        label: `${selection.length} selected ${selection.length === 1 ? "line" : "lines"}`,
+                        newFile: untracked,
+                        forText: diff.data?.text ?? "",
+                        run: untracked
+                          ? () =>
+                              discardLines(
+                                selection
+                                  .filter((s) => s.side === "new")
+                                  .map((s) => s.line),
+                              )
+                          : () =>
+                              applySelection({ cached: false, reverse: true }),
+                      })
+                    }
+                  >
+                    Discard…
+                  </Button>
+                </>
+              )}
               <Button
                 variant="ghost"
                 size="xs"
-                className="text-destructive"
                 disabled={busy}
-                onClick={() =>
-                  setDiscard({
-                    label: `${selection.length} selected ${selection.length === 1 ? "line" : "lines"}`,
-                    newFile: untracked,
-                    forText: diff.data?.text ?? "",
-                    run: untracked
-                      ? () =>
-                          discardLines(
-                            selection
-                              .filter((s) => s.side === "new")
-                              .map((s) => s.line),
-                          )
-                      : () => applySelection({ cached: false, reverse: true }),
-                  })
-                }
+                onClick={clearSelection}
               >
-                Discard…
+                Clear
               </Button>
             </>
+          ) : (
+            <>
+              <DiffLanguagePicker filePath={file.path} />
+              <DiffModeToggle />
+            </>
           )}
-          <Button
-            variant="ghost"
-            size="xs"
-            disabled={busy}
-            onClick={clearSelection}
-          >
-            Clear
-          </Button>
-        </div>
-      )}
+        </span>
+      </div>
+      {/* Mounted unconditionally so the count announces as a live update; the
+          visible count above is deliberately not the live region, which would
+          announce the same text twice. */}
+      <span role="status" aria-live="polite" className="sr-only">
+        {selectionCountText}
+      </span>
       <div className="ph-no-capture min-h-0 flex-1 overflow-auto">
         {file.path.toLowerCase().endsWith(".svg") && (
           <div className="border-b">

--- a/src/features/diff/diff-lang.ts
+++ b/src/features/diff/diff-lang.ts
@@ -61,6 +61,7 @@ const EXT_LANG: Record<string, string> = {
   // of the approximate fallbacks (toml/tf as ini, svelte as xml) used before.
   astro: "astro",
   svelte: "svelte",
+  mdx: "mdx",
   prisma: "prisma",
   sol: "solidity",
   wgsl: "wgsl",

--- a/src/features/diff/shiki-highlighter.ts
+++ b/src/features/diff/shiki-highlighter.ts
@@ -69,7 +69,8 @@ export function isShikiLang(id: string): boolean {
  * Languages Shiki bundles that highlight.js lacks (or renders poorly), offered
  * as built-in picker options. Each value is a dynamic loader that imports the
  * full grammar bundle from `@shikijs/langs` — the language plus every grammar it
- * embeds (astro/vue frontmatter = TS, <style> = CSS, expressions = TSX). The
+ * embeds (astro/vue frontmatter = TS, <style> = CSS, expressions = TSX), except
+ * mdx, which ships none and composes its own (see its entry). The
  * grammars are imported lazily (~557KB, jsx+tsx dominating) so they stay off the
  * startup chunk and load only when a diff of that language is first opened. The
  * key matches the bundle's own grammar name (Shiki's filename convention), which
@@ -86,6 +87,23 @@ const BUILTIN_LANGS: Record<
   // tsx/jsx render via Shiki because highlight.js's typescript/javascript
   // grammars don't tokenize JSX (the markup stayed plain).
   jsx: () => import("@shikijs/langs/jsx"),
+  // MDX's bundle is the mdx grammar alone — all 42 of its embeds are lazy — so
+  // the ESM header and every fenced block would render plain. Register the ones
+  // a diff needs: tsx for the header/JSX, ts/js and sql for the fences devs
+  // actually write, markdown for shared prose internals; mdx last so its own
+  // grammar wins a name collision. The remaining lazy embeds stay unregistered
+  // and those fences render plain — pulling all 42 would cost megabytes.
+  mdx: async () => {
+    const bundles = await Promise.all([
+      import("@shikijs/langs/tsx"),
+      import("@shikijs/langs/typescript"),
+      import("@shikijs/langs/javascript"),
+      import("@shikijs/langs/markdown"),
+      import("@shikijs/langs/sql"),
+      import("@shikijs/langs/mdx"),
+    ]);
+    return { default: bundles.flatMap((b) => b.default) };
+  },
   prisma: () => import("@shikijs/langs/prisma"),
   // Rust renders via Shiki because highlight.js's flat tokenizer can mis-scope
   // a lifetime/char-literal sequence and swallow the rest of the file as one

--- a/src/features/diff/shiki-theme.ts
+++ b/src/features/diff/shiki-theme.ts
@@ -82,5 +82,30 @@ export const gdDiff = {
       scope: ["entity.other.attribute-name"],
       settings: { foreground: "var(--gd-syn-attr)" },
     },
+    {
+      // Prose markup (mdx today). MDX scopes its bold/italic/link as
+      // `string.other.*` and its list markers as `variable.*`, so those already
+      // colour above; these carry the rest. `markup.code` is deliberately
+      // unmapped — it wraps a whole fenced block and would tint the embedded
+      // language's plain text.
+      scope: ["markup.heading", "entity.name.section"],
+      settings: { foreground: "var(--gd-syn-func)", fontStyle: "bold" },
+    },
+    {
+      scope: ["markup.bold"],
+      settings: { foreground: "var(--gd-syn-variable)", fontStyle: "bold" },
+    },
+    {
+      scope: ["markup.italic"],
+      settings: { foreground: "var(--gd-syn-variable)", fontStyle: "italic" },
+    },
+    {
+      scope: ["markup.quote"],
+      settings: { foreground: "var(--gd-syn-comment)", fontStyle: "italic" },
+    },
+    {
+      scope: ["markup.inline.raw", "markup.raw"],
+      settings: { foreground: "var(--gd-syn-string)" },
+    },
   ],
 } satisfies ThemeRegistration;

--- a/src/features/diff/shiki-theme.ts
+++ b/src/features/diff/shiki-theme.ts
@@ -87,8 +87,10 @@ export const gdDiff = {
       // `string.other.*` and its list markers as `variable.*`, so those already
       // colour above; these carry the rest. `markup.code` is deliberately
       // unmapped — it wraps a whole fenced block and would tint the embedded
-      // language's plain text.
-      scope: ["markup.heading", "entity.name.section"],
+      // language's plain text. `entity.name.section` is deliberately NOT here:
+      // heading text nests it under `markup.heading`, and TOML uses it for
+      // `[table]` headers, which this theme must not restyle.
+      scope: ["markup.heading"],
       settings: { foreground: "var(--gd-syn-func)", fontStyle: "bold" },
     },
     {

--- a/src/features/diff/syntax.ts
+++ b/src/features/diff/syntax.ts
@@ -76,6 +76,7 @@ const LABELS: Record<string, string> = {
   yaml: "YAML",
   ini: "INI / TOML",
   markdown: "Markdown",
+  mdx: "MDX",
   sql: "SQL",
   dockerfile: "Dockerfile",
   makefile: "Makefile",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -588,8 +588,8 @@ can safely preview and recover work you thought was gone.
 journal of the *risky* operations GitDesktop runs: local PR merges, cherry-picks, history
 edits, interactive rebases, and a rebase pull that drops commits. Each is recorded with the
 exact branch and commit it started from, and whether it finished, failed, is paused on
-conflicts, is still pending, or **ended outside the app** (a cherry-pick you continued or
-aborted in a terminal, which the journal only knows is over). If one of these operations is
+conflicts, is still pending, or **ended outside the app** (a cherry-pick or rebase pull you
+continued or aborted in a terminal, which the journal only knows is over). If one of these operations is
 interrupted (a crash or a restart mid-op), a calm recovery line
 appears above the **Changes** list naming what was interrupted and the state it started
 from. That notice only informs — it never resets or continues anything on its own (the

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -588,9 +588,9 @@ can safely preview and recover work you thought was gone.
 journal of the *risky* operations GitDesktop runs: local PR merges, cherry-picks, history
 edits, interactive rebases, and a rebase pull that drops commits. Each is recorded with the
 exact branch and commit it started from, and whether it finished, failed, is paused on
-conflicts, is still pending, or **ended outside the app** (a cherry-pick or rebase pull you
-continued or aborted in a terminal, which the journal only knows is over). If one of these operations is
-interrupted (a crash or a restart mid-op), a calm recovery line
+conflicts, is still pending, or **ended outside the app** (a cherry-pick or rebase pull
+you continued or aborted in a terminal, which the journal only knows is over). If one of
+these operations is interrupted (a crash or a restart mid-op), a calm recovery line
 appears above the **Changes** list naming what was interrupted and the state it started
 from. That notice only informs — it never resets or continues anything on its own (the
 git-native **Continue**/**Abort** for an in-progress merge, rebase, cherry-pick, or revert
@@ -1273,8 +1273,8 @@ or GitLab read that couldn't get through.
 A **local PR** is the same review workflow against any two branches with **no remote at
 all** — describe it in Markdown, comment, label, approve, close or reopen (posting your
 drafted comment alongside), and merge locally. Local PRs are private to you and never
-written into the repo. When you're ready, **promote** a local PR to a real GitHub PR or
-GitLab MR in one click, history preserved.
+written into the repo. When you're ready, **promote** a local PR to a real pull request
+on GitHub or Bitbucket, or a merge request on GitLab, in one click, history preserved.
 
 Its Conversation is the same **date-sorted activity feed** as the hosted PRs: it opens with
 a **created** marker, interleaves the branch's **pushed commits** (grouped, each short SHA

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -108,8 +108,8 @@ export function CreateLocalIssueDialog({
           <DialogHeader>
             <DialogTitle>New local issue</DialogTitle>
             <DialogDescription>
-              A private to-do for this repository, kept on your machine — no
-              GitHub involved. Publish it later if it's worth sharing.
+              A private to-do for this repository, kept on your machine. Publish
+              it later if it's worth sharing.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -303,8 +303,8 @@ export function CreateLocalPrDialog({
           <DialogHeader>
             <DialogTitle>New local pull request</DialogTitle>
             <DialogDescription>
-              Propose merging one branch into another and review it locally — no
-              GitHub involved. Merge it later with a{" "}
+              Propose merging one branch into another and review it locally —
+              nothing leaves your machine. Merge it later with a{" "}
               <span className="font-mono">--no-ff</span> commit.
             </DialogDescription>
           </DialogHeader>

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -303,9 +303,9 @@ export function CreateLocalPrDialog({
           <DialogHeader>
             <DialogTitle>New local pull request</DialogTitle>
             <DialogDescription>
-              Propose merging one branch into another and review it locally —
-              nothing leaves your machine. Merge it later with a{" "}
-              <span className="font-mono">--no-ff</span> commit.
+              Propose merging one branch into another and review it locally.
+              Merge it later with a <span className="font-mono">--no-ff</span>{" "}
+              commit.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -6,8 +6,6 @@ import {
   CheckCircleIcon,
   CheckIcon,
   DotsThreeIcon,
-  GithubLogoIcon,
-  GitlabLogoIcon,
   GitMergeIcon,
   InfoIcon,
   PencilSimpleIcon,
@@ -21,6 +19,7 @@ import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { usePanelPortalContainer } from "@/components/panel-portal";
+import { ProviderIcon } from "@/components/provider-icon";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -68,6 +67,7 @@ import {
   useRepoStatus,
   useUpdateBranchFrom,
 } from "@/lib/git/queries";
+import { providerLabel } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import type { PrSection } from "@/lib/pulls/pr-section";
@@ -205,6 +205,11 @@ export function LocalPrView({
   });
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
+  const provider = ghStatus.data?.provider;
+  // Promote copy names the detected forge. The label spans all three providers;
+  // the noun stays two-way because only GitLab calls it a merge request.
+  const promoteLabel = providerLabel(provider);
+  const promoteNoun = provider === "gitlab" ? "merge request" : "pull request";
   // Linked-issue chips on the local-PR edit path: the chips OWN the trailing ref
   // block (peeled at open, re-composed on save). A local PR's `Closes #N` lines
   // survive promotion verbatim into the real forge PR, so these become real
@@ -1067,15 +1072,15 @@ export function LocalPrView({
                 variant="outline"
                 size="sm"
                 onClick={() => setPromoteOpen(true)}
-                title={`Push the branch and open this ${ghStatus.data?.provider === "gitlab" ? "merge request on GitLab" : "PR on GitHub"}`}
+                title={`Push the branch and open this ${promoteNoun} on ${promoteLabel}`}
               >
-                {ghStatus.data?.provider === "gitlab" ? (
-                  <GitlabLogoIcon data-icon="inline-start" />
-                ) : (
-                  <GithubLogoIcon data-icon="inline-start" />
-                )}
-                Publish to{" "}
-                {ghStatus.data?.provider === "gitlab" ? "GitLab" : "GitHub"}
+                {/* ProviderIcon forwards no attributes, so the wrapper carries the
+                    `data-icon` the button's leading-icon padding keys off. An unset
+                    provider takes the same GitHub default providerLabel does. */}
+                <span data-icon="inline-start" className="flex">
+                  <ProviderIcon provider={provider ?? "github"} />
+                </span>
+                Publish to {promoteLabel}
               </Button>
             )}
             {/* The label swaps while a note rides along: the action changed

--- a/src/features/pulls/PromoteLocalPrDialog.tsx
+++ b/src/features/pulls/PromoteLocalPrDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { forgePrComment } from "@/lib/git/api";
 import { useCreatePr, useForgeStatus } from "@/lib/git/queries";
+import { providerLabel } from "@/lib/git/types";
 import type { LocalPr } from "@/lib/pulls/local";
 import { useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useSetRepoLens } from "@/lib/repo-lens/queries";
@@ -27,11 +28,12 @@ import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
 
 /**
- * Publishes a local PR to the repo's provider (GitHub or GitLab): pushes the head
- * branch, opens a real PR/MR with the same title/description, **re-posts its
- * comments** (so nothing is lost), then closes the local PR with a link to its
- * successor. Fires no automations — the local PR's creation was the pr-open
- * trigger point (see CreateLocalPrDialog), so promoting it would double-run them.
+ * Publishes a local PR to the repo's provider (GitHub, GitLab, or Bitbucket):
+ * pushes the head branch, opens a real PR/MR with the same title/description,
+ * **re-posts its comments** (so nothing is lost), then closes the local PR with
+ * a link to its successor. Fires no automations — the local PR's creation was
+ * the pr-open trigger point (see CreateLocalPrDialog), so promoting it would
+ * double-run them.
  */
 export function PromoteLocalPrDialog({
   repoPath,
@@ -50,7 +52,9 @@ export function PromoteLocalPrDialog({
   const setLens = useSetRepoLens(repoPath);
   const forge = useForgeStatus(repoPath);
   const isGitLab = forge.data?.provider === "gitlab";
-  const remoteLabel = isGitLab ? "GitLab" : "GitHub";
+  // The label names the detected forge (all three); the noun stays two-way
+  // because only GitLab calls it a merge request.
+  const remoteLabel = providerLabel(forge.data?.provider);
   const prNoun = isGitLab ? "merge request" : "pull request";
   const [draft, setDraft] = useState(false);
   const [posting, setPosting] = useState(false);

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -330,7 +330,7 @@ export function MergePrDialog({
   open: boolean;
   onClose: () => void;
   number: number;
-  /** "GitHub" / "GitLab" — where the merge happens. */
+  /** Provider name ("GitHub" / "GitLab" / "Bitbucket") — where the merge happens. */
   host: string;
   /** "pull request" / "merge request". */
   prNoun: string;

--- a/src/features/repository/OperationHistoryDialog.tsx
+++ b/src/features/repository/OperationHistoryDialog.tsx
@@ -59,8 +59,8 @@ const STATUS_META: Record<
     Icon: ProhibitIcon,
     tone: "text-muted-foreground",
   },
-  // A cherry-pick finished or abandoned in a terminal: over, but the journal never
-  // saw how it ended, so it reads as neither Done nor Failed.
+  // A paused op (cherry-pick or rebase pull) finished or abandoned in a terminal:
+  // over, but the journal never saw how it ended, so it reads as neither Done nor Failed.
   concluded: {
     label: "Ended outside the app",
     Icon: ArrowSquareOutIcon,

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -214,9 +214,9 @@ const PUSH_PROTECTION_MARKERS = [
   /^[ \t]*remote:[ \t]*-[ \t]*Push cannot contain secrets\b/m,
 ];
 
-/** GitHub refuses the push whole, so the secret is still only local and the
- *  cheap remedy — rewriting the commit — is still open. Saying that is the
- *  point: a user who reads this as a transient failure retries past it. */
+/** GitHub refuses the ref update, so the commits never land and the cheap
+ *  remedy — rewriting them — is still open. Saying that is the point: a user
+ *  who reads this as a transient failure retries past it. */
 const PUSH_PROTECTION_SUMMARY =
   "GitHub blocked this push because it detected a likely secret, so the commits were not added to the repository. Remove the secret from the commits and push again, or if it is a false positive, open the unblock link GitHub printed in the details.";
 

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -202,20 +202,13 @@ function longPathSummary(text: string): string | null {
   return LONG_PATH_MARKERS.some((m) => m.test(text)) ? LONG_PATH_SUMMARY : null;
 }
 
-/** GitHub's secret push protection refusing a push. Measured verbatim from a
- *  real rejection (github.com over HTTPS, 2026-08-11): the block arrives as
- *  `remote:`-prefixed lines carrying a `- GITHUB PUSH PROTECTION` section whose
- *  violation bullet reads `- Push cannot contain secrets`.
- *
- *  The `GH013` code that heads the same block is deliberately NOT a marker: it
- *  covers every repository rule violation, so a branch-name or signature rule
- *  would borrow advice about secrets. The secret-type banner, the file locations
- *  and the unblock URL all vary per detection and stay in Details.
- *
- *  Anchored at line start only — GitHub pads every `remote:` line with trailing
- *  spaces, which an end-anchored marker would miss. Paired with the Rust canary
- *  `push_protection_stderr_still_matches_the_frontend_markers` (git/remote.rs),
- *  which pins these line shapes against the measured stderr. */
+/** GitHub's secret push protection refusing a push (block measured verbatim,
+ *  2026-08-11). The `GH013` code heading the block is deliberately NOT a marker:
+ *  it covers every repository rule violation, so a branch-name rule would borrow
+ *  advice about secrets. Start-anchored only — GitHub pads every `remote:` line
+ *  with trailing spaces. The Rust canary
+ *  `push_protection_stderr_still_matches_the_frontend_markers` (git/remote.rs)
+ *  pins these shapes against the measured stderr. */
 const PUSH_PROTECTION_MARKERS = [
   /^[ \t]*remote:[ \t]*-[ \t]*GITHUB PUSH PROTECTION\b/m,
   /^[ \t]*remote:[ \t]*-[ \t]*Push cannot contain secrets\b/m,
@@ -225,7 +218,7 @@ const PUSH_PROTECTION_MARKERS = [
  *  cheap remedy — rewriting the commit — is still open. Saying that is the
  *  point: a user who reads this as a transient failure retries past it. */
 const PUSH_PROTECTION_SUMMARY =
-  "GitHub blocked this push because it detected a likely secret, so nothing was pushed. Remove the secret from the commits and push again, or if it is a false positive, open the unblock link GitHub printed in the details.";
+  "GitHub blocked this push because it detected a likely secret, so the commits were not added to the repository. Remove the secret from the commits and push again, or if it is a false positive, open the unblock link GitHub printed in the details.";
 
 /** The humanized line for a push blocked by secret push protection, or null when
  *  the text carries no such block. */

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -202,6 +202,39 @@ function longPathSummary(text: string): string | null {
   return LONG_PATH_MARKERS.some((m) => m.test(text)) ? LONG_PATH_SUMMARY : null;
 }
 
+/** GitHub's secret push protection refusing a push. Measured verbatim from a
+ *  real rejection (github.com over HTTPS, 2026-08-11): the block arrives as
+ *  `remote:`-prefixed lines carrying a `- GITHUB PUSH PROTECTION` section whose
+ *  violation bullet reads `- Push cannot contain secrets`.
+ *
+ *  The `GH013` code that heads the same block is deliberately NOT a marker: it
+ *  covers every repository rule violation, so a branch-name or signature rule
+ *  would borrow advice about secrets. The secret-type banner, the file locations
+ *  and the unblock URL all vary per detection and stay in Details.
+ *
+ *  Anchored at line start only — GitHub pads every `remote:` line with trailing
+ *  spaces, which an end-anchored marker would miss. Paired with the Rust canary
+ *  `push_protection_stderr_still_matches_the_frontend_markers` (git/remote.rs),
+ *  which pins these line shapes against the measured stderr. */
+const PUSH_PROTECTION_MARKERS = [
+  /^[ \t]*remote:[ \t]*-[ \t]*GITHUB PUSH PROTECTION\b/m,
+  /^[ \t]*remote:[ \t]*-[ \t]*Push cannot contain secrets\b/m,
+];
+
+/** GitHub refuses the push whole, so the secret is still only local and the
+ *  cheap remedy — rewriting the commit — is still open. Saying that is the
+ *  point: a user who reads this as a transient failure retries past it. */
+const PUSH_PROTECTION_SUMMARY =
+  "GitHub blocked this push because it detected a likely secret, so nothing was pushed. Remove the secret from the commits and push again, or if it is a false positive, open the unblock link GitHub printed in the details.";
+
+/** The humanized line for a push blocked by secret push protection, or null when
+ *  the text carries no such block. */
+function pushProtectionSummary(text: string): string | null {
+  return PUSH_PROTECTION_MARKERS.some((m) => m.test(text))
+    ? PUSH_PROTECTION_SUMMARY
+    : null;
+}
+
 /** The `git` kind is the only one carrying a stderr blob distinct from its
  *  message; every other kind folds its detail into `message` itself. */
 function gitStderr(e: AppError): string {
@@ -425,8 +458,11 @@ export function presentError(e: unknown): ErrorPresentation {
     // A rejection reason is read from the COMBINED text: it rides the `stderr`
     // blob, which the fall-through below deliberately never reads.
     // A path-length failure outranks conflict framing: git could not write the
-    // tree, so no conflict flow is actually waiting to be resolved.
+    // tree, so no conflict flow is actually waiting to be resolved. Push
+    // protection outranks both: the remote refused the push whole, which is
+    // neither a conflict nor the non-fast-forward story below.
     const summary =
+      pushProtectionSummary(combined) ??
       longPathSummary(combined) ??
       (isConflict
         ? conflictSummary(combined)

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -496,9 +496,9 @@ export interface OpLogEntry {
     | "pull_rebase_drop";
   /** Human label, e.g. "Squash-merge feature → main". */
   label: string;
-  /** "paused" = handed to you mid-op (a stopped cherry-pick), neither in-flight nor
-   *  finished. "concluded" = that pick ended outside the app, so the journal knows
-   *  only that it is over (no finish time). */
+  /** "paused" = handed to you mid-op (a stopped cherry-pick or a conflicted rebase
+   *  pull), neither in-flight nor finished. "concluded" = that op ended outside the
+   *  app, so the journal knows only that it is over (no finish time). */
   status: "pending" | "done" | "failed" | "dismissed" | "paused" | "concluded";
   /** ISO timestamp the op started. */
   startedAt: string;


### PR DESCRIPTION
A batch of independent fixes across the diff viewer, local-PR promotion, the guarded pull, the oplog, and the Actions dispatch probe. The common thread is behavior that was quietly wrong or jarring in practice: a diff that jumped under the cursor on selection, forge copy hardcoded to GitHub, a rebase pull whose paused record could never be closed correctly, and a workflow picker that re-probed the network on every open.

### Diff viewer

- Moves the selection UI into the existing file toolbar in `src/features/diff/DiffViewer.tsx`: the line count and **Stage** / **Unstage** / **Discard** buttons now render in the header row, which tints with `bg-primary/10` while a selection is live. Previously the actions mounted in a row *below* the toolbar, pushing the whole diff down on mouseup and moving the lines the user had just dragged across.
- Keeps the tint from being a colour-only cue: `selectionCountText` states the selection in words, is used for both the visible (truncatable) label and its `title`, and the selection arm drops `shrink-0` so a narrow pane takes width from the count rather than clipping the actions.
- Adds `min-h-7` to the toolbar action clusters in both `DiffViewer.tsx` and `src/features/diff/DiffSurface.tsx` so an extensionless file — where `DiffLanguagePicker` renders nothing and only the `h-6` mode toggle remains — no longer shrinks the row by 4px.
- Adds MDX highlighting: `mdx` mapped in `src/features/diff/diff-lang.ts`, labelled in `src/features/diff/syntax.ts`, and registered in `src/features/diff/shiki-highlighter.ts` as a composed loader — MDX's bundle ships no embeds, so `tsx`, `typescript`, `javascript`, `markdown` and `sql` are pulled alongside it (mdx last, so its own grammar wins the name collision).
- Extends `src/features/diff/shiki-theme.ts` with prose-markup scopes (`markup.heading`, `markup.bold`, `markup.italic`, `markup.quote`, `markup.inline.raw`); `markup.code` is deliberately left unmapped so a fenced block doesn't tint the embedded language's plain text.

### Forge-aware local PR copy

- `src/features/pulls/LocalPrView.tsx` now names the repo's own provider: the publish button, its `title`, and the icon derive from `useForgeStatus` via `providerLabel` and `ProviderIcon`, replacing the hardcoded GitHub/GitLab two-way branch and its `GithubLogoIcon`/`GitlabLogoIcon` imports.
- `src/features/pulls/PromoteLocalPrDialog.tsx` takes the same `providerLabel` treatment for `remoteLabel`, keeping the noun ("merge request") two-way since only GitLab uses it; its doc comment now covers Bitbucket.
- Drops the "no GitHub involved" phrasing from `src/features/issues/CreateLocalIssueDialog.tsx` and `src/features/pulls/CreateLocalPrDialog.tsx`, which was wrong on repositories hosted elsewhere.
- Clarifies the `host` prop doc in `src/features/pulls/RemotePrViewParts.tsx`.

### Push protection errors

- Adds `pushProtectionSummary` and `PUSH_PROTECTION_MARKERS` to `src/lib/error-summary.ts`, turning a GH013 secret-push-protection rejection into one human line that says nothing was pushed and points at the unblock link. It outranks both the long-path and conflict/non-fast-forward summaries in `presentError`, since the remote refused the push whole. `GH013` is deliberately not a marker — it heads every repository rule violation.
- Pins that contract from the Rust side in `src-tauri/src/git/remote.rs`: a measured `PUSH_PROTECTION_STDERR` fixture, a `NON_FAST_FORWARD_STDERR` negative control, and `push_protection_stderr_still_matches_the_frontend_markers`, which asserts the two bullets match the block and *not* a plain rejection.

### Guarded pull and oplog

- `src-tauri/src/git/pull_guard.rs` restores the submodule worktree update a rebase-mode `git pull` performs but a plain `git rebase` cannot: `submodule_recurse` reads the config through git's own `--bool` resolution, and `update_submodules_after_rebase` runs `git submodule update --recursive --rebase` only after a rebase that landed. `fold_submodule_failure` appends a failed step to a `ReapplyConflicted` outcome rather than replacing it, so a retained stash and unmerged paths are still reported.
- `src-tauri/src/oplog.rs` generalizes the paused-record machinery from cherry-picks to any pausable op: `PAUSABLE_OPS`, `newest_paused_op`, `is_paused_op`, and a `LiveOps` struct whose per-op closures re-probe under the lock, so a live rebase can never retire a paused pick's record (or vice versa).
- `src-tauri/src/git/ops.rs` factors the `.git`/`gitdir:` resolution into `marker_dir` and adds `rebase_marker_present` alongside `cherry_pick_marker_present`; `op_abort`/`op_continue` now dispatch per op so a rebase closes `pull_rebase_drop` and a cherry-pick closes `cherry_pick_onto`.
- Updates the user-visible wording for the new state in `src/lib/git/types.ts`, `src/features/repository/OperationHistoryDialog.tsx`, and the Operation-history section of `src/features/help/content.ts`.

### Actions dispatch probe

- Adds a process-lifetime cache to `src-tauri/src/github/actions.rs` keyed by `(slug, workflow_path, git_ref)`, with an asymmetric `ProbeTtl` (600s for a `true` verdict, 300s for `false` — a stale `false` hides an action, a stale `true` only earns a humanized 422). `plan_probes` resolves hits before the fan-out, so a cached verdict takes no `DISPATCH_PROBE_GATE` permit and spawns no `gh` process; the workflow list itself is still always re-read, and errored fetches stay uncached so they fail open.

### Changelog

- Four fragments under `changelog.d/`: `changed-diff-selection-toolbar.md`, `changed-mdx-diff-highlighting.md`, `fixed-bitbucket-promote-label.md`, and `fixed-push-protection-rejection.md`.

Relates to #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diff selections remain visible with counts and Stage, Unstage, Discard, and Clear actions in the file toolbar.
  * Added MDX syntax highlighting, including embedded TypeScript, JavaScript, TSX, SQL, and Markdown content.
  * Improved guarded rebase pulls with submodule support and resumable operations.

* **Bug Fixes**
  * Corrected provider names and icons for Bitbucket publishing.
  * Improved messaging when secret push protection blocks a push, clarifying that commits are not added.

* **Documentation**
  * Updated operation history and local pull request guidance for supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->