### PR TITLE
feat(repository,github): add an owner picker to the publish dialog

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -115,6 +115,10 @@ separators.
   an item-level handler is dead once the row span self-bounds (the
   `select-item-clip-title` guard fails on both); the closed field takes
   `onMouseEnter={clipTitleFromText}` on its `SelectValue`.
+- A `SelectControl`/`SelectField` `items` Record silently reorders integer-like
+  keys to the front (JS object semantics) — any picker whose option values are
+  user-supplied identifiers that can be all-digits (logins, slugs) must pass
+  the `order` prop with the sequence it means (exactly the keys of `items`).
 - Per-file `+added -deleted` counts render through `DiffStat`
   (`src/components/diff-stat.tsx`) — plain numbers in, optional `isBinary`
   (a muted `bin`) and `format` (Insights abbreviates via `fmt`); never

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Clone, add local, create (with README / .gitignore / license scaffolding),
 publish to GitHub, GitLab, or Bitbucket, and fork.
 
 - **Pick the owner when you publish**: publishing a local repo to GitHub
-  starts with an **Owner** select (your account or any organization you
-  belong to); Bitbucket picks a **workspace** the same way.
+  starts with an **Owner** select (your account or one of your organizations);
+  Bitbucket picks a **workspace** the same way.
 - **Repo switcher**: every repo grouped by owner, with a Recent section and a
   filter. Each row carries identity badges (the forge's logo, a cloud for an
   unrecognized remote, a folder for local-only, and a lock / buildings /

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ expand them when you want the detail.
 Clone, add local, create (with README / .gitignore / license scaffolding),
 publish to GitHub, GitLab, or Bitbucket, and fork.
 
+- **Pick the owner when you publish**: publishing a local repo to GitHub
+  starts with an **Owner** select (your account or any organization you
+  belong to); Bitbucket picks a **workspace** the same way.
 - **Repo switcher**: every repo grouped by owner, with a Recent section and a
   filter. Each row carries identity badges (the forge's logo, a cloud for an
   unrecognized remote, a folder for local-only, and a lock / buildings /

--- a/changelog.d/added-publish-owner-picker.md
+++ b/changelog.d/added-publish-owner-picker.md
@@ -1,0 +1,4 @@
+- **Owner picker when publishing to GitHub.** The publish dialog now opens with an
+  **Owner** select listing your account and every organization you belong to, and
+  creates the repository under the one you choose. Organizations that don't let you
+  create repositories are listed as disabled, with the reason on the row.

--- a/changelog.d/added-publish-owner-picker.md
+++ b/changelog.d/added-publish-owner-picker.md
@@ -1,4 +1,4 @@
 - **Owner picker when publishing to GitHub.** The publish dialog now opens with an
-  **Owner** select listing your account and every organization you belong to, and
-  creates the repository under the one you choose. Organizations that don't let you
-  create repositories are listed as disabled, with the reason on the row.
+  **Owner** select listing your account and your organizations, and creates the
+  repository under the one you choose. Organizations that don't let you create
+  repositories are listed as disabled, with the reason on the row.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -431,7 +431,9 @@ export const CHECKS = [
       // Defaults the workflow once `dispatchable` arrives; the caller's
       // preselect rides a consume-once ref, the fallback keeps `!workflow`.
       "src/features/actions/RunWorkflowDialog.tsx",
-      // Seeds the Bitbucket workspace once workspaces load; empty-field only.
+      // Workspace seed is empty-field only; the owner seed also re-seeds when
+      // the held owner is no longer in the fetched list (account switch), so
+      // it never fights a pick that's still valid.
       "src/features/repository/PublishDialog.tsx",
       // Seeds the URL field once the current remote URL query resolves.
       "src/features/repository/RemoteUrlDialog.tsx",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -371,7 +371,8 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
-    label: "Publish a local repo to GitHub, GitLab or Bitbucket",
+    label:
+      "Publish a local repo to GitHub, GitLab or Bitbucket — choose the GitHub owner or Bitbucket workspace",
   },
   {
     group: "Repository & workspace",

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -3727,6 +3727,13 @@ pub async fn forge_repo_delete(
     Ok(())
 }
 
+/// Owners the viewer can publish under — the GitHub publish owner picker.
+/// Account-scoped (no repo_path).
+#[tauri::command]
+pub async fn forge_gh_publish_owners() -> AppResult<crate::github::pr::GithubPublishOwners> {
+    crate::github::pr::gh_publish_owners().await
+}
+
 // ── Bitbucket settings sub-surfaces ──
 
 /// The viewer's Bitbucket workspaces — the publish target picker. Account-scoped

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -417,6 +417,100 @@ pub async fn gh_publish_repo(
     gh_repo_url(repo_path).await
 }
 
+/// Owners the viewer can publish a new repository under: their own account plus
+/// every org membership. GraphQL's `viewerCanCreateRepositories` folds the org
+/// member-policy AND the viewer's role server-side (probed 2026-08-31: false on
+/// a member-role org whose policy forbids member creation, true elsewhere).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GithubPublishOwners {
+    pub viewer: String,
+    pub orgs: Vec<GithubPublishOrg>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GithubPublishOrg {
+    pub login: String,
+    pub can_create: bool,
+}
+
+#[derive(Deserialize)]
+struct RawOwnersBody {
+    data: Option<RawOwnersData>,
+}
+
+#[derive(Deserialize)]
+struct RawOwnersData {
+    viewer: Option<RawOwnersViewer>,
+}
+
+#[derive(Deserialize)]
+struct RawOwnersViewer {
+    #[serde(default)]
+    login: String,
+    organizations: Option<RawOwnerOrgs>,
+}
+
+#[derive(Deserialize)]
+struct RawOwnerOrgs {
+    /// GraphQL connection nodes are nullable both as a list and per entry, so
+    /// each layer stays optional rather than defaulting a shape we didn't get.
+    nodes: Option<Vec<Option<RawOwnerOrg>>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawOwnerOrg {
+    #[serde(default)]
+    login: String,
+    #[serde(default)]
+    viewer_can_create_repositories: bool,
+}
+
+/// Response body → the publish owner list. Pure so it tests without a network.
+/// A missing viewer login is an error (there is nothing to publish under);
+/// null or login-less org entries are skipped rather than failing the list.
+fn parse_publish_owners(body: &str) -> AppResult<GithubPublishOwners> {
+    let parsed: RawOwnersBody = serde_json::from_str(body)
+        .map_err(|e| AppError::Gh(format!("could not parse the owner query: {e}")))?;
+    let viewer = parsed
+        .data
+        .and_then(|d| d.viewer)
+        .filter(|v| !v.login.trim().is_empty())
+        .ok_or_else(|| AppError::Gh("could not determine your GitHub account".into()))?;
+    let orgs = viewer
+        .organizations
+        .and_then(|o| o.nodes)
+        .unwrap_or_default()
+        .into_iter()
+        .flatten()
+        .filter(|o| !o.login.trim().is_empty())
+        .map(|o| GithubPublishOrg {
+            login: o.login,
+            can_create: o.viewer_can_create_repositories,
+        })
+        .collect();
+    Ok(GithubPublishOwners {
+        viewer: viewer.login,
+        orgs,
+    })
+}
+
+/// The viewer's publishable owners, for the publish dialog's owner picker.
+/// Account-scoped, so it runs with no repo dir; `first: 100` is a deliberate
+/// fail-open cap — the typed `owner/name` form still reaches an org past it.
+pub async fn gh_publish_owners() -> AppResult<GithubPublishOwners> {
+    let query = "query { viewer { login organizations(first: 100) { nodes { login viewerCanCreateRepositories } } } }";
+    let out = run_gh(
+        None,
+        &["api", "graphql", "-f", &format!("query={query}")],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    parse_publish_owners(&out.stdout_lossy())
+}
+
 /// The repository's web URL (works for github.com and GitHub Enterprise).
 /// Append paths like `/issues/new` for specific pages.
 pub async fn gh_repo_url(repo_path: String) -> AppResult<String> {
@@ -5791,7 +5885,8 @@ mod tests {
         external_items_from_thread_nodes,
         flatten_slurped_pages, fork_head_identity, gh_api_error_message, host_from_url,
         is_diff_too_large, is_object_id, map_timeline_node, parse_actions_run_job,
-        parse_auth_accounts, parse_pr_url_repo, pr_edit_args, pr_poll_query, pull_stack_ref,
+        parse_auth_accounts, parse_pr_url_repo, parse_publish_owners, pr_edit_args, pr_poll_query,
+        pull_stack_ref,
         real_check_time,
         real_time_or_empty, reconstruct_pr_diff, reject_upstream_create_metadata,
         rest_comment_to_out, rest_commit_to_out, rest_pull_to_pr_info, rest_review_to_out,
@@ -8007,5 +8102,59 @@ github.acme.com
             ] },
         })];
         assert!(external_items_from_thread_nodes(&nodes).is_empty());
+    }
+
+    /// Fixtures rather than a live gh: the false arm needs an org whose member
+    /// policy forbids repository creation, which no test account can conjure.
+    #[test]
+    fn parses_publish_owners_with_orgs() {
+        let body = r#"{"data":{"viewer":{"login":"theBGuy","organizations":{"nodes":[
+            {"login":"acme","viewerCanCreateRepositories":true},
+            {"login":"locked-co","viewerCanCreateRepositories":false}
+        ]}}}}"#;
+        let owners = parse_publish_owners(body).expect("parsed");
+        assert_eq!(owners.viewer, "theBGuy");
+        assert_eq!(owners.orgs.len(), 2);
+        assert_eq!(owners.orgs[0].login, "acme");
+        assert!(owners.orgs[0].can_create);
+        assert_eq!(owners.orgs[1].login, "locked-co");
+        assert!(!owners.orgs[1].can_create);
+    }
+
+    #[test]
+    fn parses_publish_owners_with_no_orgs() {
+        let body = r#"{"data":{"viewer":{"login":"solo","organizations":{"nodes":[]}}}}"#;
+        assert!(parse_publish_owners(body).expect("parsed").orgs.is_empty());
+        // A viewer without the connection at all is the same empty list.
+        let bare = r#"{"data":{"viewer":{"login":"solo"}}}"#;
+        let owners = parse_publish_owners(bare).expect("parsed");
+        assert_eq!(owners.viewer, "solo");
+        assert!(owners.orgs.is_empty());
+    }
+
+    #[test]
+    fn skips_null_org_nodes_in_publish_owners() {
+        let body = r#"{"data":{"viewer":{"login":"theBGuy","organizations":{"nodes":[
+            null, {"login":"acme","viewerCanCreateRepositories":true}
+        ]}}}}"#;
+        let owners = parse_publish_owners(body).expect("parsed");
+        assert_eq!(owners.orgs.len(), 1);
+        assert_eq!(owners.orgs[0].login, "acme");
+    }
+
+    #[test]
+    fn refuses_publish_owners_without_a_viewer_login() {
+        assert!(matches!(
+            parse_publish_owners("not json at all"),
+            Err(AppError::Gh(_))
+        ));
+        assert!(matches!(
+            parse_publish_owners(r#"{"data":{"viewer":null}}"#),
+            Err(AppError::Gh(_))
+        ));
+        assert!(matches!(
+            parse_publish_owners(r#"{"data":{"viewer":{"login":""}}}"#),
+            Err(AppError::Gh(_))
+        ));
     }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -499,8 +499,8 @@ fn parse_publish_owners(body: &str) -> AppResult<GithubPublishOwners> {
 
 /// The viewer's publishable owners, for the publish dialog's owner picker.
 /// Account-scoped, so it runs with no repo dir; `first: 100` is a deliberate
-/// unpaginated cap — an org past it is reachable by typed `owner/name` only
-/// while the dialog is in its listing-never-loaded fallback.
+/// unpaginated cap. It bounds the listing alone: a typed `owner/name` always
+/// targets that owner, so an org past the cap stays publishable.
 pub async fn gh_publish_owners() -> AppResult<GithubPublishOwners> {
     let query = "query { viewer { login organizations(first: 100) { nodes { login viewerCanCreateRepositories } } } }";
     let out = run_gh(
@@ -8134,9 +8134,11 @@ github.acme.com
     }
 
     #[test]
-    fn skips_null_org_nodes_in_publish_owners() {
+    fn skips_unusable_org_nodes_in_publish_owners() {
         let body = r#"{"data":{"viewer":{"login":"theBGuy","organizations":{"nodes":[
-            null, {"login":"acme","viewerCanCreateRepositories":true}
+            null,
+            {"login":"","viewerCanCreateRepositories":true},
+            {"login":"acme","viewerCanCreateRepositories":true}
         ]}}}}"#;
         let owners = parse_publish_owners(body).expect("parsed");
         assert_eq!(owners.orgs.len(), 1);

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -499,7 +499,8 @@ fn parse_publish_owners(body: &str) -> AppResult<GithubPublishOwners> {
 
 /// The viewer's publishable owners, for the publish dialog's owner picker.
 /// Account-scoped, so it runs with no repo dir; `first: 100` is a deliberate
-/// fail-open cap — the typed `owner/name` form still reaches an org past it.
+/// unpaginated cap — an org past it is reachable by typed `owner/name` only
+/// while the dialog is in its listing-never-loaded fallback.
 pub async fn gh_publish_owners() -> AppResult<GithubPublishOwners> {
     let query = "query { viewer { login organizations(first: 100) { nodes { login viewerCanCreateRepositories } } } }";
     let out = run_gh(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -477,6 +477,7 @@ pub fn run() {
             forge::forge_repo_visibility,
             forge::forge_publish_targets,
             forge::forge_publish_repo,
+            forge::forge_gh_publish_owners,
             forge::forge_bb_workspaces,
             forge::forge_bb_repo_settings,
             forge::forge_bb_repo_settings_update,

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -186,6 +186,8 @@ export function SelectControl({
   value,
   onValueChange,
   disabled,
+  disabledItems,
+  order,
   annotations,
   sizeToContent = false,
 }: {
@@ -196,6 +198,13 @@ export function SelectControl({
   value: string;
   onValueChange: (value: string) => void;
   disabled?: boolean;
+  /** Option keys rendered as disabled rows (skipped by keyboard nav). */
+  disabledItems?: ReadonlySet<string>;
+  /** Explicit option order. `items` is an object, so integer-like keys sort
+   *  ahead of the rest whatever order it was built in — any caller whose values
+   *  can be all-digits (logins, slugs) passes the order it means. Must hold
+   *  exactly the keys of `items`, no extras or duplicates. */
+  order?: readonly string[];
   /** Optional per-option trailing content (e.g. status chips), keyed by value.
    *  Rendered after a truncating label; keys with no entry render label-only.
    *  Never surfaces in the closed trigger — that reads the `items` map. */
@@ -209,6 +218,12 @@ export function SelectControl({
   // Opt-in rich rows: wrap the label so it can truncate and leave room for a
   // trailing annotation. Plain callers keep the exact prior markup.
   const rich = sizeToContent || annotations !== undefined;
+  const entries: [string, string][] = order
+    ? order.map((optionValue) => [
+        optionValue,
+        items[optionValue] ?? optionValue,
+      ])
+    : Object.entries(items);
   return (
     <div className="space-y-2">
       {label && <Label htmlFor={id}>{label}</Label>}
@@ -233,14 +248,22 @@ export function SelectControl({
               }
             : {})}
         >
-          {Object.entries(items).map(([optionValue, display]) =>
+          {entries.map(([optionValue, display]) =>
             rich ? (
-              <SelectItem key={optionValue} value={optionValue}>
+              <SelectItem
+                key={optionValue}
+                value={optionValue}
+                disabled={disabledItems?.has(optionValue)}
+              >
                 <span className="min-w-0 flex-1 truncate">{display}</span>
                 {annotations?.[optionValue]}
               </SelectItem>
             ) : (
-              <SelectItem key={optionValue} value={optionValue}>
+              <SelectItem
+                key={optionValue}
+                value={optionValue}
+                disabled={disabledItems?.has(optionValue)}
+              >
                 {display}
               </SelectItem>
             ),
@@ -257,6 +280,8 @@ export function SelectField({
   label,
   items,
   disabled,
+  disabledItems,
+  order,
   annotations,
   sizeToContent = false,
 }: Omit<ComponentProps<typeof SelectControl>, "value" | "onValueChange">) {
@@ -268,6 +293,8 @@ export function SelectField({
       value={field.state.value}
       onValueChange={(v) => field.handleChange(v)}
       disabled={disabled}
+      disabledItems={disabledItems}
+      order={order}
       annotations={annotations}
       sizeToContent={sizeToContent}
     />

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -198,7 +198,8 @@ export function SelectControl({
   value: string;
   onValueChange: (value: string) => void;
   disabled?: boolean;
-  /** Option keys rendered as disabled rows (skipped by keyboard nav). */
+  /** Option keys rendered as disabled rows — unselectable and skipped by
+   *  typeahead, though arrow-key highlight still visits them (aria-disabled). */
   disabledItems?: ReadonlySet<string>;
   /** Explicit option order. `items` is an object, so integer-like keys sort
    *  ahead of the rest whatever order it was built in — any caller whose values

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ReactNode, useId } from "react";
+import { type ComponentProps, type ReactNode, useEffect, useId } from "react";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -192,7 +192,8 @@ export function SelectControl({
   sizeToContent = false,
 }: {
   label?: ReactNode;
-  /** value → display label; option order follows the object's key order. */
+  /** value → display label; rendered in the object's key order unless `order`
+   *  overrides it. */
   items: Record<string, string>;
   /** The selected key; "" (or a key absent from `items`) shows no selection. */
   value: string;
@@ -225,6 +226,27 @@ export function SelectControl({
         items[optionValue] ?? optionValue,
       ])
     : Object.entries(items);
+  // A mismatched `order` is never repaired here: a key it omits is dropped, a key
+  // only it holds renders its raw value as the label, and nothing is reordered —
+  // silently fixing a caller's bug would hide a wrong list from the user. Today's
+  // callers derive `order` and `items` from one source, so this guards future ones.
+  // In an effect, not the render body (StrictMode double-invokes render); the
+  // literal `import.meta.env.DEV` leads the `&&` so Vite drops the whole block.
+  useEffect(() => {
+    if (import.meta.env.DEV && order) {
+      const missing = Object.keys(items).filter((k) => !order.includes(k));
+      const extra = order.filter((k) => !(k in items));
+      const duplicate = order.filter((k, i) => order.indexOf(k) !== i);
+      if (missing.length || extra.length || duplicate.length) {
+        console.warn("SelectControl: `order` does not match `items`", {
+          label,
+          missing,
+          extra,
+          duplicate,
+        });
+      }
+    }
+  }, [items, order, label]);
   return (
     <div className="space-y-2">
       {label && <Label htmlFor={id}>{label}</Label>}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -721,12 +721,15 @@ right on the **Push** and **Pull** buttons.
 
 A repo with no remote gets **Publish repository…** in the sync bar, and in the panel that
 stands in for the forge tabs until a remote exists. On **GitHub** the dialog opens with an
-**Owner** select above the name: your own account first, then every organization you belong
-to. Whichever you pick is where the repository is created — GitDesktop then adds it as
+**Owner** select above the name: your own account first, then your organizations (up to
+100). Whichever you pick is where the repository is created — GitDesktop then adds it as
 \`origin\` and pushes the current branch. Organizations that don't let you create
-repositories stay in the list, disabled, with **Can't create repositories** on the row. If
-the organization list can't be loaded, the name field takes an \`owner/name\` instead so you
-can still publish.
+repositories stay in the list, disabled, with **Can't create repositories** on the row.
+
+Typing \`owner/name\` in the **Name** field publishes under that owner rather than the
+select — how you reach an organization the list doesn't show. The select itself only
+disappears when the owner list has never loaded; once it has, a later refresh failure
+leaves the cached list in place.
 
 **GitLab** publishes into your own namespace, and **Bitbucket** asks for a **workspace**
 (see *Bitbucket repositories*).

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -717,6 +717,20 @@ right on the **Push** and **Pull** buttons.
 - **Push** ({{kbd:push}}) sends your commits. For a branch with no upstream yet, you'll
   see **Publish branch** instead.
 
+## Publish a local repo
+
+A repo with no remote gets **Publish repository…** in the sync bar, and in the panel that
+stands in for the forge tabs until a remote exists. On **GitHub** the dialog opens with an
+**Owner** select above the name: your own account first, then every organization you belong
+to. Whichever you pick is where the repository is created — GitDesktop then adds it as
+\`origin\` and pushes the current branch. Organizations that don't let you create
+repositories stay in the list, disabled, with **Can't create repositories** on the row. If
+the organization list can't be loaded, the name field takes an \`owner/name\` instead so you
+can still publish.
+
+**GitLab** publishes into your own namespace, and **Bitbucket** asks for a **workspace**
+(see *Bitbucket repositories*).
+
 ## Stash and reapply
 
 When a **Pull** would overwrite uncommitted changes, git refuses it — and GitDesktop offers

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -14,7 +14,11 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { required, useAppForm } from "@/lib/form";
-import { useBbWorkspaces, usePublishRepo } from "@/lib/git/queries";
+import {
+  useBbWorkspaces,
+  useGhPublishOwners,
+  usePublishRepo,
+} from "@/lib/git/queries";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
@@ -28,6 +32,40 @@ function bbSlugWarning(value: string): string | null {
   const name = value.trim();
   if (!name || BB_SLUG_RE.test(name)) return null;
   return "Only letters, numbers, and . _ - are allowed, starting with a letter or number.";
+}
+
+/** With the owner picker active the name is just the repository name: a slash
+ *  means the old typed owner/name form, and a leading dash reads as a gh flag —
+ *  a composed `owner/-x` slips past the backend's own leading-dash refusal. */
+function ghNameWarning(value: string): string | null {
+  if (value.includes("/")) {
+    return "Choose the owner above instead of typing owner/name.";
+  }
+  if (value.trim().startsWith("-")) {
+    return "A repository name can't start with a dash.";
+  }
+  return null;
+}
+
+/** Provider-specific inline hints on Name; GitLab's namespace needs none. */
+const NAME_WARNINGS: Record<
+  "github" | "gitlab" | "bitbucket",
+  ((value: string) => string | null) | undefined
+> = {
+  github: ghNameWarning,
+  gitlab: undefined,
+  bitbucket: bbSlugWarning,
+};
+
+/** A field label with a muted second line — carries the reason a picker (and
+ *  with it Publish) is disabled, which a disabled control can't hold itself. */
+function StackedLabel({ label, hint }: { label: string; hint: string }) {
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span>{label}</span>
+      <span className="font-normal text-muted-foreground">{hint}</span>
+    </span>
+  );
 }
 
 /** Space/comma-separated text → GitHub's lowercase, deduped, capped topic list.
@@ -63,6 +101,7 @@ export function PublishDialog({
   const descGen = useGenerateRepoDescription(repoPath);
   const isGitLab = provider === "gitlab";
   const isBitbucket = provider === "bitbucket";
+  const isGitHub = provider === "github";
   const remoteLabel = isBitbucket
     ? "Bitbucket"
     : isGitLab
@@ -78,9 +117,32 @@ export function PublishDialog({
     workspaces.data?.[0]?.slug ??
     "";
   // value ≠ label isn't a risk here (slug is both), but the Base UI Select still
-  // needs an items map to render the closed trigger.
-  const workspaceItems = Object.fromEntries(
-    (workspaces.data ?? []).map((w) => [w.slug, w.slug]),
+  // needs an items map to render the closed trigger. The map can't carry the
+  // order — an all-digit slug would sort to the front — so pass it separately.
+  const workspaceSlugs = (workspaces.data ?? []).map((w) => w.slug);
+  const workspaceItems = Object.fromEntries(workspaceSlugs.map((s) => [s, s]));
+
+  // GitHub creates the repo under an owner — your account or an org. Only fetched
+  // when the GitHub dialog is open. The typed `owner/name` fallback engages only
+  // when the listing NEVER loaded: react-query keeps `data` across a failed
+  // background refetch, and stale owners beat yanking the picker mid-edit.
+  const owners = useGhPublishOwners(open && isGitHub);
+  const ghPickerActive = isGitHub && !(owners.isError && !owners.data);
+  const ownerLogins = owners.data
+    ? [owners.data.viewer, ...owners.data.orgs.map((o) => o.login)]
+    : [];
+  const ownerItems = Object.fromEntries(ownerLogins.map((l) => [l, l]));
+  // Orgs whose member policy (or the viewer's role) forbids creation are shown
+  // disabled with the reason as row text — a 403 after submit explains nothing.
+  const blockedOrgs = (owners.data?.orgs ?? []).filter((o) => !o.canCreate);
+  const disabledOwners = new Set(blockedOrgs.map((o) => o.login));
+  const ownerAnnotations = Object.fromEntries(
+    blockedOrgs.map((o) => [
+      o.login,
+      <span className="shrink-0 text-[11px] text-muted-foreground">
+        Can't create repositories
+      </span>,
+    ]),
   );
 
   const form = useAppForm({
@@ -90,20 +152,28 @@ export function PublishDialog({
       homepage: "",
       topics: "",
       workspace: "",
+      owner: "",
       isPrivate: true,
     },
     onSubmit: async ({ value }) => {
+      const name = value.name.trim();
+      // The publish backend takes `owner/repo` in `name`; compose it only for an
+      // org — the viewer's own login publishes under the bare name.
+      const target =
+        ghPickerActive && value.owner && value.owner !== owners.data?.viewer
+          ? `${value.owner}/${name}`
+          : name;
       try {
         const url = await publish.mutateAsync({
           provider,
-          name: value.name.trim(),
+          name: target,
           isPrivate: value.isPrivate,
           description: value.description,
           homepage: value.homepage.trim(),
           topics: parseTopics(value.topics),
           workspace: isBitbucket ? value.workspace : undefined,
         });
-        toast.success(`Published ${value.name.trim()}`, {
+        toast.success(`Published ${target}`, {
           description: url,
           action: { label: "View", onClick: () => openUrl(url) },
         });
@@ -117,12 +187,21 @@ export function PublishDialog({
   // The live name drives the AI grounding (the repo isn't published yet).
   const nameVal = useSelector(form.store, (s) => s.values.name);
   const workspaceVal = useSelector(form.store, (s) => s.values.workspace);
+  const ownerVal = useSelector(form.store, (s) => s.values.owner);
   // Bitbucket-only submit gate: a valid slug and a chosen workspace. The name's
   // `warning` hint already explains a bad slug inline; a missing workspace can't
   // happen once the picker seeds, but guard it so submit never fires half-formed.
   const bbBlocked =
     isBitbucket &&
     (bbSlugWarning(nameVal) !== null || nameVal.trim() === "" || !workspaceVal);
+  // With the picker active the owner comes from it, so a name carrying its own
+  // owner or a leading dash can't be composed; the name's `warning` says which.
+  const ghBlocked =
+    ghPickerActive && (ghNameWarning(nameVal) !== null || !ownerVal);
+  // GitHub's hints presume the picker — without a listing at all, typed
+  // `owner/name` is the only way to reach an org, so the hints go with it.
+  const nameWarning =
+    isGitHub && !ghPickerActive ? undefined : NAME_WARNINGS[provider];
 
   const seedOnOpen = useEffectEvent(() =>
     form.reset({
@@ -131,6 +210,7 @@ export function PublishDialog({
       homepage: "",
       topics: "",
       workspace: "",
+      owner: "",
       isPrivate: true,
     }),
   );
@@ -146,6 +226,17 @@ export function PublishDialog({
   useEffect(() => {
     if (open && isBitbucket) seedWorkspace(defaultWorkspace);
   }, [open, isBitbucket, defaultWorkspace]);
+
+  // Owners load after the dialog opens; same seed-once-empty rule as workspaces.
+  const defaultOwner = owners.data?.viewer ?? "";
+  const seedOwner = useEffectEvent((login: string) => {
+    if (!form.state.values.owner && login) {
+      form.setFieldValue("owner", login);
+    }
+  });
+  useEffect(() => {
+    if (open && isGitHub) seedOwner(defaultOwner);
+  }, [open, isGitHub, defaultOwner]);
 
   // Shared by the Generate button and the generate chord below.
   function runGenerate() {
@@ -170,6 +261,15 @@ export function PublishDialog({
     enabled: aiEnabled && !descGen.generating,
     run: runGenerate,
   });
+
+  const githubScope = ghPickerActive ? (
+    <>It's created under the selected owner.</>
+  ) : (
+    <>
+      Use <span className="font-mono">owner/name</span> to publish under an
+      organization.
+    </>
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -200,22 +300,53 @@ export function PublishDialog({
               ) : isGitLab ? (
                 <>It lands in your namespace (groups aren't supported yet).</>
               ) : (
-                <>
-                  Use <span className="font-mono">owner/name</span> to publish
-                  under an organization.
-                </>
+                githubScope
               )}
             </DialogDescription>
           </DialogHeader>
           {/* Fields scroll; header and submit footer stay pinned. */}
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+            {/* GitHub creates the repo under an owner — pick it first. */}
+            {ghPickerActive && (
+              <form.AppField name="owner">
+                {(field) => (
+                  <field.SelectField
+                    label={
+                      owners.isPending ? (
+                        <StackedLabel
+                          label="Owner"
+                          hint="Loading your account and organizations…"
+                        />
+                      ) : (
+                        "Owner"
+                      )
+                    }
+                    items={ownerItems}
+                    order={ownerLogins}
+                    disabled={owners.isPending || !owners.data}
+                    disabledItems={disabledOwners}
+                    annotations={ownerAnnotations}
+                  />
+                )}
+              </form.AppField>
+            )}
             {/* Bitbucket creates the repo under a workspace — pick it first. */}
             {isBitbucket && (
               <form.AppField name="workspace">
                 {(field) => (
                   <field.SelectField
-                    label="Workspace"
+                    label={
+                      workspaces.isPending ? (
+                        <StackedLabel
+                          label="Workspace"
+                          hint="Loading your workspaces…"
+                        />
+                      ) : (
+                        "Workspace"
+                      )
+                    }
                     items={workspaceItems}
+                    order={workspaceSlugs}
                     disabled={workspaces.isPending || !workspaces.data?.length}
                   />
                 )}
@@ -229,18 +360,16 @@ export function PublishDialog({
                 <field.TextField
                   label={
                     isBitbucket ? (
-                      <span className="flex flex-col gap-0.5">
-                        <span>Name</span>
-                        <span className="font-normal text-muted-foreground">
-                          Becomes the repository URL slug on Bitbucket
-                        </span>
-                      </span>
+                      <StackedLabel
+                        label="Name"
+                        hint="Becomes the repository URL slug on Bitbucket"
+                      />
                     ) : (
                       "Name"
                     )
                   }
                   placeholder="my-project"
-                  warning={isBitbucket ? bbSlugWarning : undefined}
+                  warning={nameWarning}
                 />
               )}
             </form.AppField>
@@ -331,7 +460,9 @@ export function PublishDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={descGen.generating || bbBlocked}>
+              <form.SubmitButton
+                disabled={descGen.generating || bbBlocked || ghBlocked}
+              >
                 Publish
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -34,17 +34,34 @@ function bbSlugWarning(value: string): string | null {
   return "Only letters, numbers, and . _ - are allowed, starting with a letter or number.";
 }
 
-/** With the owner picker active the name is just the repository name: a slash
- *  means the old typed owner/name form, and a leading dash reads as a gh flag —
- *  a composed `owner/-x` slips past the backend's own leading-dash refusal. */
+/** Whether any `/`-separated segment leads with a dash. gh reads a leading dash
+ *  as a flag, and the backend's own guard only tests the whole string, so an
+ *  owner-qualified `acme/-x` reaches gh unrefused unless it's caught per segment. */
+function hasDashLedSegment(value: string): boolean {
+  return value
+    .trim()
+    .split("/")
+    .some((segment) => segment.trim().startsWith("-"));
+}
+
+/** With the owner picker active a typed `owner/name` still wins over the select,
+ *  which is how an org the listing can't reach (the 100-org cap, a token without
+ *  `read:org`) stays publishable — so the slash only earns a note. The refusals
+ *  are tested first, so a warning beside a disabled Publish always explains it. */
 function ghNameWarning(value: string): string | null {
-  if (value.includes("/")) {
-    return "Choose the owner above instead of typing owner/name.";
-  }
-  if (value.trim().startsWith("-")) {
+  if (hasDashLedSegment(value)) {
     return "A repository name can't start with a dash.";
   }
+  if (value.includes("/")) {
+    return "Publishing under the owner typed here, not the Owner select.";
+  }
   return null;
+}
+
+/** Names the owner-picker arm refuses: blank, or any segment leading with a dash.
+ *  Blank blocks silently, matching the `required` validator's no-inline-text style. */
+function ghNameBlocked(value: string): boolean {
+  return value.trim() === "" || hasDashLedSegment(value);
 }
 
 /** Provider-specific inline hints on Name; GitLab's namespace needs none. */
@@ -123,9 +140,10 @@ export function PublishDialog({
   const workspaceItems = Object.fromEntries(workspaceSlugs.map((s) => [s, s]));
 
   // GitHub creates the repo under an owner — your account or an org. Only fetched
-  // when the GitHub dialog is open. The typed `owner/name` fallback engages only
-  // when the listing NEVER loaded: react-query keeps `data` across a failed
-  // background refetch, and stale owners beat yanking the picker mid-edit.
+  // when the GitHub dialog is open. The picker is hidden only when the listing
+  // NEVER loaded: react-query keeps `data` across a failed background refetch,
+  // and stale owners beat yanking the picker mid-edit. A typed `owner/name`
+  // targets that owner either way.
   const owners = useGhPublishOwners(open && isGitHub);
   const ghPickerActive = isGitHub && !(owners.isError && !owners.data);
   const ownerLogins = owners.data
@@ -139,7 +157,9 @@ export function PublishDialog({
   const ownerAnnotations = Object.fromEntries(
     blockedOrgs.map((o) => [
       o.login,
-      <span className="shrink-0 text-[11px] text-muted-foreground">
+      // Not muted: the row's own `data-disabled:opacity-50` already halves it,
+      // and the reason a row is disabled has to stay readable.
+      <span className="shrink-0 text-[11px] text-foreground">
         Can't create repositories
       </span>,
     ]),
@@ -158,9 +178,13 @@ export function PublishDialog({
     onSubmit: async ({ value }) => {
       const name = value.name.trim();
       // The publish backend takes `owner/repo` in `name`; compose it only for an
-      // org — the viewer's own login publishes under the bare name.
+      // org — the viewer's own login publishes under the bare name, and a name
+      // that already carries an owner targets that owner as typed.
       const target =
-        ghPickerActive && value.owner && value.owner !== owners.data?.viewer
+        ghPickerActive &&
+        !name.includes("/") &&
+        value.owner &&
+        value.owner !== owners.data?.viewer
           ? `${value.owner}/${name}`
           : name;
       try {
@@ -194,10 +218,11 @@ export function PublishDialog({
   const bbBlocked =
     isBitbucket &&
     (bbSlugWarning(nameVal) !== null || nameVal.trim() === "" || !workspaceVal);
-  // With the picker active the owner comes from it, so a name carrying its own
-  // owner or a leading dash can't be composed; the name's `warning` says which.
+  // A typed owner wins, so an unseeded picker only blocks a name that would
+  // consume it; the name's `warning` explains a refused name inline.
   const ghBlocked =
-    ghPickerActive && (ghNameWarning(nameVal) !== null || !ownerVal);
+    ghPickerActive &&
+    (ghNameBlocked(nameVal) || (!ownerVal && !nameVal.includes("/")));
   // GitHub's hints presume the picker — without a listing at all, typed
   // `owner/name` is the only way to reach an org, so the hints go with it.
   const nameWarning =
@@ -263,7 +288,11 @@ export function PublishDialog({
   });
 
   const githubScope = ghPickerActive ? (
-    <>It's created under the selected owner.</>
+    <>
+      It's created under the selected owner; typing{" "}
+      <span className="font-mono">owner/name</span> publishes under that owner
+      instead.
+    </>
   ) : (
     <>
       Use <span className="font-mono">owner/name</span> to publish under an
@@ -326,6 +355,7 @@ export function PublishDialog({
                     disabled={owners.isPending || !owners.data}
                     disabledItems={disabledOwners}
                     annotations={ownerAnnotations}
+                    sizeToContent
                   />
                 )}
               </form.AppField>

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -34,9 +34,9 @@ function bbSlugWarning(value: string): string | null {
   return "Only letters, numbers, and . _ - are allowed, starting with a letter or number.";
 }
 
-/** Whether any `/`-separated segment leads with a dash. gh reads a leading dash
- *  as a flag, and the backend's own guard only tests the whole string, so an
- *  owner-qualified `acme/-x` reaches gh unrefused unless it's caught per segment. */
+/** Whether any `/`-separated segment leads with a dash. A whole-string leading
+ *  dash is the argv flag hazard the backend refuses; an inner one isn't, but takes
+ *  the same refusal on both publish paths — one rule, raised inline, not late. */
 function hasDashLedSegment(value: string): boolean {
   return value
     .trim()
@@ -44,32 +44,53 @@ function hasDashLedSegment(value: string): boolean {
     .some((segment) => segment.trim().startsWith("-"));
 }
 
-/** With the owner picker active a typed `owner/name` still wins over the select,
- *  which is how an org the listing can't reach (the 100-org cap, a token without
- *  `read:org`) stays publishable — so the slash only earns a note. The refusals
- *  are tested first, so a warning beside a disabled Publish always explains it. */
-function ghNameWarning(value: string): string | null {
+/** A slashed name that isn't exactly `owner/name` with both parts filled. */
+function malformedOwnerName(value: string): boolean {
+  if (!value.includes("/")) return false;
+  const parts = value.trim().split("/");
+  return parts.length !== 2 || parts.some((part) => part.trim() === "");
+}
+
+/** Why a GitHub name is refused, or null. Every publish path shares these, so
+ *  the message a blocked Publish needs is available whether or not the owner
+ *  picker rendered. */
+function ghNameRefusal(value: string): string | null {
   if (hasDashLedSegment(value)) {
     return "A repository name can't start with a dash.";
   }
+  if (malformedOwnerName(value)) {
+    return "Type owner/name.";
+  }
+  return null;
+}
+
+/** Names GitHub refuses: blank, or anything `ghNameRefusal` names. Blank blocks
+ *  silently, matching the `required` validator's no-inline-text style. Sharing
+ *  the refusal set with the hint keeps blocked-implies-explained structural. */
+function ghNameBlocked(value: string): boolean {
+  return value.trim() === "" || ghNameRefusal(value) !== null;
+}
+
+/** The picker arm's hints: the refusals, plus a note that a typed `owner/name`
+ *  wins over the select — that's how an org the listing can't reach (the 100-org
+ *  cap, a token without `read:org`) stays publishable. */
+function ghNameWarning(value: string): string | null {
+  const refusal = ghNameRefusal(value);
+  if (refusal) return refusal;
   if (value.includes("/")) {
     return "Publishing under the owner typed here, not the Owner select.";
   }
   return null;
 }
 
-/** Names the owner-picker arm refuses: blank, or any segment leading with a dash.
- *  Blank blocks silently, matching the `required` validator's no-inline-text style. */
-function ghNameBlocked(value: string): boolean {
-  return value.trim() === "" || hasDashLedSegment(value);
-}
-
-/** Provider-specific inline hints on Name; GitLab's namespace needs none. */
+/** Provider-specific inline hints on Name; GitLab's namespace needs none. The
+ *  GitHub entry is the refusals alone — the dialog swaps in `ghNameWarning`
+ *  where a picker exists for the advisory to point at. */
 const NAME_WARNINGS: Record<
   "github" | "gitlab" | "bitbucket",
   ((value: string) => string | null) | undefined
 > = {
-  github: ghNameWarning,
+  github: ghNameRefusal,
   gitlab: undefined,
   bitbucket: bbSlugWarning,
 };
@@ -218,15 +239,16 @@ export function PublishDialog({
   const bbBlocked =
     isBitbucket &&
     (bbSlugWarning(nameVal) !== null || nameVal.trim() === "" || !workspaceVal);
-  // A typed owner wins, so an unseeded picker only blocks a name that would
-  // consume it; the name's `warning` explains a refused name inline.
+  // Refused names are refused on every GitHub path; only the picker adds the
+  // unseeded-owner gate, and a typed owner exempts a name from it.
   const ghBlocked =
-    ghPickerActive &&
-    (ghNameBlocked(nameVal) || (!ownerVal && !nameVal.includes("/")));
-  // GitHub's hints presume the picker — without a listing at all, typed
-  // `owner/name` is the only way to reach an org, so the hints go with it.
-  const nameWarning =
-    isGitHub && !ghPickerActive ? undefined : NAME_WARNINGS[provider];
+    isGitHub &&
+    (ghNameBlocked(nameVal) ||
+      (ghPickerActive && !ownerVal && !nameVal.includes("/")));
+  // The refusals ride every arm so a refused name is explained wherever it
+  // blocks (blank and the unseeded-owner gate stay deliberately silent); the
+  // advisory names the Owner select, so it rides only the arm that renders one.
+  const nameWarning = ghPickerActive ? ghNameWarning : NAME_WARNINGS[provider];
 
   const seedOnOpen = useEffectEvent(() =>
     form.reset({
@@ -252,16 +274,23 @@ export function PublishDialog({
     if (open && isBitbucket) seedWorkspace(defaultWorkspace);
   }, [open, isBitbucket, defaultWorkspace]);
 
-  // Owners load after the dialog opens; same seed-once-empty rule as workspaces.
+  // Owners load after the dialog opens, so seed the picker once they arrive, and
+  // re-seed whenever the held owner isn't in the list the data now describes — a
+  // gh account switch refetches into a list the old viewer is absent from, and
+  // composing under it would create the repo on the wrong account. Validity is
+  // derived from the current list rather than cleared by each writer, so an org
+  // that simply drops out is covered by the same arm.
   const defaultOwner = owners.data?.viewer ?? "";
-  const seedOwner = useEffectEvent((login: string) => {
-    if (!form.state.values.owner && login) {
-      form.setFieldValue("owner", login);
+  const seedOwner = useEffectEvent((viewer: string, logins: string[]) => {
+    if (!viewer) return;
+    const held = form.state.values.owner;
+    if (!held || !logins.includes(held)) {
+      form.setFieldValue("owner", viewer);
     }
   });
   useEffect(() => {
-    if (open && isGitHub) seedOwner(defaultOwner);
-  }, [open, isGitHub, defaultOwner]);
+    if (open && isGitHub) seedOwner(defaultOwner, ownerLogins);
+  }, [open, isGitHub, defaultOwner, ownerLogins]);
 
   // Shared by the Generate button and the generate chord below.
   function runGenerate() {

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -66,6 +66,7 @@ import type {
   GhScopes,
   GhSecret,
   GhVariable,
+  GithubPublishOwners,
   GitInfo,
   GitLabHook,
   GitLabHookDelivery,
@@ -2967,6 +2968,10 @@ export const forgeGlProtectedBranchDelete = (repoPath: string, name: string) =>
  *  dialog's suggestions (host-correct for self-managed GitLab). */
 export const forgeGlMemberProjects = (repoPath: string) =>
   invoke<string[]>("forge_gl_member_projects", { repoPath });
+
+/** Owners the viewer can publish under — the GitHub publish owner picker (account-scoped). */
+export const forgeGhPublishOwners = () =>
+  invoke<GithubPublishOwners>("forge_gh_publish_owners");
 
 // ── Bitbucket settings surface — Bitbucket repos only; the GitHub / GitLab dialogs
 //    keep their own provider-shaped sections.

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -62,11 +62,11 @@ import type {
   GeneratedNotes,
   GhAccounts,
   GhBranchProtection,
+  GhPublishOwners,
   GhRepoList,
   GhScopes,
   GhSecret,
   GhVariable,
-  GithubPublishOwners,
   GitInfo,
   GitLabHook,
   GitLabHookDelivery,
@@ -2971,7 +2971,7 @@ export const forgeGlMemberProjects = (repoPath: string) =>
 
 /** Owners the viewer can publish under — the GitHub publish owner picker (account-scoped). */
 export const forgeGhPublishOwners = () =>
-  invoke<GithubPublishOwners>("forge_gh_publish_owners");
+  invoke<GhPublishOwners>("forge_gh_publish_owners");
 
 // ── Bitbucket settings surface — Bitbucket repos only; the GitHub / GitLab dialogs
 //    keep their own provider-shaped sections.

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -5838,6 +5838,18 @@ export function useGlMemberProjects(repo: string, enabled: boolean) {
   });
 }
 
+/** The viewer's publishable GitHub owners — the publish owner picker.
+ *  Account-scoped, so NOT repo-keyed; cached broadly like workspaces. */
+export function useGhPublishOwners(enabled: boolean) {
+  return useQuery({
+    queryKey: ["gh", "publish-owners"] as const,
+    queryFn: () => api.forgeGhPublishOwners(),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
 // ── Bitbucket settings surface ─────────────────────────────────────────────
 // Mirrors the useGl* hooks: repo-keyed reads (staleTime + retry:false) and mutations
 // that invalidate their read onSettled. The workspaces list is account-scoped, not

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1171,7 +1171,7 @@ export interface GitLabMrMergeState {
 }
 
 /** Owners the viewer can publish a new GitHub repository under. */
-export interface GithubPublishOwners {
+export interface GhPublishOwners {
   viewer: string;
   orgs: { login: string; canCreate: boolean }[];
 }

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -1170,6 +1170,12 @@ export interface GitLabMrMergeState {
   pipelineUrl: string;
 }
 
+/** Owners the viewer can publish a new GitHub repository under. */
+export interface GithubPublishOwners {
+  viewer: string;
+  orgs: { login: string; canCreate: boolean }[];
+}
+
 // ── Bitbucket settings surface ─────────────────────────────────────────────
 //
 // Bitbucket's repo-management model is its own shape (like GitLab's), not a mapping


### PR DESCRIPTION
Publishing a local repo to GitHub previously required typing `owner/name` into the Name field to reach an organization — an undiscoverable convention with no feedback until the create call failed. The publish dialog now opens with an **Owner** select listing your account and every organization you belong to, with orgs that forbid member repository creation shown disabled and labeled, so the constraint is visible before submit rather than as a 403 afterwards.

### Backend: owner listing

- Adds `gh_publish_owners()` in `src-tauri/src/github/pr.rs`, which runs a GraphQL query for `viewer { login organizations(first: 100) { nodes { login viewerCanCreateRepositories } } }`. `viewerCanCreateRepositories` folds the org member policy and the viewer's role server-side, so the disabled state needs no second call.
- Splits response handling into a pure `parse_publish_owners(&str)` over `RawOwnersBody`/`RawOwnersViewer`/`RawOwnerOrg`, returning the new `GithubPublishOwners` / `GithubPublishOrg` serde types. A missing viewer login is an error; null or login-less org nodes are skipped rather than failing the whole list.
- Exposes it as the account-scoped `forge_gh_publish_owners` command in `src-tauri/src/forge/mod.rs`, registered in `src-tauri/src/lib.rs`.
- Adds four unit tests covering orgs present, no orgs / absent connection, null nodes, and the three no-viewer failure arms (bad JSON, null viewer, empty login) — fixture-driven, since the `canCreate: false` arm can't be produced from a test account.

### Frontend: dialog and shared select

- `src/features/repository/PublishDialog.tsx` gains the `owner` form field: it seeds to the viewer's login once loaded (`seedOwner`, mirroring the existing workspace seeding), composes `owner/name` on submit only for a non-viewer owner, and reports the composed target in the success toast.
- Adds `ghNameWarning` plus the `NAME_WARNINGS` provider map: with the picker active a `/` in the name points the user at the Owner select, and a leading dash is refused (a composed `owner/-x` would otherwise slip past the backend's own dash check). `ghBlocked` gates the Publish button on a clean name and a chosen owner.
- Falls back to the old typed `owner/name` flow only when the listing never loaded (`ghPickerActive`), so a failed background refetch that still has cached data doesn't yank the picker mid-edit; the `DialogDescription` copy switches with it via `githubScope`.
- Extracts the previously inline Bitbucket two-line label into a shared `StackedLabel`, reused to show "Loading your account and organizations…" / "Loading your workspaces…" under the disabled pickers.
- `src/components/form/fields.tsx`: `SelectControl`/`SelectField` accept `disabledItems` (rows rendered disabled and skipped by keyboard nav) and `order` (explicit option sequence). `order` exists because an `items` Record reorders integer-like keys to the front, which would scramble all-digit logins and slugs — the Bitbucket workspace picker now passes `workspaceSlugs` for the same reason.
- Wires the IPC through `forgeGhPublishOwners` in `src/lib/git/api.ts`, the account-scoped `useGhPublishOwners(enabled)` hook in `src/lib/git/queries.ts` (5-minute `staleTime`, `retry: false`), and the `GithubPublishOwners` interface in `src/lib/git/types.ts`.

### Documentation

- `README.md`: new bullet under the repository section describing the Owner select and the Bitbucket workspace equivalent.
- `site/src/data/capabilities.ts`: extends the publish capability label to mention choosing the GitHub owner or Bitbucket workspace.
- `src/features/help/content.ts`: adds a *Publish a local repo* guide section covering the Owner select, disabled orgs, the `owner/name` fallback, and how GitLab and Bitbucket differ.
- `changelog.d/added-publish-owner-picker.md`: Keep a Changelog fragment for the new picker.
- `.claude/skills/gd-conventions/SKILL.md`: records the `items`-Record key-reordering trap and the `order` prop as the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitHub publishing now lets you choose your account or an organization as the repository owner.
  - Organizations that cannot create repositories are shown as disabled with an explanation.
  - Bitbucket publishing now supports workspace selection.
  - Repository names and owner paths are validated according to the selected provider.

- **Documentation**
  - Updated repository, publishing, and capability descriptions to reflect owner and workspace selection.
  - Added guidance for owner/name publishing overrides and organization limits.

- **Bug Fixes**
  - Improved option ordering for numeric-looking workspace identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->