### PR TITLE
feat(repository,commit,diff): support narrow and split-screen windows, add pop-out commit dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,11 +931,11 @@ review via its subscription login. The full list is under
   the version it wants, with an Update link. It also shows a live readout
   of the window's current position, size, and display (with copy-coords).
 - **Narrow windows and split-screen**: the window goes down to 640px wide,
-  so GitDesktop can sit beside your editor in a tiled layout. The sidebar
-  narrows with the window and collapses to an icon rail
-  (`Ctrl`/`⌘`+`Shift`+`B`), the file list beside a diff collapses on demand
-  or when its pane is tight, and the commit box pops out into a roomier
-  dialog reachable from any tab.
+  so GitDesktop can sit beside your editor in a tiled layout. The
+  sidebar narrows with the window and collapses to an icon rail
+  (`Ctrl`/`⌘`+`Shift`+`B`), the file list beside a diff collapses on
+  demand or when its pane is tight, and the commit box pops out into a
+  roomier dialog reachable from any tab.
 - **Window memory**: GitDesktop reopens at the size and position you left
   it, and maximized if it was, validated against your current monitors so
   an unplugged display can't strand it off-screen. Your layout is saved as

--- a/README.md
+++ b/README.md
@@ -930,6 +930,12 @@ review via its subscription login. The full list is under
   needs it (git, or the GitHub CLI) gets a warning naming the feature and
   the version it wants, with an Update link. It also shows a live readout
   of the window's current position, size, and display (with copy-coords).
+- **Narrow windows and split-screen**: the window goes down to 640px wide,
+  so GitDesktop can sit beside your editor in a tiled layout. The sidebar
+  narrows with the window and collapses to an icon rail
+  (`Ctrl`/`⌘`+`Shift`+`B`), the file list beside a diff collapses on demand
+  or when its pane is tight, and the commit box pops out into a roomier
+  dialog reachable from any tab.
 - **Window memory**: GitDesktop reopens at the size and position you left
   it, and maximized if it was, validated against your current monitors so
   an unplugged display can't strand it off-screen. Your layout is saved as

--- a/changelog.d/added-commit-dialog.md
+++ b/changelog.d/added-commit-dialog.md
@@ -1,0 +1,3 @@
+- Pop out the commit box into a dialog — a roomier editor with your staged files
+  listed alongside, reachable from the commit box or the command palette from any
+  tab, even with the sidebar collapsed.

--- a/changelog.d/changed-responsive-narrow-windows.md
+++ b/changelog.d/changed-responsive-narrow-windows.md
@@ -1,0 +1,5 @@
+- GitDesktop now fits narrow and split-screen layouts: the sidebar narrows as the
+  window does, the file list and diff toolbar collapse when space is tight, and
+  the minimum window width dropped from 960px to 640px — half of a 1080p display
+  at any scaling. The sidebar and diff file list can also be collapsed on demand
+  from the command palette or a keyboard shortcut.

--- a/changelog.d/changed-responsive-narrow-windows.md
+++ b/changelog.d/changed-responsive-narrow-windows.md
@@ -1,5 +1,6 @@
-- GitDesktop now fits narrow and split-screen layouts: the sidebar narrows as the
-  window does, the file list and diff toolbar collapse when space is tight, and
-  the minimum window width dropped from 960px to 640px — half of a 1080p display
-  at any scaling. The sidebar and diff file list can also be collapsed on demand
-  from the command palette or a keyboard shortcut.
+- GitDesktop now fits narrow and split-screen layouts: the sidebar narrows as
+  the window does, the file list collapses and the diff toolbar slims down when
+  space is tight, and the minimum window width dropped from 960px to 640px, so
+  it fits half of a 1080p display even at 150% scaling. The sidebar and diff
+  file list can also be collapsed on demand from the command palette or a
+  keyboard shortcut.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -65,6 +65,11 @@ export const capabilities: Capability[] = [
     group: "Diffs & staging",
     label: "Commit with co-authors suggested from history; amend, undo, revert",
   },
+  {
+    group: "Diffs & staging",
+    label:
+      "Pop the commit box out into a dialog — a roomier editor with your staged files alongside",
+  },
   { group: "Diffs & staging", label: "Recoverable, recycle-bin discards" },
 
   // — Branches & history —
@@ -426,6 +431,11 @@ export const capabilities: Capability[] = [
   {
     group: "Repository & workspace",
     label: "Remembers window size & position",
+  },
+  {
+    group: "Repository & workspace",
+    label:
+      "Narrow windows & split-screen layouts — down to 640px, with a collapsible sidebar and diff file list",
   },
   {
     group: "Repository & workspace",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "title": "GitDesktop",
         "width": 1280,
         "height": 800,
-        "minWidth": 960,
+        "minWidth": 640,
         "minHeight": 600
       }
     ],

--- a/src/components/detail-rail.tsx
+++ b/src/components/detail-rail.tsx
@@ -80,6 +80,9 @@ export function DetailRail({
   const refocus = useRef<boolean | null>(null);
 
   const narrow = rowWidth !== null && rowWidth < RAIL_MIN_CONTAINER_PX;
+  // Guarded state-during-render reset — React sanctions this over an effect,
+  // which would paint one stale strip frame after the row regains room; same
+  // idiom as ui/dialog.tsx and confirm-dialog-host.tsx.
   if (!narrow && transientExpand) setTransientExpand(false);
   const expanded = narrow
     ? transientExpand

--- a/src/components/detail-rail.tsx
+++ b/src/components/detail-rail.tsx
@@ -1,0 +1,187 @@
+import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  type AriaRole,
+  createContext,
+  type ReactNode,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { usePanelActive } from "@/components/panel-portal";
+import { Button } from "@/components/ui/button";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import {
+  settingsKeys,
+  useSaveSettings,
+  useSettings,
+} from "@/lib/settings/queries";
+import { useContainerWidth } from "@/lib/use-container-width";
+import { cn } from "@/lib/utils";
+
+// Below this the surrounding pane can't hold the 288px rail plus a diff wide
+// enough to read, so the rail is forced to its strip whatever the preference.
+const RAIL_MIN_CONTAINER_PX = 512;
+
+// Names the landmark when the caller's own label belongs to a list role nested
+// inside it — one name per element, or landmark navigation announces it twice.
+const LANDMARK_LABEL = "File list";
+
+// Width of the row the rail sits in; `null` until measured, and outside a
+// DetailRailRow. Unknown reads as "wide" so the rail never flashes collapsed.
+const RailWidthContext = createContext<number | null>(null);
+
+/**
+ * The rail + detail row. Measures itself so `DetailRail` can decide whether the
+ * pane has room for the file list — the measurement has to live on the row, not
+ * the rail, since the rail's own width is the thing being decided.
+ */
+export function DetailRailRow({ children }: { children: ReactNode }) {
+  const [measureRef, width] = useContainerWidth<HTMLDivElement>();
+  return (
+    <div ref={measureRef} className="flex min-h-0 flex-1">
+      <RailWidthContext value={width}>{children}</RailWidthContext>
+    </div>
+  );
+}
+
+/**
+ * The collapsible file-list rail shared by the diff detail views. Two state
+ * layers: the persisted `diffFileListCollapsed` preference governs while the
+ * row has room, and a narrow row forces the strip — an explicit expand there is
+ * local, never written back, and drops when the row regains room.
+ */
+export function DetailRail({
+  ariaLabel,
+  className,
+  role,
+  children,
+}: {
+  ariaLabel: string;
+  className?: string;
+  role?: AriaRole;
+  children: ReactNode;
+}) {
+  const rowWidth = useContext(RailWidthContext);
+  const settings = useSettings();
+  const saveSettings = useSaveSettings();
+  const queryClient = useQueryClient();
+  const panelActive = usePanelActive();
+  const [transientExpand, setTransientExpand] = useState(false);
+  const railRef = useRef<HTMLElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  // The expanded-ness a focus-carrying toggle asked for, or null when nothing is
+  // pending: each branch renders a different button node, so without the move
+  // focus drops to <body>. Single-shot — armed only on a committed flip, cleared
+  // the moment it fires, and cleared again if the write is refused. An arm that
+  // outlived its own flip would fire on the next width crossing instead, pulling
+  // focus into a rail the user never touched.
+  const refocus = useRef<boolean | null>(null);
+
+  const narrow = rowWidth !== null && rowWidth < RAIL_MIN_CONTAINER_PX;
+  if (!narrow && transientExpand) setTransientExpand(false);
+  const expanded = narrow
+    ? transientExpand
+    : !settings.data?.diffFileListCollapsed;
+
+  const toggle = () => {
+    const held = Boolean(railRef.current?.contains(document.activeElement));
+    refocus.current = null;
+    if (narrow) {
+      refocus.current = held ? !transientExpand : null;
+      setTransientExpand((prev) => !prev);
+      return;
+    }
+    const current = settings.data;
+    if (!current) return;
+    const updated = {
+      ...current,
+      diffFileListCollapsed: !current.diffFileListCollapsed,
+    };
+    refocus.current = held ? current.diffFileListCollapsed : null;
+    // Patch the cache before persisting: the rail has to flip in this commit so
+    // the focus move lands on the button that replaced the one focus was on, and
+    // so a second press reads the new value instead of re-issuing the old flip.
+    queryClient.setQueryData(settingsKeys.settings, updated);
+    saveSettings.mutate(updated, {
+      onError: () => {
+        refocus.current = null;
+        queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
+      },
+    });
+  };
+  // Only the visible tab's rail answers the action: <Activity> keeps hidden
+  // panels mounted, and its effect teardown is deferred.
+  useHotkeyAction("toggle-diff-file-list", toggle, panelActive);
+
+  // Rides the commit that actually renders the new branch — a frame scheduled
+  // from the handler could still beat react-query's notify-batched re-render.
+  useLayoutEffect(() => {
+    if (refocus.current !== expanded) return;
+    refocus.current = null;
+    toggleRef.current?.focus();
+  }, [expanded]);
+
+  if (!expanded) {
+    return (
+      <aside
+        ref={railRef}
+        aria-label={role ? LANDMARK_LABEL : ariaLabel}
+        className={cn(
+          "flex w-7 shrink-0 flex-col items-center border-r",
+          className,
+        )}
+      >
+        {/* Same h-7 box as the expanded header strip, so the button doesn't
+            shift vertically as the rail toggles. */}
+        <div className="flex h-7 shrink-0 items-center">
+          <Button
+            ref={toggleRef}
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-expanded="false"
+            aria-label="Expand file list"
+            title="Expand file list"
+            onClick={toggle}
+          >
+            <CaretRightIcon />
+          </Button>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      ref={railRef}
+      aria-label={role ? LANDMARK_LABEL : ariaLabel}
+      className={cn("flex w-72 shrink-0 flex-col border-r", className)}
+    >
+      <div className="flex h-7 shrink-0 items-center justify-end border-b px-0.5">
+        <Button
+          ref={toggleRef}
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-expanded="true"
+          aria-label="Collapse file list"
+          title="Collapse file list"
+          onClick={toggle}
+        >
+          <CaretLeftIcon />
+        </Button>
+      </div>
+      {/* The caller's role (e.g. listbox) belongs on the list itself — the
+          toggle above is not one of its options. */}
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        role={role}
+        aria-label={role ? ariaLabel : undefined}
+      >
+        {children}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -67,6 +67,32 @@ delegating to `DropdownMenuPortal`, so regenerating it into a direct
 `Menu.Portal` call would break it silently. `drawer.tsx` is vaul and has no
 container prop, so its popups are not panel-scoped.
 
+## Narrow-window width deltas
+
+A second, unrelated pair of sanctioned deltas keeps popups and scroll
+regions usable when the window is narrow. They share no code with the
+panel-portal contract above, so they are lost and restored separately.
+
+- **`scroll-area.tsx`** — `ScrollArea` renders a horizontal `ScrollBar`
+  alongside the vertical one. Base UI's viewport is `overflow: scroll` with
+  the native scrollbars suppressed, so without it horizontal overflow is
+  scrollable but shows no affordance anywhere in the app.
+- **`popover.tsx`** — `PopoverContent`'s class list caps the popup at
+  `max-w-(--available-width)`, the viewport-space variable Base UI's
+  positioner publishes. Uncapped, a popup wider than the space beside its
+  trigger hangs off-screen: the positioner is `position: fixed` and floating
+  UI's shift pins the near edge, leaving the overflow unreachable.
+
+Grep each file after regenerating it:
+
+```sh
+grep -n 'orientation="horizontal"' src/components/ui/scroll-area.tsx
+grep -n 'available-width' src/components/ui/popover.tsx
+```
+
+No match means that file's width delta is gone. `popover.tsx` carries the
+panel-portal delta too, so check both of its markers.
+
 ## Check before re-applying
 
 If one of these has to be re-created, confirm it is still needed. Verify

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -37,7 +37,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-none bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 flex w-72 max-w-(--available-width) origin-(--transform-origin) flex-col gap-2.5 rounded-none bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className,
           )}
           {...props}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -20,6 +20,9 @@ function ScrollArea({
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
+      {/* Base UI's viewport is `overflow: scroll` with native bars suppressed, so
+          without this one horizontal overflow scrolls with no visible affordance. */}
+      <ScrollBar orientation="horizontal" />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   );

--- a/src/features/commit/CommitBox.tsx
+++ b/src/features/commit/CommitBox.tsx
@@ -1,143 +1,65 @@
-import { InfoIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
+import {
+  ArrowsOutSimpleIcon,
+  InfoIcon,
+  SparkleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { AnimatePresence, m } from "motion/react";
-import { useEffect } from "react";
-import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { track } from "@/lib/analytics";
-import { triggerAutomations } from "@/lib/automations/runner";
-import { requiresPullRequest } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
-import { coAuthorTrailers } from "@/lib/git/co-authors";
-import { useCommit, useRepoStatus } from "@/lib/git/queries";
 import { formatBinding } from "@/lib/hotkeys/binding";
-import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { ACTIONS } from "@/lib/hotkeys/registry";
 import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
 import { quickTransition } from "@/lib/motion";
-import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
-import { commitDraftKey, useUiStore } from "@/lib/stores/ui";
-import { toastError } from "@/lib/toast";
+import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import { CoAuthorPicker } from "./CoAuthorPicker";
-import { useGenerateCommitMessage } from "./useGenerateCommitMessage";
+import { useCommitSubmit } from "./useCommitSubmit";
+
+// The registry entry owns this action's wording; deriving it keeps the trigger's
+// accessible name identical to the palette row that opens the same dialog.
+const POP_OUT_LABEL =
+  ACTIONS.find((a) => a.id === "open-commit-dialog")?.label ??
+  "Open commit dialog";
 
 export function CommitBox({ repoPath }: { repoPath: string }) {
-  const status = useRepoStatus(repoPath);
-  const commit = useCommit(repoPath);
-  const title = useUiStore((s) => s.commitTitle);
-  const body = useUiStore((s) => s.commitBody);
-  const amendingHash = useUiStore((s) => s.amendingHash);
-  const coAuthors = useUiStore((s) => s.commitCoAuthors);
-  const setCommitTitle = useUiStore((s) => s.setCommitTitle);
-  const setCommitBody = useUiStore((s) => s.setCommitBody);
-  const setCoAuthors = useUiStore((s) => s.setCommitCoAuthors);
-  const clearCommitDraft = useUiStore((s) => s.clearCommitDraft);
-  const restoreCommitDraft = useUiStore((s) => s.restoreCommitDraft);
-  const activeDraftKey = useUiStore((s) => s.activeDraftKey);
-  const loadCommitDraft = useUiStore((s) => s.loadCommitDraft);
-  const commitAiGenerated = useUiStore((s) => s.commitAiGenerated);
-  const { generate, cancel, generating } = useGenerateCommitMessage(repoPath);
-  const aiEnabled = useAiEnabled();
-  const aiConfigured = useAiConfigured();
-  const openSettings = useUiStore((s) => s.openSettings);
-  const rulesConfig = useEffectiveBranchRules(repoPath);
-
-  const amending = amendingHash !== null;
-  const branchName = status.data?.branch?.name ?? null;
-
-  // Point the commit box at this repo+branch's saved draft. Drafts are kept
-  // per repo+branch, so switching repos/branches preserves each in-progress
-  // message instead of clearing it.
-  useEffect(() => {
-    if (branchName) loadCommitDraft(commitDraftKey(repoPath, branchName));
-  }, [repoPath, branchName, loadCommitDraft]);
-  // A "require pull request" rule locks the branch against direct commits.
-  const locked = branchName
-    ? requiresPullRequest(rulesConfig, branchName)
-    : false;
-  const stagedCount =
-    status.data?.entries.filter((e) => e.staged !== null).length ?? 0;
-  // amending without staged changes is valid (message-only edit)
-  const canCommit =
-    title.trim().length > 0 &&
-    (stagedCount > 0 || amending) &&
-    !commit.isPending &&
-    !locked;
-
-  // The commit hotkey (Ctrl+Enter by default) fires through the global
-  // dispatcher even from the title/body fields — modifier combos are
-  // allowed in text fields — so rebinding it in Settings works everywhere.
-  useHotkeyAction("commit", doCommit, canCommit && !generating);
-  useHotkeyAction(
-    "generate-commit-message",
+  const {
+    title,
+    body,
+    coAuthors,
+    setCommitTitle,
+    setCommitBody,
+    setCoAuthors,
+    clearCommitDraft,
+    amending,
+    amendingHash,
+    branchName,
+    locked,
+    stagedCount,
+    canCommit,
+    commitDisabledReason,
+    commitLabel,
+    committing,
+    aiEnabled,
+    aiConfigured,
     generate,
-    aiEnabled && aiConfigured && stagedCount > 0 && !generating,
-  );
+    cancel,
+    generating,
+    doCommit,
+  } = useCommitSubmit(repoPath);
+  const openSettings = useUiStore((s) => s.openSettings);
+  const openCommitDialog = useUiStore((s) => s.openCommitDialog);
   // Both button hints read the effective bindings rather than the defaults, so
   // a Settings → Keyboard rebind shows up here; null = the user unbound it and
   // there is no shortcut to name.
-  const commitBinding = useEffectiveBindings().get("commit") ?? null;
+  const bindings = useEffectiveBindings();
+  const commitBinding = bindings.get("commit") ?? null;
+  const popOutBinding = bindings.get("open-commit-dialog") ?? null;
   const generateHint = useGenerateChordHint();
-
-  function doCommit() {
-    const commitTitle = title.trim();
-    // Trailers must be the final paragraph of the message.
-    const fullBody = [body.trim(), coAuthorTrailers(coAuthors)]
-      .filter(Boolean)
-      .join("\n\n");
-    // Snapshot everything the in-flight commit (and its analytics) needs, since
-    // we clear the draft *before* the async commit resolves. `draftKey` is
-    // captured too so an error restores to this branch's draft even if the user
-    // switched branches while the commit was in flight.
-    const snapshot = { title, body, coAuthors, aiGenerated: commitAiGenerated };
-    const draftKey = activeDraftKey;
-    const wasAmending = amendingHash !== null;
-    const fileCount = stagedCount;
-    // Clear optimistically so the fields empty the instant you commit (GitHub
-    // Desktop feel) instead of snapping empty once the commit resolves. Also
-    // flips canCommit false, which blocks an accidental double-submit.
-    clearCommitDraft();
-    commit.mutate(
-      { title: commitTitle, body: fullBody || undefined, amend: wasAmending },
-      {
-        onSuccess: (result) => {
-          if (!wasAmending) {
-            track({
-              name: "commit_created",
-              properties: {
-                file_count: fileCount,
-                has_ai_message: snapshot.aiGenerated,
-                has_co_authors: snapshot.coAuthors.length > 0,
-              },
-            });
-          }
-          toast.success(
-            `${wasAmending ? "Amended" : "Committed"} ${result.hash.slice(0, 7)}`,
-          );
-          // Amending rewrites an existing commit; only new commits fire
-          // on-commit automations.
-          if (!wasAmending) {
-            triggerAutomations({
-              kind: "commit",
-              repoPath,
-              hash: result.hash,
-              title: commitTitle,
-              branch: branchName ?? "",
-            });
-          }
-        },
-        onError: (e) => {
-          // The commit failed — put the message back so it isn't lost (restores
-          // amending mode too).
-          restoreCommitDraft({ ...snapshot, amendingHash }, draftKey);
-          toastError(e);
-        },
-      },
-    );
-  }
 
   return (
     <div className="space-y-2 border-t p-3">
@@ -199,12 +121,31 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
         // swallow the changes list; resize-y lets the user drag it back down
         className="ph-no-capture max-h-48 min-h-16 resize-y"
       />
-      <CoAuthorPicker
-        repoPath={repoPath}
-        value={coAuthors}
-        onChange={setCoAuthors}
-        disabled={generating}
-      />
+      {/* The co-authors row carries the pop-out trigger: it is the one row here
+          with slack, and the picker wraps its chips rather than filling it. */}
+      <div className="flex items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <CoAuthorPicker
+            repoPath={repoPath}
+            value={coAuthors}
+            onChange={setCoAuthors}
+            disabled={generating}
+          />
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={POP_OUT_LABEL}
+          title={
+            popOutBinding
+              ? `${POP_OUT_LABEL} (${formatBinding(popOutBinding)})`
+              : `${POP_OUT_LABEL} (also in the command palette)`
+          }
+          onClick={openCommitDialog}
+        >
+          <ArrowsOutSimpleIcon />
+        </Button>
+      </div>
       <div className="flex gap-2">
         {aiEnabled && (
           <AnimatePresence mode="wait" initial={false}>
@@ -269,26 +210,12 @@ export function CommitBox({ repoPath }: { repoPath: string }) {
           wrapperClassName="min-w-0 flex-1"
           className="min-w-0 flex-1"
           disabled={!canCommit || generating}
-          reason={
-            locked
-              ? "This branch requires changes via a pull request"
-              : title.trim().length === 0
-                ? "Enter a commit title first"
-                : stagedCount === 0 && !amending
-                  ? "Stage changes to commit"
-                  : null
-          }
+          reason={commitDisabledReason}
           title={commitBinding ? formatBinding(commitBinding) : undefined}
           onClick={doCommit}
         >
-          {commit.isPending && <Spinner data-icon="inline-start" />}
-          <span className="truncate">
-            {amending
-              ? "Amend last commit"
-              : `Commit${stagedCount > 0 ? ` (${stagedCount})` : ""}${
-                  branchName ? ` to ${branchName}` : ""
-                }`}
-          </span>
+          {committing && <Spinner data-icon="inline-start" />}
+          <span className="truncate">{commitLabel}</span>
         </DisabledReasonButton>
       </div>
     </div>

--- a/src/features/commit/CommitDialog.tsx
+++ b/src/features/commit/CommitDialog.tsx
@@ -1,0 +1,338 @@
+import { InfoIcon, SparkleIcon } from "@phosphor-icons/react";
+import { DiffStat } from "@/components/diff-stat";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { clipTitle } from "@/lib/clip-title";
+import { useWorkingLineStats } from "@/lib/git/queries";
+import type { ChangeKind, FileEntry } from "@/lib/git/types";
+import { formatBinding } from "@/lib/hotkeys/binding";
+import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
+import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
+import { useUiStore } from "@/lib/stores/ui";
+import { cn } from "@/lib/utils";
+import { CoAuthorPicker } from "./CoAuthorPicker";
+import { useCommitSubmit } from "./useCommitSubmit";
+
+// The Changes panel's status letters and tokens, for the read-only staged
+// summary: the same file in both surfaces must read the same letter and colour.
+const KIND_BADGE: Record<
+  ChangeKind,
+  { letter: string; label: string; className: string }
+> = {
+  added: { letter: "A", label: "Added", className: "text-success" },
+  untracked: { letter: "U", label: "Untracked", className: "text-success" },
+  modified: { letter: "M", label: "Modified", className: "text-warning" },
+  typechange: { letter: "T", label: "Type changed", className: "text-warning" },
+  deleted: { letter: "D", label: "Deleted", className: "text-destructive" },
+  renamed: { letter: "R", label: "Renamed", className: "text-info" },
+  copied: { letter: "C", label: "Copied", className: "text-info" },
+  conflicted: {
+    letter: "!",
+    label: "Conflicted",
+    className: "text-destructive",
+  },
+};
+
+/**
+ * The pop-out commit composer. Rendered exactly ONCE, hoisted in RepositoryView:
+ * it is the commit path that survives a collapsed sidebar, where the inline
+ * CommitBox is `<Activity>`-hidden and its hotkeys are unregistered.
+ *
+ * Every field reads the shared ui-store draft, so this and the box are the same
+ * message from two angles. Staging stays in the Changes panel — the file list
+ * here is read-only.
+ */
+export function CommitDialog({ repoPath }: { repoPath: string }) {
+  const open = useUiStore((s) => s.commitDialogOpen);
+  const closeCommitDialog = useUiStore((s) => s.closeCommitDialog);
+  const openSettings = useUiStore((s) => s.openSettings);
+  const {
+    title,
+    body,
+    coAuthors,
+    setCommitTitle,
+    setCommitBody,
+    setCoAuthors,
+    clearCommitDraft,
+    amending,
+    amendingHash,
+    branchName,
+    locked,
+    stagedEntries,
+    stagedCount,
+    canCommit,
+    commitDisabledReason,
+    commitLabel,
+    committing,
+    aiEnabled,
+    aiConfigured,
+    generate,
+    cancel,
+    generating,
+    doCommit,
+  } = useCommitSubmit(repoPath, {
+    active: open,
+    onCommitted: closeCommitDialog,
+  });
+  // Same query (and cache entry) the Changes panel's rows read, so a file's
+  // counts here can't disagree with its counts there. Only fetched while the
+  // list is on screen with something in it.
+  const lineStats = useWorkingLineStats(repoPath, open && stagedCount > 0);
+  const commitBinding = useEffectiveBindings().get("commit") ?? null;
+  const generateHint = useGenerateChordHint();
+
+  const stagedStats = new Map(
+    (lineStats.data?.staged ?? []).map((e) => [e.path, e]),
+  );
+  // numstat can't see untracked paths and emits duplicate noise rows for
+  // conflicted ones, so both render a blank slot — the Changes panel's rule.
+  function statFor(entry: FileEntry) {
+    if (entry.staged === "untracked" || entry.staged === "conflicted")
+      return undefined;
+    return stagedStats.get(entry.path);
+  }
+
+  const emptyStagedNote = amending
+    ? "Nothing staged — this rewrites the last commit's message only."
+    : "Nothing staged — stage files in the Changes panel.";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) closeCommitDialog();
+      }}
+    >
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Commit</DialogTitle>
+          <DialogDescription>
+            Compose the message with more room. Staging stays in the Changes
+            panel.
+          </DialogDescription>
+        </DialogHeader>
+
+        {locked && (
+          <div className="bg-muted px-2.5 py-2 text-xs text-muted-foreground">
+            <p className="flex items-start gap-2">
+              <InfoIcon className="mt-0.5 size-3.5 shrink-0" />
+              <span className="flex-1">
+                <span className="font-medium">{branchName}</span> requires
+                changes via a pull request — direct commits are blocked by a
+                branch rule.
+              </span>
+            </p>
+          </div>
+        )}
+        {amending && (
+          <div className="bg-warning/10 px-2.5 py-2 text-xs text-warning">
+            <p className="flex items-start gap-2">
+              <InfoIcon className="mt-0.5 size-3.5 shrink-0" />
+              <span className="flex-1">
+                Your changes will amend the most recent commit (
+                <span className="font-mono">{amendingHash?.slice(0, 7)}</span>).{" "}
+                <button
+                  type="button"
+                  className="font-medium underline underline-offset-2 hover:no-underline"
+                  onClick={clearCommitDraft}
+                >
+                  Stop amending
+                </button>{" "}
+                to commit them separately instead.
+              </span>
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <div className="relative">
+            <Input
+              autoFocus
+              placeholder="Commit title"
+              value={title}
+              onChange={(e) => setCommitTitle(e.target.value)}
+              disabled={generating}
+              className="ph-no-capture pr-12"
+              autoComplete="off"
+            />
+            <span
+              className={cn(
+                "pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 text-[10px] tabular-nums",
+                title.length > 72
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              )}
+            >
+              {title.length > 0 && `${title.length}/72`}
+            </span>
+          </div>
+          <Textarea
+            placeholder="Description (optional)"
+            value={body}
+            onChange={(e) => setCommitBody(e.target.value)}
+            disabled={generating}
+            // The point of the pop-out: a body field with room to write in.
+            className="ph-no-capture max-h-80 min-h-40 resize-y"
+          />
+          <CoAuthorPicker
+            repoPath={repoPath}
+            value={coAuthors}
+            onChange={setCoAuthors}
+            disabled={generating}
+          />
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+          <h3 className="text-xs font-medium text-muted-foreground">
+            Staged ({stagedCount})
+          </h3>
+          {stagedCount > 0 ? (
+            <ScrollArea className="min-h-0 flex-1 overflow-hidden border">
+              <ul className="py-1">
+                {stagedEntries.map((entry) => {
+                  const badge = KIND_BADGE[entry.staged ?? "modified"];
+                  const label = entry.origPath
+                    ? `${entry.origPath} → ${entry.path}`
+                    : entry.path;
+                  const stat = statFor(entry);
+                  return (
+                    <li
+                      key={entry.path}
+                      className="flex items-center gap-2 px-2 py-0.5 text-xs"
+                    >
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "w-3 shrink-0 font-semibold",
+                          badge.className,
+                        )}
+                      >
+                        {badge.letter}
+                      </span>
+                      {/* The letter carries no meaning for assistive tech; the
+                          name span sits ahead of the path so the kind is
+                          announced first, and its trailing space keeps the two
+                          from fusing. */}
+                      <span className="sr-only">{badge.label} </span>
+                      <span
+                        className="min-w-0 flex-1 truncate"
+                        onMouseEnter={clipTitle(label)}
+                      >
+                        {label}
+                      </span>
+                      {stat ? (
+                        <DiffStat
+                          added={stat.added}
+                          deleted={stat.deleted}
+                          isBinary={stat.isBinary}
+                          className="text-[11px]"
+                        />
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            </ScrollArea>
+          ) : (
+            <p className="text-xs text-muted-foreground">{emptyStagedNote}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          {aiEnabled && (
+            <GenerateButton
+              aiConfigured={aiConfigured}
+              generating={generating}
+              stagedCount={stagedCount}
+              hint={generateHint}
+              onGenerate={generate}
+              onCancel={cancel}
+              onSetUpAi={() => openSettings("ai")}
+            />
+          )}
+          <DisabledReasonButton
+            disabled={!canCommit || generating}
+            reason={commitDisabledReason}
+            title={commitBinding ? formatBinding(commitBinding) : undefined}
+            onClick={doCommit}
+          >
+            {committing && <Spinner data-icon="inline-start" />}
+            <span className="truncate">{commitLabel}</span>
+          </DisabledReasonButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** The footer's AI arm: cancel while a stream runs, generate when one could. */
+function GenerateButton({
+  aiConfigured,
+  generating,
+  stagedCount,
+  hint,
+  onGenerate,
+  onCancel,
+  onSetUpAi,
+}: {
+  aiConfigured: boolean;
+  generating: boolean;
+  stagedCount: number;
+  hint: string;
+  onGenerate: () => void;
+  onCancel: () => void;
+  onSetUpAi: () => void;
+}) {
+  if (generating) {
+    return (
+      <Button variant="outline" onClick={onCancel}>
+        <Spinner data-icon="inline-start" />
+        Cancel
+      </Button>
+    );
+  }
+  if (!aiConfigured) {
+    // AI is on but no provider is set up yet — turn the dead-end Generate click
+    // into a one-time path to Settings → AI.
+    return (
+      <Button
+        variant="outline"
+        onClick={onSetUpAi}
+        title="Connect an AI provider to generate commit messages"
+      >
+        <SparkleIcon data-icon="inline-start" />
+        Set up AI
+      </Button>
+    );
+  }
+  return (
+    <DisabledReasonButton
+      variant="outline"
+      disabled={stagedCount === 0}
+      reason="Stage changes to generate a commit message"
+      // The chord is only offered while it would do something — a disabled
+      // Generate's shortcut is dead too.
+      title={
+        stagedCount > 0
+          ? `Generate commit message with AI${hint}`
+          : "Generate commit message with AI"
+      }
+      onClick={onGenerate}
+    >
+      <SparkleIcon data-icon="inline-start" />
+      Generate
+    </DisabledReasonButton>
+  );
+}

--- a/src/features/commit/CommitDialog.tsx
+++ b/src/features/commit/CommitDialog.tsx
@@ -20,6 +20,7 @@ import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
+import { useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import { CoAuthorPicker } from "./CoAuthorPicker";
@@ -58,6 +59,13 @@ export function CommitDialog({ repoPath }: { repoPath: string }) {
   const open = useUiStore((s) => s.commitDialogOpen);
   const closeCommitDialog = useUiStore((s) => s.closeCommitDialog);
   const openSettings = useUiStore((s) => s.openSettings);
+  const repoTab = useUiStore((s) => s.repoTab);
+  const settings = useSettings();
+  // The one state with no commit surface mounted: a collapsed sidebar hides the
+  // Changes panel, and Activity tears CommitBox's registration down with it.
+  // This dialog is hoisted for exactly that, so the chord registers here.
+  const noCommitSurface =
+    repoTab === "changes" && (settings.data?.sidebarCollapsed ?? false);
   const {
     title,
     body,
@@ -84,6 +92,7 @@ export function CommitDialog({ repoPath }: { repoPath: string }) {
     doCommit,
   } = useCommitSubmit(repoPath, {
     active: open,
+    commitHotkeyFallback: noCommitSurface,
     onCommitted: closeCommitDialog,
   });
   // Same query (and cache entry) the Changes panel's rows read, so a file's
@@ -202,7 +211,7 @@ export function CommitDialog({ repoPath }: { repoPath: string }) {
             <ScrollArea className="min-h-0 flex-1 overflow-hidden border">
               <ul className="py-1">
                 {stagedEntries.map((entry) => {
-                  const badge = KIND_BADGE[entry.staged ?? "modified"];
+                  const badge = KIND_BADGE[entry.staged];
                   const label = entry.origPath
                     ? `${entry.origPath} → ${entry.path}`
                     : entry.path;

--- a/src/features/commit/useCommitSubmit.ts
+++ b/src/features/commit/useCommitSubmit.ts
@@ -6,7 +6,7 @@ import { requiresPullRequest } from "@/lib/branch-rules/match";
 import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
 import { coAuthorTrailers } from "@/lib/git/co-authors";
 import { useCommit, useRepoStatus } from "@/lib/git/queries";
-import type { FileEntry } from "@/lib/git/types";
+import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
 import { commitDraftKey, useUiStore } from "@/lib/stores/ui";
@@ -27,12 +27,17 @@ export function useCommitSubmit(
   repoPath: string,
   {
     active = true,
+    commitHotkeyFallback = false,
     onCommitted,
   }: {
     /** Whether this surface's hotkey registrations are live. The dialog passes
      *  its open state so a closed-but-mounted instance registers nothing
      *  enabled; the inline box is live for as long as it's mounted. */
     active?: boolean;
+    /** Keeps the `commit` chord alone live while this surface is closed, for
+     *  the state where NO commit surface is mounted to hold it. Commit-only by
+     *  design: a generation streams into a field, so it needs one on screen. */
+    commitHotkeyFallback?: boolean;
     /** Runs when a commit lands — the dialog closes itself on it. */
     onCommitted?: () => void;
   } = {},
@@ -71,8 +76,12 @@ export function useCommitSubmit(
   const locked = branchName
     ? requiresPullRequest(rulesConfig, branchName)
     : false;
-  const stagedEntries: FileEntry[] =
-    status.data?.entries.filter((e) => e.staged !== null) ?? [];
+  // Narrowed at the filter, so consumers read `staged` as a plain ChangeKind and
+  // can't paper over a mis-typed entry with a fallback kind.
+  const stagedEntries: (FileEntry & { staged: ChangeKind })[] =
+    status.data?.entries.filter(
+      (e): e is FileEntry & { staged: ChangeKind } => e.staged !== null,
+    ) ?? [];
   const stagedCount = stagedEntries.length;
   // amending without staged changes is valid (message-only edit)
   const canCommit =
@@ -104,7 +113,11 @@ export function useCommitSubmit(
   // The commit hotkey (Ctrl+Enter by default) fires through the global
   // dispatcher even from the title/body fields — modifier combos are
   // allowed in text fields — so rebinding it in Settings works everywhere.
-  useHotkeyAction("commit", doCommit, active && canCommit && !generating);
+  useHotkeyAction(
+    "commit",
+    doCommit,
+    (active || commitHotkeyFallback) && canCommit && !generating,
+  );
   useHotkeyAction(
     "generate-commit-message",
     generate,

--- a/src/features/commit/useCommitSubmit.ts
+++ b/src/features/commit/useCommitSubmit.ts
@@ -1,0 +1,202 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { track } from "@/lib/analytics";
+import { triggerAutomations } from "@/lib/automations/runner";
+import { requiresPullRequest } from "@/lib/branch-rules/match";
+import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import { coAuthorTrailers } from "@/lib/git/co-authors";
+import { useCommit, useRepoStatus } from "@/lib/git/queries";
+import type { FileEntry } from "@/lib/git/types";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
+import { commitDraftKey, useUiStore } from "@/lib/stores/ui";
+import { toastError } from "@/lib/toast";
+import { useGenerateCommitMessage } from "./useGenerateCommitMessage";
+
+/**
+ * The commit machinery behind both composing surfaces — the inline CommitBox and
+ * the pop-out CommitDialog. Every field it exposes reads the shared ui-store
+ * draft rather than local state, so the two stay in sync by construction and a
+ * generation streams into whichever is on screen.
+ *
+ * Both surfaces register the `commit` / `generate-commit-message` actions while
+ * `active`: the dispatcher runs the newest ENABLED handler, and with one store
+ * behind them either registration does the same thing.
+ */
+export function useCommitSubmit(
+  repoPath: string,
+  {
+    active = true,
+    onCommitted,
+  }: {
+    /** Whether this surface's hotkey registrations are live. The dialog passes
+     *  its open state so a closed-but-mounted instance registers nothing
+     *  enabled; the inline box is live for as long as it's mounted. */
+    active?: boolean;
+    /** Runs when a commit lands — the dialog closes itself on it. */
+    onCommitted?: () => void;
+  } = {},
+) {
+  const status = useRepoStatus(repoPath);
+  const commit = useCommit(repoPath);
+  const title = useUiStore((s) => s.commitTitle);
+  const body = useUiStore((s) => s.commitBody);
+  const amendingHash = useUiStore((s) => s.amendingHash);
+  const coAuthors = useUiStore((s) => s.commitCoAuthors);
+  const setCommitTitle = useUiStore((s) => s.setCommitTitle);
+  const setCommitBody = useUiStore((s) => s.setCommitBody);
+  const setCoAuthors = useUiStore((s) => s.setCommitCoAuthors);
+  const clearCommitDraft = useUiStore((s) => s.clearCommitDraft);
+  const restoreCommitDraft = useUiStore((s) => s.restoreCommitDraft);
+  const activeDraftKey = useUiStore((s) => s.activeDraftKey);
+  const loadCommitDraft = useUiStore((s) => s.loadCommitDraft);
+  const commitAiGenerated = useUiStore((s) => s.commitAiGenerated);
+  const { generate, cancel, generating } = useGenerateCommitMessage(repoPath);
+  const aiEnabled = useAiEnabled();
+  const aiConfigured = useAiConfigured();
+  const rulesConfig = useEffectiveBranchRules(repoPath);
+
+  const amending = amendingHash !== null;
+  const branchName = status.data?.branch?.name ?? null;
+
+  // Point the commit surfaces at this repo+branch's saved draft. Drafts are kept
+  // per repo+branch, so switching repos/branches preserves each in-progress
+  // message instead of clearing it. Idempotent (loadCommitDraft no-ops on the
+  // active key), so the two surfaces running it together costs nothing — and the
+  // dialog's copy keeps the key current while the box is Activity-hidden.
+  useEffect(() => {
+    if (branchName) loadCommitDraft(commitDraftKey(repoPath, branchName));
+  }, [repoPath, branchName, loadCommitDraft]);
+  // A "require pull request" rule locks the branch against direct commits.
+  const locked = branchName
+    ? requiresPullRequest(rulesConfig, branchName)
+    : false;
+  const stagedEntries: FileEntry[] =
+    status.data?.entries.filter((e) => e.staged !== null) ?? [];
+  const stagedCount = stagedEntries.length;
+  // amending without staged changes is valid (message-only edit)
+  const canCommit =
+    title.trim().length > 0 &&
+    (stagedCount > 0 || amending) &&
+    !commit.isPending &&
+    !locked;
+  const canGenerate = aiEnabled && aiConfigured && stagedCount > 0;
+  // Why Commit is refused, most-blocking first: a branch rule nothing the user
+  // types can lift, then the missing title, then the empty stage.
+  const commitDisabledReason = ((): string | null => {
+    switch (true) {
+      case locked:
+        return "This branch requires changes via a pull request";
+      case title.trim().length === 0:
+        return "Enter a commit title first";
+      case stagedCount === 0 && !amending:
+        return "Stage changes to commit";
+      default:
+        return null;
+    }
+  })();
+  const commitLabel = amending
+    ? "Amend last commit"
+    : `Commit${stagedCount > 0 ? ` (${stagedCount})` : ""}${
+        branchName ? ` to ${branchName}` : ""
+      }`;
+
+  // The commit hotkey (Ctrl+Enter by default) fires through the global
+  // dispatcher even from the title/body fields — modifier combos are
+  // allowed in text fields — so rebinding it in Settings works everywhere.
+  useHotkeyAction("commit", doCommit, active && canCommit && !generating);
+  useHotkeyAction(
+    "generate-commit-message",
+    generate,
+    active && canGenerate && !generating,
+  );
+
+  function doCommit() {
+    const commitTitle = title.trim();
+    // Trailers must be the final paragraph of the message.
+    const fullBody = [body.trim(), coAuthorTrailers(coAuthors)]
+      .filter(Boolean)
+      .join("\n\n");
+    // Snapshot everything the in-flight commit (and its analytics) needs, since
+    // we clear the draft *before* the async commit resolves. `draftKey` is
+    // captured too so an error restores to this branch's draft even if the user
+    // switched branches while the commit was in flight.
+    const snapshot = { title, body, coAuthors, aiGenerated: commitAiGenerated };
+    const draftKey = activeDraftKey;
+    const wasAmending = amendingHash !== null;
+    const fileCount = stagedCount;
+    // Clear optimistically so the fields empty the instant you commit (GitHub
+    // Desktop feel) instead of snapping empty once the commit resolves. Also
+    // flips canCommit false, which blocks an accidental double-submit.
+    clearCommitDraft();
+    commit.mutate(
+      { title: commitTitle, body: fullBody || undefined, amend: wasAmending },
+      {
+        onSuccess: (result) => {
+          // First, so the pop-out closes the instant the commit lands rather
+          // than behind the reporting work below.
+          onCommitted?.();
+          if (!wasAmending) {
+            track({
+              name: "commit_created",
+              properties: {
+                file_count: fileCount,
+                has_ai_message: snapshot.aiGenerated,
+                has_co_authors: snapshot.coAuthors.length > 0,
+              },
+            });
+          }
+          toast.success(
+            `${wasAmending ? "Amended" : "Committed"} ${result.hash.slice(0, 7)}`,
+          );
+          // Amending rewrites an existing commit; only new commits fire
+          // on-commit automations.
+          if (!wasAmending) {
+            triggerAutomations({
+              kind: "commit",
+              repoPath,
+              hash: result.hash,
+              title: commitTitle,
+              branch: branchName ?? "",
+            });
+          }
+        },
+        onError: (e) => {
+          // The commit failed — put the message back so it isn't lost (restores
+          // amending mode too).
+          restoreCommitDraft({ ...snapshot, amendingHash }, draftKey);
+          toastError(e);
+        },
+      },
+    );
+  }
+
+  return {
+    title,
+    body,
+    coAuthors,
+    setCommitTitle,
+    setCommitBody,
+    setCoAuthors,
+    clearCommitDraft,
+    amending,
+    amendingHash,
+    branchName,
+    locked,
+    stagedEntries,
+    stagedCount,
+    canCommit,
+    /** AI is on, a provider is set up, and there's something to describe. */
+    canGenerate,
+    commitDisabledReason,
+    /** "Commit (3) to main" / "Amend last commit" — one label for both surfaces. */
+    commitLabel,
+    committing: commit.isPending,
+    aiEnabled,
+    aiConfigured,
+    generate,
+    cancel,
+    generating,
+    doCommit,
+  };
+}

--- a/src/features/commit/useGenerateCommitMessage.ts
+++ b/src/features/commit/useGenerateCommitMessage.ts
@@ -13,8 +13,19 @@ import { resolveDraftKey, useUiStore } from "@/lib/stores/ui";
 /** Raw diff bytes requested from the backend; prompt budgeting trims further. */
 const RAW_DIFF_MAX_BYTES = 200_000;
 
+/**
+ * Aborts the one generation that can be in flight — `generating` is a single
+ * store flag every Generate affordance gates on, so there is never more than
+ * one. Module scope rather than per-instance because the inline commit box and
+ * the pop-out dialog each mount their own hook instance over that one flag: a
+ * Cancel in the surface that didn't start the run would otherwise abort its own
+ * idle controller and silently do nothing. Written and read from callbacks
+ * only — a render read would go stale under the React Compiler.
+ */
+let liveCancel: (() => void) | null = null;
+
 export function useGenerateCommitMessage(repoPath: string) {
-  const { cancel, run } = useAiStream(repoPath);
+  const { cancel: cancelOwn, run } = useAiStream(repoPath);
   const setCommitDraft = useUiStore((s) => s.setCommitDraft);
   const setGenerating = useUiStore((s) => s.setGenerating);
   const setCommitAiGenerated = useUiStore((s) => s.setCommitAiGenerated);
@@ -29,15 +40,19 @@ export function useGenerateCommitMessage(repoPath: string) {
     // switched repo or branch — drop the remaining writes and abort the stream.
     const startKey = useUiStore.getState().activeDraftKey;
     // A null startKey (pre-branch-resolution) treats any later key as a move.
-    // On a move, cancel() always aborts THIS run: a second generation can't
-    // start while `generating` is set (CommitBox gates the button and hotkey).
-    // The test is draft identity, not key equality: a branch rename re-keys the
-    // same draft, so resolve the captured key through the store's rename remaps.
+    // On a move, cancelOwn() always aborts THIS run: a second generation can't
+    // start while `generating` is set (both commit surfaces gate their button
+    // and hotkey on it). The test is draft identity, not key equality: a branch
+    // rename re-keys the same draft, so resolve the captured key through the
+    // store's rename remaps.
     const keyMoved = () => {
       const s = useUiStore.getState();
       return resolveDraftKey(s.draftKeyRemaps, startKey) !== s.activeDraftKey;
     };
     setGenerating(true);
+    // Publish this run's abort while the flag is up, so either surface's Cancel
+    // reaches it — including after the starting surface unmounts.
+    liveCancel = cancelOwn;
     const buffer = await run(
       async (settings) => {
         const exclude = await aiExcludePatterns(
@@ -72,7 +87,7 @@ export function useGenerateCommitMessage(repoPath: string) {
       {
         onChunk: (buffer) => {
           if (keyMoved()) {
-            cancel();
+            cancelOwn();
             return;
           }
           const { title, body } = splitCommitMessage(buffer);
@@ -80,6 +95,9 @@ export function useGenerateCommitMessage(repoPath: string) {
         },
       },
     );
+    // Retire the entry with the flag it shadows, and only if it is still this
+    // run's — anything else there belongs to a run that came after.
+    if (liveCancel === cancelOwn) liveCancel = null;
     // A non-null buffer means the stream ran to completion (not aborted, not
     // bailed) — mark the draft as AI-generated just as the old skeleton did.
     if (buffer !== null && !keyMoved()) setCommitAiGenerated(true);
@@ -87,11 +105,17 @@ export function useGenerateCommitMessage(repoPath: string) {
   }, [
     repoPath,
     run,
-    cancel,
+    cancelOwn,
     setCommitDraft,
     setGenerating,
     setCommitAiGenerated,
   ]);
+
+  // Every surface's Cancel aborts whichever run is live, not the one this
+  // instance happens to own.
+  const cancel = useCallback(() => {
+    liveCancel?.();
+  }, []);
 
   return { generate, cancel, generating };
 }

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -1,10 +1,12 @@
 import { useDeferredValue, useState } from "react";
+import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { DiffSurface } from "@/features/diff/DiffSurfaceLazy";
 import { FileRowActions } from "@/features/history/FileRowActions";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useBranchDiffFiles, useBranchFileDiff } from "@/lib/git/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { cn, PLACEHOLDER_FADE } from "@/lib/utils";
@@ -99,7 +101,12 @@ export function BranchDiffView({
   return (
     <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
       <header className="flex items-center gap-2 border-b px-4 py-3 text-xs">
-        <span className="font-medium">
+        {/* Branch names are unbreakable tokens — without the clamp a long pair
+            sets the whole view's minimum width. */}
+        <span
+          className="min-w-0 truncate font-medium"
+          onMouseEnter={clipTitleFromText}
+        >
           <span className="font-mono">{compare}</span> vs{" "}
           <span className="font-mono">{base}</span>
         </span>
@@ -116,15 +123,11 @@ export function BranchDiffView({
         />
       </header>
 
-      <div className="flex min-h-0 flex-1">
-        <aside
-          className={cn(
-            "flex w-72 shrink-0 flex-col border-r",
-            PLACEHOLDER_FADE,
-            staleDim,
-          )}
+      <DetailRailRow>
+        <DetailRail
+          className={cn(PLACEHOLDER_FADE, staleDim)}
           role="listbox"
-          aria-label="Changed files"
+          ariaLabel="Changed files"
         >
           {/* overflow-hidden contains the list's natural height (vendored Root is
               `relative`-only) so a long list can't leak a window scrollbar. */}
@@ -162,7 +165,7 @@ export function BranchDiffView({
               ))}
             </FileRowActions>
           </ScrollArea>
-        </aside>
+        </DetailRail>
         <main
           aria-busy={Boolean(diffDim)}
           className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}
@@ -178,7 +181,7 @@ export function BranchDiffView({
             <DiffPlaceholder message="Select a file to see its changes" />
           )}
         </main>
-      </div>
+      </DetailRailRow>
     </div>
   );
 }

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -242,7 +242,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center gap-1 border-b p-2">
+      <div className="flex flex-wrap items-center gap-1 border-b p-2">
         {(["open", "closed"] as const).map((s) => (
           <Button
             key={s}

--- a/src/features/diff/DiffLanguagePicker.tsx
+++ b/src/features/diff/DiffLanguagePicker.tsx
@@ -10,7 +10,18 @@ import { LanguagePicker } from "./LanguagePicker";
  * and lets the user set a personal override for the extension — saved
  * immediately, so every diff of that extension re-highlights at once.
  */
-export function DiffLanguagePicker({ filePath }: { filePath: string }) {
+export function DiffLanguagePicker({
+  filePath,
+  open,
+  onOpenChange,
+}: {
+  filePath: string;
+  /** Controlled popover state, forwarded straight through: the diff toolbar owns
+   *  it so the `change-diff-language` palette action can open a trigger its
+   *  container query has hidden. Omit for uncontrolled behavior. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const repoPath = useUiStore((s) => s.repoPath);
@@ -45,6 +56,8 @@ export function DiffLanguagePicker({ filePath }: { filePath: string }) {
       autoLabel="Auto-detect"
       onClear={clearLang}
       triggerClassName="text-muted-foreground"
+      open={open}
+      onOpenChange={onOpenChange}
     />
   );
 }

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -32,10 +32,7 @@ import type { CustomLanguage } from "@/lib/settings/api";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { useEffectiveSyntax } from "@/lib/syntax/queries";
-import {
-  SPLIT_MIN_CONTAINER_PX,
-  useContainerWidth,
-} from "@/lib/use-container-width";
+import { useContainerWidth } from "@/lib/use-container-width";
 import { useIsDark } from "@/lib/use-is-dark";
 import {
   capDiffText,
@@ -60,6 +57,7 @@ import {
   SYNTAX_LINE_CAP,
   shikiDiffHighlighter,
 } from "./shiki-highlighter";
+import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 import { ensureCustomLanguages } from "./syntax";
 import { useWorkerHighlight, type WorkerAsts } from "./use-worker-highlight";
 
@@ -1229,6 +1227,18 @@ export function DiffContent({
   // The picker's trigger is hidden below @md, so the palette action is its only
   // route at narrow widths — which makes the open state the toolbar's to own.
   const [langOpen, setLangOpen] = useState(false);
+  const langWrapRef = useRef<HTMLSpanElement>(null);
+  const controlsRef = useRef<HTMLSpanElement>(null);
+  // Closing below @md re-hides the trigger in the same commit, so Base UI's
+  // focus-return lands on a display:none node and focus falls to <body>. Catch
+  // exactly that case — `offsetParent === null` means the wrapper really went
+  // away — and leave the normal return-to-trigger alone at wider widths.
+  const returnFocusIfTriggerHidden = () =>
+    requestAnimationFrame(() => {
+      if (langWrapRef.current?.offsetParent === null) {
+        controlsRef.current?.focus();
+      }
+    });
   // Computed above the early-return chain (which the `emptyDiff` arm joins, so
   // the text is trimmed once) because the registration below is a hook: offer
   // the action only in the states that actually render the picker.
@@ -1283,33 +1293,50 @@ export function DiffContent({
       className="ph-no-capture @container/diff-pane flex h-full flex-col"
     >
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
-        {/* The truncation notice rides an sr-only sibling rather than visible
-            text: as visible text it was ~200px that refused to shrink, painting
-            over the controls on any pane under ~1155px. */}
         <span
           className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
           title={filePath}
         >
           {filePath}
         </span>
+        {/* ~200px of unshrinkable text, so it shows only where the pane has the
+            room; the sr-only twin carries it at every width, and `aria-hidden`
+            on the visible copy keeps the two from announcing twice. */}
         {data.isTruncated && (
-          <span className="sr-only">(truncated — diff too large)</span>
+          <>
+            <span aria-hidden className="hidden shrink-0 @2xl/diff-pane:inline">
+              (truncated — diff too large)
+            </span>
+            <span className="sr-only">(truncated — diff too large)</span>
+          </>
         )}
         {/* min-h-7 pins the cluster to the language picker's h-7 trigger, so an
             extensionless file — where the picker renders nothing and only the
-            xs (h-6) mode toggle remains — doesn't shrink the row by 4px. */}
-        <span className="flex min-h-7 shrink-0 items-center gap-1.5">
+            xs (h-6) mode toggle remains — doesn't shrink the row by 4px.
+            tabIndex/outline-none make it a silent landing spot for focus when
+            the picker closes with its trigger already hidden. */}
+        <span
+          ref={controlsRef}
+          tabIndex={-1}
+          className="flex min-h-7 shrink-0 items-center gap-1.5 outline-none"
+        >
           {/* The only variable-width control here (its label follows the
               language name), so it's the one that goes under @md — leaving the
               row a fixed floor. It must stay laid out while its popup is open,
               though: Base UI anchors to the trigger, and a display:none trigger
               positions the popup at 0,0. `empty:hidden` keeps the row's gap off
               an extensionless file, where the picker renders nothing. */}
-          <span className="hidden @md/diff-pane:flex empty:hidden has-[[data-popup-open]]:flex">
+          <span
+            ref={langWrapRef}
+            className="hidden @md/diff-pane:flex empty:hidden has-[[data-popup-open]]:flex"
+          >
             <DiffLanguagePicker
               filePath={filePath}
               open={langOpen}
-              onOpenChange={setLangOpen}
+              onOpenChange={(open) => {
+                setLangOpen(open);
+                if (!open) returnFocusIfTriggerHidden();
+              }}
             />
           </span>
           <DiffModeToggle splitDisabled={narrowPane} />

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -59,6 +59,7 @@ import {
 } from "./shiki-highlighter";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 import { ensureCustomLanguages } from "./syntax";
+import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
 import { useWorkerHighlight, type WorkerAsts } from "./use-worker-highlight";
 
 /**
@@ -1227,18 +1228,11 @@ export function DiffContent({
   // The picker's trigger is hidden below @md, so the palette action is its only
   // route at narrow widths — which makes the open state the toolbar's to own.
   const [langOpen, setLangOpen] = useState(false);
-  const langWrapRef = useRef<HTMLSpanElement>(null);
-  const controlsRef = useRef<HTMLSpanElement>(null);
-  // Closing below @md re-hides the trigger in the same commit, so Base UI's
-  // focus-return lands on a display:none node and focus falls to <body>. Catch
-  // exactly that case — `offsetParent === null` means the wrapper really went
-  // away — and leave the normal return-to-trigger alone at wider widths.
-  const returnFocusIfTriggerHidden = () =>
-    requestAnimationFrame(() => {
-      if (langWrapRef.current?.offsetParent === null) {
-        controlsRef.current?.focus();
-      }
-    });
+  const {
+    wrapRef: langWrapRef,
+    controlsRef,
+    returnFocusIfTriggerHidden,
+  } = useHiddenTriggerFocus();
   // Computed above the early-return chain (which the `emptyDiff` arm joins, so
   // the text is trimmed once) because the registration below is a hook: offer
   // the action only in the states that actually render the picker.

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -22,14 +22,20 @@ import {
   useRef,
   useState,
 } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { useFileAtRev } from "@/lib/git/queries";
 import type { FileDiff } from "@/lib/git/types";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import type { CustomLanguage } from "@/lib/settings/api";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { useEffectiveSyntax } from "@/lib/syntax/queries";
+import {
+  SPLIT_MIN_CONTAINER_PX,
+  useContainerWidth,
+} from "@/lib/use-container-width";
 import { useIsDark } from "@/lib/use-is-dark";
 import {
   capDiffText,
@@ -42,7 +48,7 @@ import {
 import { DiffErrorBoundary } from "./DiffErrorBoundary";
 import { DiffLanguagePicker } from "./DiffLanguagePicker";
 import { DiffPlaceholder } from "./DiffPlaceholder";
-import { diffLang } from "./diff-lang";
+import { diffLang, fileExt } from "./diff-lang";
 import { djb2 } from "./highlight-worker-shared";
 import { installHljsGapIsolation } from "./hljs-gap-isolation";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
@@ -160,32 +166,49 @@ function decodeBase64Utf8(b64: string): string {
 }
 
 /** The persisted Unified/Split preference toggle. */
-export function DiffModeToggle() {
+export function DiffModeToggle({
+  splitDisabled = false,
+}: {
+  /** The pane is too narrow to render split (see {@link SPLIT_MIN_CONTAINER_PX}).
+   *  The active segment follows what's ON SCREEN, so Unified reads as active
+   *  while the override holds — and because it does, its write is withheld too:
+   *  a persisted `split` must survive the narrow pane that hid it, so neither
+   *  button may touch the preference while the override stands in for it. */
+  splitDisabled?: boolean;
+}) {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const viewMode = settings.data?.diffViewMode ?? "unified";
+  const effectiveViewMode = splitDisabled ? "unified" : viewMode;
   return (
+    // DisabledReasonButton's wrapper span has no `data-slot`, so it opts out of
+    // ButtonGroup's border-collapse/rounding child selectors — this call site
+    // owns the seam on the Button instead (same arrangement as SyncControls).
     <ButtonGroup>
       <Button
-        variant={viewMode === "unified" ? "secondary" : "ghost"}
+        variant={effectiveViewMode === "unified" ? "secondary" : "ghost"}
         size="xs"
         onClick={() =>
+          !splitDisabled &&
           settings.data &&
           saveSettings.mutate({ ...settings.data, diffViewMode: "unified" })
         }
       >
         Unified
       </Button>
-      <Button
-        variant={viewMode === "split" ? "secondary" : "ghost"}
+      <DisabledReasonButton
+        variant={effectiveViewMode === "split" ? "secondary" : "ghost"}
         size="xs"
+        disabled={splitDisabled}
+        reason="Pane too narrow for split view"
+        className="border-l-0 focus-visible:relative focus-visible:z-10"
         onClick={() =>
           settings.data &&
           saveSettings.mutate({ ...settings.data, diffViewMode: "split" })
         }
       >
         Split
-      </Button>
+      </DisabledReasonButton>
     </ButtonGroup>
   );
 }
@@ -203,6 +226,7 @@ export function GitDiffView({
   contentRevs,
   lineAnchors,
   lineWidget,
+  forceUnified,
 }: {
   filePath: string;
   text: string;
@@ -213,6 +237,9 @@ export function GitDiffView({
   lineAnchors?: DiffLineAnchor[];
   /** Inline composer opened from a diff line. Absent = plain read-only diff. */
   lineWidget?: LineWidget;
+  /** Render unified whatever the preference says — the measuring pane sets this
+   *  when it's too narrow for split. Omitted = follow the preference. */
+  forceUnified?: boolean;
 }) {
   return (
     <DiffErrorBoundary resetKey={`${filePath} ${text.length}`}>
@@ -223,6 +250,7 @@ export function GitDiffView({
         contentRevs={contentRevs}
         lineAnchors={lineAnchors}
         lineWidget={lineWidget}
+        forceUnified={forceUnified}
       />
     </DiffErrorBoundary>
   );
@@ -603,6 +631,7 @@ function RenderedDiff({
   contentRevs,
   lineAnchors,
   lineWidget,
+  forceUnified,
 }: {
   filePath: string;
   text: string;
@@ -610,10 +639,15 @@ function RenderedDiff({
   contentRevs?: DiffContentRevs;
   lineAnchors?: DiffLineAnchor[];
   lineWidget?: LineWidget;
+  forceUnified?: boolean;
 }) {
   const settings = useSettings();
   const isDark = useIsDark();
-  const viewMode = settings.data?.diffViewMode ?? "unified";
+  // The narrow-pane override renders unified without ever writing the setting,
+  // so widening the pane restores the user's split preference on its own.
+  const viewMode = forceUnified
+    ? "unified"
+    : (settings.data?.diffViewMode ?? "unified");
 
   // Large diffs are capped (the renderer isn't virtualized — see cap-diff.ts);
   // "Show full diff" opts into the whole thing. Reset when the file changes so
@@ -1184,6 +1218,34 @@ export function DiffContent({
   /** Inline composer opened from a diff line (PR review). Absent = read-only. */
   lineWidget?: LineWidget;
 }) {
+  // The pane measures itself: this surface mounts at widths from a full window
+  // down to a rail-flanked column, and both the split gate and the toolbar's
+  // container queries key off THIS box, not the viewport.
+  const [paneRef, paneWidth] = useContainerWidth<HTMLDivElement>();
+  // Pre-measure (`null`) is deliberately NOT an override, so the first paint
+  // matches the persisted preference instead of flashing split→unified→split.
+  const narrowPane = paneWidth !== null && paneWidth < SPLIT_MIN_CONTAINER_PX;
+
+  // The picker's trigger is hidden below @md, so the palette action is its only
+  // route at narrow widths — which makes the open state the toolbar's to own.
+  const [langOpen, setLangOpen] = useState(false);
+  // Computed above the early-return chain (which the `emptyDiff` arm joins, so
+  // the text is trimmed once) because the registration below is a hook: offer
+  // the action only in the states that actually render the picker.
+  const emptyDiff = data !== undefined && data.text.trim() === "";
+  const showsToolbar =
+    !isPending &&
+    !isError &&
+    data !== undefined &&
+    data.filePath === filePath &&
+    !data.isBinary &&
+    !emptyDiff;
+  useHotkeyAction(
+    "change-diff-language",
+    () => setLangOpen(true),
+    showsToolbar && Boolean(fileExt(filePath)),
+  );
+
   // Diffs load near-instantly from local git, so a skeleton only adds a flash
   // and a layout shift on the way to the real content — render nothing until
   // it's ready.
@@ -1203,7 +1265,7 @@ export function DiffContent({
     }
     return <DiffPlaceholder message="Binary file — no text diff available" />;
   }
-  if (!data.text.trim()) {
+  if (emptyDiff) {
     return <DiffPlaceholder message="No changes to show" />;
   }
 
@@ -1216,22 +1278,41 @@ export function DiffContent({
   return (
     // ph-no-capture: blocks the whole pane (file path + diff body) from session
     // replay — this is user code/paths. See src/components/Redacted.tsx.
-    <div className="ph-no-capture flex h-full flex-col">
+    <div
+      ref={paneRef}
+      className="ph-no-capture @container/diff-pane flex h-full flex-col"
+    >
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
-        <span className="flex min-w-0 flex-1 items-center gap-1 font-mono text-xs text-muted-foreground">
-          <span className="min-w-0 truncate" title={filePath}>
-            {filePath}
-          </span>
-          {data.isTruncated && (
-            <span className="shrink-0">(truncated — diff too large)</span>
-          )}
+        {/* The truncation notice rides an sr-only sibling rather than visible
+            text: as visible text it was ~200px that refused to shrink, painting
+            over the controls on any pane under ~1155px. */}
+        <span
+          className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
+          title={filePath}
+        >
+          {filePath}
         </span>
+        {data.isTruncated && (
+          <span className="sr-only">(truncated — diff too large)</span>
+        )}
         {/* min-h-7 pins the cluster to the language picker's h-7 trigger, so an
             extensionless file — where the picker renders nothing and only the
             xs (h-6) mode toggle remains — doesn't shrink the row by 4px. */}
         <span className="flex min-h-7 shrink-0 items-center gap-1.5">
-          <DiffLanguagePicker filePath={filePath} />
-          <DiffModeToggle />
+          {/* The only variable-width control here (its label follows the
+              language name), so it's the one that goes under @md — leaving the
+              row a fixed floor. It must stay laid out while its popup is open,
+              though: Base UI anchors to the trigger, and a display:none trigger
+              positions the popup at 0,0. `empty:hidden` keeps the row's gap off
+              an extensionless file, where the picker renders nothing. */}
+          <span className="hidden @md/diff-pane:flex empty:hidden has-[[data-popup-open]]:flex">
+            <DiffLanguagePicker
+              filePath={filePath}
+              open={langOpen}
+              onOpenChange={setLangOpen}
+            />
+          </span>
+          <DiffModeToggle splitDisabled={narrowPane} />
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
@@ -1253,6 +1334,7 @@ export function DiffContent({
           contentRevs={data.isTruncated ? undefined : contentRevs}
           lineAnchors={lineAnchors}
           lineWidget={lineWidget}
+          forceUnified={narrowPane}
         />
       </div>
     </div>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -49,6 +49,10 @@ import type { SelectedFile } from "@/lib/stores/ui";
 import { useUiStore } from "@/lib/stores/ui";
 import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { toastError } from "@/lib/toast";
+import {
+  SPLIT_MIN_CONTAINER_PX,
+  useContainerWidth,
+} from "@/lib/use-container-width";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
 import { useRetained } from "@/lib/use-retained";
@@ -70,6 +74,7 @@ import {
   useFileContent,
   useShikiRouting,
 } from "./DiffSurface";
+import { fileExt } from "./diff-lang";
 import { ImagePanes } from "./ImageDiff";
 
 /** Working-tree diff for the file selected in the changes panel. */
@@ -164,7 +169,14 @@ function WorkingTreeDiff({
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const isDark = useIsDark();
-  const viewMode = settings.data?.diffViewMode ?? "unified";
+  // Split needs a legible column count per side; under it this pane renders
+  // unified without ever writing the preference back (`null` = not yet
+  // measured, which stays on the preference so the first paint doesn't flash).
+  const [paneRef, paneWidth] = useContainerWidth<HTMLDivElement>();
+  const narrowPane = paneWidth !== null && paneWidth < SPLIT_MIN_CONTAINER_PX;
+  const viewMode = narrowPane
+    ? "unified"
+    : (settings.data?.diffViewMode ?? "unified");
   const [discard, setDiscard] = useState<{
     label: string;
     run: () => void;
@@ -184,6 +196,9 @@ function WorkingTreeDiff({
     forText: string;
   } | null>(null);
   const clearSelection = useCallback(() => setSelectionState(null), []);
+  // Owned here so the palette action can open the picker; the trigger itself is
+  // always visible in this toolbar, so this is the action's only reason to exist.
+  const [langOpen, setLangOpen] = useState(false);
   // `parsed`, `hunkMode`, and `busy` are computed above the `!hunkMode` early
   // return because the hotkey registrations below run unconditionally and read
   // them.
@@ -234,6 +249,16 @@ function WorkingTreeDiff({
     "clear-line-selection",
     clearSelection,
     hunkMode && selection !== null && !busy && discard === null,
+  );
+  // Only this toolbar's own arm registers: outside hunk mode the fallback
+  // DiffSurface below renders the picker and registers for itself, and a child's
+  // effect runs first — so an ungated registration here would win the dispatch
+  // (newest handler) and open a toolbar that isn't on screen. The selection arm
+  // replaces the picker with its stage/discard buttons, hence `selection`.
+  useHotkeyAction(
+    "change-diff-language",
+    () => setLangOpen(true),
+    hunkMode && selection === null && Boolean(fileExt(file.path)),
   );
   // Any Discard confirm's `run` captured line numbers (or a hunk) at open
   // time — close it the moment the diff text moves on from the text it was
@@ -335,7 +360,7 @@ function WorkingTreeDiff({
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div ref={paneRef} className="@container/staging-pane flex h-full flex-col">
       {/* The selection actions take over this row rather than opening one of
           their own: a row that mounts below the toolbar pushes the whole diff
           down on mouseup, moving the lines the user just dragged across. */}
@@ -438,8 +463,21 @@ function WorkingTreeDiff({
             </>
           ) : (
             <>
-              <DiffLanguagePicker filePath={file.path} />
-              <DiffModeToggle />
+              {/* Same treatment as the read-only surface's toolbar: the picker
+                  is this row's only variable-width control (its label follows
+                  the language name), so it goes under @md to give the row a
+                  fixed floor — but stays laid out while its popup is open,
+                  since Base UI anchors to the trigger and a display:none
+                  trigger positions the popup at 0,0. `empty:hidden` keeps the
+                  row's gap off an extensionless file. */}
+              <span className="hidden @md/staging-pane:flex empty:hidden has-[[data-popup-open]]:flex">
+                <DiffLanguagePicker
+                  filePath={file.path}
+                  open={langOpen}
+                  onOpenChange={setLangOpen}
+                />
+              </span>
+              <DiffModeToggle splitDisabled={narrowPane} />
             </>
           )}
         </span>

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -49,10 +49,7 @@ import type { SelectedFile } from "@/lib/stores/ui";
 import { useUiStore } from "@/lib/stores/ui";
 import { useEffectiveSyntax } from "@/lib/syntax/queries";
 import { toastError } from "@/lib/toast";
-import {
-  SPLIT_MIN_CONTAINER_PX,
-  useContainerWidth,
-} from "@/lib/use-container-width";
+import { useContainerWidth } from "@/lib/use-container-width";
 import { useIsDark } from "@/lib/use-is-dark";
 import { useLatestRef } from "@/lib/use-latest-ref";
 import { useRetained } from "@/lib/use-retained";
@@ -76,6 +73,7 @@ import {
 } from "./DiffSurface";
 import { fileExt } from "./diff-lang";
 import { ImagePanes } from "./ImageDiff";
+import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 
 /** Working-tree diff for the file selected in the changes panel. */
 export function DiffViewer({ repoPath }: { repoPath: string }) {
@@ -196,9 +194,22 @@ function WorkingTreeDiff({
     forText: string;
   } | null>(null);
   const clearSelection = useCallback(() => setSelectionState(null), []);
-  // Owned here so the palette action can open the picker; the trigger itself is
-  // always visible in this toolbar, so this is the action's only reason to exist.
+  // Owned here so the palette action can open the picker: this toolbar folds
+  // the trigger under @md like the read-only surface does, so below that width
+  // the action is the only route to it.
   const [langOpen, setLangOpen] = useState(false);
+  const langWrapRef = useRef<HTMLSpanElement>(null);
+  const controlsRef = useRef<HTMLSpanElement>(null);
+  // Closing below @md re-hides the trigger in the same commit, so Base UI's
+  // focus-return lands on a display:none node and focus falls to <body>. Catch
+  // exactly that case — `offsetParent === null` means the wrapper really went
+  // away — and leave the normal return-to-trigger alone at wider widths.
+  const returnFocusIfTriggerHidden = () =>
+    requestAnimationFrame(() => {
+      if (langWrapRef.current?.offsetParent === null) {
+        controlsRef.current?.focus();
+      }
+    });
   // `parsed`, `hunkMode`, and `busy` are computed above the `!hunkMode` early
   // return because the hotkey registrations below run unconditionally and read
   // them.
@@ -384,10 +395,14 @@ function WorkingTreeDiff({
             The selection arm drops shrink-0 so a narrow pane takes width from
             the count (which truncates) instead of overflowing the row; every
             Button is shrink-0 by default, so the actions are the floor and
-            can never be squeezed or clipped. */}
+            can never be squeezed or clipped. tabIndex/outline-none make this a
+            silent landing spot for focus when the picker closes with its
+            trigger already hidden. */}
         <span
+          ref={controlsRef}
+          tabIndex={-1}
           className={cn(
-            "flex min-h-7 items-center gap-1.5",
+            "flex min-h-7 items-center gap-1.5 outline-none",
             selection === null && "shrink-0",
           )}
         >
@@ -470,11 +485,17 @@ function WorkingTreeDiff({
                   since Base UI anchors to the trigger and a display:none
                   trigger positions the popup at 0,0. `empty:hidden` keeps the
                   row's gap off an extensionless file. */}
-              <span className="hidden @md/staging-pane:flex empty:hidden has-[[data-popup-open]]:flex">
+              <span
+                ref={langWrapRef}
+                className="hidden @md/staging-pane:flex empty:hidden has-[[data-popup-open]]:flex"
+              >
                 <DiffLanguagePicker
                   filePath={file.path}
                   open={langOpen}
-                  onOpenChange={setLangOpen}
+                  onOpenChange={(open) => {
+                    setLangOpen(open);
+                    if (!open) returnFocusIfTriggerHidden();
+                  }}
                 />
               </span>
               <DiffModeToggle splitDisabled={narrowPane} />

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -74,6 +74,7 @@ import {
 import { fileExt } from "./diff-lang";
 import { ImagePanes } from "./ImageDiff";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
+import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
 
 /** Working-tree diff for the file selected in the changes panel. */
 export function DiffViewer({ repoPath }: { repoPath: string }) {
@@ -198,18 +199,11 @@ function WorkingTreeDiff({
   // the trigger under @md like the read-only surface does, so below that width
   // the action is the only route to it.
   const [langOpen, setLangOpen] = useState(false);
-  const langWrapRef = useRef<HTMLSpanElement>(null);
-  const controlsRef = useRef<HTMLSpanElement>(null);
-  // Closing below @md re-hides the trigger in the same commit, so Base UI's
-  // focus-return lands on a display:none node and focus falls to <body>. Catch
-  // exactly that case — `offsetParent === null` means the wrapper really went
-  // away — and leave the normal return-to-trigger alone at wider widths.
-  const returnFocusIfTriggerHidden = () =>
-    requestAnimationFrame(() => {
-      if (langWrapRef.current?.offsetParent === null) {
-        controlsRef.current?.focus();
-      }
-    });
+  const {
+    wrapRef: langWrapRef,
+    controlsRef,
+    returnFocusIfTriggerHidden,
+  } = useHiddenTriggerFocus();
   // `parsed`, `hunkMode`, and `busy` are computed above the `!hunkMode` early
   // return because the hotkey registrations below run unconditionally and read
   // them.

--- a/src/features/diff/LanguagePicker.tsx
+++ b/src/features/diff/LanguagePicker.tsx
@@ -23,6 +23,8 @@ export function LanguagePicker({
   autoLabel,
   onClear,
   triggerClassName,
+  open: openProp,
+  onOpenChange,
 }: {
   /** Selected language id; "" means unset. */
   value: string;
@@ -32,8 +34,19 @@ export function LanguagePicker({
   autoLabel?: string;
   onClear?: () => void;
   triggerClassName?: string;
+  /** Controlled popover state, for callers that open the picker from elsewhere
+   *  (a command-palette action). Omit for the built-in uncontrolled behavior. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  // The internal state tracks every transition even while controlled, so a
+  // caller that stops passing `open` resumes from the state actually on screen.
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  function setOpen(next: boolean) {
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  }
   const [query, setQuery] = useState("");
 
   const customIds = customLanguages.map((c) => c.id).filter(Boolean);

--- a/src/features/diff/split-threshold.ts
+++ b/src/features/diff/split-threshold.ts
@@ -1,0 +1,11 @@
+/**
+ * Narrowest container that still fits a side-by-side diff: below it a split
+ * view keeps under ~40 monospace columns per side once the ~91px of line-number
+ * and marker gutters are taken out, so the surfaces fall back to unified.
+ *
+ * Its own module rather than a member of `cap-diff`: the surfaces that need
+ * only the threshold (an agent transcript's inline diff, the conflict preview)
+ * reach the renderer itself through a lazy boundary, and importing the cap
+ * helpers to get one number would pull them back into the eager chunk.
+ */
+export const SPLIT_MIN_CONTAINER_PX = 672;

--- a/src/features/diff/use-hidden-trigger-focus.ts
+++ b/src/features/diff/use-hidden-trigger-focus.ts
@@ -1,0 +1,28 @@
+import { type RefObject, useRef } from "react";
+
+/**
+ * Focus rescue for a popover whose trigger can be hidden by a container query.
+ *
+ * Closing below the query's threshold re-hides the trigger in the same commit,
+ * so Base UI's focus-return lands on a display:none node and focus falls to
+ * `<body>`. Attach `wrapRef` to the element the query hides and `controlsRef`
+ * to a `tabIndex={-1}` neighbour that survives, then call
+ * `returnFocusIfTriggerHidden` from the close arm of `onOpenChange`: it catches
+ * exactly that case — `offsetParent === null` means the wrapper really went
+ * away — and leaves the normal return-to-trigger alone at wider widths.
+ */
+export function useHiddenTriggerFocus(): {
+  wrapRef: RefObject<HTMLSpanElement | null>;
+  controlsRef: RefObject<HTMLSpanElement | null>;
+  returnFocusIfTriggerHidden: () => void;
+} {
+  const wrapRef = useRef<HTMLSpanElement>(null);
+  const controlsRef = useRef<HTMLSpanElement>(null);
+  const returnFocusIfTriggerHidden = () =>
+    requestAnimationFrame(() => {
+      if (wrapRef.current?.offsetParent === null) {
+        controlsRef.current?.focus();
+      }
+    });
+  return { wrapRef, controlsRef, returnFocusIfTriggerHidden };
+}

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -217,8 +217,10 @@ export function ExploreScreen() {
         </p>
       )}
 
+      {/* The tab strip scrolls inside itself so its two tabs can't widen the
+          body on a narrow window. */}
       {!searching && !isBitbucket && (
-        <div className="border-b px-3 py-2">
+        <div className="overflow-x-auto border-b px-3 py-2">
           <Tabs
             value={effectiveZeroMode}
             onValueChange={(v) => setZeroMode(v as ZeroMode)}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -89,6 +89,13 @@ three primary views — **Changes**, **History**, and **Pull Requests** — and 
 and **Insights**. The More button shows the active secondary tab's name, so the
 rail always says where you are.
 
+The lists those tabs open (changes, commits, pull requests) fill the **sidebar** down
+the left. It narrows as you narrow the window, and collapses to a strip of tab icons:
+use the button at the end of the tab row, {{kbd:toggle-sidebar}}, or the command
+palette. Collapsed, the detail pane takes the full width and the icons still switch
+tabs; your filters, selections, and scroll position are all where you left them when
+you expand it again.
+
 Switch tabs with the number keys ({{kbd:tab-changes}} through {{kbd:tab-insights}}; see
 *Keyboard & navigation*). Issues, Discussions, Actions, and Tags need \`gh\` and a
 GitHub remote; **Findings** works on a GitHub remote with \`gh\` or a GitLab one with
@@ -180,7 +187,9 @@ contributors, language makeup, activity, traffic), open **Insights** from the me
 
 The app remembers each window's **position and size** across launches, including which
 monitor it was on. Your layout is saved as you arrange the window, so an unexpected
-shutdown doesn't lose it. See **Settings → About** for the current coordinates.`,
+shutdown doesn't lose it. The window goes down to a narrow, split-screen width, so
+GitDesktop can sit beside your editor on half a screen. See **Settings → About** for
+the current coordinates.`,
   },
   {
     id: "explore",
@@ -390,13 +399,23 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 ## The diff viewer
 
 - **Syntax highlighting** for most languages, with a per-file **language override** if a
-  file is detected wrong (or turn highlighting off).
+  file is detected wrong (or turn highlighting off). A narrow pane drops the override's
+  button from the toolbar; *Change diff language…* in the command palette (palette-only
+  by default — bind a key in **Settings → Keyboard**) still opens the picker.
 - **Image diffs** render side by side.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
 - Files that look **generated or minified** (one enormous line — bundles, source maps,
   \`.tsbuildinfo\`) show a placeholder instead of freezing the view — **Show diff anyway**
   renders a safely shortened version.
+- **Split renders as unified** while the pane is too narrow for two readable columns;
+  hover the **Split** button and it says so. Your preference is kept either way, so
+  widening the pane brings the split view back.
+- **The file list beside a diff collapses** to a thin strip, handing the diff the whole
+  pane. Use the caret above the list, or *Collapse or expand the diff file list*
+  (palette-only by default — bind a key in Settings); a pane too narrow to hold both
+  collapses it for you. You'll find that list on a commit's files, in **Compare**, and
+  on a pull request's **Files** and **Commits** tabs.
 
 ## Committing
 
@@ -405,6 +424,11 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
 
 - **Co-authors** — add collaborators; the picker suggests people from the repo's history
   and writes proper \`Co-authored-by:\` trailers.
+- **Pop the box out** into a dialog with room to write and your staged files listed
+  beside it: use the commit box's **Open commit dialog** button, or the same command
+  in the palette (palette-only by default — bind a key in Settings). That list is
+  read-only; staging stays in the **Changes** panel. The palette route reaches the
+  dialog from any tab, and with the sidebar collapsed.
 {{ai}}- **Generate with AI** ({{kbd:generate-commit-message}}) — write the summary and
   description from your staged diff (see *AI & automations*).
 {{/ai}}- After committing, **Undo** ({{kbd:undo-commit}}) reverses the last commit and

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -414,8 +414,9 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **The file list beside a diff collapses** to a thin strip, handing the diff the whole
   pane. Use the caret above the list, or *Collapse or expand the diff file list*
   (palette-only by default — bind a key in Settings); a pane too narrow to hold both
-  collapses it for you. You'll find that list on a commit's files, in **Compare**, and
-  on a pull request's **Files** and **Commits** tabs.
+  collapses it for you. You'll find that list on a commit's files, in **Compare**, on a
+  pull request's **Files** and **Commits** tabs, and anywhere else a file list
+  sits beside a diff.
 
 ## Committing
 

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -2,6 +2,7 @@ import { CopyIcon, DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import { useDeferredValue, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
+import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -401,13 +402,10 @@ export function CommitDetailView({
         )}
       </header>
 
-      <div className="flex min-h-0 flex-1">
-        <aside
-          className={cn(
-            "flex w-72 shrink-0 flex-col border-r",
-            PLACEHOLDER_FADE,
-            staleDim,
-          )}
+      <DetailRailRow>
+        <DetailRail
+          ariaLabel="Changed files"
+          className={cn(PLACEHOLDER_FADE, staleDim)}
         >
           <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
             {files.data.length} changed file{files.data.length === 1 ? "" : "s"}
@@ -449,7 +447,7 @@ export function CommitDetailView({
               ))}
             </FileRowActions>
           </ScrollArea>
-        </aside>
+        </DetailRail>
         <main
           aria-busy={Boolean(diffDim)}
           className={cn("min-w-0 flex-1", PLACEHOLDER_FADE, diffDim)}
@@ -468,7 +466,7 @@ export function CommitDetailView({
             <DiffPlaceholder message="Select a file to see its changes" />
           )}
         </main>
-      </div>
+      </DetailRailRow>
 
       {/* Mounted for every commit, rendering only where comments are supported:
           arrowing through history must not tear down its per-commit drafts. */}

--- a/src/features/issues/JiraIssueSidebar.tsx
+++ b/src/features/issues/JiraIssueSidebar.tsx
@@ -70,8 +70,13 @@ export function JiraIssueSidebar({
 
   return (
     <aside
+      // Stacked below the body once JiraIssueView's pane drops under 672px, where
+      // it keeps its own scroller (the body's ScrollArea is a sibling, so a single
+      // shared scroll would mean moving the rail inside it). The cap is what keeps
+      // that scroller reachable: uncapped, `shrink-0` takes the rail's full natural
+      // height and leaves the body none.
       className={cn(
-        "w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4",
+        "w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4 @max-2xl/jira-detail:max-h-[45%] @max-2xl/jira-detail:w-full @max-2xl/jira-detail:border-t @max-2xl/jira-detail:border-l-0",
         className,
       )}
     >

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -1625,15 +1625,21 @@ export function JiraIssueView({
   }
 
   return (
-    <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
+    <div
+      className="@container/jira-detail flex h-full flex-col"
+      aria-busy={Boolean(staleDim)}
+    >
       <header className="space-y-2 border-b px-4 py-3">
-        <div className="flex items-start gap-2">
+        {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap, so
+            the actions would stay put and the title collapse instead. Growing also
+            replaces the spacer that used to right-align them. */}
+        <div className="flex flex-wrap items-start gap-2">
           {/* The key is the PROP (always the issue you selected); the summary is
               fetched, so it fades rather than disappearing — hiding it would
               collapse the header's height mid-transition. */}
           <h2
             className={cn(
-              "min-w-0 text-sm font-medium",
+              "min-w-0 flex-auto text-sm font-medium break-words",
               PLACEHOLDER_FADE,
               staleDim,
             )}
@@ -1643,7 +1649,6 @@ export function JiraIssueView({
             </span>{" "}
             {issue.summary}
           </h2>
-          <span className="flex-1" />
           {/* Absent while a placeholder is served: the verb comes from the
               LOADED issue's status, so a click during that window would fire the
               wrong transition against the issue you actually selected. */}
@@ -1720,8 +1725,13 @@ export function JiraIssueView({
         </div>
       </header>
 
-      <div className="flex min-h-0 flex-1">
-        <div className="flex min-w-0 flex-1 flex-col">
+      {/* Below ~672px of pane the 256px rail leaves under ~57ch of body, so it
+          stacks under the thread instead (see JiraIssueSidebar). */}
+      <div className="flex min-h-0 flex-1 @max-2xl/jira-detail:flex-col">
+        {/* `min-h-0` only bites once stacked: the auto minimum size applies to the
+            flex MAIN axis, so in the column the body would otherwise floor at its
+            thread's full height and push a scrollbar onto the document. */}
+        <div className="flex min-w-0 flex-1 flex-col @max-2xl/jira-detail:min-h-0">
           {/* overflow-hidden contains the content's natural height (vendored
               Root is `relative`-only) so a long issue can't leak a window
               scrollbar. */}

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -184,9 +184,13 @@ export function LocalIssueView({
   return (
     <div className="flex h-full flex-col">
       <header className="space-y-2 border-b px-4 py-3">
-        <div className="flex items-start gap-2">
-          <h2 className="text-sm font-medium">{issue.title}</h2>
-          <span className="flex-1" />
+        {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap, so
+            the actions would stay put and the title collapse instead. Growing also
+            replaces the spacer that used to right-align them. */}
+        <div className="flex flex-wrap items-start gap-2">
+          <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
+            {issue.title}
+          </h2>
           <PlanIssueButton title={issue.title} body={issue.body} />
           {isOpen && (
             <SolveIssueButton
@@ -360,7 +364,7 @@ export function LocalIssueView({
         submitLabel="Comment"
       />
 
-      <div className="flex items-center gap-2 border-t p-3">
+      <div className="flex flex-wrap items-center gap-2 border-t p-3">
         <Button
           variant="outline"
           size="sm"

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -757,16 +757,18 @@ export function RemoteIssueView({
   );
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="@container/issue-detail flex h-full flex-col">
       <header className="space-y-2 border-b px-4 py-3">
-        <div className="flex items-start gap-2">
-          <h2 className="text-sm font-medium">
+        {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap, so
+            the actions would stay put and the title collapse instead. Growing also
+            replaces the spacer that used to right-align them. */}
+        <div className="flex flex-wrap items-start gap-2">
+          <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
             {issue.title}{" "}
             <span className="font-normal text-muted-foreground">
               #{issue.number}
             </span>
           </h2>
-          <span className="flex-1" />
           {/* Both seed an AI run from the rendered issue, so they're absent while
               that issue isn't the one you selected. */}
           {!detailsStale && (
@@ -985,8 +987,13 @@ export function RemoteIssueView({
           )}
         </div>
       </header>
-      <div className="flex min-h-0 flex-1">
-        <div className="flex min-w-0 flex-1 flex-col">
+      {/* Below ~672px of pane the 256px rail leaves under ~57ch of body, so it
+          stacks under the thread instead (see IssueRail). */}
+      <div className="flex min-h-0 flex-1 @max-2xl/issue-detail:flex-col">
+        {/* `min-h-0` only bites once stacked: the auto minimum size applies to the
+            flex MAIN axis, so in the column the body would otherwise floor at its
+            thread's full height and push a scrollbar onto the document. */}
+        <div className="flex min-w-0 flex-1 flex-col @max-2xl/issue-detail:min-h-0">
           {/* overflow-hidden contains the thread's natural height (vendored Root is
               `relative`-only) so a long issue can't leak a window scrollbar. */}
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -71,7 +71,12 @@ export type IssueRailRow = {
  *  can't be unconditional. */
 export function IssueRail({ rows }: { rows: IssueRailRow[] }) {
   return (
-    <aside className="w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4">
+    // Stacked below the body once RemoteIssueView's pane drops under 672px, where
+    // it keeps its own scroller (the body's ScrollArea is a sibling, so a single
+    // shared scroll would mean moving the rail inside it). The cap is what keeps
+    // that scroller reachable: uncapped, `shrink-0` takes the rail's full natural
+    // height and leaves the body none.
+    <aside className="w-64 shrink-0 space-y-4 overflow-y-auto border-l p-4 @max-2xl/issue-detail:max-h-[45%] @max-2xl/issue-detail:w-full @max-2xl/issue-detail:border-t @max-2xl/issue-detail:border-l-0">
       {rows.map((row) => {
         if (!row.when) return null;
         return row.heading === undefined ? (

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -625,9 +625,13 @@ export function LocalPrView({
     return (
       <div className="flex h-full flex-col">
         <header className="space-y-2 border-b px-4 py-3">
-          <div className="flex items-start gap-2">
-            <h2 className="text-sm font-medium">{pr.title}</h2>
-            <span className="flex-1" />
+          {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap,
+              so the badge would stay put and the title collapse instead. Growing
+              also replaces the spacer that used to right-align it. */}
+          <div className="flex flex-wrap items-start gap-2">
+            <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
+              {pr.title}
+            </h2>
             <Badge variant="secondary" className="capitalize">
               {pr.status}
             </Badge>
@@ -661,9 +665,13 @@ export function LocalPrView({
   return (
     <div className="flex h-full flex-col">
       <header className="space-y-2 border-b px-4 py-3">
-        <div className="flex items-start gap-2">
-          <h2 className="text-sm font-medium">{pr.title}</h2>
-          <span className="flex-1" />
+        {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap, so
+            the actions would stay put and the title collapse instead. Growing also
+            replaces the spacer that used to right-align them. */}
+        <div className="flex flex-wrap items-start gap-2">
+          <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
+            {pr.title}
+          </h2>
           {pr.status === "open" && (
             <Button
               variant="outline"
@@ -767,7 +775,7 @@ export function LocalPrView({
             ))}
           </div>
         )}
-        <div className="flex gap-1 pt-1">
+        <div className="flex flex-wrap gap-1 pt-1">
           {availableSections.map((s) => (
             <Button
               key={s}
@@ -1064,7 +1072,7 @@ export function LocalPrView({
 
       {pr.status === "open" && renderMergeStatus()}
 
-      <div className="flex items-center gap-2 border-t p-3">
+      <div className="flex flex-wrap items-center gap-2 border-t p-3">
         {pr.status === "open" && (
           <>
             {forgeFeatureReady(ghStatus.data, "mrCreate") && (

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -1,5 +1,6 @@
 import { CopyIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
+import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -209,8 +210,8 @@ export function PrCommitDetail({
       ) : diff.isError ? (
         <DiffPlaceholder message="Could not load this commit's changes" />
       ) : (
-        <div className="flex min-h-0 flex-1">
-          <aside className="flex w-72 shrink-0 flex-col border-r">
+        <DetailRailRow>
+          <DetailRail ariaLabel="Changed files">
             <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
               {files.length} changed file{files.length === 1 ? "" : "s"}
             </p>
@@ -248,7 +249,7 @@ export function PrCommitDetail({
                 ))}
               </FileRowActions>
             </ScrollArea>
-          </aside>
+          </DetailRail>
           <main className="flex min-w-0 flex-1 flex-col">
             <div className="min-h-0 flex-1">
               {effectivePath && fileDiff ? (
@@ -275,7 +276,7 @@ export function PrCommitDetail({
               lens={lens}
             />
           </main>
-        </div>
+        </DetailRailRow>
       )}
     </div>
   );

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2219,14 +2219,16 @@ export function RemotePrView({
     return (
       <div className="flex h-full flex-col">
         <header className="space-y-2 border-b px-4 py-3">
-          <div className="flex items-start gap-2">
-            <h2 className="text-sm font-medium">
+          {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap,
+              so the badge would stay put and the title collapse instead. Growing
+              also replaces the spacer that used to right-align it. */}
+          <div className="flex flex-wrap items-start gap-2">
+            <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
               {pr.title}{" "}
               <span className="font-normal text-muted-foreground">
                 #{pr.number}
               </span>
             </h2>
-            <span className="flex-1" />
             <Badge variant="secondary" className="capitalize">
               {pr.state.toLowerCase()}
             </Badge>
@@ -2436,14 +2438,16 @@ export function RemotePrView({
   return (
     <div className="flex h-full flex-col">
       <header className="@container/pr-header space-y-2 border-b px-4 py-3">
-        <div className="flex items-start gap-2">
-          <h2 className="text-sm font-medium">
+        {/* `flex-auto`, not `flex-1`: a basis-0 title never triggers the wrap, so
+            the actions would stay put and the title collapse instead. Growing also
+            replaces the spacer that used to right-align them. */}
+        <div className="flex flex-wrap items-start gap-2">
+          <h2 className="min-w-0 flex-auto text-sm font-medium break-words">
             {pr.title}{" "}
             <span className="font-normal text-muted-foreground">
               #{pr.number}
             </span>
           </h2>
-          <span className="flex-1" />
           {isOpen &&
             canWrite &&
             (repoStatus.data?.branch?.name === pr.headRefName ? (
@@ -2611,7 +2615,7 @@ export function RemotePrView({
           provider={providerKey}
           crossRepository={!!pr.crossRepository}
         />
-        <div className="flex gap-1 pt-1">
+        <div className="flex flex-wrap gap-1 pt-1">
           {availableSections.map((s) => (
             <Button
               key={s}
@@ -3161,7 +3165,7 @@ export function RemotePrView({
           Convert-to-draft pair — shown when any is available, each control gated
           individually. */}
       {isOpen && (canChangeState || canMerge || canWrite) && (
-        <div className="flex items-center gap-2 border-t p-3">
+        <div className="flex flex-wrap items-center gap-2 border-t p-3">
           {/* One Ready / Convert-to-draft pair for all three providers: GitLab
               (`glab mr update`) and Bitbucket (PUT `draft`) via `canToggleDraft`;
               GitHub folds in via `canWrite` and routes the same `setDraft` mutation

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -1,5 +1,6 @@
 import { ClockIcon } from "@phosphor-icons/react";
 import { type ComponentProps, useMemo, useState } from "react";
+import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -270,8 +271,8 @@ export function PrFilesPane({
   ));
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <aside className="flex w-72 shrink-0 flex-col border-r">
+    <DetailRailRow>
+      <DetailRail ariaLabel="Changed files">
         {/* overflow-hidden contains the list's natural height (vendored Root is
             `relative`-only) so a long file list can't leak a window scrollbar. */}
         <ScrollArea className="min-h-0 flex-1 overflow-hidden">
@@ -287,7 +288,7 @@ export function PrFilesPane({
             <div onKeyDown={onFilesKeyDown}>{fileRows}</div>
           )}
         </ScrollArea>
-      </aside>
+      </DetailRail>
       <main className="min-w-0 flex-1">
         {effectivePath ? (
           <DiffContent
@@ -302,7 +303,7 @@ export function PrFilesPane({
           <DiffPlaceholder message="Select a file to see its changes" />
         )}
       </main>
-    </div>
+    </DetailRailRow>
   );
 }
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1945,7 +1945,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           <Popover.Trigger
             disabled={busy || amending}
             render={
-              <Button variant="ghost" size="sm" className="min-w-0 shrink">
+              <Button
+                variant="ghost"
+                size="sm"
+                // overflow-hidden clips the box the shrink cascade squeezes;
+                // without it the icons (shrink-0) spill out both sides into the
+                // separator and the repository menu on a narrow header.
+                className="min-w-0 shrink overflow-hidden"
+              >
                 <GitBranchIcon data-icon="inline-start" />
                 <span
                   className="min-w-0 truncate"

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -12,6 +12,7 @@ import { ButtonGroup } from "@/components/ui/button-group";
 import { Spinner } from "@/components/ui/spinner";
 import { GitDiffView } from "@/features/diff/DiffSurfaceLazy";
 import { HighlightedCode } from "@/features/diff/HighlightedCode";
+import { SPLIT_MIN_CONTAINER_PX } from "@/features/diff/split-threshold";
 import {
   buildConflictPrompt,
   extractResolvedContent,
@@ -30,6 +31,7 @@ import { useResolveConflict } from "@/lib/git/queries";
 import { useReviewConfigured, useSettings } from "@/lib/settings/queries";
 import { useConflictResolve } from "@/lib/stores/conflict-resolve";
 import { toastError } from "@/lib/toast";
+import { useContainerWidth } from "@/lib/use-container-width";
 import { useLatestRef } from "@/lib/use-latest-ref";
 
 type Phase = "loading" | "streaming" | "ready" | "blocked" | "idle";
@@ -70,6 +72,9 @@ export function ConflictResolveView({
   // navigate-away) can't settle the shared state the newer run now owns.
   const genRef = useRef(0);
   const textRef = useLatestRef(text);
+  // The resolve view shares the diff pane's width budget, so the preview takes
+  // the same legibility gate: below it, render unified.
+  const [paneRef, paneWidth] = useContainerWidth<HTMLDivElement>();
 
   const markersLeft = phase === "ready" && hasConflictMarkers(proposed);
 
@@ -265,7 +270,7 @@ export function ConflictResolveView({
       )}
 
       {/* Body */}
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div ref={paneRef} className="min-h-0 flex-1 overflow-auto">
         {phase === "blocked" ? (
           <p className="p-4 text-xs text-muted-foreground">
             <span className="font-mono">{baseName(path)}</span> matches your AI
@@ -293,6 +298,9 @@ export function ConflictResolveView({
               filePath={path}
               text={previewDiff}
               repoPath={repoPath}
+              forceUnified={
+                paneWidth !== null && paneWidth < SPLIT_MIN_CONTAINER_PX
+              }
             />
           ) : (
             <HighlightedCode

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -2,22 +2,30 @@ import {
   CaretDownIcon,
   ChatCircleIcon,
   CircleDashedIcon,
+  DotsThreeIcon,
+  FilesIcon,
   GitBranchIcon,
   GitCommitIcon,
   GitPullRequestIcon,
   ListChecksIcon,
   PlayIcon,
   ShieldCheckIcon,
+  SidebarSimpleIcon,
   TagIcon,
 } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   Activity,
+  type KeyboardEvent,
   lazy,
   type ReactNode,
   Suspense,
   useDeferredValue,
   useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
   useState,
   useTransition,
 } from "react";
@@ -39,6 +47,7 @@ import { useRunNotifications } from "@/features/actions/useRunNotifications";
 import { CodeTodoDetailView } from "@/features/code-todos/CodeTodoDetailView";
 import { CodeTodosPanel } from "@/features/code-todos/CodeTodosPanel";
 import { CommitBox } from "@/features/commit/CommitBox";
+import { CommitDialog } from "@/features/commit/CommitDialog";
 import { BranchDiffView } from "@/features/compare/BranchDiffView";
 import { ComparePanel } from "@/features/compare/ComparePanel";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -72,11 +81,22 @@ import {
   useForgeStatus,
   useRepoStatus,
 } from "@/lib/git/queries";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import {
+  bindingToAriaKeyshortcuts,
+  formatBinding,
+} from "@/lib/hotkeys/binding";
+import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useLensGate, useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useScripts } from "@/lib/scripts/queries";
-import { useAiEnabled, useRepoAlias } from "@/lib/settings/queries";
+import {
+  settingsKeys,
+  useAiEnabled,
+  useRepoAlias,
+  useSaveSettings,
+  useSettings,
+} from "@/lib/settings/queries";
 import { useTaskRunStore } from "@/lib/stores/taskRun";
 import {
   type RepoTab,
@@ -130,7 +150,7 @@ const DiffViewer = lazy(() =>
 );
 
 // Secondary surfaces live behind a "More ▾" overflow so the three primary tabs
-// keep their full labels in the fixed-width rail. The trigger shows the active
+// keep their full labels in the narrow tab rail. The trigger shows the active
 // secondary tab's name (e.g. "Issues ▾") so the rail still says where you are.
 // Compare keeps its `mod+3` shortcut here — the number keys bind per-tab, not by
 // rail position, so it stays reachable exactly like the other secondary tabs.
@@ -191,6 +211,168 @@ function TabPanel({
   );
 }
 
+// The collapsed sidebar's icon rail. Icons follow the surfaces' house pairings:
+// the changes list is FilesIcon (ComparePanel's "All changes" row), a commit is
+// GitCommitIcon, a pull request GitPullRequestIcon — the same glyphs the detail
+// placeholders in this file use.
+const RAIL_TABS: {
+  id: "changes" | "history" | "pulls";
+  label: string;
+  icon: typeof FilesIcon;
+}[] = [
+  { id: "changes", label: "Changes", icon: FilesIcon },
+  { id: "history", label: "History", icon: GitCommitIcon },
+  { id: "pulls", label: "PRs", icon: GitPullRequestIcon },
+];
+
+type RailId = (typeof RAIL_TABS)[number]["id"] | "more";
+
+const RAIL_IDS: RailId[] = ["changes", "history", "pulls", "more"];
+
+const RAIL_BUTTON_CLASS =
+  "relative flex h-9 w-full shrink-0 items-center justify-center outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset";
+// Active carries a shape cue as well as the tokens — the edge bar is the
+// vendored tab trigger's `after:` underline turned onto the rail's right edge.
+const RAIL_ACTIVE_CLASS =
+  "bg-accent text-accent-foreground after:absolute after:inset-y-0 after:right-0 after:w-0.5 after:bg-foreground";
+const RAIL_IDLE_CLASS =
+  "text-muted-foreground hover:bg-muted/60 hover:text-foreground";
+
+/**
+ * The four tab affordances of the collapsed sidebar: the three primary tabs plus
+ * the same More overflow menu. Module scope (like TabPanel) so it isn't a fresh
+ * component type each render. Selection stays in settings/ui state; the rail only
+ * owns which of its buttons the roving tabindex sits on.
+ */
+function SidebarRail({
+  repoTab,
+  onChangeTab,
+  onSelectSecondary,
+  secondaryTabs,
+  activeSecondaryLabel,
+  taskRunning,
+  toggle,
+}: {
+  repoTab: RepoTab;
+  onChangeTab: (tab: RepoTab) => void;
+  /** Picking a secondary tab also expands the sidebar — its list is the surface. */
+  onSelectSecondary: (tab: RepoTab) => void;
+  secondaryTabs: { tab: RepoTab; label: string }[];
+  activeSecondaryLabel: string | null;
+  taskRunning: boolean;
+  /** The expand control, pinned to the rail's foot. An action, not a tab: it
+   *  stays out of the arrow-key order and is reached by Tab. */
+  toggle: ReactNode;
+}) {
+  const activeId: RailId =
+    RAIL_TABS.find((t) => t.id === repoTab)?.id ?? "more";
+  // The roving target follows the active surface until an arrow key moves it:
+  // More opens a menu rather than switching tabs, so focus there has no
+  // selection to derive itself from.
+  const [focusedId, setFocusedId] = useState<RailId | null>(null);
+  const currentId = focusedId ?? activeId;
+  const railNav = listKeyboardNav<RailId>({
+    items: RAIL_IDS,
+    activeIndex: RAIL_IDS.indexOf(currentId),
+    onActivate: (id) => {
+      setFocusedId(id);
+      if (id !== "more") onChangeTab(id);
+    },
+    rowKey: (id) => id,
+    rowAttr: "data-rail-tab",
+  });
+  // Capture phase: the More button is a Base UI menu trigger, which opens the
+  // menu on ArrowUp/ArrowDown and stops the event before it could bubble to the
+  // rail. Arrows rove the rail; Enter/Space/click still open the menu.
+  function onKeyDownCapture(e: KeyboardEvent) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    if (!(e.target instanceof HTMLElement)) return;
+    // Only the tab buttons rove — the toggle shares the rail but is an action.
+    if (e.target.closest("[data-rail-tab]") === null) return;
+    // An open menu owns the arrows: a pointer-opened popup can leave focus on
+    // the trigger, and its own list navigation must win there.
+    if (e.target.closest("[data-popup-open]") !== null) return;
+    e.stopPropagation();
+    railNav(e);
+  }
+
+  const moreLabel = activeSecondaryLabel ?? "More tabs";
+  const moreRunning = taskRunning && repoTab !== "tasks";
+
+  return (
+    <nav
+      aria-label="Repository tabs"
+      className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+      onKeyDownCapture={onKeyDownCapture}
+    >
+      {RAIL_TABS.map(({ id, label, icon: Icon }) => (
+        <button
+          key={id}
+          type="button"
+          data-rail-tab={id}
+          tabIndex={id === currentId ? 0 : -1}
+          aria-current={id === activeId ? "page" : undefined}
+          aria-label={label}
+          title={label}
+          onClick={() => {
+            setFocusedId(id);
+            onChangeTab(id);
+          }}
+          className={cn(
+            RAIL_BUTTON_CLASS,
+            id === activeId ? RAIL_ACTIVE_CLASS : RAIL_IDLE_CLASS,
+          )}
+        >
+          <Icon className="size-4" />
+        </button>
+      ))}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          title={moreRunning ? `${moreLabel} — a task is running` : moreLabel}
+          render={
+            <button
+              type="button"
+              data-rail-tab="more"
+              tabIndex={currentId === "more" ? 0 : -1}
+              aria-current={activeId === "more" ? "page" : undefined}
+              aria-label={moreLabel}
+              onClick={() => setFocusedId("more")}
+              className={cn(
+                RAIL_BUTTON_CLASS,
+                activeId === "more" ? RAIL_ACTIVE_CLASS : RAIL_IDLE_CLASS,
+              )}
+            />
+          }
+        >
+          <DotsThreeIcon className="size-4" weight="bold" />
+          {moreRunning && (
+            <span
+              className="absolute top-1.5 right-1.5 size-1.5 rounded-full bg-primary ring-2 ring-background"
+              aria-hidden
+            />
+          )}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="right" className="min-w-44">
+          {secondaryTabs.map(({ tab, label }) => (
+            <DropdownMenuItem
+              key={tab}
+              onClick={() => onSelectSecondary(tab)}
+              className={cn(
+                repoTab === tab && "bg-accent text-accent-foreground",
+              )}
+            >
+              {label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {/* `mt-auto`: the toggle sits at the rail's foot, separated from the tabs
+          by whatever height is left, without a row of its own. */}
+      <div className="mt-auto">{toggle}</div>
+    </nav>
+  );
+}
+
 export function RepositoryView() {
   const repoPath = useUiStore((s) => s.repoPath);
   const closeRepo = useUiStore((s) => s.closeRepo);
@@ -210,6 +392,7 @@ export function RepositoryView() {
   const selectedTodo = useUiStore((s) => s.selectedTodo);
   const localPrCreate = useUiStore((s) => s.localPrCreate);
   const closeLocalPrCreate = useUiStore((s) => s.closeLocalPrCreate);
+  const openCommitDialog = useUiStore((s) => s.openCommitDialog);
   // The detail panes run off deferred selections so rapidly arrowing a list
   // (commits, PRs) only loads + renders the item landed on, not every one
   // passed. The lists' own highlights use the live values, so they stay snappy.
@@ -276,6 +459,22 @@ export function RepositoryView() {
   const hasTasks = (scripts.data?.tasks.length ?? 0) > 0;
   // A running task shows a dot on the "More" trigger when you're on another tab.
   const taskRunning = useTaskRunStore((s) => s.activeRun?.status === "running");
+  // Sidebar collapse: persisted, and only ever flipped by the user (the toggle,
+  // the shortcut, or the palette) — the app never collapses it on their behalf.
+  const settings = useSettings();
+  const saveSettings = useSaveSettings();
+  const queryClient = useQueryClient();
+  const sidebarCollapsed = settings.data?.sidebarCollapsed ?? false;
+  const sidebarRef = useRef<HTMLElement>(null);
+  const sidebarToggleRef = useRef<HTMLButtonElement>(null);
+  const sidebarPanelsId = useId();
+  const sidebarBinding = useEffectiveBindings().get("toggle-sidebar") ?? null;
+  // Holds the collapse value whose commit should hand focus to the toggle (null
+  // = nothing pending). Each mode renders its own toggle, so the hand-off can
+  // only happen once the new one exists — and it is consumed on that commit
+  // rather than from a frame scheduled in the handler, because the preference
+  // lives in react-query, whose notify-batched re-render can land after one.
+  const refocusToggleRef = useRef<boolean | null>(null);
 
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");
@@ -294,6 +493,45 @@ export function RepositoryView() {
     startTabTransition(() => setRepoTab(tab));
   }
 
+  /** The one writer for the collapse preference.
+   *  @returns whether it actually changed — false while settings are still
+   *  loading, or when the preference already held `next`. Callers arming
+   *  follow-up work on the transition gate on it. */
+  function setSidebarCollapsed(next: boolean): boolean {
+    const current = settings.data;
+    if (!current || current.sidebarCollapsed === next) return false;
+    // Focus sitting in the sidebar is about to be hidden (the panels) or
+    // unmounted (this mode's toggle, the rail), so it can't be re-homed until
+    // the new mode has rendered its own toggle — arm the hand-off for that
+    // commit rather than focusing a node this flip is about to take away.
+    if (sidebarRef.current?.contains(document.activeElement)) {
+      refocusToggleRef.current = next;
+    }
+    const updated = { ...current, sidebarCollapsed: next };
+    // Patch the cache before persisting: the flip has to land this render, or a
+    // fast double-press reads the stale value and re-issues it — one flip, not
+    // two. A failed write refetches the stored truth back over the patch.
+    queryClient.setQueryData(settingsKeys.settings, updated);
+    saveSettings.mutate(updated, {
+      onError: () =>
+        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+    });
+    return true;
+  }
+
+  function toggleSidebar() {
+    setSidebarCollapsed(!sidebarCollapsed);
+  }
+
+  // A secondary tab's own list IS the sidebar, so picking one from the collapsed
+  // rail expands it — selecting into a hidden list would be a dead end. The menu
+  // returns focus to the rail trigger it is about to unmount, so the toggle
+  // claims it instead.
+  function selectSecondaryFromRail(tab: RepoTab) {
+    changeTab(tab);
+    if (setSidebarCollapsed(false)) refocusToggleRef.current = false;
+  }
+
   // Tab switching mirrors GitHub Desktop's Ctrl+1–4 by default.
   useHotkeyAction("tab-changes", () => changeTab("changes"));
   useHotkeyAction("tab-history", () => changeTab("history"));
@@ -309,6 +547,7 @@ export function RepositoryView() {
   useHotkeyAction("tab-tasks", () => changeTab("tasks"));
   // The Agent tab only exists when AI features are shown (palette-only binding).
   useHotkeyAction("tab-agent", () => changeTab("agent"), aiEnabled);
+  useHotkeyAction("toggle-sidebar", toggleSidebar);
   useHotkeyAction("back-to-repositories", closeRepo);
   // Palette "Run a task…": open the picker from any tab (only when there are
   // tasks to run and running is enabled).
@@ -344,6 +583,10 @@ export function RepositoryView() {
   useHotkeyAction("create-tag", () => requestCreate("tag"));
   // Palette-only "Blame file…": open the fuzzy tracked-file picker from any tab.
   useHotkeyAction("blame-file", () => setBlamePickerOpen(true));
+  // Palette "Open commit dialog": enabled whenever a repo is open — the dialog
+  // explains an un-committable state itself, so opening it empty still tells the
+  // user where they stand.
+  useHotkeyAction("open-commit-dialog", openCommitDialog);
 
   // Fork/upstream lens (PR + Issues surfaces). Wired ONCE here — not in the
   // panels, which can be mounted together under <Activity> (double-register).
@@ -406,6 +649,15 @@ export function RepositoryView() {
       .setTitle(`${title} — ${APP_TITLE}`)
       .catch(() => undefined);
   }, [repoName, alias, headLabel]);
+  useLayoutEffect(() => {
+    if (refocusToggleRef.current !== sidebarCollapsed) return;
+    refocusToggleRef.current = null;
+    // One frame, inside the commit that rendered the new mode's toggle: a Base
+    // UI menu returns focus to its (now unmounted) trigger as it closes and
+    // would otherwise win.
+    requestAnimationFrame(() => sidebarToggleRef.current?.focus());
+  }, [sidebarCollapsed]);
+
   // Reset to the bare title only when the repo view unmounts (repo closed).
   useEffect(() => {
     return () => {
@@ -419,9 +671,52 @@ export function RepositoryView() {
 
   const secondaryTabs = SECONDARY_TABS.filter((t) => aiEnabled || !t.ai);
   const activeSecondary = secondaryTabs.find((t) => t.tab === repoTab);
+  // Tooltip = the action with its effective shortcut appended, e.g. "Collapse
+  // sidebar (Ctrl+Shift+B)"; unbound leaves the bare label. `aria-keyshortcuts`
+  // carries the chord on the ARIA channel so it stays out of the button's name.
+  const sidebarToggleLabel = sidebarCollapsed
+    ? "Expand sidebar"
+    : "Collapse sidebar";
+  const sidebarToggleTitle =
+    sidebarBinding === null
+      ? sidebarToggleLabel
+      : `${sidebarToggleLabel} (${formatBinding(sidebarBinding)})`;
+  // One toggle with two homes — the tab row while expanded, the icon rail's foot
+  // while collapsed — and exactly one mounted at a time (each home renders under
+  // the opposite condition), so both can carry the ref the focus-return effect
+  // aims at.
+  function sidebarToggleButton(className: string) {
+    return (
+      <button
+        ref={sidebarToggleRef}
+        type="button"
+        aria-label={sidebarToggleLabel}
+        aria-expanded={!sidebarCollapsed}
+        aria-controls={sidebarPanelsId}
+        aria-keyshortcuts={
+          sidebarBinding === null
+            ? undefined
+            : bindingToAriaKeyshortcuts(sidebarBinding)
+        }
+        title={sidebarToggleTitle}
+        onClick={toggleSidebar}
+        className={className}
+      >
+        <SidebarSimpleIcon className="size-4" />
+      </button>
+    );
+  }
+  // Panel activity for the ASIDE's tabs: a collapsed sidebar draws none of them,
+  // and Activity defers a hidden panel's effects but not its queries — so the
+  // polls and scans (line counts, runs, findings, the TODO git-grep) stand down
+  // with the panel that would show them. The main pane keeps its own condition:
+  // its detail view is what the user is looking at while the sidebar is closed.
+  function sidebarTabActive(tab: RepoTab): boolean {
+    return repoTab === tab && !sidebarCollapsed;
+  }
   // One source for panel visibility: ChangesPanel gates its line-count poll on
   // the same flag that shows the panel, so the two can't drift apart.
-  const changesActive = repoTab === "changes";
+  const changesActive = sidebarTabActive("changes");
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -430,134 +725,180 @@ export function RepositoryView() {
       <WorktreeRemovalBanner repoPath={repoPath} />
       <PrCreateBanner repoPath={repoPath} />
       <div className="flex min-h-0 flex-1">
-        <aside className="flex w-96 shrink-0 flex-col border-r">
-          <Tabs
-            value={repoTab}
-            onValueChange={(value) => changeTab(value as RepoTab)}
-          >
-            <TabsList className="w-full">
-              <TabsTrigger value="changes" className="min-w-0 flex-1">
-                Changes
-              </TabsTrigger>
-              <TabsTrigger value="history" className="min-w-0 flex-1">
-                History
-              </TabsTrigger>
-              <TabsTrigger value="pulls" className="min-w-0 flex-1">
-                PRs
-              </TabsTrigger>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  title={
-                    taskRunning && repoTab !== "tasks"
-                      ? "A task is running"
-                      : undefined
-                  }
-                  render={
-                    <button
-                      type="button"
-                      aria-label="More tabs"
-                      className={cn(
-                        "relative inline-flex h-[calc(100%-1px)] shrink-0 items-center justify-center gap-1 rounded-none border border-transparent px-2 text-xs font-medium whitespace-nowrap text-foreground/60 transition-all hover:text-foreground data-popup-open:text-foreground dark:text-muted-foreground dark:hover:text-foreground [&_svg]:size-4 [&_svg]:shrink-0",
-                        activeSecondary &&
-                          "bg-background text-foreground dark:border-input dark:bg-input/30 dark:text-foreground",
-                      )}
-                    />
-                  }
-                >
-                  {taskRunning && repoTab !== "tasks" && (
-                    <span
-                      className="size-1.5 shrink-0 rounded-full bg-primary"
-                      aria-hidden
-                    />
-                  )}
-                  {activeSecondary?.label ?? "More"}
-                  <CaretDownIcon data-icon="inline-end" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-44">
-                  {secondaryTabs.map(({ tab, label }) => (
-                    <DropdownMenuItem
-                      key={tab}
-                      onClick={() => changeTab(tab)}
-                      className={cn(
-                        repoTab === tab && "bg-accent text-accent-foreground",
-                      )}
-                    >
-                      {label}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </TabsList>
-          </Tabs>
-          <TabPanel active={changesActive}>
-            <ChangesPanel repoPath={repoPath} active={changesActive} />
-            <CommitBox repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "history"}>
-            <HistoryPanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "compare"}>
-            <ComparePanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "pulls"}>
-            <PullRequestsPanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "issues"}>
-            <IssuesPanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "discussions"}>
-            <DiscussionsPanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "actions"}>
-            <ActionsPanel repoPath={repoPath} active={repoTab === "actions"} />
-          </TabPanel>
-          <TabPanel active={repoTab === "findings"}>
-            <FindingsPanel
-              repoPath={repoPath}
-              active={repoTab === "findings"}
-            />
-          </TabPanel>
-          <TabPanel active={repoTab === "tags"}>
-            <TagsPanel repoPath={repoPath} />
-          </TabPanel>
-          <TabPanel active={repoTab === "insights"}>
-            <InsightsPanel
-              repoPath={repoPath}
-              active={repoTab === "insights"}
-            />
-          </TabPanel>
-          <TabPanel active={repoTab === "code-todos"}>
-            <CodeTodosPanel
-              repoPath={repoPath}
-              active={repoTab === "code-todos"}
-            />
-          </TabPanel>
-          <TabPanel active={repoTab === "tasks"}>
-            <TasksPanel />
-          </TabPanel>
-          {aiEnabled && (
-            <TabPanel active={repoTab === "agent"}>
-              {agentSeen && (
-                <Suspense
-                  fallback={
-                    <LazyPanelFallback
-                      name="agent sessions"
-                      className="min-h-0 flex-1 gap-1.5"
-                      rows={[
-                        "h-7 w-20",
-                        "h-8 w-full",
-                        "h-14 w-full",
-                        "h-14 w-full",
-                        "h-14 w-full",
-                      ]}
-                    />
-                  }
-                >
-                  <SessionList repoPath={repoPath} />
-                </Suspense>
-              )}
-            </TabPanel>
+        {/* The sidebar shares the window's shrink with the content pane: it
+            gives up width down to a 288px floor (the narrowest that still fits
+            its toolbars) instead of the content pane absorbing every pixel. */}
+        <aside
+          ref={sidebarRef}
+          className={cn(
+            "flex shrink-0 flex-col border-r",
+            sidebarCollapsed ? "w-12" : "w-[clamp(288px,32vw,384px)]",
           )}
+        >
+          {sidebarCollapsed && (
+            <SidebarRail
+              repoTab={repoTab}
+              onChangeTab={changeTab}
+              onSelectSecondary={selectSecondaryFromRail}
+              secondaryTabs={secondaryTabs}
+              activeSecondaryLabel={activeSecondary?.label ?? null}
+              taskRunning={taskRunning}
+              toggle={sidebarToggleButton(
+                cn(RAIL_BUTTON_CLASS, RAIL_IDLE_CLASS),
+              )}
+            />
+          )}
+          {/* Hidden, never unmounted: the panels keep the state their Activity
+              wrappers exist to preserve (filters, selections, scroll) across a
+              collapse round-trip, and `hidden` also takes them out of the tab
+              order and the accessibility tree. */}
+          <div
+            id={sidebarPanelsId}
+            className={cn(
+              "flex min-h-0 flex-1 flex-col",
+              sidebarCollapsed && "hidden",
+            )}
+          >
+            <Tabs
+              value={repoTab}
+              onValueChange={(value) => changeTab(value as RepoTab)}
+            >
+              <TabsList className="w-full">
+                <TabsTrigger value="changes" className="min-w-0 flex-1">
+                  <span className="min-w-0 truncate">Changes</span>
+                </TabsTrigger>
+                <TabsTrigger value="history" className="min-w-0 flex-1">
+                  <span className="min-w-0 truncate">History</span>
+                </TabsTrigger>
+                <TabsTrigger value="pulls" className="min-w-0 flex-1">
+                  <span className="min-w-0 truncate">PRs</span>
+                </TabsTrigger>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    title={
+                      taskRunning && repoTab !== "tasks"
+                        ? "A task is running"
+                        : undefined
+                    }
+                    render={
+                      <button
+                        type="button"
+                        aria-label="More tabs"
+                        className={cn(
+                          "relative inline-flex h-[calc(100%-1px)] shrink-0 items-center justify-center gap-1 rounded-none border border-transparent px-2 text-xs font-medium whitespace-nowrap text-foreground/60 transition-all hover:text-foreground data-popup-open:text-foreground dark:text-muted-foreground dark:hover:text-foreground [&_svg]:size-4 [&_svg]:shrink-0",
+                          activeSecondary &&
+                            "bg-background text-foreground dark:border-input dark:bg-input/30 dark:text-foreground",
+                        )}
+                      />
+                    }
+                  >
+                    {taskRunning && repoTab !== "tasks" && (
+                      <span
+                        className="size-1.5 shrink-0 rounded-full bg-primary"
+                        aria-hidden
+                      />
+                    )}
+                    <span className="max-w-24 truncate">
+                      {activeSecondary?.label ?? "More"}
+                    </span>
+                    <CaretDownIcon data-icon="inline-end" />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-44">
+                    {secondaryTabs.map(({ tab, label }) => (
+                      <DropdownMenuItem
+                        key={tab}
+                        onClick={() => changeTab(tab)}
+                        className={cn(
+                          repoTab === tab && "bg-accent text-accent-foreground",
+                        )}
+                      >
+                        {label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                {/* Rides the tab row rather than a strip of its own: the three
+                    triggers are `flex-1 min-w-0` and truncate, so this and the
+                    More button (both `shrink-0`) come out of label width. */}
+                {!sidebarCollapsed &&
+                  sidebarToggleButton(
+                    "inline-flex h-[calc(100%-1px)] w-7 shrink-0 items-center justify-center rounded-none border border-transparent text-foreground/60 outline-none transition-all hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset dark:text-muted-foreground dark:hover:text-foreground [&_svg]:shrink-0",
+                  )}
+              </TabsList>
+            </Tabs>
+            <TabPanel active={changesActive}>
+              <ChangesPanel repoPath={repoPath} active={changesActive} />
+              <CommitBox repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("history")}>
+              <HistoryPanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("compare")}>
+              <ComparePanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("pulls")}>
+              <PullRequestsPanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("issues")}>
+              <IssuesPanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("discussions")}>
+              <DiscussionsPanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("actions")}>
+              <ActionsPanel
+                repoPath={repoPath}
+                active={sidebarTabActive("actions")}
+              />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("findings")}>
+              <FindingsPanel
+                repoPath={repoPath}
+                active={sidebarTabActive("findings")}
+              />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("tags")}>
+              <TagsPanel repoPath={repoPath} />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("insights")}>
+              <InsightsPanel
+                repoPath={repoPath}
+                active={sidebarTabActive("insights")}
+              />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("code-todos")}>
+              <CodeTodosPanel
+                repoPath={repoPath}
+                active={sidebarTabActive("code-todos")}
+              />
+            </TabPanel>
+            <TabPanel active={sidebarTabActive("tasks")}>
+              <TasksPanel />
+            </TabPanel>
+            {aiEnabled && (
+              <TabPanel active={sidebarTabActive("agent")}>
+                {agentSeen && (
+                  <Suspense
+                    fallback={
+                      <LazyPanelFallback
+                        name="agent sessions"
+                        className="min-h-0 flex-1 gap-1.5"
+                        rows={[
+                          "h-7 w-20",
+                          "h-8 w-full",
+                          "h-14 w-full",
+                          "h-14 w-full",
+                          "h-14 w-full",
+                        ]}
+                      />
+                    }
+                  >
+                    <SessionList repoPath={repoPath} />
+                  </Suspense>
+                )}
+              </TabPanel>
+            )}
+          </div>
         </aside>
         <main className="min-w-0 flex-1">
           <TabPanel active={repoTab === "changes"}>
@@ -772,6 +1113,10 @@ export function RepositoryView() {
           if (!o) closeLocalPrCreate();
         }}
       />
+      {/* Hoisted: the commit path that outlives the inline box. A collapsed
+          sidebar hides the aside's panels, so CommitBox's <Activity> tears down
+          its effects and its `commit` hotkey with them. */}
+      <CommitDialog repoPath={repoPath} />
       {/* Palette "Run a task…" picker + the shared run-confirmation dialog.
           Hoisted here so both are reachable from any tab. */}
       <RunTaskPicker

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -229,7 +229,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // carries the reason + remedy AND the count — the count needs a full-contrast
   // home while the button itself sits at disabled opacity. The chains pick the
   // first matching state; `undefined` means the visible label alone suffices
-  // (enabled + synced), so no tooltip and no aria-label are emitted.
+  // (enabled + synced), so no tooltip is emitted and the aria-label falls back
+  // to that bare label — it can't fall back to the CONTENT, which is hidden
+  // below `md`.
   const aheadCount = head?.ahead ?? 0;
   const behindCount = head?.behind ?? 0;
   const pushLabel = diverged
@@ -284,9 +286,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // today's value — the raw description, possibly undefined. `aria-keyshortcuts`
   // carries the shortcut on the proper ARIA channel so it stays OUT of each
   // button's accessible name — for Push/Pull that name is the description-only
-  // `aria-label`; Fetch sets none, so its name is the visible "Fetch" label
-  // (deliberate: its description is the volatile "Last fetched …" string, which
-  // must stay tooltip-only, never a name). Omitted when unbound.
+  // `aria-label`; Fetch pins its own to the same word as its visible label,
+  // because below `md` that label is hidden and the volatile "Last fetched …"
+  // title would otherwise become the name. Omitted when unbound.
   const pushBinding = bindings.get("push") ?? null;
   const pullBinding = bindings.get("pull") ?? null;
   const fetchBinding = bindings.get("fetch") ?? null;
@@ -517,8 +519,12 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           size="sm"
           disabled={busy}
           title={fetchHintTitle}
+          aria-label="Fetch"
           aria-keyshortcuts={fetchKeyshortcuts}
-          className="focus-visible:relative focus-visible:z-10"
+          // max-md:pr-1.5 re-centers the glyph once the label is hidden: the
+          // sm size is px-2.5 and the leading-icon rule already pulls the left
+          // side to pl-1.5, so without this the icon sits 4px off-center.
+          className="focus-visible:relative focus-visible:z-10 max-md:pr-1.5"
           onClick={() => doFetch(false)}
         >
           {fetchRemote.isPending ? (
@@ -526,7 +532,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           ) : (
             <ArrowsClockwiseIcon data-icon="inline-start" />
           )}
-          Fetch
+          {/* Labels drop below `md` so the header fits a 640px window; every
+              icon, count, and accessible name stays put at every width. */}
+          <span className="hidden md:inline">Fetch</span>
         </DisabledReasonButton>
         <DisabledReasonButton
           variant="outline"
@@ -536,9 +544,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           // description, so a describedby copy would read it twice; the wrapper
           // still hovers `pullTitle`, shortcut included.
           title={pullTitle}
-          aria-label={pullDescription}
+          aria-label={pullDescription ?? "Pull"}
           aria-keyshortcuts={pullKeyshortcuts}
-          className="border-l-0 focus-visible:relative focus-visible:z-10"
+          className="border-l-0 focus-visible:relative focus-visible:z-10 max-md:pr-1.5"
           onClick={() => doPull("ffOnly")}
         >
           {/* Covers the recovery compounds too: with the preference on they
@@ -548,7 +556,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           ) : (
             <ArrowDownIcon data-icon="inline-start" />
           )}
-          Pull
+          <span className="hidden md:inline">Pull</span>
           {behindCount > 0 && (
             <span
               aria-hidden="true"
@@ -622,9 +630,9 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           size="sm"
           disabled={busy || detached}
           title={pushTitle}
-          aria-label={pushDescription}
+          aria-label={pushDescription ?? pushLabel}
           aria-keyshortcuts={pushKeyshortcuts}
-          className="border-l-0 focus-visible:relative focus-visible:z-10"
+          className="border-l-0 focus-visible:relative focus-visible:z-10 max-md:pr-1.5"
           onClick={() => {
             if (diverged) {
               setForceConfirmOpen(true);
@@ -640,7 +648,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           ) : (
             <ArrowUpIcon data-icon="inline-start" />
           )}
-          {pushLabel}
+          <span className="hidden md:inline">{pushLabel}</span>
           {aheadCount > 0 && (
             <span
               aria-hidden="true"

--- a/src/features/repository/insights/InsightsBoard.tsx
+++ b/src/features/repository/insights/InsightsBoard.tsx
@@ -151,7 +151,7 @@ export function InsightsBoard({
     // a flex-item sizing hint is inert there and the grid's natural height would
     // leak into the document instead of scrolling inside the board.
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-b p-2">
+      <div className="flex flex-wrap items-center justify-between border-b p-2">
         <h2 className="px-1 text-xs font-medium text-muted-foreground">
           Insights
         </h2>

--- a/src/features/sessions/AgentTranscript.tsx
+++ b/src/features/sessions/AgentTranscript.tsx
@@ -14,9 +14,11 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { type ComponentType, useState } from "react";
 import { Markdown } from "@/components/ui/markdown";
 import { GitDiffView } from "@/features/diff/DiffSurfaceLazy";
+import { SPLIT_MIN_CONTAINER_PX } from "@/features/diff/split-threshold";
 import type { AgentToolKind, TranscriptSegment } from "@/lib/ai/agent";
 import { useSessionFileDiff } from "@/lib/git/queries";
 import type { FileDiff } from "@/lib/git/types";
+import { useContainerWidth } from "@/lib/use-container-width";
 import { cn } from "@/lib/utils";
 import { AgentNarration } from "./AgentNarration";
 
@@ -157,6 +159,10 @@ function InlineDiff({
   repoPath?: string;
   diff: UseQueryResult<FileDiff>;
 }) {
+  // A transcript step's diff sits inside the conversation column, which is
+  // narrower than a diff pane at any window size — measure it so split never
+  // renders below two legible columns.
+  const [paneRef, paneWidth] = useContainerWidth<HTMLDivElement>();
   let body: React.ReactNode;
   if (diff.isPending) {
     body = <InlineNote>Loading diff…</InlineNote>;
@@ -172,12 +178,16 @@ function InlineDiff({
         filePath={filePath}
         text={diff.data.text}
         repoPath={repoPath}
+        forceUnified={paneWidth !== null && paneWidth < SPLIT_MIN_CONTAINER_PX}
       />
     );
   }
   // ph-no-capture: the diff is user code/paths — keep it out of session replay.
   return (
-    <div className="ph-no-capture max-h-96 overflow-auto border-t border-border/60 text-xs">
+    <div
+      ref={paneRef}
+      className="ph-no-capture max-h-96 overflow-auto border-t border-border/60 text-xs"
+    >
       {body}
     </div>
   );

--- a/src/features/sessions/WorktreeChangesView.tsx
+++ b/src/features/sessions/WorktreeChangesView.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useState } from "react";
+import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -103,8 +104,8 @@ export function WorktreeChangesView({ repoPath }: { repoPath: string }) {
         </span>
       </header>
 
-      <div className="flex min-h-0 flex-1">
-        <aside className="flex w-72 shrink-0 flex-col border-r">
+      <DetailRailRow>
+        <DetailRail ariaLabel="Changed files">
           {/* overflow-hidden contains the list's natural height (vendored Root is
               `relative`-only) so a long file list can't leak a window scrollbar. */}
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">
@@ -133,7 +134,7 @@ export function WorktreeChangesView({ repoPath }: { repoPath: string }) {
               ))}
             </div>
           </ScrollArea>
-        </aside>
+        </DetailRail>
         <main className="min-w-0 flex-1">
           {deferredPath ? (
             <DiffSurface
@@ -149,7 +150,7 @@ export function WorktreeChangesView({ repoPath }: { repoPath: string }) {
             <DiffPlaceholder message="Select a file to see its changes" />
           )}
         </main>
-      </div>
+      </DetailRailRow>
     </div>
   );
 }

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { isHostAllowed, normalizeHost } from "@/lib/ai/allowed-hosts";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { withForm } from "@/lib/form";
 import { deleteMcpSecret } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
@@ -210,7 +211,7 @@ export const McpServersSection = withForm({
 
     return (
       <section className="space-y-4">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <h2 className="text-sm font-medium">MCP servers</h2>
             <p className="text-xs text-muted-foreground">
@@ -221,7 +222,7 @@ export const McpServersSection = withForm({
               servers on your machine. Secrets are stored in your OS keychain.
             </p>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex items-center gap-2">
             <Button
               variant="ghost"
               size="sm"
@@ -316,7 +317,13 @@ export const McpServersSection = withForm({
                       }}
                       className="flex items-center gap-2 rounded border px-3 py-2 outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     >
-                      <span className="shrink-0 font-mono text-xs font-medium">
+                      {/* Truncatable, not shrink-0: an unbounded name is the
+                          row's width floor, and the badges beside it are the
+                          part that must never be clipped. */}
+                      <span
+                        className="min-w-0 truncate font-mono text-xs font-medium"
+                        onMouseEnter={clipTitleFromText}
+                      >
                         {server.name}
                       </span>
                       <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase">

--- a/src/features/settings/settings-form.ts
+++ b/src/features/settings/settings-form.ts
@@ -8,15 +8,27 @@ import { type AppSettings, DEFAULT_SETTINGS } from "@/lib/settings/api";
  */
 export type SettingsDraft = Omit<
   AppSettings,
-  "recentRepos" | "diffViewMode" | "defaultBranch" | "theme"
+  | "recentRepos"
+  | "diffViewMode"
+  | "defaultBranch"
+  | "theme"
+  | "diffFileListCollapsed"
+  | "sidebarCollapsed"
 >;
 
 export function toDraft(settings: AppSettings): SettingsDraft {
   // defaultBranch is dropped: it now lives in global git config, edited by its
-  // own form in GitSection, not the bulk Save bar. theme + diffViewMode are
-  // apply-on-change prefs owned by their own controls, not the bulk Save bar.
-  const { recentRepos, diffViewMode, defaultBranch, theme, ...draft } =
-    settings;
+  // own form in GitSection, not the bulk Save bar. theme, diffViewMode, and the
+  // two collapse prefs are apply-on-change, owned by their own controls.
+  const {
+    recentRepos,
+    diffViewMode,
+    defaultBranch,
+    theme,
+    diffFileListCollapsed,
+    sidebarCollapsed,
+    ...draft
+  } = settings;
   return draft;
 }
 

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -206,6 +206,22 @@ export const ACTIONS = [
     category: "Navigation",
     defaultBinding: null,
   },
+  {
+    id: "toggle-sidebar",
+    label: "Collapse or expand the sidebar",
+    category: "Navigation",
+    // mod+b is Show branches, so this takes the shifted form of VS Code's
+    // sidebar chord rather than the plain one.
+    defaultBinding: "mod+shift+b",
+  },
+  {
+    id: "toggle-diff-file-list",
+    label: "Collapse or expand the diff file list",
+    category: "Navigation",
+    // Palette-only by default: it applies on the diff detail surfaces alone, so
+    // it ships without spending a chord. Users can bind a key.
+    defaultBinding: null,
+  },
 
   // Repository
   {
@@ -576,6 +592,14 @@ export const ACTIONS = [
     defaultBinding: "mod+enter",
   },
   {
+    id: "open-commit-dialog",
+    label: "Open commit dialog",
+    category: "Changes",
+    // Palette-only: the dialog is the commit path that exists at every width and
+    // collapse state, so it must be reachable without the inline commit box.
+    defaultBinding: null,
+  },
+  {
     id: "generate-commit-message",
     // The id is persisted in user rebindings, so it keeps its commit-box origin;
     // the chord now drives whatever Generate surface is on screen.
@@ -635,6 +659,14 @@ export const ACTIONS = [
     id: "unstage-selected-files",
     label: "Unstage selected files",
     category: "Changes",
+    defaultBinding: null,
+  },
+  {
+    id: "change-diff-language",
+    label: "Change diff language…",
+    category: "Changes",
+    // Palette-only: it opens the diff language picker, which the diff toolbar
+    // hides at narrow pane widths.
     defaultBinding: null,
   },
 

--- a/src/lib/hotkeys/useGenerateChord.ts
+++ b/src/lib/hotkeys/useGenerateChord.ts
@@ -26,10 +26,10 @@ export interface GenerateAction {
  * listener. `run` undefined means the surface has no generator at all — Hide-AI
  * removed it, or a shared dialog's host passes none — and the chord falls
  * through untouched instead. Nothing generates behind a dialog in that arm
- * either, because the only global handler is the commit box's: Hide-AI leaves
- * it registered but DISABLED, and the listener runs the newest ENABLED handler
- * or none; and off the Changes tab the commit box is unmounted, so it isn't
- * registered at all.
+ * either, because the global handlers are the two commit surfaces' (the box and
+ * the hoisted commit dialog, both via useCommitSubmit): Hide-AI leaves them
+ * registered but DISABLED, and the listener runs the newest ENABLED handler or
+ * none; the box unregisters off the Changes tab and the dialog while closed.
  *
  * Auto-repeat is dropped without swallowing, matching that global listener —
  * holding the chord must not re-fire before the generating flag lands.

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -290,6 +290,12 @@ export interface AppSettings {
    *  one-line peek strip. Global, so the reading space is reclaimed everywhere at
    *  once; the surface's own actions stay docked either way. */
   commentComposerCollapsed: boolean;
+  /** Collapse the file-list rail on the diff detail views. Only applies where the
+   *  pane is wide enough to show the rail at all; narrower panes hide it regardless. */
+  diffFileListCollapsed: boolean;
+  /** Collapse the repository view's left sidebar down to an icon rail. User-toggled
+   *  only — the app never collapses or expands it on the user's behalf. */
+  sidebarCollapsed: boolean;
   /** ISO-8601 expiry the user optionally entered for a Bitbucket (Atlassian) API token —
    *  Bitbucket never reports one, so it's user-supplied. null = not provided; cleared on
    *  disconnect. */
@@ -358,6 +364,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   diffViewMode: "unified",
   collapsedConversationSections: [],
   commentComposerCollapsed: false,
+  diffFileListCollapsed: false,
+  sidebarCollapsed: false,
   bitbucketTokenExpiresAt: null,
 };
 

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -148,6 +148,7 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   // chip's promised session persistence on any repo round-trip.
   compareBranch: null,
   localPrCreate: null,
+  commitDialogOpen: false,
   selectedPr: null,
   pendingPrSection: null,
   pendingReviewId: null,
@@ -282,6 +283,11 @@ interface UiState {
    *  a panel-hosted instance would conceal with the tab that launched it mid-close,
    *  deferring its close and unmount until that tab is next shown. */
   localPrCreate: { defaultHead?: string; defaultBase?: string } | null;
+  /** Whether the pop-out commit dialog is open. In the store (not panel state)
+   *  because the dialog is hoisted at RepositoryView level and opens from the
+   *  palette as well as the commit box — including while the sidebar is
+   *  collapsed, where the inline box is Activity-hidden. Not persisted. */
+  commitDialogOpen: boolean;
   /** Selected workflow run (databaseId) on the Actions tab. */
   selectedRunId: number | null;
   /** Selected finding on the Findings tab. */
@@ -401,6 +407,9 @@ interface UiState {
     defaultBase?: string;
   }) => void;
   closeLocalPrCreate: () => void;
+  /** Open / close the hoisted pop-out commit dialog. */
+  openCommitDialog: () => void;
+  closeCommitDialog: () => void;
   selectRun: (id: number | null) => void;
   selectFinding: (finding: SelectedFinding | null) => void;
   setFindingsLimits: (limits: FindingsLimits) => void;
@@ -509,6 +518,7 @@ export const useUiStore = create<UiState>()((set, get) => {
     pendingIssueDraft: null,
     pendingCreate: null,
     localPrCreate: null,
+    commitDialogOpen: false,
     selectedRunId: null,
     selectedFinding: null,
     findingsLimits: DEFAULT_FINDINGS_LIMITS,
@@ -623,6 +633,8 @@ export const useUiStore = create<UiState>()((set, get) => {
     clearPendingCreate: () => set({ pendingCreate: null }),
     openLocalPrCreate: (seeds) => set({ localPrCreate: seeds ?? {} }),
     closeLocalPrCreate: () => set({ localPrCreate: null }),
+    openCommitDialog: () => set({ commitDialogOpen: true }),
+    closeCommitDialog: () => set({ commitDialogOpen: false }),
     selectRun: (id) => set({ selectedRunId: id }),
     selectFinding: (finding) => set({ selectedFinding: finding }),
     setFindingsLimits: (limits) => set({ findingsLimits: limits }),

--- a/src/lib/use-container-width.ts
+++ b/src/lib/use-container-width.ts
@@ -1,13 +1,6 @@
 import { type RefCallback, useCallback, useRef, useState } from "react";
 
 /**
- * Narrowest container that still fits a side-by-side diff: below it a split
- * view keeps under ~40 monospace columns per side once the ~91px of line-number
- * and marker gutters are taken out, so the surfaces fall back to unified.
- */
-export const SPLIT_MIN_CONTAINER_PX = 672;
-
-/**
  * Measures the BORDER-box width of the element the returned ref is attached to
  * — the same box `getBoundingClientRect` reports, so the first measurement and
  * every observed one agree even on a padded or bordered element. Width is React

--- a/src/lib/use-container-width.ts
+++ b/src/lib/use-container-width.ts
@@ -1,0 +1,44 @@
+import { type RefCallback, useCallback, useRef, useState } from "react";
+
+/**
+ * Narrowest container that still fits a side-by-side diff: below it a split
+ * view keeps under ~40 monospace columns per side once the ~91px of line-number
+ * and marker gutters are taken out, so the surfaces fall back to unified.
+ */
+export const SPLIT_MIN_CONTAINER_PX = 672;
+
+/**
+ * Measures the BORDER-box width of the element the returned ref is attached to
+ * — the same box `getBoundingClientRect` reports, so the first measurement and
+ * every observed one agree even on a padded or bordered element. Width is React
+ * state (a mutable module/ref value would be invisible to the compiler's render
+ * memoization) and integer-rounded so sub-pixel resizes don't re-render.
+ * `null` until the first measurement lands.
+ */
+export function useContainerWidth<T extends HTMLElement>(): [
+  RefCallback<T>,
+  number | null,
+] {
+  const [width, setWidth] = useState<number | null>(null);
+  const observer = useRef<ResizeObserver | null>(null);
+  const measureRef = useCallback((el: T | null) => {
+    observer.current?.disconnect();
+    observer.current = null;
+    // Detach (unmount, or <Activity> hiding the panel): keep the last width so
+    // a re-show renders at the size it had rather than flashing the fallback.
+    if (!el) return;
+    setWidth(Math.round(el.getBoundingClientRect().width));
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      // `contentRect` is the CONTENT box; fall back to it only where
+      // borderBoxSize is unavailable, so the two measurement paths can't
+      // disagree by the element's padding + border.
+      const border = entry.borderBoxSize?.[0]?.inlineSize;
+      setWidth(Math.round(border ?? entry.contentRect.width));
+    });
+    ro.observe(el);
+    observer.current = ro;
+  }, []);
+  return [measureRef, width];
+}


### PR DESCRIPTION
Drops the minimum window width from 960px to 640px so GitDesktop can sit beside an editor in a tiled layout, and reworks every surface that assumed a wide window — the sidebar, the diff file-list rail, issue/PR detail headers, and the commit box. Because a collapsed sidebar hides the inline commit box, the commit composer also gains a pop-out dialog that is reachable from any tab.

### Window and sidebar

- Lowers `minWidth` from `960` to `640` in `src-tauri/tauri.conf.json`.
- Adds `src/lib/use-container-width.ts` — a `useContainerWidth` hook plus the shared `SPLIT_MIN_CONTAINER_PX` threshold, so panes decide their own layout from their own box rather than the viewport.
- Reworks `src/features/repository/RepositoryView.tsx` (the bulk of the diff) so the sidebar narrows with the window and collapses to an icon rail that still switches tabs, and hoists `CommitDialog` so it survives that collapse.
- Persists the new `sidebarCollapsed` and `diffFileListCollapsed` preferences in `src/lib/settings/api.ts`, and excludes both from the bulk Save draft in `src/features/settings/settings-form.ts` — they are apply-on-change, owned by their own controls.
- Registers the new `toggle-sidebar`, `toggle-diff-file-list`, `open-commit-dialog`, and `change-diff-language` actions in `src/lib/hotkeys/registry.ts`.

### Collapsible diff file list

- Adds `src/components/detail-rail.tsx` with `DetailRailRow` (measures the row) and `DetailRail` (the collapsible rail). Two state layers: the persisted preference governs while the row has room, and a row under `RAIL_MIN_CONTAINER_PX` forces the strip with a local, non-persisted expand. Focus is moved onto the replacement toggle button via a single-shot `refocus` ref so it can't drop to `<body>`.
- Adopts the rail in `src/features/history/CommitDetailView.tsx`, `src/features/compare/BranchDiffView.tsx`, `src/features/pulls/PrCommitDetail.tsx`, and `src/features/pulls/RemotePrViewParts.tsx`, replacing each view's fixed `w-72` `<aside>`.

### Diff surface

- `src/features/diff/DiffSurface.tsx` and `src/features/diff/DiffViewer.tsx` measure their own pane and render unified below `SPLIT_MIN_CONTAINER_PX` without writing the preference back, so widening restores split. Pre-measurement (`null`) deliberately follows the preference to avoid a first-paint flash.
- `DiffModeToggle` takes `splitDisabled` and renders Split through `DisabledReasonButton` with a "Pane too narrow for split view" reason; the write is withheld while the override stands in.
- `src/features/diff/LanguagePicker.tsx` and `DiffLanguagePicker.tsx` accept controlled `open` / `onOpenChange`, so the `change-diff-language` action can open a trigger the toolbar's container query has hidden; `DiffViewer` gates its registration on hunk mode to avoid stealing the dispatch from the fallback surface.

### Commit dialog

- Extracts the commit machinery into `src/features/commit/useCommitSubmit.ts` — draft loading, branch-rule lock, staged entries, `canCommit` / disabled reason / label, and the `commit` and `generate-commit-message` hotkey registrations behind an `active` flag.
- Adds `src/features/commit/CommitDialog.tsx`: a roomier composer with a read-only staged-file list (status letters mirroring the Changes panel, line stats from the same `useWorkingLineStats` cache entry), closing itself on commit.
- Rewrites `src/features/commit/CommitBox.tsx` on top of the shared hook and adds the pop-out trigger, deriving its label from the registry entry so it matches the palette row.
- Publishes the in-flight abort at module scope in `src/features/commit/useGenerateCommitMessage.ts` (`liveCancel`) so Cancel in either surface aborts the run that is actually streaming, and retires the entry only when it still belongs to that run.

### Detail views reflow

- Issue and PR headers wrap instead of squeezing the title: `flex-wrap` plus a `flex-auto`, `break-words` heading replaces the `flex-1` spacer in `RemoteIssueView.tsx`, `LocalIssueView.tsx`, `JiraIssueView.tsx`, `LocalPrView.tsx`, and `RemotePrView.tsx`.
- The metadata rails stack under the thread below `@max-2xl` with their own capped scroller in `RemoteIssueViewParts.tsx` (`IssueRail`) and `JiraIssueSidebar.tsx`; the body containers pick up `min-h-0` so the stacked column can't leak a document scrollbar.
- Smaller wrapping/overflow fixes in `SyncControls.tsx`, `InsightsBoard.tsx`, `ConversationListPanel.tsx`, `ExploreScreen.tsx`, `McpServersSection.tsx`, `WorktreeChangesView.tsx`, and an `overflow-hidden` on the `BranchSwitcher.tsx` trigger so its icons can't spill on a narrow header.

### Vendored UI deltas

- `src/components/ui/scroll-area.tsx` renders a horizontal `ScrollBar` — Base UI's viewport is `overflow: scroll` with native bars suppressed, so horizontal overflow otherwise scrolls with no affordance.
- `src/components/ui/popover.tsx` caps popups at `max-w-(--available-width)` so a popup wider than the space beside its trigger can't hang off-screen.
- Both deltas are inventoried under a new "Narrow-window width deltas" section in `src/components/ui/README.md`, with grep markers to detect a re-vendor.

### Documentation

- README gains a "Narrow windows and split-screen" bullet.
- `site/src/data/capabilities.ts` adds the commit-dialog and narrow-window capabilities.
- `src/features/help/content.ts` documents the collapsible sidebar, the narrow-pane split fallback, the collapsible file list, and the pop-out commit dialog, using `{{kbd:…}}` tokens.
- Changelog fragments: `changelog.d/added-commit-dialog.md` and `changelog.d/changed-responsive-narrow-windows.md`.

Relates to #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pop-out commit dialog with staged-file context, AI message generation, and access from any tab or the command palette.
  - Added collapsible sidebars and changed-file rails with keyboard shortcuts and saved preferences.
  - Added responsive layouts for windows and split panes as narrow as 640px.
  - Diff views now adapt to narrow panes with unified mode, collapsible file lists, and horizontal scrolling.
  - Improved narrow-layout behavior for issue views, toolbars, tabs, and popovers.

- **Documentation**
  - Updated help content, capabilities, and release documentation for responsive layouts and commit dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->