### PR TITLE
feat(pulls,actions): give branch names their own list-row line

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -163,6 +163,10 @@ separators.
 - A lazy panel's `Suspense` fallback is `LazyPanelFallback`
   (`src/components/lazy-panel-fallback.tsx`) — never `fallback={null}`: a blank
   region has no aria-busy and announces nothing to assistive tech.
+- Loading placeholders for a bordered row list are `ListRowSkeleton`
+  (`src/components/list-row-skeleton.tsx`) with `lines` matching the real row's
+  line count — flush `border-b px-3 py-2` rows, never a padded stack of
+  fixed-height bars, so a cold load doesn't shift the list as rows arrive.
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -163,10 +163,13 @@ separators.
 - A lazy panel's `Suspense` fallback is `LazyPanelFallback`
   (`src/components/lazy-panel-fallback.tsx`) — never `fallback={null}`: a blank
   region has no aria-busy and announces nothing to assistive tech.
-- Loading placeholders for a bordered row list are `ListRowSkeleton`
-  (`src/components/list-row-skeleton.tsx`) with `lines` matching the real row's
-  line count — flush `border-b px-3 py-2` rows, never a padded stack of
-  fixed-height bars, so a cold load doesn't shift the list as rows arrive.
+- Loading placeholders for a bordered row list are `ListRowSkeletons`
+  (`src/components/list-row-skeleton.tsx`), with `lines` matching the real row's
+  line count and `name` naming the content ("Loading pull requests…") — flush
+  `border-b px-3 py-2` rows, never a padded stack of fixed-height bars, so a
+  cold load doesn't shift the list as rows arrive. It carries the group's
+  `aria-busy` + sr-only status; `ListRowSkeleton` is the single row it wraps,
+  not a call-site component.
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.

--- a/changelog.d/changed-list-rows-three-lines.md
+++ b/changelog.d/changed-list-rows-three-lines.md
@@ -1,0 +1,2 @@
+- Pull request and workflow run list rows now give the branch its own line, so
+  branch names and ages stay readable on narrow panels.

--- a/changelog.d/changed-list-rows-three-lines.md
+++ b/changelog.d/changed-list-rows-three-lines.md
@@ -1,2 +1,2 @@
-- Pull request and workflow run list rows now give the branch its own line, so
-  branch names and ages stay readable on narrow panels.
+- Pull request, workflow run, and pipeline list rows now give the branch its
+  own line, so branch names and ages stay readable on narrow panels.

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/** Per-line bar widths, staggered so the shimmer reads as lines of text. */
+const BAR_WIDTHS = ["w-3/5", "w-2/5", "w-1/2"];
+
+/**
+ * A placeholder shaped like one row of a bordered list: the same flush
+ * `border-b px-3 py-2` box and per-line rhythm as the real rows, so real rows
+ * replace skeletons without shifting the list. `lines` must match the real
+ * row's line count (2 = issue rows, 3 = PR / workflow-run / Jira rows).
+ */
+export function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
+  return (
+    <div className="border-b px-3 py-2">
+      {/* Index key: a fixed static list that never reorders. */}
+      {BAR_WIDTHS.slice(0, lines).map((width, i) => (
+        <Skeleton key={i} className={cn("h-4", width, i > 0 && "mt-0.5")} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -11,7 +11,7 @@ const BAR_WIDTHS = ["w-3/5", "w-2/5", "w-1/2"];
  * workflow-run / Jira rows). Callers render `ListRowSkeletons` instead — it
  * wraps this one with the busy announcement a loading region owes readers.
  */
-export function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
+function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
   return (
     <div className="border-b px-3 py-2">
       {/* Index key: a fixed static list that never reorders. */}

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -5,10 +5,11 @@ import { cn } from "@/lib/utils";
 const BAR_WIDTHS = ["w-3/5", "w-2/5", "w-1/2"];
 
 /**
- * A placeholder shaped like one row of a bordered list: the same flush
- * `border-b px-3 py-2` box and per-line rhythm as the real rows, so real rows
- * replace skeletons without shifting the list. `lines` must match the real
- * row's line count (2 = issue rows, 3 = PR / workflow-run / Jira rows).
+ * One row placeholder: the same flush `border-b px-3 py-2` box and per-line
+ * rhythm as the real rows, so real rows replace skeletons without shifting the
+ * list. `lines` must match the real row's line count (2 = issue rows, 3 = PR /
+ * workflow-run / Jira rows). Callers render `ListRowSkeletons` instead — it
+ * wraps this one with the busy announcement a loading region owes readers.
  */
 export function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
   return (
@@ -16,6 +17,34 @@ export function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
       {/* Index key: a fixed static list that never reorders. */}
       {BAR_WIDTHS.slice(0, lines).map((width, i) => (
         <Skeleton key={i} className={cn("h-4", width, i > 0 && "mt-0.5")} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A loading section's rows, announced once for the whole group rather than per
+ * row. `name` names the content as a reader hears it — "Loading pull requests…".
+ */
+export function ListRowSkeletons({
+  rows,
+  lines,
+  name,
+}: {
+  rows: number;
+  lines: 2 | 3;
+  name: string;
+}) {
+  return (
+    <div aria-busy>
+      {/* aria-busy alone has no text; role="status" gives the busy region words
+          for readers that announce it. */}
+      <span role="status" className="sr-only">
+        Loading {name}…
+      </span>
+      {/* Index key: a fixed static list that never reorders. */}
+      {Array.from({ length: rows }, (_, i) => (
+        <ListRowSkeleton key={i} lines={lines} />
       ))}
     </div>
   );

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -88,6 +88,7 @@ export function ActionsPanel({
   const writeReason = writeAccessReason(writeAccess.data);
   const writeBlocked = writeAccess.data?.canPush === false;
   const runNoun = isPipelines ? "pipeline" : "workflow";
+  const ciFeature = isPipelines ? "pipelines" : "workflow runs";
   const runHint =
     writeReason ??
     (ghReady
@@ -246,22 +247,11 @@ export function ActionsPanel({
           is `relative`-only) so a long list can't leak a window scrollbar. */}
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {forge.isPending ? (
-          <ListRowSkeletons
-            rows={2}
-            lines={3}
-            name={isPipelines ? "pipelines" : "workflow runs"}
-          />
+          <ListRowSkeletons rows={2} lines={3} name={ciFeature} />
         ) : !ghReady ? (
-          <ForgeNotReady
-            repoPath={repoPath}
-            feature={isPipelines ? "pipelines" : "workflow runs"}
-          />
+          <ForgeNotReady repoPath={repoPath} feature={ciFeature} />
         ) : runs.isPending ? (
-          <ListRowSkeletons
-            rows={3}
-            lines={3}
-            name={isPipelines ? "pipelines" : "workflow runs"}
-          />
+          <ListRowSkeletons rows={3} lines={3} name={ciFeature} />
         ) : runs.isError ? (
           <p className="px-3 py-4 text-xs text-muted-foreground">
             Couldn't load {runNoun} runs. Refresh to try again.

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -3,7 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { type MouseEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
-import { ListRowSkeleton } from "@/components/list-row-skeleton";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -246,21 +246,22 @@ export function ActionsPanel({
           is `relative`-only) so a long list can't leak a window scrollbar. */}
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {forge.isPending ? (
-          <>
-            <ListRowSkeleton lines={3} />
-            <ListRowSkeleton lines={3} />
-          </>
+          <ListRowSkeletons
+            rows={2}
+            lines={3}
+            name={isPipelines ? "pipelines" : "workflow runs"}
+          />
         ) : !ghReady ? (
           <ForgeNotReady
             repoPath={repoPath}
             feature={isPipelines ? "pipelines" : "workflow runs"}
           />
         ) : runs.isPending ? (
-          <>
-            <ListRowSkeleton lines={3} />
-            <ListRowSkeleton lines={3} />
-            <ListRowSkeleton lines={3} />
-          </>
+          <ListRowSkeletons
+            rows={3}
+            lines={3}
+            name={isPipelines ? "pipelines" : "workflow runs"}
+          />
         ) : runs.isError ? (
           <p className="px-3 py-4 text-xs text-muted-foreground">
             Couldn't load {runNoun} runs. Refresh to try again.
@@ -369,7 +370,7 @@ export function ActionsPanel({
                     >
                       {/* Tag/commit-triggered runs have no branch — the dash
                           keeps the row's three-line height. */}
-                      {run.headBranch || "—"}
+                      {run.headBranch || <span aria-hidden="true">—</span>}
                     </p>
                   </button>
                 );

--- a/src/features/actions/ActionsPanel.tsx
+++ b/src/features/actions/ActionsPanel.tsx
@@ -3,6 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { type MouseEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,8 +21,8 @@ import {
 } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { suppressContextMenu } from "@/lib/context-menu";
 import {
   forgeFeatureReady,
@@ -245,21 +246,21 @@ export function ActionsPanel({
           is `relative`-only) so a long list can't leak a window scrollbar. */}
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {forge.isPending ? (
-          <div className="space-y-2 p-3">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-          </div>
+          <>
+            <ListRowSkeleton lines={3} />
+            <ListRowSkeleton lines={3} />
+          </>
         ) : !ghReady ? (
           <ForgeNotReady
             repoPath={repoPath}
             feature={isPipelines ? "pipelines" : "workflow runs"}
           />
         ) : runs.isPending ? (
-          <div className="space-y-2 p-3">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-          </div>
+          <>
+            <ListRowSkeleton lines={3} />
+            <ListRowSkeleton lines={3} />
+            <ListRowSkeleton lines={3} />
+          </>
         ) : runs.isError ? (
           <p className="px-3 py-4 text-xs text-muted-foreground">
             Couldn't load {runNoun} runs. Refresh to try again.
@@ -349,8 +350,11 @@ export function ActionsPanel({
                         {run.displayTitle}
                       </span>
                     </p>
-                    <p className="mt-0.5 truncate pl-5 text-[11px] text-muted-foreground">
-                      {run.workflowName} · {run.headBranch} ·{" "}
+                    <p
+                      className="mt-0.5 truncate pl-5 text-[11px] text-muted-foreground"
+                      onMouseEnter={clipTitleFromText}
+                    >
+                      {run.workflowName} ·{" "}
                       {statusLabel(run.status, run.conclusion)}
                       {parseableDate(run.updatedAt) && (
                         <>
@@ -358,6 +362,14 @@ export function ActionsPanel({
                           <RelativeTime date={run.updatedAt} />
                         </>
                       )}
+                    </p>
+                    <p
+                      className="mt-0.5 truncate pl-5 text-[11px] text-muted-foreground"
+                      onMouseEnter={clipTitleFromText}
+                    >
+                      {/* Tag/commit-triggered runs have no branch — the dash
+                          keeps the row's three-line height. */}
+                      {run.headBranch || "—"}
                     </p>
                   </button>
                 );

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   type Ref,
 } from "react";
+import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -15,7 +16,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
 import { cn } from "@/lib/utils";
 import { LoadMoreRow } from "./LoadMoreRow";
@@ -145,6 +145,9 @@ export function ConversationListPanel<L, R, J = never>(props: {
   renderRemoteRow: (item: R) => ReactNode;
   /** Skeleton rows while the GitHub list loads (PR=2, issue=3). */
   remoteSkeletonRows: number;
+  /** Lines per skeleton row: match the panel's real row layout (three-line
+   *  PR rows vs two-line issue rows); `remoteSkeletonRows` sets the count. */
+  skeletonLines?: 2 | 3;
   /** The remote list fetch failed — render `remoteErrorSlot` in place of the
    *  empty state so a failed load doesn't read as "no items". Omit (the default)
    *  and the remote section behaves exactly as before. */
@@ -228,6 +231,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
     onRemoteHover,
     renderRemoteRow,
     remoteSkeletonRows,
+    skeletonLines = 2,
     remoteError,
     remoteErrorSlot,
     localNoun,
@@ -370,19 +374,15 @@ export function ConversationListPanel<L, R, J = never>(props: {
           />
           {!remoteCollapsed &&
             (ghPending ? (
-              <div className="space-y-2 p-3">
-                <Skeleton className="h-9 w-full" />
-              </div>
+              <ListRowSkeleton lines={skeletonLines} />
             ) : !ghReady ? (
               (remoteNotReadySlot ?? (
                 <ForgeNotReady repoPath={repoPath} feature={feature} />
               ))
             ) : listPending ? (
-              <div className="space-y-2 p-3">
-                {Array.from({ length: remoteSkeletonRows }, (_, i) => (
-                  <Skeleton key={i} className="h-9 w-full" />
-                ))}
-              </div>
+              Array.from({ length: remoteSkeletonRows }, (_, i) => (
+                <ListRowSkeleton key={i} lines={skeletonLines} />
+              ))
             ) : remoteError ? (
               (remoteErrorSlot ?? (
                 <p className="px-3 py-4 text-xs text-muted-foreground">
@@ -419,11 +419,11 @@ export function ConversationListPanel<L, R, J = never>(props: {
                 )}
               </div>
               {jira.pending ? (
-                <div className="space-y-2 p-3">
-                  {Array.from({ length: jira.skeletonRows }, (_, i) => (
-                    <Skeleton key={i} className="h-9 w-full" />
-                  ))}
-                </div>
+                // Jira rows are three-line (status chips · title · key/updated),
+                // unlike this panel's own two-line issue rows.
+                Array.from({ length: jira.skeletonRows }, (_, i) => (
+                  <ListRowSkeleton key={i} lines={3} />
+                ))
               ) : jira.isError ? (
                 (jira.errorSlot ?? (
                   <p className="px-3 py-4 text-xs text-muted-foreground">

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
   type Ref,
 } from "react";
-import { ListRowSkeleton } from "@/components/list-row-skeleton";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -143,11 +143,12 @@ export function ConversationListPanel<L, R, J = never>(props: {
   onSelectRemote: (item: R) => void;
   onRemoteHover: (item: R) => void;
   renderRemoteRow: (item: R) => ReactNode;
-  /** Skeleton rows while the GitHub list loads (PR=2, issue=3). */
+  /** Skeleton rows while the GitHub list loads (PR=2, issue=3) — the row COUNT,
+   *  not lines; see `skeletonRowLines`. */
   remoteSkeletonRows: number;
   /** Lines per skeleton row: match the panel's real row layout (three-line
    *  PR rows vs two-line issue rows); `remoteSkeletonRows` sets the count. */
-  skeletonLines?: 2 | 3;
+  skeletonRowLines?: 2 | 3;
   /** The remote list fetch failed — render `remoteErrorSlot` in place of the
    *  empty state so a failed load doesn't read as "no items". Omit (the default)
    *  and the remote section behaves exactly as before. */
@@ -231,7 +232,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
     onRemoteHover,
     renderRemoteRow,
     remoteSkeletonRows,
-    skeletonLines = 2,
+    skeletonRowLines = 2,
     remoteError,
     remoteErrorSlot,
     localNoun,
@@ -374,15 +375,21 @@ export function ConversationListPanel<L, R, J = never>(props: {
           />
           {!remoteCollapsed &&
             (ghPending ? (
-              <ListRowSkeleton lines={skeletonLines} />
+              <ListRowSkeletons
+                rows={1}
+                lines={skeletonRowLines}
+                name={remoteNoun}
+              />
             ) : !ghReady ? (
               (remoteNotReadySlot ?? (
                 <ForgeNotReady repoPath={repoPath} feature={feature} />
               ))
             ) : listPending ? (
-              Array.from({ length: remoteSkeletonRows }, (_, i) => (
-                <ListRowSkeleton key={i} lines={skeletonLines} />
-              ))
+              <ListRowSkeletons
+                rows={remoteSkeletonRows}
+                lines={skeletonRowLines}
+                name={remoteNoun}
+              />
             ) : remoteError ? (
               (remoteErrorSlot ?? (
                 <p className="px-3 py-4 text-xs text-muted-foreground">
@@ -421,9 +428,11 @@ export function ConversationListPanel<L, R, J = never>(props: {
               {jira.pending ? (
                 // Jira rows are three-line (status chips · title · key/updated),
                 // unlike this panel's own two-line issue rows.
-                Array.from({ length: jira.skeletonRows }, (_, i) => (
-                  <ListRowSkeleton key={i} lines={3} />
-                ))
+                <ListRowSkeletons
+                  rows={jira.skeletonRows}
+                  lines={3}
+                  name="Jira issues"
+                />
               ) : jira.isError ? (
                 (jira.errorSlot ?? (
                   <p className="px-3 py-4 text-xs text-muted-foreground">

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -307,7 +307,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
               >
                 {created && <RelativeTime date={pr.createdAt} />}
                 {pr.archived && (created ? " · archived" : "archived")}
-                {!created && !pr.archived && "—"}
+                {!created && !pr.archived && <span aria-hidden="true">—</span>}
               </p>
               <p
                 className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground"
@@ -460,7 +460,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
           </>
         )}
         remoteSkeletonRows={2}
-        skeletonLines={3}
+        skeletonRowLines={3}
         localNoun="pull requests"
         remoteNoun={remoteNoun}
       >

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -18,6 +18,7 @@ import { PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
 import { RepoLensSwitcher } from "@/features/conversations/RepoLensSwitcher";
 import { useCollapsedSections } from "@/features/conversations/useCollapsedSections";
 import { useLocalRemoteFilter } from "@/features/conversations/useLocalRemoteFilter";
+import { clipTitleFromText } from "@/lib/clip-title";
 import type { PrStateFilter } from "@/lib/git/api";
 import { displayLogin } from "@/lib/git/bot-login";
 import {
@@ -285,31 +286,38 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
           selectedPr?.kind === "local" && selectedPr.id === pr.id
         }
         onSelectLocal={(pr) => selectPr({ kind: "local", id: pr.id })}
-        renderLocalRow={(pr) => (
-          <>
-            <p className="flex items-center gap-1.5 text-xs font-medium">
-              <GitPullRequestIcon className="size-3 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 truncate" title={pr.title}>
-                {pr.title}
-              </span>
-              {pr.status !== "open" && (
-                <Badge variant="secondary" className="capitalize">
-                  {pr.status}
-                </Badge>
-              )}
-            </p>
-            <p className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground">
-              {parseableDate(pr.createdAt) && (
-                <>
-                  <RelativeTime date={pr.createdAt} />
-                  {" · "}
-                </>
-              )}
-              {pr.head} → {pr.base}
-              {pr.archived ? " · archived" : ""}
-            </p>
-          </>
-        )}
+        renderLocalRow={(pr) => {
+          const created = parseableDate(pr.createdAt);
+          return (
+            <>
+              <p className="flex items-center gap-1.5 text-xs font-medium">
+                <GitPullRequestIcon className="size-3 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 truncate" title={pr.title}>
+                  {pr.title}
+                </span>
+                {pr.status !== "open" && (
+                  <Badge variant="secondary" className="capitalize">
+                    {pr.status}
+                  </Badge>
+                )}
+              </p>
+              <p
+                className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground"
+                onMouseEnter={clipTitleFromText}
+              >
+                {created && <RelativeTime date={pr.createdAt} />}
+                {pr.archived && (created ? " · archived" : "archived")}
+                {!created && !pr.archived && "—"}
+              </p>
+              <p
+                className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground"
+                onMouseEnter={clipTitleFromText}
+              >
+                {pr.head} → {pr.base}
+              </p>
+            </>
+          );
+        }}
         localRowContextMenu={(pr, row) => (
           <LocalPrContextMenu repoPath={repoPath} pr={pr}>
             {row}
@@ -399,11 +407,14 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
                 </span>
               )}
             </p>
-            <p className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground">
+            <p
+              className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground"
+              onMouseEnter={clipTitleFromText}
+            >
               #{pr.number}
-              {/* Ahead of the branch names so the row's truncation can't eat it.
-                  Text carries the meaning; the label is self-contained so the
-                  glyph reads on its own. */}
+              {/* Indicators lead this line: truncation eats the tail first, so
+                  the age and author drop before the glyphs. Text carries the
+                  meaning; the label is self-contained so the glyph reads alone. */}
               {mergeMap?.get(pr.number) === "conflicting" && (
                 <>
                   {" · "}
@@ -432,19 +443,24 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
                   </span>
                 </>
               )}
-              {" · "}
-              {pr.author ? `${displayLogin(pr.author.login)} · ` : ""}
+              {pr.author ? ` · ${displayLogin(pr.author.login)}` : ""}
               {parseableDate(pr.createdAt) && (
                 <>
-                  <RelativeTime date={pr.createdAt} />
                   {" · "}
+                  <RelativeTime date={pr.createdAt} />
                 </>
               )}
+            </p>
+            <p
+              className="mt-0.5 truncate pl-4 text-[11px] text-muted-foreground"
+              onMouseEnter={clipTitleFromText}
+            >
               {pr.headRefName} → {pr.baseRefName}
             </p>
           </>
         )}
         remoteSkeletonRows={2}
+        skeletonLines={3}
         localNoun="pull requests"
         remoteNoun={remoteNoun}
       >


### PR DESCRIPTION
Pull request and workflow run rows crammed the branch names onto the same muted line as the age, author, and status, so the branch — usually the thing you're scanning for — was the first thing truncation ate on a narrow panel. This gives the branch its own line in those rows and reshapes the loading placeholders so a cold load no longer shifts the list as real rows arrive.

### Row layout

- Splits `renderLocalRow` in `src/features/pulls/PullRequestsPanel.tsx` into three lines: title, then age plus an `archived` marker, then `pr.head → pr.base` on its own line. When a row has neither a parseable `createdAt` nor `archived`, an em dash holds the middle line so the row keeps its height.
- Splits the remote PR row in the same file the same way — `#number`, status glyphs, author, and age on the middle line, `pr.headRefName → pr.baseRefName` on the third. Author and age now trail the glyphs rather than leading them, since truncation eats the tail first; the inline comment explaining the ordering is updated to match.
- Moves `run.headBranch` onto its own third line in `src/features/actions/ActionsPanel.tsx`, leaving workflow name, status, and updated time on the middle line. Tag- and commit-triggered runs have no branch, so an em dash preserves the three-line height.
- Wires `clipTitleFromText` (`@/lib/clip-title`) to `onMouseEnter` on the new and existing secondary lines in both panels, so a clipped line can still be read in full on hover.

### Loading skeletons

- Adds `ListRowSkeleton` in `src/components/list-row-skeleton.tsx`: a placeholder shaped like a real row — flush `border-b px-3 py-2`, staggered per-line bar widths — taking `lines` of `2 | 3`.
- Adds an optional `skeletonLines` prop (defaulting to `2`) to `ConversationListPanel` in `src/features/conversations/ConversationListPanel.tsx` and replaces the padded `Skeleton` stacks in the remote-pending and list-pending branches with `ListRowSkeleton`. The Jira section is pinned to three lines, since its rows are three-line regardless of the panel's own row shape.
- `PullRequestsPanel` passes `skeletonLines={3}` to match its now three-line rows; `ActionsPanel` swaps both of its pending states over to three-line `ListRowSkeleton` rows.

### Docs and conventions

- Records the skeleton primitive as a house rule in `.claude/skills/gd-conventions/SKILL.md`: bordered row lists use `ListRowSkeleton` with `lines` matching the real row, never a padded stack of fixed-height bars.
- Adds the changelog fragment `changelog.d/changed-list-rows-three-lines.md`. This is a row-layout refinement rather than a new surface, so it carries the fragment and the convention line only — no README, site, or in-app guide copy describes the old two-line rows.

Relates to #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request and workflow run lists now display branch names on a separate line for improved readability on narrow panels.
  * Loading placeholders now better match the layout and number of lines in their corresponding list rows.

* **Bug Fixes**
  * Reduced layout shifting while pull request, workflow, conversation, and Jira lists are loading.
  * Long row text now clips more consistently when hovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->