### PR TITLE
feat(worktrees,branches): show last-active time, fix archive and promote progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ plus markers for never-published and upstream-deleted branches), its +/−
 divergence vs. the default branch (labeled with the default's name), and a
 PR badge.
 
-- **Clean up branches** ⭐: one reviewed list that archives or deletes every
-  stale branch — merged into the default branch (directly, or, where the
+- **Clean up branches** ⭐: one reviewed list that archives or deletes your
+  stale branches — merged into the default branch (directly, or, where the
   forge connection supplies them, by a recent pull request, so squash and
   rebase merges count) or with no commits in a chosen window. Pull-request
   matches go by branch name, so they only badge a row with the PR that took

--- a/README.md
+++ b/README.md
@@ -174,10 +174,12 @@ PR badge.
   its own name.
 - **Worktree manager**: create, switch between, rename, lock, promote a
   worktree's branch into your main checkout, and remove linked worktrees, so
-  you can work on several branches in parallel folders without stashing.
-  One-click jumps to the main workspace sit right in the branch switcher,
-  where each worktree row also carries a context menu with the management
-  actions it supports, and a branch's own menu can remove its worktree.
+  you can work on several branches in parallel folders without stashing. Each
+  row shows when that worktree was last active, so the ones you've finished
+  with are easy to spot. One-click jumps to the main workspace sit right in
+  the branch switcher, where each worktree row also carries a context menu
+  with the management actions it supports, and a branch's own menu can remove
+  its worktree.
 - **Compare**: a tab with a three-dot diff, commits ahead/behind,
   merge/rebase, and jump-to-PR. Each ahead/behind commit shows its tag chips
   and carries a context menu — checkout, cherry-pick, create a branch or tag,

--- a/changelog.d/added-worktree-last-activity.md
+++ b/changelog.d/added-worktree-last-activity.md
@@ -1,0 +1,2 @@
+- The worktree manager shows when each worktree was last active, so the ones
+  you've finished with are easy to spot.

--- a/changelog.d/fixed-archive-worktree-branch.md
+++ b/changelog.d/fixed-archive-worktree-branch.md
@@ -1,0 +1,2 @@
+- A branch checked out in another worktree stays in the branch list: **Archive**
+  is disabled for it, and the menu item names the reason.

--- a/changelog.d/fixed-archive-worktree-branch.md
+++ b/changelog.d/fixed-archive-worktree-branch.md
@@ -1,2 +1,3 @@
-- A branch checked out in another worktree stays in the branch list: **Archive**
-  is disabled for it, and the menu item names the reason.
+- A branch checked out in another worktree stays in the branch list. **Archive**
+  is disabled for it and the menu item names the reason; **Clean up branches**
+  leaves it out of both its archive and delete lists.

--- a/changelog.d/fixed-promote-progress.md
+++ b/changelog.d/fixed-promote-progress.md
@@ -1,0 +1,4 @@
+- Promoting a worktree keeps a status line on screen through every step:
+  removing its worktree, stashing your main workspace changes, then checking out
+  the branch — so a slow promote reads as running, right up to the moment the
+  branch lands.

--- a/changelog.d/fixed-worktree-lists-offline.md
+++ b/changelog.d/fixed-worktree-lists-offline.md
@@ -1,0 +1,3 @@
+- Worktree lists read straight from the repository, with or without a
+  connection: the **Worktrees** manager, the promote dialog's checks, and the
+  branch pickers' "checked out in another worktree" badges all work offline.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -381,7 +381,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
-    label: "Worktree manager — create, switch, rename, lock, promote & remove",
+    label:
+      "Worktree manager — create, switch, rename, lock, promote & remove, with a last-active time per worktree",
     highlight: true,
   },
   {

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -97,6 +97,9 @@ async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
 /// for a worktree under `worktree.useRelativePaths` / `--relative-paths`
 /// (`gitdir: ../<main>/.git/worktrees/<name>`); measured, git 2.51.1. Joining on the
 /// repo path resolves those and leaves an absolute pointer untouched.
+///
+/// `git::worktree::worktree_last_activity_ms` duplicates this resolution rule, so a
+/// change here has to land there too until both are hoisted into one shared helper.
 fn marker_dir(repo: &str) -> Option<std::path::PathBuf> {
     let repo_root = Path::new(repo);
     let dot_git = repo_root.join(".git");

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -1278,9 +1278,14 @@ prunable gitdir file points to non-existent location
     /// The last-activity probe over both worktree shapes: the main checkout,
     /// whose `.git` is a directory, and a linked one, whose `.git` is a pointer
     /// file. Then the index-over-HEAD priority, which every order-blind
-    /// assertion above would also pass for a HEAD-first probe, and the fallback
-    /// chain — index gone leaves HEAD, both gone reports nothing rather than
-    /// erroring.
+    /// assertion above would also pass for a HEAD-first probe, the relative form
+    /// of that pointer, and the fallback chain — index gone leaves HEAD, both
+    /// gone reports nothing rather than erroring.
+    ///
+    /// The pointer is rewritten in place and never restored, so every assertion
+    /// after that stage resolves through the RELATIVE form rather than git's
+    /// absolute one. Deliberate: it keeps both arms exercised, and the admin
+    /// paths the deletions use come from the repo path, not the pointer.
     #[tokio::test]
     async fn last_activity_reads_both_worktree_shapes_and_falls_back() {
         let (base, repo_s) = setup_repo("last-activity").await;
@@ -1335,6 +1340,24 @@ prunable gitdir file points to non-existent location
             worktree_last_activity_ms(&wt_s),
             Some(index_ms),
             "the index is the signal, not HEAD"
+        );
+
+        // git records an ABSOLUTE pointer unless `worktree.useRelativePaths` is on,
+        // so only a hand-built one exercises the relative arm at the filesystem level.
+        let repo_dir = std::path::Path::new(&repo_s)
+            .file_name()
+            .expect("the temp repo has a directory name")
+            .to_string_lossy()
+            .into_owned();
+        std::fs::write(
+            wt.join(".git"),
+            format!("gitdir: ../{repo_dir}/.git/worktrees/age-wt\n"),
+        )
+        .expect("rewrite the pointer in its relative form");
+        assert_eq!(
+            worktree_last_activity_ms(&wt_s),
+            Some(index_ms),
+            "a relative gitdir pointer resolves against the worktree"
         );
 
         std::fs::remove_file(&index).expect("drop the linked index");

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -47,6 +47,9 @@ pub struct UserWorktree {
     pub is_locked: bool,
     /// The lock reason, when one was given (else "").
     pub lock_reason: String,
+    /// Epoch ms of the worktree's last git activity, probed from its index
+    /// file's mtime with HEAD as the fallback. `None` when neither is readable.
+    pub last_activity_ms: Option<i64>,
 }
 
 /// Normalizes a worktree path for cross-source comparison: git prints forward
@@ -187,6 +190,7 @@ pub async fn git_worktree_list_user(
             is_detached: w.detached,
             is_locked: w.locked.is_some(),
             lock_reason: w.locked.unwrap_or_default(),
+            last_activity_ms: worktree_last_activity_ms(&w.path),
             path: w.path,
             branch: w.branch,
             head: w.head,
@@ -721,6 +725,53 @@ fn is_session_worktree(
     false
 }
 
+/// The target of a linked worktree's `.git` pointer file (`gitdir: <path>`).
+/// The recorded path may be relative to the worktree, so callers resolve it.
+fn parse_gitdir_pointer(content: &str) -> Option<&str> {
+    content
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("gitdir:"))
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+}
+
+/// A file's mtime as epoch ms, or `None` when it is unreadable.
+fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let ms = modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    i64::try_from(ms).ok()
+}
+
+/// When git last did work in this worktree, as epoch ms. The index file's mtime
+/// is the signal: it moves on checkout, stage, commit, and status alike, whereas
+/// the admin directory's own mtime and `logs/HEAD` are rewritten wholesale by a
+/// `gc` pass, which makes every dormant worktree look freshly used (measured on
+/// 8 real worktrees, 2026-08-30). HEAD's mtime is the fallback. `None` on
+/// anything unreadable — one worktree with odd admin files must never fail the
+/// whole list.
+fn worktree_last_activity_ms(worktree_path: &str) -> Option<i64> {
+    let root = std::path::Path::new(worktree_path);
+    let dotgit = root.join(".git");
+    // `git::ops::marker_dir` resolves the same `.git`-dir-or-pointer question for
+    // op markers, so a change to either resolution rule has to land in both until
+    // they are hoisted into one shared helper.
+    let admin = match std::fs::metadata(&dotgit) {
+        Ok(meta) if meta.is_dir() => dotgit,
+        // A linked worktree's `.git` is a pointer to `<repo>/.git/worktrees/<id>`,
+        // recorded relative under `worktree.useRelativePaths` — joining on the
+        // tree resolves that and leaves an absolute pointer untouched.
+        Ok(_) => {
+            let pointer = std::fs::read_to_string(&dotgit).ok()?;
+            root.join(parse_gitdir_pointer(&pointer)?)
+        }
+        Err(_) => return None,
+    };
+    file_mtime_ms(&admin.join("index")).or_else(|| file_mtime_ms(&admin.join("HEAD")))
+}
+
 /// Parses `git worktree list --porcelain` into one `WorktreeInfo` per stanza.
 /// Stanzas are blank-line separated; each carries a `worktree <path>` line and
 /// (unless detached) a `branch refs/heads/<name>` line.
@@ -873,6 +924,26 @@ prunable gitdir file points to non-existent location
             ..Default::default()
         };
         assert!(!is_session_worktree(&user, &registry, app_root));
+    }
+
+    #[test]
+    fn parse_gitdir_pointer_reads_absolute_relative_and_padded_forms() {
+        assert_eq!(
+            parse_gitdir_pointer("gitdir: C:/repos/app/.git/worktrees/wt\n"),
+            Some("C:/repos/app/.git/worktrees/wt")
+        );
+        assert_eq!(
+            parse_gitdir_pointer("gitdir: ../repo/.git/worktrees/wt"),
+            Some("../repo/.git/worktrees/wt")
+        );
+        // No space after the colon, and a trailing blank line.
+        assert_eq!(
+            parse_gitdir_pointer("gitdir:/srv/repo/.git/worktrees/wt\n\n"),
+            Some("/srv/repo/.git/worktrees/wt")
+        );
+        assert_eq!(parse_gitdir_pointer("gitdir:\n"), None);
+        assert_eq!(parse_gitdir_pointer("not a pointer file\n"), None);
+        assert_eq!(parse_gitdir_pointer(""), None);
     }
 
     #[test]
@@ -1201,6 +1272,82 @@ prunable gitdir file points to non-existent location
         assert!(
             !registry(&repo_s).await.contains("/gone-wt"),
             "the stale admin entry is gone"
+        );
+    }
+
+    /// The last-activity probe over both worktree shapes: the main checkout,
+    /// whose `.git` is a directory, and a linked one, whose `.git` is a pointer
+    /// file. Then the index-over-HEAD priority, which every order-blind
+    /// assertion above would also pass for a HEAD-first probe, and the fallback
+    /// chain — index gone leaves HEAD, both gone reports nothing rather than
+    /// erroring.
+    #[tokio::test]
+    async fn last_activity_reads_both_worktree_shapes_and_falls_back() {
+        let (base, repo_s) = setup_repo("last-activity").await;
+        let wt = base.path().join("age-wt");
+        let wt_s = wt.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "-b", "feat-age", &wt_s, "HEAD"]).await;
+
+        let now = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        for path in [&repo_s, &wt_s] {
+            let ms = worktree_last_activity_ms(path)
+                .unwrap_or_else(|| panic!("a live worktree has a readable mtime: {path}"));
+            assert!(
+                (ms - now).abs() < 5 * 60 * 1000,
+                "{path}: {ms} is not within 5 minutes of {now}"
+            );
+        }
+
+        let admin = std::path::Path::new(&repo_s)
+            .join(".git")
+            .join("worktrees")
+            .join("age-wt");
+        let index = admin.join("index");
+        let head = admin.join("HEAD");
+
+        // Backdate the index an hour with its bytes untouched, so the two stamps
+        // are ordered and far apart: the probe must report the OLDER one, which
+        // neither a HEAD-first nor a newest-of-the-two resolution can. Setting the
+        // time rather than sleeping keeps this off the filesystem's timestamp
+        // granularity.
+        let handle = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&index)
+            .expect("open the linked index");
+        handle
+            .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(3600))
+            .expect("backdate the linked index");
+        drop(handle);
+
+        let index_ms = file_mtime_ms(&index).expect("the backdated index has an mtime");
+        let head_ms = file_mtime_ms(&head).expect("HEAD has an mtime");
+        assert!(
+            index_ms < head_ms,
+            "the fixture must separate the stamps: index {index_ms}, HEAD {head_ms}"
+        );
+        assert_eq!(
+            worktree_last_activity_ms(&wt_s),
+            Some(index_ms),
+            "the index is the signal, not HEAD"
+        );
+
+        std::fs::remove_file(&index).expect("drop the linked index");
+        assert_eq!(
+            worktree_last_activity_ms(&wt_s),
+            Some(head_ms),
+            "HEAD carries the fallback when the index is unreadable"
+        );
+        std::fs::remove_file(&head).expect("drop the linked HEAD");
+        assert_eq!(
+            worktree_last_activity_ms(&wt_s),
+            None,
+            "an unreadable probe reports nothing instead of failing"
         );
     }
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -519,14 +519,14 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
-  it, collapsing it into an "Archived" section. The branch you're on, the default
-  branch, and a branch checked out in another worktree can't be archived;
-  **Unarchive** has no such limit — it works even on the branch you're checked out on. When creating, the **Base it on** picker is a
-  searchable list grouped into **Local** and **Remote** branches, so you can start
-  from *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
-  starts from the remote tip and leaves the new branch with **no upstream**, so its first
-  push publishes it under its own name — pairs with pushing a branch without switching to it
-  (below).
+  it, collapsing it into an "Archived" section. The branch you're on, the default branch,
+  and a branch checked out in another worktree can't be archived; **Unarchive** has no such
+  limit — it works even on the branch you're checked out on. When creating, the
+  **Base it on** picker is a searchable list grouped into **Local** and **Remote** branches,
+  so you can start from *any* branch — not just the one you're on. Basing on a remote branch
+  (e.g. \`origin/epic/…\`) starts from the remote tip and leaves the new branch with
+  **no upstream**, so its first push publishes it under its own name — pairs with pushing a
+  branch without switching to it (below).
 - **Clean up branches** — from the switcher's menu or the command palette — opens a bulk
   sweep of stale branches: those **merged** into the default branch — directly, or, where
   the repository's forge connection can supply them, through a recent pull request, so
@@ -537,7 +537,8 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   calls merged, and idle ones, start **pre-checked**; a pull-request match goes by branch
   name, so it never pre-checks a row on its own — it badges one for you to confirm. Review
   the list, then **archive** them (reversible) or **delete** them together. The current
-  branch, the default branch, and protected branches are never included.
+  branch, the default branch, and branches checked out in another worktree are never
+  included; deleting also skips protected branches.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
   or renaming one. Whenever the working tree can't describe the branch being named —
   it's clean, or you're renaming a branch you aren't on — it names it from that

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -519,9 +519,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and labeled with the default branch's name.
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
-  it, collapsing it into an "Archived" section. The branch you're on and the default
-  branch can't be archived; **Unarchive** has no such limit — it works even on the
-  branch you're checked out on. When creating, the **Base it on** picker is a
+  it, collapsing it into an "Archived" section. The branch you're on, the default
+  branch, and a branch checked out in another worktree can't be archived;
+  **Unarchive** has no such limit — it works even on the branch you're checked out on. When creating, the **Base it on** picker is a
   searchable list grouped into **Local** and **Remote** branches, so you can start
   from *any* branch — not just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`)
   starts from the remote tip and leaves the new branch with **no upstream**, so its first
@@ -652,7 +652,9 @@ settings*.)
 
 **Worktrees…** (in the ⋮ menu, or the command palette) manages linked worktrees — extra
 folders that each check out a different branch of the same repository, so you can build,
-test, or review several branches at once without stashing or switching.
+test, or review several branches at once without stashing or switching. Each row
+shows when git last did work in that worktree (hover the time for the exact date),
+so the ones you've finished with stand out.
 
 - **Add** a worktree on a new branch (from any base) or an existing one; it's checked out
   into its own folder, defaulting to a sibling of the repository.
@@ -677,8 +679,9 @@ test, or review several branches at once without stashing or switching.
   stash*), and promoting is blocked while the main workspace has a merge, rebase,
   cherry-pick or revert in progress, or unresolved conflicts. Works even on the worktree
   you're currently in. The dialog closes right away and the promote finishes on its own;
-  its removal step shows the same line at the top of the repository view and the same
-  **Removing…** row as a delete.
+  a status line at the top of the repository view names each step (removing the worktree,
+  stashing your changes, checking out the branch) until the branch lands in your main
+  workspace.
 - **Repair links** (footer) re-connects worktrees if you moved or renamed the repository
   folder in your file manager, which otherwise breaks the path each worktree records.
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -108,6 +108,7 @@ import {
 import {
   CleanupBranchesDialog,
   prCheckStateFrom,
+  worktreeCheckStateFrom,
 } from "./CleanupBranchesDialog";
 import { CreateBranchDialog } from "./CreateBranchDialog";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
@@ -483,8 +484,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // Branches checked out in *another* worktree → that worktree's path. Git
   // forbids the same branch in two worktrees, so these can't be checked out
   // here; the row offers to open the worktree instead. The active repo's own
-  // branch is excluded (it's the one you're on). Fetched only while open.
-  const userWorktrees = useUserWorktrees(repoPath, open);
+  // branch is excluded (it's the one you're on). Fetched while the menu OR the
+  // cleanup dialog is open: that dialog's archive and delete exclusions read
+  // this map, and the cleanup hotkey closes the menu on its way to it.
+  const userWorktrees = useUserWorktrees(repoPath, open || cleanupOpen);
   const activeNorm = normPath(repoPath);
   const worktreeByBranch = useMemo(() => {
     const map = new Map<string, string>();
@@ -494,9 +497,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
     return map;
   }, [userWorktrees.data, activeNorm]);
-  // Cross-worktree navigation (fetched only while open): the main workspace, the
-  // other worktrees you can jump to, and whether you're currently in a linked
-  // (non-main) worktree — where a branch checkout lands here, not in main.
+  // Cross-worktree navigation (same fetch as the map above): the main
+  // workspace, the other worktrees you can jump to, and whether you're
+  // currently in a linked (non-main) worktree — where a branch checkout lands
+  // here, not in main.
   const worktreeList = userWorktrees.data ?? [];
   const currentWorktree = worktreeList.find(
     (w) => normPath(w.path) === activeNorm,
@@ -821,8 +825,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       // branch not already occupied by another worktree (that checkout fails too).
       if (deleteTarget === currentName) {
         // Fetch occupancy FRESH: the cached `worktreeByBranch` is gated on the
-        // popover being open, but a delete can fire from the `delete-branch`
-        // hotkey that never opened it — leaving the map empty and the guard moot.
+        // popover or the cleanup dialog being open, and the `delete-branch`
+        // hotkey opens neither — leaving the map empty and the guard moot.
         let occupied: Set<string>;
         try {
           const wts = await listUserWorktrees(repoPath);
@@ -2417,6 +2421,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentBranch={currentName}
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
+        // The map is empty until the read lands and stays empty if it fails, so
+        // the dialog is told which, and holds its list rather than acting on an
+        // exclusion that isn't answering yet.
+        worktreeCheckState={worktreeCheckStateFrom(userWorktrees)}
         prMergedByBranch={mergedPrByBranch}
         // Only the closed list carries merged PRs, and `canGh` is what says the
         // query runs at all — so the dialog is told which of the four it got,

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -95,6 +95,7 @@ import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
 import {
   isWorktreePromoting,
   useWorktreeRemovals,
+  WORKTREE_PROMOTING_MESSAGE,
 } from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
 import { useRetained } from "@/lib/use-retained";
@@ -1376,7 +1377,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       // surface offers to delete the active checkout, and a promote marks its
       // removal under the main workspace's key, never this one's.
       if (isWorktreePromoting(here.path)) {
-        toast.info("This worktree is being promoted.");
+        toast.info(WORKTREE_PROMOTING_MESSAGE);
         return;
       }
       setPromoteTarget(here);
@@ -1390,18 +1391,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const div = divByName.get(branch.name);
     const canUpdate = Boolean(defaultName) && branch.name !== defaultName;
     const deletionBlocked = isDeletionBlocked(rulesConfig, branch.name);
-    // Archiving hides a branch from the branch surfaces, so it's refused for the
-    // branch you're on and for the default branch. Unarchiving is never refused —
-    // an archived branch can be checked out, and this is its only way back.
+    // Archiving hides a branch from the branch surfaces, so it's refused for a
+    // branch that is somewhere in use: the one you're on, the default, and one
+    // another worktree has checked out. Unarchiving is never refused — an
+    // archived branch can be checked out, and this is its only way back.
     const archiveLabel = branch.archived ? "Unarchive" : "Archive";
-    // Best-effort by design: a null `defaultName` (still loading, or unresolvable)
-    // drops the default-branch guard rather than disabling Archive everywhere.
-    const archiveBlockedReason = (() => {
-      if (branch.archived) return null;
-      if (branch.isCurrent) return "current branch";
-      if (branch.name === defaultName) return "default branch";
-      return null;
-    })();
     // The worktree (other than the active checkout) this branch occupies, when
     // any — the Delete worktree… item gates on it (git refuses to remove the
     // main working tree).
@@ -1412,6 +1406,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const rowWorktreeRemoving = Boolean(
       rowWorktree && removingPaths.has(rowWorktree.path),
     );
+    // Best-effort by design: a null `defaultName` (still loading, or unresolvable)
+    // drops the default-branch guard rather than disabling Archive everywhere.
+    const archiveBlockedReason = (() => {
+      if (branch.archived) return null;
+      if (branch.isCurrent) return "current branch";
+      if (branch.name === defaultName) return "default branch";
+      if (inWorktree) return "checked out in another worktree";
+      return null;
+    })();
     // Outbound sync gating. `pushable` = tracked on a KNOWN remote and ahead →
     // offer a plain push to that remote (disabled with "(diverged)" when also
     // behind); the backend resolves to the branch's own upstream remote.

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1412,10 +1412,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     );
     // Best-effort by design: a null `defaultName` (still loading, or unresolvable)
     // drops the default-branch guard rather than disabling Archive everywhere.
+    // The worktree guard is HELD rather than dropped while its read is in
+    // flight — the map is empty until it lands, which would offer Archive on a
+    // branch the answer excludes. A FAILED read falls through to best-effort:
+    // no answer is coming, and holding the item forever helps no one.
     const archiveBlockedReason = (() => {
       if (branch.archived) return null;
       if (branch.isCurrent) return "current branch";
       if (branch.name === defaultName) return "default branch";
+      if (userWorktrees.data === undefined && !userWorktrees.isError)
+        return "checking worktrees…";
       if (inWorktree) return "checked out in another worktree";
       return null;
     })();

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -82,6 +82,35 @@ export function prCheckStateFrom(
   return "checked";
 }
 
+/**
+ * How far the worktree read behind the `isInWorktree` exclusion got. That
+ * predicate answers false for every branch until the read lands, so its state is
+ * what the dialog holds on: `"pending"` — no answer yet, and a list painted from
+ * it could offer a branch the settled answer excludes; `"failed"` — the read
+ * failed, a coverage gap the dialog names; `"checked"` — the exclusion is real.
+ */
+export type WorktreeCheckState = "pending" | "failed" | "checked";
+
+/** Derives that state from the worktree query. Absent data covers both a read in
+ *  flight and one that never started — the same thing to a caller that has no
+ *  answer to act on. */
+export function worktreeCheckStateFrom(q: {
+  isError: boolean;
+  data: unknown;
+}): WorktreeCheckState {
+  if (q.isError) return "failed";
+  if (q.data === undefined) return "pending";
+  return "checked";
+}
+
+/** Why a stale branch can still be off the list, per mode — the empty state
+ *  names it rather than claiming nothing is stale, which the branches sitting on
+ *  disk would contradict. */
+const EMPTY_EXCLUDED_REASON: Record<Mode, string> = {
+  archive: "already archived or checked out in another worktree",
+  delete: "protected by branch rules or checked out in another worktree",
+};
+
 /** The empty state's merged clause, per PR-check outcome. It names pull requests
  *  only where they were actually read: a failed read gets its own caveat below,
  *  and a check that never ran says nothing about them either way. The `pending`
@@ -171,8 +200,9 @@ function RowBadge({
  * local branches that are stale — **merged into the default branch** or **idle
  * past the selected age window** — and lets the user Archive (reversible hide via
  * the `gitdesktopArchived` flag) or Delete (`git branch -D`) the selected set in
- * one pass. The current branch, the default branch, and `gd/session/*` branches
- * are never candidates; Delete additionally excludes rule-protected branches.
+ * one pass. The current branch, the default branch, `gd/session/*` branches, and
+ * branches checked out in another worktree are never candidates; Archive also
+ * skips already-archived branches, and Delete skips rule-protected ones.
  *
  * Merged detection has two sources: branch divergence (`ahead === 0`, no extra
  * backend) and the switcher's PR map, which catches the squash and rebase merges
@@ -188,6 +218,7 @@ export function CleanupBranchesDialog({
   currentBranch,
   isProtected,
   isInWorktree,
+  worktreeCheckState,
   prMergedByBranch,
   prCheckState,
   prCheckPaused,
@@ -203,6 +234,12 @@ export function CleanupBranchesDialog({
   /** True when a branch is checked out in another worktree — git can't delete it,
    *  and archiving would hide a branch that's in use, so both modes drop it. */
   isInWorktree: (name: string) => boolean;
+  /** Whether {@link isInWorktree} has an answer yet. An advisory read that would
+   *  have refused an action must be held on, never acted around: while this is
+   *  `"pending"` the predicate is a stand-in that excludes nothing, so the list
+   *  neither paints nor pre-selects. (`useEffectiveBranchRulesSettling` carries
+   *  the same contract for the branch rules behind `isProtected`.) */
+  worktreeCheckState: WorktreeCheckState;
   /** Branch name → the label of the merged pull request it maps to ("#123").
    *  Name-keyed and limited to the PRs the app has fetched, so it labels rows,
    *  never selects them. */
@@ -302,6 +339,11 @@ export function CleanupBranchesDialog({
     });
   }, [stale, mode, isProtected, isInWorktree]);
 
+  // Until the worktree read lands, `isInWorktree` excludes nothing, so every
+  // candidate below is provisional — the list stays behind the skeleton and the
+  // selection stays unseeded rather than offering a row the answer would remove.
+  const checkingWorktrees = worktreeCheckState === "pending";
+
   // Re-check every candidate whenever the set itself changes — opening, switching
   // mode, adjusting the window, or divergence resolving to reveal merged branches.
   const candidateNames = useMemo(
@@ -327,9 +369,12 @@ export function CleanupBranchesDialog({
   const autoSelectKey = [...autoSelectNames].sort().join("\n");
   useEffect(() => {
     if (running) return; // don't clobber a batch mid-flight
+    // Nothing may be pre-selected off a stand-in exclusion: the seed re-runs
+    // once the worktree read lands and the excluded rows are really gone.
+    if (checkingWorktrees) return;
     setSelected(new Set(autoSelectKey ? autoSelectKey.split("\n") : []));
     setActiveName(null);
-  }, [autoSelectKey, running]);
+  }, [autoSelectKey, running, checkingWorktrees]);
 
   // First load: a merged signal still in flight and nothing has surfaced yet.
   // Age-based candidates already show instantly (branch data is cached), so this
@@ -341,9 +386,18 @@ export function CleanupBranchesDialog({
   // shows: the check line stays sr-only on the empty first paint (the skeleton
   // is the visual signal there) and on a parked re-check of an answered list,
   // whose visible staleness caveat is a surface this change doesn't own.
+  const stillChecking = checkingMerged || checkingWorktrees;
   const showCheckLine =
-    checkingMerged && (prCheckPaused || candidates.length > 0);
+    stillChecking && (prCheckPaused || candidates.length > 0);
   const showPrFailedLine = prCheckState === "failed" && candidates.length > 0;
+  // Unlike the pull-request caveat, this one shows on an empty list too: a
+  // failed read leaves the exclusion vacuous, which the empty state's own copy
+  // would otherwise assert as real.
+  const worktreeCheckFailed = worktreeCheckState === "failed";
+  // A provisional list is no list: the skeleton covers the whole worktree wait,
+  // not just the empty first paint the merged check gates.
+  const showSkeleton =
+    checkingWorktrees || (checkingMerged && candidates.length === 0);
 
   const selectedCount = candidateNames.filter((n) => selected.has(n)).length;
   const allChecked =
@@ -442,6 +496,14 @@ export function CleanupBranchesDialog({
   const primaryLabel = running
     ? `${gerund}… ${progress?.done ?? 0}/${progress?.total ?? 0}`
     : `${verb} ${pluralBranches(selectedCount)}`;
+  // The mode's own exclusions can empty the list while stale branches remain, so
+  // both empty states name the exclusion instead of reporting none. One string
+  // for the prose and the live region — a reader and a listener get the same
+  // sentence.
+  const allStaleExcluded = candidates.length === 0 && stale.length > 0;
+  const emptyStatus = allStaleExcluded
+    ? `${pluralBranches(stale.length)} ${stale.length === 1 ? "is" : "are"} stale but excluded from ${verb}: ${EMPTY_EXCLUDED_REASON[mode]}.`
+    : "No stale branches.";
 
   return (
     <>
@@ -529,8 +591,10 @@ export function CleanupBranchesDialog({
           </div>
 
           {/* Select-all header — a tri-state indicator (the vendored Checkbox
-              has no indeterminate visual, and components/ui/ is off-limits). */}
-          {candidates.length > 0 && (
+              has no indeterminate visual, and components/ui/ is off-limits).
+              Withheld while the list is provisional — it would count rows the
+              worktree read may still remove. */}
+          {candidates.length > 0 && !checkingWorktrees && (
             <button
               type="button"
               disabled={running}
@@ -572,22 +636,25 @@ export function CleanupBranchesDialog({
               role="status"
               className={cn(
                 "flex flex-col gap-0.5",
-                !showCheckLine && !showPrFailedLine && "sr-only",
+                !showCheckLine &&
+                  !showPrFailedLine &&
+                  !worktreeCheckFailed &&
+                  "sr-only",
               )}
             >
               {/* A parked pull-request read is still waiting, so it keeps the
                   waiting line; the resting line reports the count and claims
                   nothing about the check, which is what a `role="status"`
                   region can honestly repeat on every mode and window change. */}
-              {checkingMerged || prCheckPaused ? (
+              {stillChecking || prCheckPaused ? (
                 <MergedCheckLine
                   paused={prCheckPaused}
-                  srOnly={!checkingMerged}
+                  srOnly={!stillChecking}
                 />
               ) : (
                 <p className="sr-only">
                   {candidates.length === 0
-                    ? "No stale branches."
+                    ? emptyStatus
                     : `${pluralBranches(candidates.length)} to review.`}
                 </p>
               )}
@@ -605,19 +672,33 @@ export function CleanupBranchesDialog({
                   one may be missing.
                 </p>
               ) : null}
+              {worktreeCheckFailed ? (
+                <p className="px-1 py-1 text-[11px] text-muted-foreground">
+                  Worktree checkouts couldn't be read, so a branch checked out
+                  in another worktree may be listed.
+                </p>
+              ) : null}
             </div>
 
             {/* List / skeleton / empty */}
-            {checkingMerged && candidates.length === 0 ? (
+            {showSkeleton ? (
               <CheckingMergedPlaceholder paused={prCheckPaused} />
             ) : candidates.length === 0 ? (
               <p className="py-6 text-center text-xs text-muted-foreground">
-                No stale branches — nothing is merged into{" "}
-                <span className="font-mono">
-                  {defaultBranch ?? "the default branch"}
-                </span>
-                {EMPTY_MERGED_CLAUSE[prCheckState]}
-                {windowDays} days. Try a shorter window.
+                {allStaleExcluded ? (
+                  emptyStatus
+                ) : (
+                  <>
+                    No stale branches — nothing is merged into{" "}
+                    <span className="font-mono">
+                      {defaultBranch ?? "the default branch"}
+                    </span>
+                    {EMPTY_MERGED_CLAUSE[prCheckState]}
+                    {windowDays} days. Try a shorter window.
+                  </>
+                )}
+                {/* Carried by BOTH arms: an excluded-only list is just as
+                    incomplete when the pull-request read failed. */}
                 {prCheckState === "failed"
                   ? " Pull requests couldn't be checked, so a branch merged through one may be missing here."
                   : null}
@@ -681,7 +762,7 @@ export function CleanupBranchesDialog({
             <Button
               type="button"
               variant={mode === "delete" ? "destructive" : "default"}
-              disabled={selectedCount === 0 || running}
+              disabled={selectedCount === 0 || running || checkingWorktrees}
               onClick={onPrimary}
             >
               {primaryLabel}

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -201,7 +201,7 @@ export function CleanupBranchesDialog({
   /** True when a branch is blocked from deletion by an effective branch rule. */
   isProtected: (name: string) => boolean;
   /** True when a branch is checked out in another worktree — git can't delete it,
-   *  so it's dropped from the delete candidates (it can still be archived). */
+   *  and archiving would hide a branch that's in use, so both modes drop it. */
   isInWorktree: (name: string) => boolean;
   /** Branch name → the label of the merged pull request it maps to ("#123").
    *  Name-keyed and limited to the PRs the app has fetched, so it labels rows,
@@ -282,13 +282,16 @@ export function CleanupBranchesDialog({
     windowDays,
   ]);
 
-  // Mode-specific candidates. Archive hides — already-archived branches are a
-  // no-op, so drop them. Delete is permanent — drop rule-protected branches
+  // Mode-specific candidates. Archive hides — drop already-archived branches
+  // (a no-op) and ones checked out in another worktree (in use; the row menu
+  // refuses those too). Delete is permanent — drop rule-protected branches
   // (they'd fail anyway), but keep archived ones (a final sweep may want them).
   const candidates = useMemo(() => {
     const list =
       mode === "archive"
-        ? stale.filter((c) => !c.branch.archived)
+        ? stale.filter(
+            (c) => !c.branch.archived && !isInWorktree(c.branch.name),
+          )
         : stale.filter(
             (c) => !isProtected(c.branch.name) && !isInWorktree(c.branch.name),
           );

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -86,21 +86,35 @@ export function prCheckStateFrom(
  * How far the worktree read behind the `isInWorktree` exclusion got. That
  * predicate answers false for every branch until the read lands, so its state is
  * what the dialog holds on: `"pending"` — no answer yet, and a list painted from
- * it could offer a branch the settled answer excludes; `"failed"` — the read
- * failed, a coverage gap the dialog names; `"checked"` — the exclusion is real.
+ * it could offer a branch the settled answer excludes; `"failed"` — no answer is
+ * coming, a coverage gap the dialog names; `"checked"` — the exclusion is real.
  */
 export type WorktreeCheckState = "pending" | "failed" | "checked";
 
 /** Derives that state from the worktree query. Absent data covers both a read in
  *  flight and one that never started — the same thing to a caller that has no
- *  answer to act on. */
+ *  answer to act on.
+ *
+ *  A PARKED read (react-query's offline mode) counts as failed rather than
+ *  pending: nothing will resolve it on its own, so the list must paint with the
+ *  caveat instead of waiting out the session. `useUserWorktrees` sets
+ *  `networkMode: "always"` for its local git read, which should keep that arm
+ *  unreachable — it is the net for a caller that doesn't.
+ *
+ *  Placeholder data is a stand-in for another key's rows, never an answer about
+ *  this repo, so it reads as pending. That query sets no placeholder today; this
+ *  is the same net. */
 export function worktreeCheckStateFrom(q: {
   isError: boolean;
+  fetchStatus: "fetching" | "paused" | "idle";
+  isPlaceholderData: boolean;
   data: unknown;
 }): WorktreeCheckState {
   if (q.isError) return "failed";
-  if (q.data === undefined) return "pending";
-  return "checked";
+  // Data in hand answers the exclusion even while a refetch is parked behind it.
+  if (q.data !== undefined && !q.isPlaceholderData) return "checked";
+  if (q.fetchStatus === "paused") return "failed";
+  return "pending";
 }
 
 /** Why a stale branch can still be off the list, per mode — the empty state
@@ -125,16 +139,25 @@ const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
   unavailable: " and nothing is idle for ",
 };
 
-/** The one-line status above the candidate list while merged detection runs.
- *  A parked check has no progress to report, so it names what it's waiting on
- *  rather than implying the read is underway — and only the pull-request half
- *  can park, since divergence reads local objects with no connection at all.
- *  `srOnly` announces it without drawing it, for the states that show no
- *  status line today. */
-function MergedCheckLine({
+/** What the candidate list is waiting on, per outstanding read. The two settle
+ *  independently, so the line names the one actually running rather than
+ *  whichever came first. */
+const CHECKING_COPY: Record<"merged" | "worktrees", string> = {
+  merged: "Checking which branches are merged…",
+  worktrees: "Checking which branches are checked out in another worktree…",
+};
+
+/** The one-line status above the candidate list while a check it depends on
+ *  runs. A parked check has no progress to report, so it names what it's waiting
+ *  on rather than implying the read is underway — and only the pull-request half
+ *  can park, since both git reads work on local objects. `srOnly` announces it
+ *  without drawing it, for the states that show no status line today. */
+function CheckingLine({
+  what,
   paused,
   srOnly,
 }: {
+  what: "merged" | "worktrees";
   paused: boolean;
   srOnly?: boolean;
 }) {
@@ -146,7 +169,7 @@ function MergedCheckLine({
     >
       {paused
         ? "Waiting for a connection to check which branches were merged through a pull request…"
-        : "Checking which branches are merged…"}
+        : CHECKING_COPY[what]}
     </p>
   );
 }
@@ -647,7 +670,8 @@ export function CleanupBranchesDialog({
                   nothing about the check, which is what a `role="status"`
                   region can honestly repeat on every mode and window change. */}
               {stillChecking || prCheckPaused ? (
-                <MergedCheckLine
+                <CheckingLine
+                  what={checkingMerged ? "merged" : "worktrees"}
                   paused={prCheckPaused}
                   srOnly={!stillChecking}
                 />

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -174,10 +174,11 @@ function CheckingLine({
   );
 }
 
-/** Empty first paint while merged detection runs. An animated skeleton over a
- *  parked check would be a false activity signal, so a parked check paints
- *  nothing here — the status region above already names what it's waiting on. */
-function CheckingMergedPlaceholder({ paused }: { paused: boolean }) {
+/** First paint while a check the list depends on runs. An animated skeleton over
+ *  a parked pull-request read would be a false activity signal, so a parked read
+ *  paints nothing here — the status region above already names what it's waiting
+ *  on. */
+function CheckingPlaceholder({ paused }: { paused: boolean }) {
   if (paused) return null;
   return (
     <div className="space-y-1 py-2" aria-busy>
@@ -706,7 +707,7 @@ export function CleanupBranchesDialog({
 
             {/* List / skeleton / empty */}
             {showSkeleton ? (
-              <CheckingMergedPlaceholder paused={prCheckPaused} />
+              <CheckingPlaceholder paused={prCheckPaused} />
             ) : candidates.length === 0 ? (
               <p className="py-6 text-center text-xs text-muted-foreground">
                 {allStaleExcluded ? (

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -406,8 +406,7 @@ export function CleanupBranchesDialog({
   const pausedMergedCheck = checkingMerged && prCheckPaused;
   // Which of the status region's lines are DRAWN — it announces more than it
   // shows: the check line stays sr-only on the empty first paint (the skeleton
-  // is the visual signal there) and on a parked re-check of an answered list,
-  // whose visible staleness caveat is a surface this change doesn't own.
+  // is the visual signal there).
   const stillChecking = checkingMerged || checkingWorktrees;
   const showCheckLine =
     stillChecking && (pausedMergedCheck || candidates.length > 0);
@@ -664,10 +663,11 @@ export function CleanupBranchesDialog({
                   "sr-only",
               )}
             >
-              {/* A parked pull-request read is still waiting, so it keeps the
-                  waiting line; the resting line reports the count and claims
-                  nothing about the check, which is what a `role="status"`
-                  region can honestly repeat on every mode and window change. */}
+              {/* A parked FIRST pull-request fetch is still waiting, so it keeps
+                  the waiting line; a parked refetch over settled data falls
+                  through to the resting line, which reports the count and claims
+                  nothing about the check — what a `role="status"` region can
+                  honestly repeat on every mode and window change. */}
               {stillChecking ? (
                 <CheckingLine
                   what={checkingMerged ? "merged" : "worktrees"}
@@ -704,7 +704,11 @@ export function CleanupBranchesDialog({
 
             {/* List / skeleton / empty */}
             {showSkeleton ? (
-              <CheckingPlaceholder paused={pausedMergedCheck} />
+              // A running local worktree read is real activity, so it earns the
+              // skeleton even while the pull-request fetch sits parked.
+              <CheckingPlaceholder
+                paused={pausedMergedCheck && !checkingWorktrees}
+              />
             ) : candidates.length === 0 ? (
               <p className="py-6 text-center text-xs text-muted-foreground">
                 {allStaleExcluded ? (

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -150,23 +150,16 @@ const CHECKING_COPY: Record<"merged" | "worktrees", string> = {
 /** The one-line status above the candidate list while a check it depends on
  *  runs. A parked check has no progress to report, so it names what it's waiting
  *  on rather than implying the read is underway — and only the pull-request half
- *  can park, since both git reads work on local objects. `srOnly` announces it
- *  without drawing it, for the states that show no status line today. */
+ *  can park, since both git reads work on local objects. */
 function CheckingLine({
   what,
   paused,
-  srOnly,
 }: {
   what: "merged" | "worktrees";
   paused: boolean;
-  srOnly?: boolean;
 }) {
   return (
-    <p
-      className={
-        srOnly ? "sr-only" : "px-1 py-1 text-[11px] text-muted-foreground"
-      }
-    >
+    <p className="px-1 py-1 text-[11px] text-muted-foreground">
       {paused
         ? "Waiting for a connection to check which branches were merged through a pull request…"
         : CHECKING_COPY[what]}
@@ -406,13 +399,18 @@ export function CleanupBranchesDialog({
   const checkingMerged =
     (Boolean(defaultBranch) && divergence.isLoading) ||
     prCheckState === "pending";
+  // Parked matters only while the merged check is still outstanding: a parked
+  // FIRST fetch keeps `checkingMerged` true (prCheckState "pending"), while a
+  // parked background refetch over settled data has nothing to wait for — and
+  // its connection copy would answer for the local reads still running.
+  const pausedMergedCheck = checkingMerged && prCheckPaused;
   // Which of the status region's lines are DRAWN — it announces more than it
   // shows: the check line stays sr-only on the empty first paint (the skeleton
   // is the visual signal there) and on a parked re-check of an answered list,
   // whose visible staleness caveat is a surface this change doesn't own.
   const stillChecking = checkingMerged || checkingWorktrees;
   const showCheckLine =
-    stillChecking && (prCheckPaused || candidates.length > 0);
+    stillChecking && (pausedMergedCheck || candidates.length > 0);
   const showPrFailedLine = prCheckState === "failed" && candidates.length > 0;
   // Unlike the pull-request caveat, this one shows on an empty list too: a
   // failed read leaves the exclusion vacuous, which the empty state's own copy
@@ -670,11 +668,10 @@ export function CleanupBranchesDialog({
                   waiting line; the resting line reports the count and claims
                   nothing about the check, which is what a `role="status"`
                   region can honestly repeat on every mode and window change. */}
-              {stillChecking || prCheckPaused ? (
+              {stillChecking ? (
                 <CheckingLine
                   what={checkingMerged ? "merged" : "worktrees"}
-                  paused={prCheckPaused}
-                  srOnly={!stillChecking}
+                  paused={pausedMergedCheck}
                 />
               ) : (
                 <p className="sr-only">
@@ -707,7 +704,7 @@ export function CleanupBranchesDialog({
 
             {/* List / skeleton / empty */}
             {showSkeleton ? (
-              <CheckingPlaceholder paused={prCheckPaused} />
+              <CheckingPlaceholder paused={pausedMergedCheck} />
             ) : candidates.length === 0 ? (
               <p className="py-6 text-center text-xs text-muted-foreground">
                 {allStaleExcluded ? (

--- a/src/features/repository/WorktreeRemovalBanner.tsx
+++ b/src/features/repository/WorktreeRemovalBanner.tsx
@@ -1,5 +1,33 @@
 import { Spinner } from "@/components/ui/spinner";
-import { useWorktreeRemovals } from "@/lib/stores/worktree-removal";
+import {
+  useWorktreeRemovals,
+  type WorktreeRemoval,
+} from "@/lib/stores/worktree-removal";
+
+/** The line's wording per step, halved around the name it renders in the middle.
+ *  A promote passes through three of these; a plain delete only ever reads
+ *  `none`. */
+const PHASE_COPY: Record<
+  NonNullable<WorktreeRemoval["promotePhase"]> | "none",
+  { before: string; after: string }
+> = {
+  none: {
+    before: "Removing worktree ",
+    after: "… This can take a few minutes.",
+  },
+  removing: {
+    before: "Promoting ",
+    after: " — removing its worktree… This can take a few minutes.",
+  },
+  stashing: {
+    before: "Promoting ",
+    after: " — stashing your main workspace changes…",
+  },
+  "checking-out": {
+    before: "Promoting ",
+    after: " — checking out the branch…",
+  },
+};
 
 /**
  * Keeps a running worktree removal visible after its dialog is dismissed. A
@@ -7,6 +35,9 @@ import { useWorktreeRemovals } from "@/lib/stores/worktree-removal";
  * view's layout flow (one line per removal, pushing content down) rather than
  * in a toast that expires or an overlay that covers the header. There is
  * nothing to press: a removal can't be cancelled, only waited out.
+ *
+ * A promote's line stays up past the removal and names the step it's on, so the
+ * stash and checkout that follow don't read as a stall.
  */
 export function WorktreeRemovalBanner({ repoPath }: { repoPath: string }) {
   const removals = useWorktreeRemovals(repoPath);
@@ -19,18 +50,22 @@ export function WorktreeRemovalBanner({ repoPath }: { repoPath: string }) {
     // No aria-busy: on a live region it tells a screen reader to withhold
     // announcements until it clears, the opposite of what this line is for.
     <div role="status" className={removals.length > 0 ? "border-b" : "sr-only"}>
-      {removals.map((r) => (
-        <div
-          key={r.path}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs"
-        >
-          <Spinner aria-hidden className="size-3.5 shrink-0" />
-          <span className="min-w-0 truncate" title={r.path}>
-            Removing worktree <span className="font-mono">{r.name}</span>… This
-            can take a few minutes.
-          </span>
-        </div>
-      ))}
+      {removals.map((r) => {
+        const copy = PHASE_COPY[r.promotePhase ?? "none"];
+        return (
+          <div
+            key={r.path}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs"
+          >
+            <Spinner aria-hidden className="size-3.5 shrink-0" />
+            <span className="min-w-0 truncate" title={r.path}>
+              {copy.before}
+              <span className="font-mono">{r.name}</span>
+              {copy.after}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { RelativeTime } from "@/components/relative-time";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -62,7 +63,9 @@ import {
   isWorktreePromoting,
   useIsRemovingWorktree,
   useWorktreeRemovals,
+  WORKTREE_PROMOTING_MESSAGE,
 } from "@/lib/stores/worktree-removal";
+import { validEpochMs } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
@@ -156,9 +159,9 @@ function WorktreeList({
 
   async function handleOpen(w: UserWorktree) {
     if (normPath(w.path) === activeNorm) return; // already here
-    // Its folder is on its way out. Not just the removal entry: a promote gaps
-    // it on both ends — the claim lands before markRemoval, and the tail runs
-    // on past the delete with nothing left in `removingPaths`.
+    // Its folder is on its way out. Not just the removal entry: a promote's
+    // claim opens before markRemoval and releases only after the entry has
+    // settled, so the entry alone misses both ends.
     if (refuseWhileLeaving(w.path, removingPaths.has(w.path))) return;
     await openWorktree(w.path);
     onClose();
@@ -319,7 +322,15 @@ function WorktreeRow({
   onDelete: () => void;
   onPromote: () => void;
 }) {
-  const { path, branch, isMain, isDetached, isLocked, lockReason } = worktree;
+  const {
+    path,
+    branch,
+    isMain,
+    isDetached,
+    isLocked,
+    lockReason,
+    lastActivityMs,
+  } = worktree;
 
   const itemLabel = (label: string, otherReason?: string) =>
     worktreeItemLabel(label, isRemoving, otherReason);
@@ -382,6 +393,12 @@ function WorktreeRow({
             {path}
           </span>
         </span>
+        {lastActivityMs != null && validEpochMs(lastActivityMs) && (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            Active{" "}
+            <RelativeTime date={new Date(lastActivityMs).toISOString()} />
+          </span>
+        )}
       </button>
 
       <DropdownMenu>
@@ -540,7 +557,7 @@ export function refuseWhileLeaving(path: string, removing: boolean): boolean {
     return true;
   }
   if (isWorktreePromoting(path)) {
-    toast.info("This worktree is being promoted.");
+    toast.info(WORKTREE_PROMOTING_MESSAGE);
     return true;
   }
   return false;

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -280,12 +280,17 @@ export const worktreeKey = (repo: string) =>
   ["repo", repo, "user-worktrees"] as const;
 
 /** The repo's user-facing worktrees (session worktrees filtered out by the
- *  backend). `enabled` gates the fetch so it only runs while the manager is open. */
+ *  backend). `enabled` gates the fetch to the surface asking for it — the
+ *  manager, the branch switcher and its cleanup dialog, the branch pickers. */
 export function useUserWorktrees(repo: string, enabled = true) {
   return useQuery({
     queryKey: worktreeKey(repo),
     queryFn: () => listUserWorktrees(repo),
     enabled: enabled && Boolean(repo),
+    // A local `git worktree list` read. react-query's default "online" mode
+    // parks the fetch whenever the OS reports no connection, and a parked query
+    // is neither loading nor errored — a consumer waiting on it waits forever.
+    networkMode: "always",
   });
 }
 

--- a/src/lib/git/worktree.ts
+++ b/src/lib/git/worktree.ts
@@ -43,6 +43,9 @@ export interface UserWorktree {
   isLocked: boolean;
   /** Lock reason, when one was given (else ""). */
   lockReason: string;
+  /** Epoch ms of the worktree's last git activity, probed from its index file's
+   *  mtime with HEAD as the fallback. null when neither is readable. */
+  lastActivityMs: number | null;
 }
 
 /** Lists the repo's *user* worktrees for the worktree manager — every checkout

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -16,6 +16,9 @@ export interface WorktreeRemoval {
   name: string;
   /** Epoch ms the removal started. */
   startedAt: number;
+  /** Which step of a promote this entry is on. Set only by the promote path — a
+   *  plain delete leaves it undefined, and the removal ends with its own step. */
+  promotePhase?: "removing" | "stashing" | "checking-out";
 }
 
 /** The open delete dialog's hooks for the removal it launched. */
@@ -135,6 +138,10 @@ export function isWorktreePromoting(path: string): boolean {
   return promotingWorktrees.has(normPath(path));
 }
 
+/** The refusal every surface shows for a worktree a promote has claimed — one
+ *  spelling, so the store's refusals and the callers' can't drift apart. */
+export const WORKTREE_PROMOTING_MESSAGE = "This worktree is being promoted.";
+
 // `_set` unused: every write goes through the module-level helpers below, so a
 // runner that outlives its dialog reaches state the same way the starters do.
 export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
@@ -147,7 +154,7 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       if (isRemovalInFlight(get().byRepo, repoPath, path))
         return "This worktree is already being removed.";
       if (promotingWorktrees.has(normPath(path)))
-        return "This worktree is being promoted.";
+        return WORKTREE_PROMOTING_MESSAGE;
       markRemoval(repoPath, path, name);
       void run(repoPath, path, force);
       return null;
@@ -159,7 +166,7 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       if (isRemovalInFlight(get().byRepo, mainPath, worktreePath))
         return "This worktree is already being removed.";
       if (promotingWorktrees.has(normPath(worktreePath)))
-        return "This worktree is being promoted.";
+        return WORKTREE_PROMOTING_MESSAGE;
       if (promotingMains.has(normPath(mainPath)))
         return "Another worktree is already being promoted to your main workspace.";
       promotingMains.add(normPath(mainPath));
@@ -173,16 +180,43 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
   }),
 );
 
-function markRemoval(repoPath: string, path: string, name: string) {
+function markRemoval(
+  repoPath: string,
+  path: string,
+  name: string,
+  promotePhase?: WorktreeRemoval["promotePhase"],
+) {
   useWorktreeRemovalStore.setState((s) => ({
     byRepo: {
       ...s.byRepo,
       [repoPath]: {
         ...s.byRepo[repoPath],
-        [path]: { path, name, startedAt: Date.now() },
+        [path]: { path, name, startedAt: Date.now(), promotePhase },
       },
     },
   }));
+}
+
+/** Moves an existing entry on to the next promote step; a missing entry is a
+ *  defensive no-op. */
+function advancePromotePhase(
+  repoKey: string,
+  path: string,
+  phase: WorktreeRemoval["promotePhase"],
+) {
+  useWorktreeRemovalStore.setState((s) => {
+    const entry = s.byRepo[repoKey]?.[path];
+    if (!entry) return s;
+    return {
+      byRepo: {
+        ...s.byRepo,
+        [repoKey]: {
+          ...s.byRepo[repoKey],
+          [path]: { ...entry, promotePhase: phase },
+        },
+      },
+    };
+  });
 }
 
 function clearRemoval(repoPath: string, path: string) {
@@ -269,8 +303,8 @@ async function removeWorktreeFreeingBranch(repoPath: string, path: string) {
  * Runs one promote to completion: free the branch (remove its worktree, keep the
  * branch) then check it out in the main workspace. Store-owned so the composite
  * survives its dialog, which closes as soon as the store accepts the promote;
- * its removal step shows in the main workspace's own removal line and manager
- * row like any other.
+ * the main workspace's own removal line carries it step by step, and its removal
+ * step shows in the manager's row like any other.
  *
  * The generic removal toast and the listener stack stay out of this path: they
  * are the delete dialog's contract, and promote ends on its own composite toast.
@@ -305,22 +339,35 @@ async function runPromote(
     useUiStore.getState().openRepo(info);
     await new Promise((resolve) => setTimeout(resolve, 80));
     // Main is the active repo now, so the removal is visible where the user is.
-    markRemoval(activeKey, worktreePath, branch);
+    markRemoval(activeKey, worktreePath, branch, "removing");
     markedKey = activeKey;
     // Free the branch: remove the worktree but KEEP the branch (null) — we
     // check it out in main next. force=false: the clean-tree guard already ran.
     await removeWorktreeFreeingBranch(mainPath, worktreePath);
     removed = true;
     await pruneWorktrees(mainPath).catch(() => undefined);
-    settleRemoval(activeKey, worktreePath);
-    markedKey = null;
+    // The removed row has to leave the manager's list now, while the entry
+    // stays on to report the tail: these are `settleRemoval`'s invalidations
+    // without its clear.
+    void queryClient.invalidateQueries({ queryKey: worktreeKey(activeKey) });
+    void queryClient.invalidateQueries({
+      queryKey: repoKeys.branches(activeKey),
+    });
+    advancePromotePhase(
+      activeKey,
+      worktreePath,
+      willStash ? "stashing" : "checking-out",
+    );
     // The branch's working tree is free now; stash main's own WIP (if any) so
     // the checkout can't be blocked, then land main on the promoted branch.
     if (willStash) {
       await gitStashAll(mainPath);
       stashed = true;
+      advancePromotePhase(activeKey, worktreePath, "checking-out");
     }
     await gitCheckoutBranch(mainPath, branch);
+    settleRemoval(activeKey, worktreePath);
+    markedKey = null;
     await queryClient.invalidateQueries({ queryKey: repoKeys.all(activeKey) });
     toast.success(
       willStash

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -142,6 +142,11 @@ export function isWorktreePromoting(path: string): boolean {
  *  spelling, so the store's refusals and the callers' can't drift apart. */
 export const WORKTREE_PROMOTING_MESSAGE = "This worktree is being promoted.";
 
+/** Both starters' refusal of a duplicate attempt. "Already" is the store's own
+ *  word for a second attempt on the same target, and belongs only here — a
+ *  caller that never asked for the removal states the state instead. */
+const WORKTREE_REMOVING_MESSAGE = "This worktree is already being removed.";
+
 // `_set` unused: every write goes through the module-level helpers below, so a
 // runner that outlives its dialog reaches state the same way the starters do.
 export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
@@ -152,7 +157,7 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       // Matched on the directory, not the string: today's callers all spell it
       // the ui store's way, but the admission rule shouldn't depend on that.
       if (isRemovalInFlight(get().byRepo, repoPath, path))
-        return "This worktree is already being removed.";
+        return WORKTREE_REMOVING_MESSAGE;
       if (promotingWorktrees.has(normPath(path)))
         return WORKTREE_PROMOTING_MESSAGE;
       markRemoval(repoPath, path, name);
@@ -164,7 +169,7 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
       // `mainPath` is git's spelling; the entry this would collide with was
       // written under the ui store's. Match on the directory, not the string.
       if (isRemovalInFlight(get().byRepo, mainPath, worktreePath))
-        return "This worktree is already being removed.";
+        return WORKTREE_REMOVING_MESSAGE;
       if (promotingWorktrees.has(normPath(worktreePath)))
         return WORKTREE_PROMOTING_MESSAGE;
       if (promotingMains.has(normPath(mainPath)))

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -239,13 +239,20 @@ function clearRemoval(repoPath: string, path: string) {
   });
 }
 
-/** Drops the entry and refreshes what a settled removal changed: the manager's
- *  list, plus branches (a removed worktree frees its branch for checkout
- *  elsewhere) — the same set the worktree mutations invalidate. */
-function settleRemoval(repoPath: string, path: string) {
-  clearRemoval(repoPath, path);
+/** Refreshes what a completed removal changed: the manager's list, plus branches
+ *  (a removed worktree frees its branch for checkout elsewhere) — the same set
+ *  the worktree mutations invalidate. Separate from {@link settleRemoval}
+ *  because the promote path refreshes at its removal step while its entry stays
+ *  on screen for the rest of the composite. */
+function invalidateAfterRemoval(repoPath: string) {
   void queryClient.invalidateQueries({ queryKey: worktreeKey(repoPath) });
   void queryClient.invalidateQueries({ queryKey: repoKeys.branches(repoPath) });
+}
+
+/** Drops the entry and refreshes what the removal changed. */
+function settleRemoval(repoPath: string, path: string) {
+  clearRemoval(repoPath, path);
+  invalidateAfterRemoval(repoPath);
 }
 
 /**
@@ -351,13 +358,9 @@ async function runPromote(
     await removeWorktreeFreeingBranch(mainPath, worktreePath);
     removed = true;
     await pruneWorktrees(mainPath).catch(() => undefined);
-    // The removed row has to leave the manager's list now, while the entry
-    // stays on to report the tail: these are `settleRemoval`'s invalidations
-    // without its clear.
-    void queryClient.invalidateQueries({ queryKey: worktreeKey(activeKey) });
-    void queryClient.invalidateQueries({
-      queryKey: repoKeys.branches(activeKey),
-    });
+    // The removed row leaves the manager's list now; the entry stays on, so the
+    // line can go on reporting the tail.
+    invalidateAfterRemoval(activeKey);
     advancePromotePhase(
       activeKey,
       worktreePath,
@@ -384,13 +387,20 @@ async function runPromote(
     if (markedKey) settleRemoval(markedKey, worktreePath);
     if (removed) {
       // The worktree is already gone and the branch is free but not checked
-      // out — surface the recovery path (with git's error as the detail).
-      toast.error(
-        `Removed the worktree, but couldn't check out ${branch} in your main workspace — switch to it there manually.${
-          stashed ? " Your changes are stashed — use Pop latest stash." : ""
-        }`,
-        { description: e instanceof Error ? e.message : String(e) },
-      );
+      // out — surface the recovery path (with git's error as the detail). Which
+      // path depends on the step: a promote that wanted a stash and never got
+      // one stopped there, and the changes it left in place are exactly what
+      // would block "check it out yourself".
+      const stashedClause = stashed
+        ? " Your changes are stashed — use Pop latest stash."
+        : "";
+      const message =
+        willStash && !stashed
+          ? `Removed the worktree, but couldn't stash your main workspace changes — commit or stash them, then check out ${branch} manually.`
+          : `Removed the worktree, but couldn't check out ${branch} in your main workspace — switch to it there manually.${stashedClause}`;
+      toast.error(message, {
+        description: e instanceof Error ? e.message : String(e),
+      });
     } else {
       toastError(e);
     }


### PR DESCRIPTION
Adds a per-worktree "last active" timestamp to the worktree manager so dormant worktrees are easy to spot, and fixes two related rough edges: **Archive** was offered for branches checked out in another worktree, and a promote's progress line vanished partway through the operation, leaving the stash and checkout steps looking like a stall.

### Last-activity probe (backend)

- Adds `last_activity_ms: Option<i64>` to `UserWorktree` in `src-tauri/src/git/worktree.rs`, populated in `git_worktree_list_user`, with the matching `lastActivityMs: number | null` field on the TS interface in `src/lib/git/worktree.ts`.
- Implements `worktree_last_activity_ms`, which resolves a worktree's admin directory (a `.git` directory for the main checkout, or the `gitdir:` pointer file for a linked one) and reads the index file's mtime, falling back to `HEAD`. The doc comment records why the index is the signal: `logs/HEAD` and the admin dir's own mtime are rewritten wholesale by `gc`, making dormant worktrees look fresh.
- Adds helpers `parse_gitdir_pointer` and `file_mtime_ms`; an unreadable probe returns `None` rather than failing the whole list.
- Notes in a comment that `git::ops::marker_dir` answers the same `.git`-dir-or-pointer question, so both must change together until they're hoisted into a shared helper.
- Tests: `parse_gitdir_pointer_reads_absolute_relative_and_padded_forms` covers absolute, relative, no-space and empty pointer forms; `last_activity_reads_both_worktree_shapes_and_falls_back` builds a real repo plus linked worktree, backdates the linked index an hour to prove index-over-HEAD priority (an order-blind assertion would pass for a HEAD-first probe), then removes each file to exercise the fallback chain down to `None`.

### Worktree manager UI

- `src/features/repository/WorktreesDialog.tsx` renders an "Active &lt;relative time&gt;" label per row via `RelativeTime`, guarded by `validEpochMs` so an implausible stamp renders nothing.

### Promote progress

- `src/lib/stores/worktree-removal.ts` adds an optional `promotePhase` (`"removing" | "stashing" | "checking-out"`) to `WorktreeRemoval`, an `advancePromotePhase` updater, and a `promotePhase` argument on `markRemoval`.
- `runPromote` no longer calls `settleRemoval` right after the worktree is removed. It now fires the worktree and branch invalidations directly (so the removed row leaves the manager's list) while keeping the entry alive, advances the phase through stash and checkout, and settles only once `gitCheckoutBranch` returns.
- `src/features/repository/WorktreeRemovalBanner.tsx` gains a `PHASE_COPY` table that splits each step's wording around the worktree name, so the banner reads "Promoting `x` — stashing your main workspace changes…" instead of disappearing. A plain delete keeps its existing `none` copy.
- Extracts `WORKTREE_PROMOTING_MESSAGE` in the store and uses it from `BranchSwitcher.tsx` and `WorktreesDialog.tsx`'s `refuseWhileLeaving`, so the store's refusal and the callers' can't drift.

### Archive gating for in-use branches

- `BranchSwitcher.tsx` adds `checked out in another worktree` to `archiveBlockedReason` (moved below the `inWorktree` computation it now depends on), so the menu item is disabled and names the reason.
- `CleanupBranchesDialog.tsx` drops in-worktree branches from the archive candidates too, matching the delete mode; the `isInWorktree` prop doc is updated accordingly.

### Documentation

- `README.md`: the worktree-manager bullet now mentions the last-active time.
- `site/src/data/capabilities.ts`: extends the worktree-manager capability label.
- `src/features/help/content.ts`: documents the per-row activity time, adds the worktree case to the list of branches that can't be archived, and rewrites the promote paragraph to describe the step-by-step status line.
- Changelog fragments: `changelog.d/added-worktree-last-activity.md`, `changelog.d/fixed-archive-worktree-branch.md`, and `changelog.d/fixed-promote-progress.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree rows now show when they were last active.
  * Worktree promotion displays progress through each step.
  * Worktree information remains available while offline.
* **Bug Fixes**
  * Branches checked out in another worktree remain listed and cannot be archived or deleted by cleanup.
  * Cleanup now clearly indicates excluded branches and warns if worktree checks fail.
* **Documentation**
  * Updated the user guide, README, capability descriptions, and changelog to reflect these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->