### PR TITLE
feat(markdown,issues,pulls): link #123 and @user references in rendered bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,10 +863,18 @@ review via its subscription login. The full list is under
   heading hierarchy, and syntax-highlighted code in ~190 languages (light
   and dark).
 - **Mention & reference autocomplete**: on GitHub and GitLab repos, type
-  `@` in a comment box, reply, edit, diff line comment, or release notes to
-  pick a person and `#` to pick from the recently updated open issues and pull
-  requests, with arrow keys and Enter to accept. GitLab adds `!` for merge
-  requests; each forge offers only the references it links.
+  `@` in a comment box, reply, edit, diff line comment, release notes, or a
+  local PR or issue's description and comments to pick a person and `#` to
+  pick from the recently updated open issues and pull requests, with arrow
+  keys and Enter to accept. GitLab adds `!` for merge requests; each forge
+  offers only the references it links.
+- **References are links**: `#123` and `@user` in a rendered description,
+  comment, review thread, AI review, or release note open what they name. On
+  GitHub, `#123` opens that issue or pull request in the app, whichever it
+  turns out to be; on GitLab, `#123` opens the issue and `!123` the merge
+  request. `@user` opens the profile in your browser. Bitbucket bodies leave
+  references plain, matching Bitbucket itself, and a reference inside a code
+  span or fence stays plain text.
 - **Collapsible comment box**: fold the comment box down to a one-line strip to
   read more of the thread, on every conversation surface — pull requests and
   issues (local, on the forge, and Jira), discussions, and commits. Approve,

--- a/changelog.d/added-local-editor-mentions.md
+++ b/changelog.d/added-local-editor-mentions.md
@@ -1,0 +1,4 @@
+- **Mention autocomplete in local PRs and issues.** On GitHub and GitLab repos,
+  `@`, `#`, and `!` complete people, issues, and pull requests in a local pull
+  request's or issue's description and its comment box, the same way they do on
+  the hosted conversation surfaces.

--- a/changelog.d/added-local-editor-mentions.md
+++ b/changelog.d/added-local-editor-mentions.md
@@ -1,4 +1,4 @@
 - **Mention autocomplete in local PRs and issues.** On GitHub and GitLab repos,
-  `@`, `#`, and `!` complete people, issues, and pull requests in a local pull
-  request's or issue's description and its comment box, the same way they do on
-  the hosted conversation surfaces.
+  a local pull request's or issue's description and comment box complete `@`
+  people and `#` issues and pull requests, with GitLab adding `!` for merge
+  requests, the same way the hosted conversation surfaces do.

--- a/changelog.d/added-reference-autolinks.md
+++ b/changelog.d/added-reference-autolinks.md
@@ -1,0 +1,7 @@
+- **References are links.** `#123` and `@user` now open what they name from any
+  rendered body: descriptions, comments, review threads, AI reviews, and release
+  notes. On GitHub, `#123` opens that issue or pull request in the app, whichever
+  it turns out to be; on GitLab, `#123` opens the issue and `!123` the merge
+  request. `@user` opens the profile in your browser. Bitbucket bodies leave
+  references plain, matching Bitbucket itself, and a reference inside a code span
+  or fence stays plain text everywhere.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -506,7 +506,12 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
-      "@mention & #reference autocomplete — GitHub & GitLab comments, replies, release notes",
+      "@mention & #reference autocomplete — GitHub & GitLab comments, replies, release notes, local PRs & issues",
+  },
+  {
+    group: "Keyboard & Markdown",
+    label:
+      "Reference autolinks — #123 and @user open the pull request, issue, or profile they name",
   },
 
   // — AI · generate & review —

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -506,12 +506,12 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
-      "@mention & #reference autocomplete — GitHub & GitLab comments, replies, release notes, local PRs & issues",
+      "@mention & #reference autocomplete, plus !123 on GitLab — GitHub & GitLab comments, replies, release notes, local PRs & issues",
   },
   {
     group: "Keyboard & Markdown",
     label:
-      "Reference autolinks — #123 and @user open the pull request, issue, or profile they name",
+      "Reference autolinks — #123, @user, and GitLab's !123 open the issue, pull request, or profile they name",
   },
 
   // — AI · generate & review —

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -508,6 +508,8 @@ export function MarkdownEditor({
           )}
         >
           {value.trim() ? (
+            // No refs: in-app navigation from inside an open editor closes the
+            // host dialog via the identity-change reset and discards the draft.
             <Markdown>{value}</Markdown>
           ) : (
             <p className="text-xs text-muted-foreground">Nothing to preview</p>

--- a/src/components/ui/markdown-refs.ts
+++ b/src/components/ui/markdown-refs.ts
@@ -1,0 +1,145 @@
+import type { RendererExtension, TokenizerExtension, Tokens } from "marked";
+import {
+  type MentionTrigger,
+  TRIGGERS,
+} from "@/features/conversations/useMentionCandidates";
+import type { ForgeProvider, RemoteLens } from "@/lib/git/types";
+
+/** What a rendered markdown body needs to linkify forge references: whose
+ *  reference grammar applies, plus the repo and lens a click resolves under. */
+export interface MarkdownRefs {
+  provider: ForgeProvider;
+  repoPath: string;
+  lens: RemoteLens;
+}
+
+/** The `data-ref` values the renderer emits; the click dispatch in markdown.tsx
+ *  routes on exactly these. `issue-or-pr` is GitHub's single number space, which
+ *  nothing in the body can resolve — that happens at click time. */
+export type MarkdownRefKind = "issue-or-pr" | "issue" | "mr" | "user";
+
+/** What each forge's triggers ADDRESS. Which triggers are live at all stays
+ *  TRIGGERS' call (the app's shipped per-forge autolink contract), so the two
+ *  tables can't disagree — Bitbucket autolinks nothing, and lists nothing. */
+const REF_KIND: Record<
+  ForgeProvider,
+  Partial<Record<MentionTrigger, MarkdownRefKind>>
+> = {
+  github: { "#": "issue-or-pr", "@": "user" },
+  gitlab: { "#": "issue", "!": "mr", "@": "user" },
+  bitbucket: {},
+};
+
+/** No forge numbers an item 0, so `#0` is prose. */
+const NUMBER_RE = /^([#!])([1-9]\d{0,9})(?!\w)/;
+/** GitHub's handle grammar: alphanumerics with single internal hyphens, 39 chars
+ *  at most. Deliberately conservative for GitLab, whose logins may hold dots. A
+ *  following `.`/`/` that CONTINUES into a word is part of a longer name or path
+ *  (`@jane.doe`, `@group/sub`), so the whole thing stays plain rather than
+ *  linking a prefix — sentence-ending punctuation still closes a mention. */
+const USER_RE = /^@([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})(?![\w-])(?![./]\w)/;
+/** A reference only opens at a boundary: a word char keeps `word#123` plain, `/`
+ *  keeps a URL fragment plain, and `&` keeps entities like `&#39;` unlinkified.
+ *  Emphasis inherits the asymmetry — `**bold**#278` links where `_italic_#278`
+ *  stays plain, because `_` is itself a word char. */
+const BLOCKED_BEFORE = /[\w/&]/;
+
+let activeRefs: MarkdownRefs | null = null;
+
+/**
+ * Point the extensions at the body about to be parsed. `md.parse` is synchronous
+ * (`{ async: false }`) and JS is single-threaded, so a set → parse → clear around
+ * that one call can never interleave with another body's parse.
+ */
+export function setActiveMarkdownRefs(refs: MarkdownRefs | null): void {
+  activeRefs = refs;
+}
+
+/** Inert fallbacks: a provider string from outside the union (wire drift) must
+ *  degrade to plain text, never throw mid-render. */
+const NO_TRIGGERS: readonly string[] = [];
+const NO_KINDS: Partial<Record<MentionTrigger, MarkdownRefKind>> = {};
+
+/** The active forge's two tables, or null when nothing can match — no context,
+ *  or a forge that autolinks nothing (Bitbucket), which must not pay for a scan. */
+function activeTables(): {
+  triggers: readonly string[];
+  kinds: Partial<Record<MentionTrigger, MarkdownRefKind>>;
+} | null {
+  if (!activeRefs) return null;
+  const { provider } = activeRefs;
+  const triggers =
+    (TRIGGERS[provider] as readonly string[] | undefined) ?? NO_TRIGGERS;
+  if (triggers.length === 0) return null;
+  return { triggers, kinds: REF_KIND[provider] ?? NO_KINDS };
+}
+
+/** What `ch` addresses on the active forge — undefined with no context, or when
+ *  this forge doesn't autolink that trigger. */
+function activeKind(ch: string): MarkdownRefKind | undefined {
+  const tables = activeTables();
+  if (!tables?.triggers.includes(ch)) return undefined;
+  return tables.kinds[ch as MentionTrigger];
+}
+
+interface RefToken extends Tokens.Generic {
+  type: "forgeRef";
+  raw: string;
+  kind: MarkdownRefKind;
+  num?: string;
+  user?: string;
+}
+
+export const forgeRefExtension: TokenizerExtension & RendererExtension = {
+  name: "forgeRef",
+  level: "inline",
+  // marked calls `start` with the source MINUS its first character and cuts the
+  // pending text token right before the returned index — that cut is what lands
+  // the tokenizer on a reference. Returning undefined when there is no context
+  // leaves the cut, and so the output, byte-identical to unextended marked.
+  start(src) {
+    const tables = activeTables();
+    if (!tables) return undefined;
+    for (let i = 0; i < src.length; i++) {
+      const ch = src[i];
+      if (!tables.triggers.includes(ch)) continue;
+      if (!tables.kinds[ch as MentionTrigger]) continue;
+      if (i > 0 && BLOCKED_BEFORE.test(src[i - 1])) continue;
+      return i;
+    }
+    return undefined;
+  },
+  tokenizer(src, tokens) {
+    // A link label's tokens are lexed with `inLink` set (marked's own guard for
+    // its autolinker): an anchor nested there is split by the HTML parser, which
+    // strands the outer link's href.
+    if (this.lexer.state.inLink) return undefined;
+    const kind = activeKind(src[0]);
+    if (!kind) return undefined;
+    // The tokenizer gets no lookbehind and `start` cannot see the character
+    // before its own slice, so the preceding token's last char is the only way
+    // to enforce the boundary at those two positions.
+    const prev = tokens.at(-1)?.raw;
+    if (prev && BLOCKED_BEFORE.test(prev.slice(-1))) return undefined;
+    if (kind === "user") {
+      const user = USER_RE.exec(src);
+      return user
+        ? { type: "forgeRef", raw: user[0], kind, user: user[1] }
+        : undefined;
+    }
+    const num = NUMBER_RE.exec(src);
+    return num
+      ? { type: "forgeRef", raw: num[0], kind, num: num[2] }
+      : undefined;
+  },
+  renderer(token) {
+    const ref = token as RefToken;
+    // Both regexes admit only alphanumerics, `-` and the trigger char, so the
+    // interpolated values carry nothing HTML-special. `href="#"` keeps the link
+    // focusable and hoverable; the click dispatch preventDefaults it.
+    const attr = ref.user
+      ? `data-ref-user="${ref.user}"`
+      : `data-ref-num="${ref.num}"`;
+    return `<a href="#" data-ref="${ref.kind}" ${attr}>${ref.raw}</a>`;
+  },
+};

--- a/src/components/ui/markdown-refs.ts
+++ b/src/components/ui/markdown-refs.ts
@@ -1,8 +1,5 @@
 import type { RendererExtension, TokenizerExtension, Tokens } from "marked";
-import {
-  type MentionTrigger,
-  TRIGGERS,
-} from "@/features/conversations/useMentionCandidates";
+import { type MentionTrigger, TRIGGERS } from "@/lib/git/mention-triggers";
 import type { ForgeProvider, RemoteLens } from "@/lib/git/types";
 
 /** What a rendered markdown body needs to linkify forge references: whose
@@ -30,14 +27,36 @@ const REF_KIND: Record<
   bitbucket: {},
 };
 
-/** No forge numbers an item 0, so `#0` is prose. */
-const NUMBER_RE = /^([#!])([1-9]\d{0,9})(?!\w)/;
-/** GitHub's handle grammar: alphanumerics with single internal hyphens, 39 chars
- *  at most. Deliberately conservative for GitLab, whose logins may hold dots. A
- *  following `.`/`/` that CONTINUES into a word is part of a longer name or path
- *  (`@jane.doe`, `@group/sub`), so the whole thing stays plain rather than
- *  linking a prefix — sentence-ending punctuation still closes a mention. */
-const USER_RE = /^@([a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38})(?![\w-])(?![./]\w)/;
+/** The grammars of the VALUES this renderer emits into `data-ref-num` /
+ *  `data-ref-user`. Both the tokenizer's match and the click dispatch's
+ *  re-validation are built from these fragments so the two can never drift.
+ *  No forge numbers an item 0, so `#0` is prose; handles follow GitHub's rule
+ *  (alphanumerics with single internal hyphens, 39 chars at most), which is
+ *  deliberately conservative for GitLab, whose logins may hold dots. */
+const NUMBER_SRC = String.raw`[1-9]\d{0,9}`;
+const USER_SRC = String.raw`[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}`;
+
+const NUMBER_RE = new RegExp(String.raw`^([#!])(${NUMBER_SRC})(?!\w)`);
+/** A following `.`/`/` that CONTINUES into a word belongs to a longer name or
+ *  path (`@jane.doe`, `@group/sub`), so the whole thing stays plain rather than
+ *  linking a prefix; sentence-ending punctuation still closes a mention. */
+const USER_RE = new RegExp(String.raw`^@(${USER_SRC})(?![\w-])(?![./]\w)`);
+const NUMBER_VALUE_RE = new RegExp(String.raw`^${NUMBER_SRC}$`);
+const USER_VALUE_RE = new RegExp(String.raw`^${USER_SRC}$`);
+
+/** Whether an anchor's `data-ref-num` is one this renderer could have emitted.
+ *  Raw HTML authored in a body survives sanitization with its `data-*` intact,
+ *  so the dispatch re-checks before it navigates or builds a forge URL. */
+export function isValidRefNum(value: string | undefined): value is string {
+  return value !== undefined && NUMBER_VALUE_RE.test(value);
+}
+
+/** The `data-ref-user` twin of {@link isValidRefNum} — rejects paths and any
+ *  other crafted value that could steer the profile URL. */
+export function isValidRefUser(value: string | undefined): value is string {
+  return value !== undefined && USER_VALUE_RE.test(value);
+}
+
 /** A reference only opens at a boundary: a word char keeps `word#123` plain, `/`
  *  keeps a URL fragment plain, and `&` keeps entities like `&#39;` unlinkified.
  *  Emphasis inherits the asymmetry — `**bold**#278` links where `_italic_#278`
@@ -60,18 +79,36 @@ export function setActiveMarkdownRefs(refs: MarkdownRefs | null): void {
 const NO_TRIGGERS: readonly string[] = [];
 const NO_KINDS: Partial<Record<MentionTrigger, MarkdownRefKind>> = {};
 
-/** The active forge's two tables, or null when nothing can match — no context,
- *  or a forge that autolinks nothing (Bitbucket), which must not pay for a scan. */
-function activeTables(): {
+/** A forge's two tables, or null when nothing can match — a forge that autolinks
+ *  nothing (Bitbucket) must not pay for a scan. */
+function tablesFor(provider: ForgeProvider): {
   triggers: readonly string[];
   kinds: Partial<Record<MentionTrigger, MarkdownRefKind>>;
 } | null {
-  if (!activeRefs) return null;
-  const { provider } = activeRefs;
   const triggers =
     (TRIGGERS[provider] as readonly string[] | undefined) ?? NO_TRIGGERS;
   if (triggers.length === 0) return null;
   return { triggers, kinds: REF_KIND[provider] ?? NO_KINDS };
+}
+
+/** {@link tablesFor} for the body currently being parsed. */
+function activeTables() {
+  return activeRefs ? tablesFor(activeRefs.provider) : null;
+}
+
+/** Whether `kind` is one this renderer could have emitted for `provider` — the
+ *  dispatch's guard against a `data-ref` naming a kind this forge never
+ *  produces (GitLab's `mr` on GitHub, anything at all on Bitbucket). Derived
+ *  from the same two tables the tokenizer reads, so the pair can't drift. */
+export function isEmittableRefKind(
+  provider: ForgeProvider,
+  kind: string | undefined,
+): kind is MarkdownRefKind {
+  const tables = tablesFor(provider);
+  if (!tables || kind === undefined) return false;
+  return tables.triggers.some(
+    (ch) => tables.kinds[ch as MentionTrigger] === kind,
+  );
 }
 
 /** What `ch` addresses on the active forge — undefined with no context, or when
@@ -110,10 +147,12 @@ export const forgeRefExtension: TokenizerExtension & RendererExtension = {
     return undefined;
   },
   tokenizer(src, tokens) {
-    // A link label's tokens are lexed with `inLink` set (marked's own guard for
-    // its autolinker): an anchor nested there is split by the HTML parser, which
-    // strands the outer link's href.
-    if (this.lexer.state.inLink) return undefined;
+    // marked's two raw-HTML states, both fatal to a nested anchor: inside a link
+    // label the HTML parser splits the anchor and strands the outer href, and
+    // inside a `<pre|code|kbd|script>` run the reference is quoted text that
+    // must stay text.
+    if (this.lexer.state.inLink || this.lexer.state.inRawBlock)
+      return undefined;
     const kind = activeKind(src[0]);
     if (!kind) return undefined;
     // The tokenizer gets no lookbehind and `start` cannot see the character

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -220,7 +220,8 @@ export function Markdown({
     // GitHub's `#N` addresses one number space, so the kind resolves here: a
     // cached list that already holds the number answers for free (its issue
     // lists exclude PRs), and otherwise the issues endpoint answers for PR
-    // numbers too — a `/pull/` URL is what tells the two apart.
+    // numbers too — the URL's resource segment (…/pull/N vs …/issues/N) tells
+    // the two apart; a substring test would misfire on a repo named `pull`.
     const cachedHas = (list: "pr-list" | "issue-list") =>
       queryClient
         .getQueriesData<{ number: number }[]>({
@@ -240,7 +241,7 @@ export function Markdown({
       const issue = await queryClient.fetchQuery(
         issueDetailsOptions(repoPath, number, lens),
       );
-      if (issue.url.includes("/pull/")) openPr();
+      if (new URL(issue.url).pathname.split("/").at(-2) === "pull") openPr();
       else openIssue();
     } catch (e) {
       toastError(e);

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -6,7 +6,7 @@ import DOMPurify from "dompurify";
 // build (see markdown-hljs.ts), which registers into this same core singleton.
 import hljs from "highlight.js/lib/common";
 import { Marked } from "marked";
-import { useMemo, useSyncExternalStore } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { diffLang } from "@/features/diff/diff-lang";
 import { forgeRepoUrl } from "@/lib/git/api";
 import { issueDetailsOptions } from "@/lib/git/queries";
@@ -18,6 +18,9 @@ import { cn } from "@/lib/utils";
 import { hljsUpgradeStore, upgradeToFullHljs } from "./markdown-hljs";
 import {
   forgeRefExtension,
+  isEmittableRefKind,
+  isValidRefNum,
+  isValidRefUser,
   type MarkdownRefs,
   setActiveMarkdownRefs,
 } from "./markdown-refs";
@@ -99,9 +102,11 @@ export function Markdown({
   refs?: MarkdownRefs;
 }) {
   const queryClient = useQueryClient();
-  const selectPr = useUiStore((s) => s.selectPr);
-  const selectIssue = useUiStore((s) => s.selectIssue);
-  const setRepoTab = useUiStore((s) => s.setRepoTab);
+  // Cold list caches are the norm on local surfaces, so the resolve fetch can be
+  // the only gap between click and navigation. The fetch is cache-first, so the
+  // cursor plus aria-busy is the whole affordance: a spinner or a toast would be
+  // louder than this warrants.
+  const [resolving, setResolving] = useState(false);
   // Subscribe to the highlight.js upgrade: when a fence's exotic language pulls
   // in the full build, this snapshot changes, re-parsing so the previously-plain
   // fence highlights. (Module state read during render is invisible to the React
@@ -130,23 +135,36 @@ export function Markdown({
   /** Navigate to whatever a rendered reference anchor points at. */
   async function openRef(anchor: HTMLAnchorElement) {
     if (!refs) return;
-    const { repoPath, lens } = refs;
+    const { provider, repoPath, lens } = refs;
     const kind = anchor.dataset.ref;
+    // Body-authored raw HTML reaches here with its `data-*` intact (DOMPurify
+    // keeps them by design), so every value is re-checked against the grammar
+    // the renderer emits before it can steer a URL or a selection — the kind
+    // against THIS forge's row, since one forge's kinds aren't another's.
+    if (!isEmittableRefKind(provider, kind)) return;
     if (kind === "user") {
       const user = anchor.dataset.refUser;
-      if (!user) return;
+      if (!isValidRefUser(user)) return;
+      setResolving(true);
       try {
-        // Origin off the repo's server-truth web URL, so GitHub Enterprise and
-        // self-managed GitLab hosts resolve without a host table.
+        // Origin off the repo's server-truth web URL, so GitHub Enterprise and a
+        // self-managed GitLab at a host root need no host table. An instance
+        // served under a path prefix loses that prefix here.
         const origin = new URL(await forgeRepoUrl(repoPath)).origin;
-        await openUrl(`${origin}/${user}`);
+        await openUrl(`${origin}/${encodeURIComponent(user)}`);
       } catch (e) {
         toastError(e);
+      } finally {
+        setResolving(false);
       }
       return;
     }
-    const number = Number(anchor.dataset.refNum);
-    if (!Number.isInteger(number)) return;
+    const refNum = anchor.dataset.refNum;
+    if (!isValidRefNum(refNum)) return;
+    const number = Number(refNum);
+    // Fire-time reads of stable store actions: subscribing would put three
+    // listeners on every rendered body, most of which never carry a reference.
+    const { selectPr, selectIssue, setRepoTab } = useUiStore.getState();
     const openPr = () => {
       selectPr({ kind: "remote", id: String(number) });
       setRepoTab("pulls");
@@ -173,6 +191,7 @@ export function Markdown({
     const activeLens =
       queryClient.getQueryData<RemoteLens>(lensKey(repoPath)) ?? "origin";
     if (activeLens !== lens) {
+      setResolving(true);
       try {
         const details = await queryClient.fetchQuery(
           issueDetailsOptions(repoPath, number, lens),
@@ -180,6 +199,8 @@ export function Markdown({
         await openUrl(details.url);
       } catch (e) {
         toastError(e);
+      } finally {
+        setResolving(false);
       }
       return;
     }
@@ -201,6 +222,7 @@ export function Markdown({
       openIssue();
       return;
     }
+    setResolving(true);
     try {
       const issue = await queryClient.fetchQuery(
         issueDetailsOptions(repoPath, number, lens),
@@ -209,6 +231,8 @@ export function Markdown({
       else openIssue();
     } catch (e) {
       toastError(e);
+    } finally {
+      setResolving(false);
     }
   }
 
@@ -233,6 +257,9 @@ export function Markdown({
   return (
     <div
       onClick={onClick}
+      // The cursor can't reach a keyboard or screen-reader user; aria-busy is
+      // the same signal for them.
+      aria-busy={resolving}
       className={cn(
         "markdown-body text-xs/relaxed break-words",
         // Margins collapse at the edges so previews/comments have no leading or
@@ -249,6 +276,10 @@ export function Markdown({
         // Nested lists hug their parent item rather than opening a full gap.
         "[&_li_ul]:my-1 [&_li_ol]:my-1",
         "[&_a]:cursor-pointer [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-foreground",
+        // AFTER the anchor block, not before: tw-merge keeps the later of two
+        // `[&_a]:cursor-*` classes, so listing this first leaves the anchor on
+        // cursor-pointer and the busy state invisible where the pointer actually is.
+        resolving && "cursor-progress [&_a]:cursor-progress",
         "[&_code]:rounded-none [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]",
         "[&_pre]:my-2.5 [&_pre]:overflow-x-auto [&_pre]:border [&_pre]:border-border [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-[0.85em] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[1em]",
         "[&_blockquote]:my-2.5 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -132,19 +132,34 @@ export function Markdown({
     }
   }, [children, hljsVersion, refs?.provider, refs?.repoPath, refs?.lens]);
 
-  /** Navigate to whatever a rendered reference anchor points at. */
-  async function openRef(anchor: HTMLAnchorElement) {
-    if (!refs) return;
-    const { provider, repoPath, lens } = refs;
+  /**
+   * The reference this anchor addresses, or null when it isn't one this body can
+   * act on. Body-authored raw HTML reaches the DOM with its `data-*` intact
+   * (DOMPurify keeps them by design), so the kind is checked against THIS forge's
+   * row and every value against the grammar the renderer emits. Synchronous
+   * because the click handler decides whether to claim the event on its answer.
+   */
+  function refTarget(anchor: HTMLAnchorElement) {
+    if (!refs) return null;
     const kind = anchor.dataset.ref;
-    // Body-authored raw HTML reaches here with its `data-*` intact (DOMPurify
-    // keeps them by design), so every value is re-checked against the grammar
-    // the renderer emits before it can steer a URL or a selection — the kind
-    // against THIS forge's row, since one forge's kinds aren't another's.
-    if (!isEmittableRefKind(provider, kind)) return;
+    if (!isEmittableRefKind(refs.provider, kind)) return null;
     if (kind === "user") {
       const user = anchor.dataset.refUser;
-      if (!isValidRefUser(user)) return;
+      return isValidRefUser(user) ? ({ kind, user } as const) : null;
+    }
+    const refNum = anchor.dataset.refNum;
+    return isValidRefNum(refNum)
+      ? ({ kind, number: Number(refNum) } as const)
+      : null;
+  }
+
+  /** Navigate to whatever a validated reference target points at. */
+  async function openRef(target: NonNullable<ReturnType<typeof refTarget>>) {
+    if (!refs) return;
+    const { repoPath, lens } = refs;
+    const { kind } = target;
+    if (kind === "user") {
+      const { user } = target;
       setResolving(true);
       try {
         // Origin off the repo's server-truth web URL, so GitHub Enterprise and a
@@ -159,9 +174,7 @@ export function Markdown({
       }
       return;
     }
-    const refNum = anchor.dataset.refNum;
-    if (!isValidRefNum(refNum)) return;
-    const number = Number(refNum);
+    const { number } = target;
     // Fire-time reads of stable store actions: subscribing would put three
     // listeners on every rendered body, most of which never carry a reference.
     const { selectPr, selectIssue, setRepoTab } = useUiStore.getState();
@@ -237,14 +250,18 @@ export function Markdown({
   }
 
   // Event delegation over the rendered body, most specific target first: a forge
-  // reference navigates in-app, and any other external link opens in the system
-  // browser rather than navigating the embedded webview.
+  // reference navigates in-app, then any external link opens in the system browser
+  // rather than navigating the embedded webview, and the fall-through past both is
+  // the seam a future image branch slots into. The in-app branch claims the event
+  // only for a target that fully validates, so a `data-ref` this renderer didn't
+  // emit keeps whatever behavior its href already gives it.
   function onClick(e: React.MouseEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
     if (!anchor) return;
-    if (anchor.dataset.ref) {
+    const target = refTarget(anchor);
+    if (target) {
       e.preventDefault();
-      void openRef(anchor);
+      void openRef(target);
       return;
     }
     const href = anchor.getAttribute("href");

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import DOMPurify from "dompurify";
 // Static `lib/common` (~37 languages) so the common fences highlight instantly
@@ -7,8 +8,19 @@ import hljs from "highlight.js/lib/common";
 import { Marked } from "marked";
 import { useMemo, useSyncExternalStore } from "react";
 import { diffLang } from "@/features/diff/diff-lang";
+import { forgeRepoUrl } from "@/lib/git/api";
+import { issueDetailsOptions } from "@/lib/git/queries";
+import type { RemoteLens } from "@/lib/git/types";
+import { lensKey } from "@/lib/repo-lens/queries";
+import { useUiStore } from "@/lib/stores/ui";
+import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { hljsUpgradeStore, upgradeToFullHljs } from "./markdown-hljs";
+import {
+  forgeRefExtension,
+  type MarkdownRefs,
+  setActiveMarkdownRefs,
+} from "./markdown-refs";
 import "./markdown-highlight.css";
 
 /**
@@ -59,6 +71,10 @@ md.use({
     },
   },
 });
+// Forge references (`#N` / `!N` / `@user`) are GitHub-style post-processing, not
+// GFM, so they only linkify through this extension — and only while a body's
+// active context names a provider (see markdown-refs.ts).
+md.use({ extensions: [forgeRefExtension] });
 
 /**
  * Renders GitHub-flavored Markdown (PR descriptions, comments, AI output).
@@ -73,10 +89,19 @@ md.use({
 export function Markdown({
   children,
   className,
+  refs,
 }: {
   children: string;
   className?: string;
+  /** Forge context that linkifies `#N` / `!N` / `@user` and routes a click on
+   *  one in-app. Omitted (or before forge status resolves) the body renders
+   *  exactly as it did without the extension. */
+  refs?: MarkdownRefs;
 }) {
+  const queryClient = useQueryClient();
+  const selectPr = useUiStore((s) => s.selectPr);
+  const selectIssue = useUiStore((s) => s.selectIssue);
+  const setRepoTab = useUiStore((s) => s.setRepoTab);
   // Subscribe to the highlight.js upgrade: when a fence's exotic language pulls
   // in the full build, this snapshot changes, re-parsing so the previously-plain
   // fence highlights. (Module state read during render is invisible to the React
@@ -89,16 +114,116 @@ export function Markdown({
   // hljsVersion is a deliberate rebuild trigger: marked reads the now-upgraded
   // hljs during parse via module state, not a value passed in, so bumping it is
   // what forces the re-parse that highlights the previously-plain fence.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hljsVersion is an intentional rebuild trigger, not read directly
+  // The ref deps are the three primitives rather than `refs` itself, so a caller
+  // rebuilding the object each render can't re-parse every body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hljsVersion is an intentional rebuild trigger, and `refs` is deliberately tracked by its primitives
   const html = useMemo(() => {
-    const raw = md.parse(children, { async: false }) as string;
-    return DOMPurify.sanitize(raw);
-  }, [children, hljsVersion]);
+    setActiveMarkdownRefs(refs ?? null);
+    try {
+      const raw = md.parse(children, { async: false }) as string;
+      return DOMPurify.sanitize(raw);
+    } finally {
+      setActiveMarkdownRefs(null);
+    }
+  }, [children, hljsVersion, refs?.provider, refs?.repoPath, refs?.lens]);
 
-  // Intercept link clicks (event delegation) so they open externally rather
-  // than navigating the embedded webview.
+  /** Navigate to whatever a rendered reference anchor points at. */
+  async function openRef(anchor: HTMLAnchorElement) {
+    if (!refs) return;
+    const { repoPath, lens } = refs;
+    const kind = anchor.dataset.ref;
+    if (kind === "user") {
+      const user = anchor.dataset.refUser;
+      if (!user) return;
+      try {
+        // Origin off the repo's server-truth web URL, so GitHub Enterprise and
+        // self-managed GitLab hosts resolve without a host table.
+        const origin = new URL(await forgeRepoUrl(repoPath)).origin;
+        await openUrl(`${origin}/${user}`);
+      } catch (e) {
+        toastError(e);
+      }
+      return;
+    }
+    const number = Number(anchor.dataset.refNum);
+    if (!Number.isInteger(number)) return;
+    const openPr = () => {
+      selectPr({ kind: "remote", id: String(number) });
+      setRepoTab("pulls");
+    };
+    const openIssue = () => {
+      selectIssue({ kind: "remote", id: String(number) });
+      setRepoTab("issues");
+    };
+    // GitLab's two kinds skip the lens check below: the origin/upstream lens is
+    // GitHub-fork-only, so a mismatch can't arise here.
+    if (kind === "mr") {
+      openPr();
+      return;
+    }
+    if (kind === "issue") {
+      openIssue();
+      return;
+    }
+    // selectPr/selectIssue hand over a bare number that the destination view
+    // resolves under the repo's ACTIVE lens, so a body rendered under the other
+    // one (a local view, or any surface pinned to origin) can only reach the
+    // right item by leaving the app. A cold cache reads as "origin", matching
+    // useRepoLens' own fallback.
+    const activeLens =
+      queryClient.getQueryData<RemoteLens>(lensKey(repoPath)) ?? "origin";
+    if (activeLens !== lens) {
+      try {
+        const details = await queryClient.fetchQuery(
+          issueDetailsOptions(repoPath, number, lens),
+        );
+        await openUrl(details.url);
+      } catch (e) {
+        toastError(e);
+      }
+      return;
+    }
+    // GitHub's `#N` addresses one number space, so the kind resolves here: a
+    // cached list that already holds the number answers for free (its issue
+    // lists exclude PRs), and otherwise the issues endpoint answers for PR
+    // numbers too — a `/pull/` URL is what tells the two apart.
+    const cachedHas = (list: "pr-list" | "issue-list") =>
+      queryClient
+        .getQueriesData<{ number: number }[]>({
+          queryKey: ["repo", repoPath, list, lens],
+        })
+        .some(([, rows]) => rows?.some((row) => row.number === number));
+    if (cachedHas("pr-list")) {
+      openPr();
+      return;
+    }
+    if (cachedHas("issue-list")) {
+      openIssue();
+      return;
+    }
+    try {
+      const issue = await queryClient.fetchQuery(
+        issueDetailsOptions(repoPath, number, lens),
+      );
+      if (issue.url.includes("/pull/")) openPr();
+      else openIssue();
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  // Event delegation over the rendered body, most specific target first: a forge
+  // reference navigates in-app, and any other external link opens in the system
+  // browser rather than navigating the embedded webview.
   function onClick(e: React.MouseEvent) {
-    const href = (e.target as HTMLElement).closest("a")?.getAttribute("href");
+    const anchor = (e.target as HTMLElement).closest("a");
+    if (!anchor) return;
+    if (anchor.dataset.ref) {
+      e.preventDefault();
+      void openRef(anchor);
+      return;
+    }
+    const href = anchor.getAttribute("href");
     if (href && /^(https?:|mailto:)/.test(href)) {
       e.preventDefault();
       openUrl(href);

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -87,8 +87,8 @@ interface EditTitleBodyDialogProps {
    *  byte-identically. */
   belowBody?: ReactNode;
   /** Opt in to `@`/`#`/`!` autocomplete in the description field, matching the
-   *  composer below the thread. The renderer autolinks references on local bodies
-   *  too, so the local views pass it as the remote ones do. */
+   *  composer below the thread. Local views pass it because their rendered bodies
+   *  linkify those references; the editor's own preview deliberately doesn't. */
   mentions?: MentionSource;
 }
 

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -87,8 +87,8 @@ interface EditTitleBodyDialogProps {
    *  byte-identically. */
   belowBody?: ReactNode;
   /** Opt in to `@`/`#`/`!` autocomplete in the description field, matching the
-   *  composer below the thread. The local views omit it (nothing autolinks a
-   *  local body). */
+   *  composer below the thread. The renderer autolinks references on local bodies
+   *  too, so the local views pass it as the remote ones do. */
   mentions?: MentionSource;
 }
 

--- a/src/features/conversations/LocalComment.tsx
+++ b/src/features/conversations/LocalComment.tsx
@@ -12,6 +12,7 @@ import {
 import { Markdown } from "@/components/ui/markdown";
 import { copyText } from "@/lib/clipboard";
 import { CommentEditor } from "./CommentEditor";
+import type { MentionSource } from "./useMentionCandidates";
 
 /**
  * A comment on a local (offline) PR or issue. Local comments aren't tied to
@@ -25,6 +26,7 @@ export function LocalComment({
   onDelete,
   onHide,
   onUnhide,
+  mentions,
 }: {
   comment: {
     body: string;
@@ -41,6 +43,9 @@ export function LocalComment({
   onHide: () => void;
   /** Un-collapses the comment. */
   onUnhide: () => void;
+  /** The surface's forge context: drives `@`/`#`/`!` autocomplete while editing
+   *  and linkifies the same references in the rendered body. */
+  mentions?: MentionSource;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
@@ -123,6 +128,7 @@ export function LocalComment({
           }}
           onCancel={() => setEditing(false)}
           textareaClassName="max-h-48 min-h-16 resize-y"
+          mentions={mentions}
         />
       ) : hidden && !expanded ? (
         <button
@@ -143,7 +149,7 @@ export function LocalComment({
               Hide comment
             </button>
           )}
-          <Markdown>{comment.body}</Markdown>
+          <Markdown refs={mentions?.refs}>{comment.body}</Markdown>
         </>
       )}
     </div>

--- a/src/features/conversations/Thread.tsx
+++ b/src/features/conversations/Thread.tsx
@@ -307,7 +307,7 @@ export function Thread({
             (renderBody ? (
               renderBody(thread.body)
             ) : (
-              <Markdown>{thread.body}</Markdown>
+              <Markdown refs={mentions?.refs}>{thread.body}</Markdown>
             ))}
         </>
       )}

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -1,8 +1,7 @@
 import { useCallback, useState } from "react";
-// Type-only, so it is erased at compile time: markdown-refs.ts imports TRIGGERS
-// from here, and only an erased import keeps that cycle off the runtime graph.
 import type { MarkdownRefs } from "@/components/ui/markdown-refs";
 import { useForgeGhHost } from "@/lib/git/host";
+import { type MentionTrigger, TRIGGERS } from "@/lib/git/mention-triggers";
 import { useAssignableUsers, useIssueList, usePrList } from "@/lib/git/queries";
 import type {
   ForgeProvider,
@@ -12,8 +11,7 @@ import type {
   RemoteLens,
 } from "@/lib/git/types";
 
-/** A character that opens the suggestion popover when typed at a word boundary. */
-export type MentionTrigger = "@" | "#" | "!";
+export type { MentionTrigger };
 
 export interface MentionCandidate {
   /** Stable React key, unique per row. */
@@ -48,19 +46,6 @@ export interface MentionSource {
     query: string,
   ) => { items: MentionCandidate[]; loading: boolean; isError: boolean };
 }
-
-/**
- * Which triggers each forge autolinks in a comment body. GitHub resolves `#N` from a
- * single number space covering issues AND PRs; GitLab numbers them separately (`#`
- * issues, `!` merge requests). Bitbucket autolinks neither a bare `#N` nor a plain
- * `@nickname` written through its API — its mentions need `@{accountId}`, which
- * `forge_assignable_users` has no Bitbucket arm to supply, so it offers none.
- */
-export const TRIGGERS: Record<ForgeProvider, readonly MentionTrigger[]> = {
-  github: ["@", "#"],
-  gitlab: ["@", "#", "!"],
-  bitbucket: [],
-};
 
 /** No provider resolved yet: the source is inert (no triggers, no queries). */
 const NO_TRIGGERS: readonly MentionTrigger[] = [];

--- a/src/features/conversations/useMentionCandidates.ts
+++ b/src/features/conversations/useMentionCandidates.ts
@@ -1,4 +1,7 @@
 import { useCallback, useState } from "react";
+// Type-only, so it is erased at compile time: markdown-refs.ts imports TRIGGERS
+// from here, and only an erased import keeps that cycle off the runtime graph.
+import type { MarkdownRefs } from "@/components/ui/markdown-refs";
 import { useForgeGhHost } from "@/lib/git/host";
 import { useAssignableUsers, useIssueList, usePrList } from "@/lib/git/queries";
 import type {
@@ -31,6 +34,10 @@ export interface MentionSource {
   triggers: readonly MentionTrigger[];
   /** GitHub host for login-derived avatars; `null` off GitHub. */
   ghHost: string | null;
+  /** The same forge context, shaped for the markdown renderer so a body can
+   *  linkify the references this source helps write. Undefined whenever the
+   *  source is inert (forge status unresolved, or no hosted remote). */
+  refs?: MarkdownRefs;
   /** First time a trigger token opens — flips the lazy queries on. Idempotent. */
   onActive: () => void;
   /** Pure filter over cached data; called during render. `isError` reports that a
@@ -49,7 +56,7 @@ export interface MentionSource {
  * `@nickname` written through its API — its mentions need `@{accountId}`, which
  * `forge_assignable_users` has no Bitbucket arm to supply, so it offers none.
  */
-const TRIGGERS: Record<ForgeProvider, readonly MentionTrigger[]> = {
+export const TRIGGERS: Record<ForgeProvider, readonly MentionTrigger[]> = {
   github: ["@", "#"],
   gitlab: ["@", "#", "!"],
   bitbucket: [],
@@ -248,5 +255,11 @@ export function useMentionCandidates({
     };
   };
 
-  return { triggers, ghHost, onActive, query };
+  return {
+    triggers,
+    ghHost,
+    refs: provider ? { provider, repoPath, lens } : undefined,
+    onActive,
+    query,
+  };
 }

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -753,7 +753,7 @@ export function DiscussionView({
               </DropdownMenu>
             </p>
             {hasVisibleBody(d.body) ? (
-              <Markdown>{d.body}</Markdown>
+              <Markdown refs={mentions.refs}>{d.body}</Markdown>
             ) : (
               <p className="text-xs text-muted-foreground italic">
                 No description provided.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -918,17 +918,26 @@ tabs and a formatting toolbar (bold, italic, headings, quote, code, links, and b
 you write Markdown — issues, discussions, and release notes. On **GitHub** and
 **GitLab** repos, typing **@** suggests people and **#** suggests the recently updated
 **open** issues and pull requests (on GitLab, **#** covers issues and **!** covers
-merge requests). That works
-in the comment box at the bottom of a pull request, issue, discussion, or commit, and
-in replies, edits, line comments on a diff, and release notes; arrow keys move through
-the list, Enter or Tab accepts, and Esc dismisses it. The comment box itself folds to a
-one-line strip when you want more of the thread on screen: the caret at the left of its
-button row collapses it, and clicking the strip (or starting a quote reply) opens it
-again with the cursor in the editor. The caret keeps that slot in both states, so
-collapsing leaves the pointer on the control that opens the box back up. Folded, the
+merge requests). That works in the comment box at the bottom of a pull request, issue,
+discussion, or commit, in replies, edits, line comments on a diff, and release notes,
+and in a local pull request's or issue's description and comment box; arrow keys move
+through the list, Enter or Tab accepts, and Esc dismisses it. The comment box itself
+folds to a one-line strip when you want more of the thread on screen: the caret at the
+left of its button row collapses it, and clicking the strip (or starting a quote reply)
+opens it again with the cursor in the editor. The caret keeps that slot in both states,
+so collapsing leaves the pointer on the control that opens the box back up. Folded, the
 surface's own actions stay on the strip and a saved draft shows its first line there;
 the choice is remembered across every conversation surface and across restarts, and the
 command palette's **Collapse or expand the comment box** toggles it too.
+
+Those references are links once a body is rendered. On **GitHub** and **GitLab**, a
+**#123** in a description, comment, review thread,{{ai}} AI review,{{/ai}} or release note opens that
+pull request or issue right here in the app — GitHub numbers issues and pull requests in
+one sequence, so GitDesktop works out which of the two you meant and takes you to the
+matching tab; on GitLab, **#123** is an issue and **!123** a merge request. **@user**
+opens that person's profile in your browser. **Bitbucket** bodies leave references plain,
+matching Bitbucket itself, and a reference inside backticks or a fenced code block stays
+plain text everywhere.
 
 ## Conflicts with the base branch
 
@@ -1300,6 +1309,8 @@ all** — describe it in Markdown, comment, label, approve, close or reopen (pos
 drafted comment alongside), and merge locally. Local PRs are private to you and never
 written into the repo. When you're ready, **promote** a local PR to a real pull request
 on GitHub or Bitbucket, or a merge request on GitLab, in one click, history preserved.
+On a GitHub or GitLab repo the description and comment box complete **@** mentions and
+**#** references like the hosted ones, and render them as links you can click through.
 
 Its Conversation is the same **date-sorted activity feed** as the hosted PRs: it opens with
 a **created** marker, interleaves the branch's **pushed commits** (grouped, each short SHA
@@ -1571,7 +1582,9 @@ credential** with one button instead of re-entering it.
 A **local issue** is a private, offline to-do tracked in the app — create, edit, label,
 and close or reopen it with no remote, your drafted comment posted alongside. When it's
 ready to share, **promote** it to a GitHub or GitLab issue — or, when the repo has a
-**linked Jira project**, to a Jira issue — in one click.
+**linked Jira project**, to a Jira issue — in one click. On a GitHub or GitLab repo its
+description and comments complete **@** mentions and **#** references, and render them as
+links, the same way the hosted issues do.
 {{ai}}
 ## Hand off to an agent
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -934,7 +934,9 @@ Those references are links once a body is rendered. On **GitHub** and **GitLab**
 **#123** in a description, comment, review thread,{{ai}} AI review,{{/ai}} or release note opens that
 pull request or issue right here in the app — GitHub numbers issues and pull requests in
 one sequence, so GitDesktop works out which of the two you meant and takes you to the
-matching tab; on GitLab, **#123** is an issue and **!123** a merge request. **@user**
+matching tab (a body you're viewing under a fork's other remote opens the item on the
+forge instead, so the number always lands where it belongs); on GitLab, **#123** is an
+issue and **!123** a merge request. **@user**
 opens that person's profile in your browser. **Bitbucket** bodies leave references plain,
 matching Bitbucket itself, and a reference inside backticks or a fenced code block stays
 plain text everywhere.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1310,7 +1310,8 @@ drafted comment alongside), and merge locally. Local PRs are private to you and 
 written into the repo. When you're ready, **promote** a local PR to a real pull request
 on GitHub or Bitbucket, or a merge request on GitLab, in one click, history preserved.
 On a GitHub or GitLab repo the description and comment box complete **@** mentions and
-**#** references like the hosted ones, and render them as links you can click through.
+**#** references (**!** merge requests too on GitLab) like the hosted ones, and render
+them as links you can click through.
 
 Its Conversation is the same **date-sorted activity feed** as the hosted PRs: it opens with
 a **created** marker, interleaves the branch's **pushed commits** (grouped, each short SHA
@@ -1583,8 +1584,8 @@ A **local issue** is a private, offline to-do tracked in the app — create, edi
 and close or reopen it with no remote, your drafted comment posted alongside. When it's
 ready to share, **promote** it to a GitHub or GitLab issue — or, when the repo has a
 **linked Jira project**, to a Jira issue — in one click. On a GitHub or GitLab repo its
-description and comments complete **@** mentions and **#** references, and render them as
-links, the same way the hosted issues do.
+description and comments complete **@** mentions and **#** references (**!** merge
+requests too on GitLab), and render them as links, the same way the hosted issues do.
 {{ai}}
 ## Hand off to an agent
 

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import type { MarkdownRefs } from "@/components/ui/markdown-refs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
@@ -135,10 +136,16 @@ export function CommitDetailView({
   // the diff drives off `deferredPath` (not effectivePath) — so use deferredPath
   // throughout, letting anchors/widget follow the file the diff actually shows
   // while rapid arrow-keying settles.
+  // Inline comment bodies linkify against the same origin-lens repo they were
+  // read from; the resolved provider only, never `providerKey`'s GitHub default.
+  const commentRefs: MarkdownRefs | undefined = provider
+    ? { provider, repoPath, lens: "origin" }
+    : undefined;
   const lineAnchors = useCommitLineAnchors(
     comments.data,
     providerKey === "github" ? remoteSections : undefined,
     commentsEnabled ? deferredPath : null,
+    commentRefs,
   );
   // Both commit queries keep serving the PREVIOUS commit while the selected one
   // loads, so everything derived from them is that commit's until it lands.

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/features/conversations/EditTitleBodyDialog";
 import { LocalComment } from "@/features/conversations/LocalComment";
 import { useLocalConversation } from "@/features/conversations/useLocalConversation";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { copyText } from "@/lib/clipboard";
 import { forgeFeatureReady, useForgeStatus } from "@/lib/git/queries";
@@ -73,6 +74,11 @@ export function LocalIssueView({
   const selectIssue = useUiStore((s) => s.selectIssue);
   const selectedIssue = useUiStore((s) => s.selectedIssue);
   const ghStatus = useForgeStatus(repoPath);
+  const provider = ghStatus.data?.provider;
+  // A local issue's body and comments autolink the forge's references like any
+  // other body, and its editors complete them. Local issues have no lens, so
+  // the candidate lists come off "origin".
+  const mentions = useMentionCandidates({ repoPath, lens: "origin", provider });
   // Two independent publish gates: the forge's static issue-create capability
   // and a live per-user Jira permission probe. The Publish affordance shows when
   // EITHER is available; the dialog itself parameterizes / offers a choice.
@@ -303,7 +309,7 @@ export function LocalIssueView({
           <div className="group flex items-start justify-between gap-2 border-b pb-3">
             <div className="min-w-0 flex-1">
               {issue.body.trim() ? (
-                <Markdown>{issue.body}</Markdown>
+                <Markdown refs={mentions.refs}>{issue.body}</Markdown>
               ) : (
                 <p className="text-xs text-muted-foreground">No description.</p>
               )}
@@ -345,6 +351,7 @@ export function LocalIssueView({
               onDelete={() => setDeletingCommentId(c.id)}
               onHide={() => setCommentHidden(c.id, true)}
               onUnhide={() => setCommentHidden(c.id, false)}
+              mentions={mentions}
             />
           ))}
           {issue.comments.length === 0 && (
@@ -362,6 +369,7 @@ export function LocalIssueView({
         onSubmit={addComment}
         onClear={() => setComment("")}
         submitLabel="Comment"
+        mentions={mentions}
       />
 
       <div className="flex flex-wrap items-center gap-2 border-t p-3">
@@ -516,6 +524,7 @@ export function LocalIssueView({
         description="Updates the title and description of this local issue."
         contentClassName={undefined}
         bodyTextareaClassName="max-h-72"
+        mentions={mentions}
       />
 
       <DeleteCommentDialog

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -1062,7 +1062,7 @@ export function RemoteIssueView({
                   </DropdownMenu>
                 </p>
                 {hasVisibleBody(issue.body) ? (
-                  <Markdown>{issue.body}</Markdown>
+                  <Markdown refs={mentions.refs}>{issue.body}</Markdown>
                 ) : (
                   <p className="text-xs text-muted-foreground italic">
                     No description provided.

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -4,6 +4,7 @@ import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
+import type { MarkdownRefs } from "@/components/ui/markdown-refs";
 import { CommentComposer } from "@/features/conversations/CommentComposer";
 import { DeleteCommentDialog } from "@/features/conversations/DeleteCommentDialog";
 import { Thread } from "@/features/conversations/Thread";
@@ -149,9 +150,20 @@ export function useCommitLineAnchors(
   comments: CommitCommentOut[] | undefined,
   sections: DiffSections | undefined,
   path: string | null,
+  refs?: MarkdownRefs,
 ): DiffLineAnchor[] {
+  // Held by field, not by object: `useMentionCandidates` rebuilds `refs` every
+  // render, and DiffSurface keys its widgets on anchor identity — an object dep
+  // would re-identify every anchor on every pass.
+  const refProvider = refs?.provider;
+  const refRepoPath = refs?.repoPath;
+  const refLens = refs?.lens;
   return useMemo<DiffLineAnchor[]>(() => {
     if (!path) return [];
+    const bodyRefs: MarkdownRefs | undefined =
+      refProvider && refRepoPath && refLens
+        ? { provider: refProvider, repoPath: refRepoPath, lens: refLens }
+        : undefined;
     const byLine = new Map<number, CommitCommentOut[]>();
     for (const c of comments ?? []) {
       if (c.path !== path) continue;
@@ -176,13 +188,13 @@ export function useCommitLineAnchors(
                 )}
                 <p className="text-[11px] font-medium">{c.author}</p>
               </div>
-              <Markdown>{c.body}</Markdown>
+              <Markdown refs={bodyRefs}>{c.body}</Markdown>
             </div>
           ))}
         </div>
       ),
     }));
-  }, [comments, sections, path]);
+  }, [comments, sections, path, refProvider, refRepoPath, refLens]);
 }
 
 /** Map a flat commit comment onto the {@link Thread} prop shape — commit

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/features/conversations/EditTitleBodyDialog";
 import { LocalComment } from "@/features/conversations/LocalComment";
 import { useLocalConversation } from "@/features/conversations/useLocalConversation";
+import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { CommitDetailView } from "@/features/history/CommitDetailView";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
@@ -206,6 +207,9 @@ export function LocalPrView({
   const [promoteOpen, setPromoteOpen] = useState(false);
   const ghStatus = useForgeStatus(repoPath);
   const provider = ghStatus.data?.provider;
+  // A local PR's body and comments autolink the forge's references like any other
+  // body, and its editors complete them. Local PRs have no lens, so "origin".
+  const mentions = useMentionCandidates({ repoPath, lens: "origin", provider });
   // Promote copy names the detected forge. The label spans all three providers;
   // the noun stays two-way because only GitLab calls it a merge request.
   const promoteLabel = providerLabel(provider);
@@ -853,7 +857,7 @@ export function LocalPrView({
               <div className="group flex items-start justify-between gap-2 border-b pb-3">
                 <div className="min-w-0 flex-1">
                   {pr.body.trim() ? (
-                    <Markdown>{pr.body}</Markdown>
+                    <Markdown refs={mentions.refs}>{pr.body}</Markdown>
                   ) : (
                     <p className="text-xs text-muted-foreground">
                       No description.
@@ -944,6 +948,7 @@ export function LocalPrView({
                         onDelete={() => setDeletingCommentId(c.id)}
                         onHide={() => setCommentHidden(c.id, true)}
                         onUnhide={() => setCommentHidden(c.id, false)}
+                        mentions={mentions}
                       />
                     ),
                   });
@@ -1008,6 +1013,7 @@ export function LocalPrView({
             submitLabel="Comment"
             ariaLabel="Leave a note"
             placeholder="Leave a note…"
+            mentions={mentions}
             actions={
               pr.status === "open" && (
                 <Button
@@ -1237,6 +1243,7 @@ export function LocalPrView({
         description="Updates the title and description of this local pull request."
         contentClassName={undefined}
         bodyTextareaClassName="max-h-72"
+        mentions={mentions}
         onGenerate={aiEnabled ? runGenerate : undefined}
         generating={prGen.generating}
         generateDisabled={ahead.length === 0}

--- a/src/features/pulls/PendingReviewBar.tsx
+++ b/src/features/pulls/PendingReviewBar.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { CommentEditor } from "@/features/conversations/CommentEditor";
+import { useForgeStatus } from "@/lib/git/queries";
 import type { RemoteLens } from "@/lib/git/types";
 import {
   type ReviewDraft,
@@ -45,6 +46,10 @@ export function DraftCommentCard({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const updateDraft = useUpdateReviewDraft(repoPath, lens, number);
   const removeDraft = useRemoveReviewDraft(repoPath, lens, number);
+  // A draft body carries the same references the posted comment will, so the
+  // preview linkifies them against the PR's repo.
+  const provider = useForgeStatus(repoPath).data?.provider;
+  const refs = provider ? { provider, repoPath, lens } : undefined;
 
   const next = body.trim();
   const canSave = next.length > 0 && next !== draft.body.trim();
@@ -103,7 +108,7 @@ export function DraftCommentCard({
           textareaClassName="max-h-48 min-h-16 resize-y"
         />
       ) : (
-        <Markdown>{draft.body}</Markdown>
+        <Markdown refs={refs}>{draft.body}</Markdown>
       )}
       <ConfirmDialog
         open={confirmDelete}

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -111,6 +111,7 @@ export function PrCommitDetail({
     comments.data,
     sections,
     effectivePath,
+    { provider, repoPath, lens },
   );
 
   const selected = files.find((f) => f.path === effectivePath);

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/ai/providers";
 import type { AiProviderId, ReviewMode } from "@/lib/ai/types";
 import { copyText } from "@/lib/clipboard";
+import { useForgeStatus } from "@/lib/git/queries";
 import { quickTransition } from "@/lib/motion";
 import {
   useExternalReviews,
@@ -207,6 +208,17 @@ export function PrReviewPanel({
   const notes = useReviewerNotes(context.repoPath, prKind, prRef);
   const hasNotes = Boolean(notes.data?.reviewNotes?.trim());
   const [ignoreNotes, setIgnoreNotes] = useState(false);
+
+  // Review output cites `#N` constantly, so linkify it against the PR's own repo.
+  // `context.provider` is the AI provider — the FORGE one comes from forge status.
+  const forgeProvider = useForgeStatus(context.repoPath).data?.provider;
+  const refs = forgeProvider
+    ? {
+        provider: forgeProvider,
+        repoPath: context.repoPath,
+        lens: context.lens,
+      }
+    : undefined;
 
   const globalReviewAi = settings.data?.reviewAi;
   // Optional dedicated config for security audits (Settings → AI). When set and
@@ -761,11 +773,11 @@ export function PrReviewPanel({
                 </span>
               </p>
               {/* Keep any partial output that streamed before it failed. */}
-              {text.trim() && <Markdown>{text}</Markdown>}
+              {text.trim() && <Markdown refs={refs}>{text}</Markdown>}
             </div>
           ) : text.trim() ? (
             <>
-              <Markdown>{text}</Markdown>
+              <Markdown refs={refs}>{text}</Markdown>
               {thoughts.trim() && <ThoughtsDisclosure thoughts={thoughts} />}
             </>
           ) : generating ? (
@@ -784,7 +796,7 @@ export function PrReviewPanel({
                   — partial output kept. Run it again for a full review.
                 </span>
               </p>
-              <Markdown>{reviewText(keptPartial)}</Markdown>
+              <Markdown refs={refs}>{reviewText(keptPartial)}</Markdown>
               {/* After a restart this record is the only copy of the output, so it needs
                   its own copy path — the live run's Copy above is gone with the run. */}
               <Button

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2741,7 +2741,7 @@ export function RemotePrView({
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">
                     {pr.body.trim() ? (
-                      <Markdown>{pr.body}</Markdown>
+                      <Markdown refs={mentions.refs}>{pr.body}</Markdown>
                     ) : (
                       <p className="text-xs text-muted-foreground">
                         No description provided.

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { Textarea } from "@/components/ui/textarea";
 import { copyText } from "@/lib/clipboard";
+import { useForgeStatus } from "@/lib/git/queries";
 import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
@@ -51,6 +52,10 @@ export function ReviewHistory({
   prKind: "remote" | "local";
   prRef: string;
 }) {
+  // Stored review text cites `#N` the same way a live run does, so it linkifies
+  // against this repo's forge.
+  const provider = useForgeStatus(repoPath).data?.provider;
+  const refs = provider ? { provider, repoPath, lens } : undefined;
   const history = useReviewHistory(repoPath, lens, prKind, prRef);
   const partials = useReviewPartials(repoPath, lens, prKind, prRef);
   const del = useDeleteReview(repoPath, lens, prKind, prRef);
@@ -276,7 +281,7 @@ export function ReviewHistory({
                             and this disclosure sits in the panel's fixed header, above the
                             Close/Merge controls. */}
                         <div className="max-h-64 overflow-y-auto">
-                          <Markdown>{reviewText(r)}</Markdown>
+                          <Markdown refs={refs}>{reviewText(r)}</Markdown>
                           {r.thoughts?.trim() && (
                             <ThoughtsDisclosure thoughts={r.thoughts} />
                           )}

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -718,7 +718,9 @@ export function ReviewThreadCard({
                   <div className="space-y-3">
                     {splitSuggestionSegments(body).map((seg, i) =>
                       seg.kind === "md" ? (
-                        <Markdown key={i}>{seg.text}</Markdown>
+                        <Markdown key={i} refs={mentions?.refs}>
+                          {seg.text}
+                        </Markdown>
                       ) : (
                         <SuggestionBlock
                           key={i}

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -353,7 +353,7 @@ export function TagDetailView({
         <ScrollArea className="min-h-0 flex-1 overflow-hidden">
           <div className={cn("space-y-4 p-4", PLACEHOLDER_FADE, staleDim)}>
             {rel.body.trim() ? (
-              <Markdown>{rel.body}</Markdown>
+              <Markdown refs={mentions.refs}>{rel.body}</Markdown>
             ) : (
               <p className="text-xs text-muted-foreground italic">
                 No release notes.

--- a/src/lib/git/mention-triggers.ts
+++ b/src/lib/git/mention-triggers.ts
@@ -1,0 +1,20 @@
+import type { ForgeProvider } from "./types";
+
+/** A character that opens the suggestion popover when typed at a word boundary. */
+export type MentionTrigger = "@" | "#" | "!";
+
+/**
+ * Which triggers each forge autolinks in a comment body. GitHub resolves `#N` from a
+ * single number space covering issues AND PRs; GitLab numbers them separately (`#`
+ * issues, `!` merge requests). Bitbucket autolinks neither a bare `#N` nor a plain
+ * `@nickname` written through its API — its mentions need `@{accountId}`, which
+ * `forge_assignable_users` has no Bitbucket arm to supply, so it offers none.
+ *
+ * A leaf module so both the composer autocomplete and the markdown renderer can read
+ * one table without either pulling in the other's dependencies.
+ */
+export const TRIGGERS: Record<ForgeProvider, readonly MentionTrigger[]> = {
+  github: ["@", "#"],
+  gitlab: ["@", "#", "!"],
+  bitbucket: [],
+};

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -15,7 +15,7 @@ import { loadRepoLens, saveRepoLens } from "./store";
 // refetches an active query whatever its staleTime — which would re-read disk
 // and overwrite a session-only lens applied by a navigation, repainting the
 // other lens's pull request under the selected number.
-const lensKey = (repo: string) => ["repo-lens", repo] as const;
+export const lensKey = (repo: string) => ["repo-lens", repo] as const;
 
 /** The raw persisted lens for a repo, unfiltered by the gate. Prefer
  *  {@link useRepoLens} in surfaces — this exists so the setter and the switcher


### PR DESCRIPTION
Rendered Markdown bodies now treat forge references as links: `#123`, `!123`, and `@user` open the pull request, issue, or profile they name instead of sitting there as plain text. The same forge context also unlocks `@`/`#`/`!` autocomplete in local PR and issue editors, which previously opted out because nothing autolinked a local body.

### Reference tokenizing and rendering

- Adds `src/components/ui/markdown-refs.ts` — a marked `TokenizerExtension`/`RendererExtension` pair (`forgeRefExtension`) plus the `MarkdownRefs` context shape. A per-forge `REF_KIND` table maps triggers to what they address (GitHub `#` → `issue-or-pr`, GitLab `#` → `issue` and `!` → `mr`, `@` → `user`, Bitbucket → nothing), keyed off the existing `TRIGGERS` table so the two can't disagree.
- Guards the grammar against false positives: `NUMBER_RE` rejects `#0`, `USER_RE` follows GitHub's handle rules and declines prefixes of longer names/paths, `BLOCKED_BEFORE` keeps `word#123`, URL fragments, and entities like `&#39;` plain, and the tokenizer bails on `lexer.state.inLink` so anchors don't nest.
- `setActiveMarkdownRefs` scopes the active context around one synchronous `md.parse`; with no context the extension's `start` returns `undefined`, leaving output byte-identical to unextended marked.

### Renderer plumbing and click routing

- `src/components/ui/markdown.tsx`: `Markdown` takes an optional `refs` prop, registers the extension via `md.use`, and sets/clears the active context around `md.parse` in a `try`/`finally`. The `useMemo` deps track `refs.provider`/`repoPath`/`lens` individually so a caller rebuilding the object each render doesn't re-parse every body.
- Click delegation now checks `data-ref` before the existing external-link branch and hands off to `openRef`: `@user` resolves an origin from `forgeRepoUrl` (so Enterprise and self-managed hosts work without a host table) and opens the profile externally; GitLab's `issue`/`mr` route straight to `selectIssue`/`selectPr` plus `setRepoTab`.
- GitHub's single number space is resolved at click time — cached `pr-list`/`issue-list` query data answers for free, otherwise `issueDetailsOptions` decides by whether the URL contains `/pull/`. When the body's lens differs from the repo's active lens, the item is opened on the web instead of mis-resolving the number in-app.
- `src/lib/repo-lens/queries.ts`: exports `lensKey` so the renderer can read the active lens out of the query cache.

### Passing forge context through the surfaces

- Remote conversation bodies pass `mentions.refs`: `RemotePrView`, `RemoteIssueView`, `DiscussionView`, `TagDetailView`, `Thread`, and `ReviewThreads`.
- AI review output linkifies too — `PrReviewPanel` (live, error-partial, and kept-partial renders), `ReviewHistory`, and the `DraftCommentCard` preview in `PendingReviewBar` each read the *forge* provider from `useForgeStatus`, distinct from the AI provider in `context`.
- `useCommitLineAnchors` in `CommitComments.tsx` accepts optional refs and holds them by field in its `useMemo` deps, since `DiffSurface` keys widgets on anchor identity; `CommitDetailView` passes the origin-lens context and `PrCommitDetail` the PR's.
- `markdown-editor.tsx` deliberately renders its preview without refs — a comment records that in-app navigation from an open editor would close the host dialog and discard the draft.

### Mentions and autolinks on local PRs and issues

- `useMentionCandidates.ts` exports `TRIGGERS` (imported type-only in `markdown-refs.ts` to keep the cycle off the runtime graph) and returns `refs` on `MentionSource`, undefined while the source is inert.
- `LocalPrView.tsx` and `LocalIssueView.tsx` call `useMentionCandidates` with `lens: "origin"` and feed it to the description, comment composer, `LocalComment`, and `EditTitleBodyDialog`.
- `LocalComment.tsx` gains a `mentions` prop driving both the edit-time completion and the rendered body; `EditTitleBodyDialog.tsx`'s `mentions` doc comment is updated now that local views do pass it.

### Documentation

- `README.md`: extends the mention/reference autocomplete bullet to cover local PR and issue editors, and adds a "References are links" bullet covering the per-forge behavior, including that Bitbucket bodies and code spans/fences stay plain.
- `site/src/data/capabilities.ts`: updates the autocomplete label and adds a reference-autolinks capability line.
- `src/features/help/content.ts`: rewrites the mention paragraph, adds a paragraph on rendered references with the AI review mention wrapped in `{{ai}}…{{/ai}}`, and updates the local PR and local issue sections.
- Adds `changelog.d/added-reference-autolinks.md` and `changelog.d/added-local-editor-mentions.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `@`, `#`, and GitLab `!` autocomplete to local pull request and issue descriptions and comments.
  * References such as `#123`, `!123`, and `@user` now render as links across descriptions, comments, review threads, AI reviews, and release notes.
  * Links open relevant issues, pull requests, merge requests, or profiles when supported; code spans and Bitbucket references remain plain text.

* **Documentation**
  * Updated help content and capability documentation with supported surfaces and forge-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->