### PR TITLE
fix(ui,repository): settle loading placeholders into the layout they replace

### DIFF
--- a/changelog.d/changed-changes-tab-loading-placeholder.md
+++ b/changelog.d/changed-changes-tab-loading-placeholder.md
@@ -1,1 +1,2 @@
-- The Changes tab settles without jumping: its loading placeholder sits where the clean-tree message lands and only appears when loading takes a moment.
+- The **Changes** tab holds its place while it loads: the placeholder sits
+  where the clean-tree summary lands, and a quick load skips it entirely.

--- a/changelog.d/changed-changes-tab-loading-placeholder.md
+++ b/changelog.d/changed-changes-tab-loading-placeholder.md
@@ -1,0 +1,1 @@
+- The Changes tab settles without jumping: its loading placeholder sits where the clean-tree message lands and only appears when loading takes a moment.

--- a/changelog.d/changed-list-skeletons-match-rows.md
+++ b/changelog.d/changed-list-skeletons-match-rows.md
@@ -1,1 +1,3 @@
-- Loading placeholders in the discussions, history, tags, compare, and findings lists now match the rows they load into, keeping those lists steady on first open.
+- Loading placeholders in the **Issues**, **Pull requests**, **Actions**,
+  **Discussions**, **History**, **Tags**, **Compare**, and **Findings** lists
+  now match the rows they load into, so lists stay steady on first open.

--- a/changelog.d/changed-list-skeletons-match-rows.md
+++ b/changelog.d/changed-list-skeletons-match-rows.md
@@ -1,0 +1,1 @@
+- Loading placeholders in the discussions, history, tags, compare, and findings lists now match the rows they load into, keeping those lists steady on first open.

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -8,7 +8,8 @@ import { cn } from "@/lib/utils";
  * `indent` (the default) lines after the first sit where icon-led rows put
  * their meta lines (≈ their `pl-4`/`pl-5`); avatar-column lists, whose lines
  * share one left edge, pass `indent={false}`. `lines` must match the real
- * row's line count (2 = issue rows, 3 = PR / workflow-run / Jira rows).
+ * row's line count (2 = issue / commit / tag / finding rows, 3 = PR /
+ * workflow-run / Jira / discussion rows).
  * Callers render `ListRowSkeletons` instead — it wraps this one with the busy
  * announcement a loading region owes readers.
  */
@@ -42,16 +43,19 @@ export function ListRowSkeletons({
   indent?: boolean;
 }) {
   return (
-    <div aria-busy>
-      {/* aria-busy alone has no text; role="status" gives the busy region words
-          for readers that announce it. */}
+    <>
+      {/* Outside the aria-busy subtree: busy suppresses descendant live-region
+          announcements until it flips false, and this container unmounts
+          instead of flipping. */}
       <span role="status" className="sr-only">
         Loading {name}…
       </span>
-      {/* Index key: a fixed static list that never reorders. */}
-      {Array.from({ length: rows }, (_, i) => (
-        <ListRowSkeleton key={i} lines={lines} indent={indent} />
-      ))}
-    </div>
+      <div aria-busy>
+        {/* Index key: a fixed static list that never reorders. */}
+        {Array.from({ length: rows }, (_, i) => (
+          <ListRowSkeleton key={i} lines={lines} indent={indent} />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -4,18 +4,23 @@ import { cn } from "@/lib/utils";
 /**
  * One row placeholder: the same flush `border-b px-3 py-2` box and per-line
  * rhythm as the real rows, so real rows replace skeletons without shifting the
- * list. Bars run full width — the real lines truncate across the row — with
- * lines after the first indented like the real meta lines. `lines` must match
- * the real row's line count (2 = issue rows, 3 = PR / workflow-run / Jira
- * rows). Callers render `ListRowSkeletons` instead — it wraps this one with
- * the busy announcement a loading region owes readers.
+ * list. Bars run full width — the real lines truncate across the row. With
+ * `indent` (the default) lines after the first sit where icon-led rows put
+ * their meta lines (≈ their `pl-4`/`pl-5`); avatar-column lists, whose lines
+ * share one left edge, pass `indent={false}`. `lines` must match the real
+ * row's line count (2 = issue rows, 3 = PR / workflow-run / Jira rows).
+ * Callers render `ListRowSkeletons` instead — it wraps this one with the busy
+ * announcement a loading region owes readers.
  */
-function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
+function ListRowSkeleton({ lines, indent }: { lines: 2 | 3; indent: boolean }) {
   return (
     <div className="border-b px-3 py-2">
       {/* Index key: a fixed static list that never reorders. */}
       {Array.from({ length: lines }, (_, i) => (
-        <Skeleton key={i} className={cn("h-4", i > 0 && "mt-0.5 ml-4")} />
+        <Skeleton
+          key={i}
+          className={cn("h-4", i > 0 && "mt-0.5", i > 0 && indent && "ml-4")}
+        />
       ))}
     </div>
   );
@@ -29,10 +34,12 @@ export function ListRowSkeletons({
   rows,
   lines,
   name,
+  indent = true,
 }: {
   rows: number;
   lines: 2 | 3;
   name: string;
+  indent?: boolean;
 }) {
   return (
     <div aria-busy>
@@ -43,7 +50,7 @@ export function ListRowSkeletons({
       </span>
       {/* Index key: a fixed static list that never reorders. */}
       {Array.from({ length: rows }, (_, i) => (
-        <ListRowSkeleton key={i} lines={lines} />
+        <ListRowSkeleton key={i} lines={lines} indent={indent} />
       ))}
     </div>
   );

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -1,22 +1,21 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
-/** Per-line bar widths, staggered so the shimmer reads as lines of text. */
-const BAR_WIDTHS = ["w-3/5", "w-2/5", "w-1/2"];
-
 /**
  * One row placeholder: the same flush `border-b px-3 py-2` box and per-line
  * rhythm as the real rows, so real rows replace skeletons without shifting the
- * list. `lines` must match the real row's line count (2 = issue rows, 3 = PR /
- * workflow-run / Jira rows). Callers render `ListRowSkeletons` instead — it
- * wraps this one with the busy announcement a loading region owes readers.
+ * list. Bars run full width — the real lines truncate across the row — with
+ * lines after the first indented like the real meta lines. `lines` must match
+ * the real row's line count (2 = issue rows, 3 = PR / workflow-run / Jira
+ * rows). Callers render `ListRowSkeletons` instead — it wraps this one with
+ * the busy announcement a loading region owes readers.
  */
 function ListRowSkeleton({ lines }: { lines: 2 | 3 }) {
   return (
     <div className="border-b px-3 py-2">
       {/* Index key: a fixed static list that never reorders. */}
-      {BAR_WIDTHS.slice(0, lines).map((width, i) => (
-        <Skeleton key={i} className={cn("h-4", width, i > 0 && "mt-0.5")} />
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton key={i} className={cn("h-4", i > 0 && "mt-0.5 ml-4")} />
       ))}
     </div>
   );

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -7,9 +7,9 @@ import { cn } from "@/lib/utils";
  * list. Bars run full width — the real lines truncate across the row. With
  * `indent` (the default) lines after the first sit where icon-led rows put
  * their meta lines (≈ their `pl-4`/`pl-5`); lists whose lines share one left
- * edge (avatar-column or chip-led) pass `indent={false}`. `lines` must match the real
- * row's line count (2 = issue / commit / tag / finding rows, 3 = PR /
- * workflow-run / Jira / discussion rows).
+ * edge (avatar-column or chip-led) pass `indent={false}`.
+ * `lines` must match the real row's line count (2 = issue / commit / tag /
+ * finding rows, 3 = PR / workflow-run / Jira / discussion rows).
  * Callers render `ListRowSkeletons` instead — it wraps this one with the busy
  * announcement a loading region owes readers.
  */

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -6,8 +6,8 @@ import { cn } from "@/lib/utils";
  * rhythm as the real rows, so real rows replace skeletons without shifting the
  * list. Bars run full width — the real lines truncate across the row. With
  * `indent` (the default) lines after the first sit where icon-led rows put
- * their meta lines (≈ their `pl-4`/`pl-5`); avatar-column lists, whose lines
- * share one left edge, pass `indent={false}`. `lines` must match the real
+ * their meta lines (≈ their `pl-4`/`pl-5`); lists whose lines share one left
+ * edge (avatar-column or chip-led) pass `indent={false}`. `lines` must match the real
  * row's line count (2 = issue / commit / tag / finding rows, 3 = PR /
  * workflow-run / Jira / discussion rows).
  * Callers render `ListRowSkeletons` instead — it wraps this one with the busy

--- a/src/features/compare/ComparePanel.tsx
+++ b/src/features/compare/ComparePanel.tsx
@@ -10,6 +10,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { type MouseEvent, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -445,10 +446,7 @@ export function ComparePanel({ repoPath }: { repoPath: string }) {
           </button>
 
           {comparison.isPending ? (
-            <div className="space-y-2 p-3">
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-full" />
-            </div>
+            <ListRowSkeletons rows={2} lines={2} name="commits" />
           ) : (
             /* overflow-hidden contains the list's natural height (vendored Root
                is `relative`-only) so a long list can't leak a window scrollbar. */

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -427,11 +427,13 @@ export function ConversationListPanel<L, R, J = never>(props: {
               </div>
               {jira.pending ? (
                 // Jira rows are three-line (status chips · title · key/updated),
-                // unlike this panel's own two-line issue rows.
+                // unlike this panel's own two-line issue rows — and chip-led
+                // with all three lines flush, so no meta indent.
                 <ListRowSkeletons
                   rows={jira.skeletonRows}
                   lines={3}
                   name="Jira issues"
+                  indent={false}
                 />
               ) : jira.isError ? (
                 (jira.errorSlot ?? (

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -108,6 +108,12 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
     rowKey: (t) => String(t.number),
   });
 
+  // The forge-status and discussions-meta probes both precede any list data, so
+  // both render the same single-row placeholder.
+  const probeSkeleton = (
+    <ListRowSkeletons rows={1} lines={3} indent={false} name="discussions" />
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-1 border-b p-2">
@@ -184,12 +190,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         <div onKeyDown={onListKeyDown}>
           {gh.isPending ? (
-            <ListRowSkeletons
-              rows={1}
-              lines={3}
-              indent={false}
-              name="discussions"
-            />
+            probeSkeleton
           ) : !ghReady ? (
             <ForgeNotReady repoPath={repoPath} feature="discussions" />
           ) : !forgeSupports(gh.data, "discussions") ? (
@@ -197,12 +198,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
               Discussions aren't available on this repository's host.
             </p>
           ) : meta.isPending ? (
-            <ListRowSkeletons
-              rows={1}
-              lines={3}
-              indent={false}
-              name="discussions"
-            />
+            probeSkeleton
           ) : meta.isError ? (
             <p className="px-3 py-6 text-center text-xs text-muted-foreground">
               Couldn't load discussions for this repository.

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -1,6 +1,7 @@
 import { CaretDownIcon, PlusIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -13,7 +14,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import { LoadMoreRow, PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
 import { LabelChip } from "@/features/conversations/Thread";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
@@ -184,9 +184,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         <div onKeyDown={onListKeyDown}>
           {gh.isPending ? (
-            <div className="space-y-2 p-3">
-              <Skeleton className="h-9 w-full" />
-            </div>
+            <ListRowSkeletons rows={1} lines={3} name="discussions" />
           ) : !ghReady ? (
             <ForgeNotReady repoPath={repoPath} feature="discussions" />
           ) : !forgeSupports(gh.data, "discussions") ? (
@@ -194,9 +192,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
               Discussions aren't available on this repository's host.
             </p>
           ) : meta.isPending ? (
-            <div className="space-y-2 p-3">
-              <Skeleton className="h-9 w-full" />
-            </div>
+            <ListRowSkeletons rows={1} lines={3} name="discussions" />
           ) : meta.isError ? (
             <p className="px-3 py-6 text-center text-xs text-muted-foreground">
               Couldn't load discussions for this repository.
@@ -206,11 +202,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
               Discussions aren't enabled for this repository.
             </p>
           ) : list.isPending ? (
-            <div className="space-y-2 p-3">
-              <Skeleton className="h-9 w-full" />
-              <Skeleton className="h-9 w-full" />
-              <Skeleton className="h-9 w-full" />
-            </div>
+            <ListRowSkeletons rows={3} lines={3} name="discussions" />
           ) : visible.length === 0 ? (
             <p className="px-3 py-4 text-xs text-muted-foreground">
               {discussions.length > 0

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -184,7 +184,12 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         <div onKeyDown={onListKeyDown}>
           {gh.isPending ? (
-            <ListRowSkeletons rows={1} lines={3} name="discussions" />
+            <ListRowSkeletons
+              rows={1}
+              lines={3}
+              indent={false}
+              name="discussions"
+            />
           ) : !ghReady ? (
             <ForgeNotReady repoPath={repoPath} feature="discussions" />
           ) : !forgeSupports(gh.data, "discussions") ? (
@@ -192,7 +197,12 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
               Discussions aren't available on this repository's host.
             </p>
           ) : meta.isPending ? (
-            <ListRowSkeletons rows={1} lines={3} name="discussions" />
+            <ListRowSkeletons
+              rows={1}
+              lines={3}
+              indent={false}
+              name="discussions"
+            />
           ) : meta.isError ? (
             <p className="px-3 py-6 text-center text-xs text-muted-foreground">
               Couldn't load discussions for this repository.
@@ -202,7 +212,12 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
               Discussions aren't enabled for this repository.
             </p>
           ) : list.isPending ? (
-            <ListRowSkeletons rows={3} lines={3} name="discussions" />
+            <ListRowSkeletons
+              rows={3}
+              lines={3}
+              indent={false}
+              name="discussions"
+            />
           ) : visible.length === 0 ? (
             <p className="px-3 py-4 text-xs text-muted-foreground">
               {discussions.length > 0

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -9,6 +9,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { type MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,7 +28,6 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { copyText } from "@/lib/clipboard";
@@ -348,10 +348,8 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
 
   if (log.isPending) {
     return (
-      <div className="flex-1 space-y-3 p-3">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
+      <div className="flex-1">
+        <ListRowSkeletons rows={3} lines={2} name="commits" />
       </div>
     );
   }

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -348,9 +348,21 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
 
   if (log.isPending) {
     return (
-      <div className="flex-1">
-        <ListRowSkeletons rows={3} lines={2} name="commits" />
-      </div>
+      <>
+        <div className="border-b p-2">
+          {/* The real filter mounts disabled so the header doesn't shift the
+              rows when the log lands. */}
+          <Input
+            disabled
+            placeholder="Filter loaded commits, or search all history"
+            className="h-7"
+            autoComplete="off"
+          />
+        </div>
+        <div className="flex-1">
+          <ListRowSkeletons rows={3} lines={2} indent={false} name="commits" />
+        </div>
+      </>
     );
   }
 

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -80,6 +80,8 @@ import {
 import { SquashDialog } from "./RewriteDialogs";
 import { useAmendWithConfirm } from "./useAmendCommit";
 
+const FILTER_PLACEHOLDER = "Filter loaded commits, or search all history";
+
 export function HistoryPanel({ repoPath }: { repoPath: string }) {
   const log = useLog(repoPath);
   // Batch-resolve commit-author avatars for the log's authors (GitHub-only,
@@ -350,11 +352,11 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     return (
       <>
         <div className="border-b p-2">
-          {/* The real filter mounts disabled so the header doesn't shift the
-              rows when the log lands. */}
+          {/* A disabled copy of the header below, so the rows don't shift when
+              the log lands. */}
           <Input
             disabled
-            placeholder="Filter loaded commits, or search all history"
+            placeholder={FILTER_PLACEHOLDER}
             className="h-7"
             autoComplete="off"
           />
@@ -749,7 +751,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
             // Clearing the box returns to filtering the loaded pages.
             if (!e.target.value.trim()) setSearchMode(false);
           }}
-          placeholder="Filter loaded commits, or search all history"
+          placeholder={FILTER_PLACEHOLDER}
           className="h-7"
           autoComplete="off"
         />

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -715,27 +715,34 @@ export function ChangesPanel({
       // Geometry copied from the empty state (Empty gap-4 p-6; EmptyMedia
       // size-8 mb-2; header gap-2) so a clean tree resolves its icon/title
       // onto these bars. The 150ms animation delay keeps a fast status
-      // resolve from ever painting a placeholder.
+      // resolve from ever painting a placeholder. A dirty tree resolves
+      // top-anchored instead; the placeholder bets on the clean-tree outcome
+      // (owner call), so that swap is a content change, not an anchor miss.
       // A delayed paint isn't motion, so the 0-duration animation runs
       // unconditionally; the fade is the motion-safe layer on top.
-      <div
-        aria-busy
-        className="flex flex-1 flex-col items-center justify-center gap-4 p-6 animate-in fade-in-0 delay-150 duration-0 fill-mode-backwards motion-safe:duration-200"
-      >
-        {/* aria-busy alone has no text; role="status" gives the busy region
-            words for readers that announce it. */}
+      <>
+        {/* Outside the aria-busy subtree, for the same reason as the shared
+            skeleton component. It may announce for a load that resolves inside
+            the 150ms visual delay — a polite region, accepted. */}
         <span role="status" className="sr-only">
           Loading changes…
         </span>
-        {/* pb-48 reserves the empty state's action stack (2-5 h-7 buttons +
-            gaps), calibrated to the fullest 5-button case — shorter stacks
-            resolve the header a few px higher. */}
-        <div className="flex flex-col items-center gap-2 pb-48">
-          <Skeleton className="mb-2 size-8" />
-          <Skeleton className="h-5 w-32" />
-          <Skeleton className="h-5 w-36" />
+        <div
+          aria-busy
+          className="flex flex-1 flex-col items-center justify-center gap-4 p-6 animate-in fade-in-0 delay-150 duration-0 fill-mode-backwards motion-safe:duration-200"
+        >
+          {/* pb-28 reserves the action stack the swap actually paints: the
+              compare + forge queries are gated on status resolving, so the
+              PR / View-on-GitHub buttons cannot be present yet (3 h-7 buttons
+              + gaps). They pop in as those queries land — that later shift is
+              the empty state's own, independent of this placeholder. */}
+          <div className="flex flex-col items-center gap-2 pb-28">
+            <Skeleton className="mb-2 size-8" />
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-5 w-36" />
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -732,10 +732,11 @@ export function ChangesPanel({
           className="flex flex-1 flex-col items-center justify-center gap-4 p-6 animate-in fade-in-0 delay-150 duration-0 fill-mode-backwards motion-safe:duration-200"
         >
           {/* pb-28 reserves the action stack the swap actually paints: the
-              compare + forge queries are gated on status resolving, so the
-              PR / View-on-GitHub buttons cannot be present yet (3 h-7 buttons
-              + gaps). They pop in as those queries land — that later shift is
-              the empty state's own, independent of this placeholder. */}
+              compare query stays disabled until status resolves and the forge
+              probe hasn't answered yet, so the PR / View-on-GitHub buttons
+              cannot be present (3 h-7 buttons + gaps). They pop in as those
+              queries land — that later shift is the empty state's own,
+              independent of this placeholder. */}
           <div className="flex flex-col items-center gap-2 pb-28">
             <Skeleton className="mb-2 size-8" />
             <Skeleton className="h-5 w-32" />

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -712,10 +712,28 @@ export function ChangesPanel({
 
   if (status.isPending) {
     return (
-      <div className="flex-1 space-y-2 p-3">
-        <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-8 w-full" />
-        <Skeleton className="h-8 w-full" />
+      // Anchored to the empty state's geometry (Empty gap-4 p-6; EmptyMedia
+      // size-8 mb-2; header gap-2): a clean tree resolves onto these bars in
+      // place, and the file list crossfades in as categorically different
+      // content — neither reads as a jump. The animation delay keeps a fast
+      // status resolve from flashing a placeholder at all.
+      <div
+        aria-busy
+        className="flex flex-1 flex-col items-center justify-center gap-4 p-6 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:delay-150 motion-safe:duration-200 motion-safe:fill-mode-backwards"
+      >
+        {/* aria-busy alone has no text; role="status" gives the busy region
+            words for readers that announce it. */}
+        <span role="status" className="sr-only">
+          Loading changes…
+        </span>
+        {/* pb-48 stands in for the empty state's action stack (4-5 h-8
+            buttons + gaps), so this centered column puts the disc where the
+            resolved icon lands — without it the icon resolves ~90px higher. */}
+        <div className="flex flex-col items-center gap-2 pb-48">
+          <Skeleton className="mb-2 size-8" />
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-5 w-36" />
+        </div>
       </div>
     );
   }

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -712,23 +712,24 @@ export function ChangesPanel({
 
   if (status.isPending) {
     return (
-      // Anchored to the empty state's geometry (Empty gap-4 p-6; EmptyMedia
-      // size-8 mb-2; header gap-2): a clean tree resolves onto these bars in
-      // place, and the file list crossfades in as categorically different
-      // content — neither reads as a jump. The animation delay keeps a fast
-      // status resolve from flashing a placeholder at all.
+      // Geometry copied from the empty state (Empty gap-4 p-6; EmptyMedia
+      // size-8 mb-2; header gap-2) so a clean tree resolves its icon/title
+      // onto these bars. The 150ms animation delay keeps a fast status
+      // resolve from ever painting a placeholder.
+      // A delayed paint isn't motion, so the 0-duration animation runs
+      // unconditionally; the fade is the motion-safe layer on top.
       <div
         aria-busy
-        className="flex flex-1 flex-col items-center justify-center gap-4 p-6 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:delay-150 motion-safe:duration-200 motion-safe:fill-mode-backwards"
+        className="flex flex-1 flex-col items-center justify-center gap-4 p-6 animate-in fade-in-0 delay-150 duration-0 fill-mode-backwards motion-safe:duration-200"
       >
         {/* aria-busy alone has no text; role="status" gives the busy region
             words for readers that announce it. */}
         <span role="status" className="sr-only">
           Loading changes…
         </span>
-        {/* pb-48 stands in for the empty state's action stack (4-5 h-8
-            buttons + gaps), so this centered column puts the disc where the
-            resolved icon lands — without it the icon resolves ~90px higher. */}
+        {/* pb-48 reserves the empty state's action stack (2-5 h-7 buttons +
+            gaps), calibrated to the fullest 5-button case — shorter stacks
+            resolve the header a few px higher. */}
         <div className="flex flex-col items-center gap-2 pb-48">
           <Skeleton className="mb-2 size-8" />
           <Skeleton className="h-5 w-32" />

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -401,8 +401,10 @@ function PathLabel({ path, line }: { path: string; line: number | null }) {
   );
 }
 
-function RowSkeletons() {
-  return <ListRowSkeletons rows={2} lines={2} name="findings" />;
+// `name` per call site: several sections load independently and can all be
+// pending at once, so one shared noun would announce the same region repeatedly.
+function RowSkeletons({ name }: { name: string }) {
+  return <ListRowSkeletons rows={2} lines={2} indent={false} name={name} />;
 }
 
 /** A full-width, in-flow explanation of why a category has no usable data, with
@@ -1448,7 +1450,7 @@ export function FindingsPanel({
           without containment a long list leaks a window scrollbar. */}
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {forge.isPending ? (
-          <RowSkeletons />
+          <RowSkeletons name="security findings" />
         ) : !ready ? (
           <ForgeNotReady repoPath={repoPath} feature="security findings" />
         ) : !supported ? (
@@ -1459,7 +1461,7 @@ export function FindingsPanel({
           gl.isError ? (
             <LoadFailed category="findings" onRetry={() => gl.refetch()} />
           ) : !glOut ? (
-            <RowSkeletons />
+            <RowSkeletons name="security findings" />
           ) : glOut.pipelineState !== "found" ? (
             <GlNoPipelineCard
               state={glOut.pipelineState}
@@ -1569,7 +1571,7 @@ export function FindingsPanel({
                 onRetry={() => alerts.refetch()}
               />
             ) : !alertsOut ? (
-              <RowSkeletons />
+              <RowSkeletons name="dependency alerts" />
             ) : alertsOut.availability !== "available" ? (
               <UnavailableCard
                 availability={alertsOut.availability}
@@ -1674,7 +1676,7 @@ export function FindingsPanel({
                 onRetry={() => codeScanning.refetch()}
               />
             ) : !codeScanningOut ? (
-              <RowSkeletons />
+              <RowSkeletons name="code scanning alerts" />
             ) : codeScanningOut.availability !== "available" ? (
               <UnavailableCard
                 availability={codeScanningOut.availability}
@@ -1795,7 +1797,7 @@ export function FindingsPanel({
                 onRetry={() => secrets.refetch()}
               />
             ) : !secretsOut ? (
-              <RowSkeletons />
+              <RowSkeletons name="secret scanning alerts" />
             ) : secretsOut.availability !== "available" ? (
               <UnavailableCard
                 availability={secretsOut.availability}
@@ -1921,7 +1923,7 @@ export function FindingsPanel({
                 onRetry={() => advisories.refetch()}
               />
             ) : !advisoriesOut ? (
-              <RowSkeletons />
+              <RowSkeletons name="advisories" />
             ) : advisoriesOut.availability !== "available" ? (
               <UnavailableCard
                 availability={advisoriesOut.availability}

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -14,6 +14,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -25,7 +26,6 @@ import {
 } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import { LoadMoreRow, PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
 import {
@@ -402,12 +402,7 @@ function PathLabel({ path, line }: { path: string; line: number | null }) {
 }
 
 function RowSkeletons() {
-  return (
-    <div className="space-y-2 p-3">
-      <Skeleton className="h-10 w-full" />
-      <Skeleton className="h-10 w-full" />
-    </div>
-  );
+  return <ListRowSkeletons rows={2} lines={2} name="findings" />;
 }
 
 /** A full-width, in-flow explanation of why a category has no usable data, with

--- a/src/features/tags/TagsPanel.tsx
+++ b/src/features/tags/TagsPanel.tsx
@@ -1,6 +1,7 @@
 import { CaretDownIcon, PlusIcon, TagIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import {
   forgeFeatureReady,
@@ -194,10 +194,7 @@ export function TagsPanel({ repoPath }: { repoPath: string }) {
           `relative`-only) so a long list can't leak a window scrollbar. */}
       <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {tagList.isPending ? (
-          <div className="space-y-2 p-3">
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-9 w-full" />
-          </div>
+          <ListRowSkeletons rows={2} lines={2} name="tags" />
         ) : visible.length === 0 ? (
           <p className="px-3 py-4 text-xs text-muted-foreground">
             {rows.length > 0


### PR DESCRIPTION
Loading states across the app rendered ad-hoc `Skeleton` stacks whose geometry didn't match the content that replaced them, so lists and the Changes tab visibly jumped on first resolve. This reshapes those placeholders to sit where the real content lands: list panels now share the existing `ListRowSkeletons` row placeholder, and the Changes tab placeholder is anchored to the empty state's geometry.

### Shared list skeleton

- Reworks `ListRowSkeleton` in `src/components/list-row-skeleton.tsx` to draw full-width bars (the real lines truncate across the row) instead of the staggered `BAR_WIDTHS` fractions, and indents lines after the first with `ml-4` to match the real rows' meta lines. The doc comment is updated to describe the new rhythm.
- Replaces the bespoke skeleton stacks with `ListRowSkeletons` at every list call site, sized to the rows each list loads into:
  - `src/features/discussions/DiscussionsPanel.tsx` — all three pending branches (forge probe, metadata, list) now use 3-line rows named `discussions`.
  - `src/features/history/HistoryPanel.tsx` — three 2-line `commits` rows, wrapped in a plain `flex-1` container.
  - `src/features/tags/TagsPanel.tsx` — two 2-line `tags` rows.
  - `src/features/compare/ComparePanel.tsx` — two 2-line `commits` rows.
  - `src/features/security-findings/FindingsPanel.tsx` — `RowSkeletons` now delegates to two 2-line `findings` rows.
- Drops the now-unused `Skeleton` imports from the Discussions, History, Tags, and Findings panels; the busy announcement each loading region owes readers now comes from `ListRowSkeletons` rather than being absent.

### Changes tab placeholder

- Rebuilds the `status.isPending` branch in `src/features/repository/ChangesPanel.tsx` as a centered column matching the empty state's geometry (`gap-4 p-6`, a `size-8` disc for `EmptyMedia`, `gap-2` header rhythm), with `pb-48` standing in for the empty state's action stack so the disc lands where the resolved icon does.
- Gates the placeholder behind a `motion-safe` fade-in with a 150ms delay and `fill-mode-backwards`, so a fast status resolve never flashes a placeholder.
- Adds `aria-busy` on the container plus an `sr-only` `role="status"` "Loading changes…" line, since `aria-busy` alone gives readers no text to announce.

### Changelog

- Adds `changelog.d/changed-changes-tab-loading-placeholder.md` and `changelog.d/changed-list-skeletons-match-rows.md` covering the two behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated loading placeholders across Changes, History, Discussions, Compare, Tags, Security Findings, and Jira views to better match loaded content.
  * Changes tab loading now preserves its position and reserves space for the clean-tree summary.
  * Added clearer announcements for independently loading sections.

* **Bug Fixes**
  * Reduced visual shifting when lists initially appear.
  * Improved loading-state accessibility and layout consistency across panels.
  * Refined loading layouts for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->