### PR TITLE
feat(markdown,diff): add reference previews and fullscreen image viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,9 +872,19 @@ review via its subscription login. The full list is under
   comment, review thread, AI review, or release note open what they name. On
   GitHub, `#123` opens that issue or pull request in the app, whichever it
   turns out to be; on GitLab, `#123` opens the issue and `!123` the merge
-  request. `@user` opens the profile in your browser. Bitbucket bodies leave
+  request. `@user` opens the profile in your browser. Hover a reference, or
+  reach it with Tab, and a **preview card** shows what you'd be opening: the
+  state (Open, Merged, Closed, or Draft), title, and author of an issue or
+  pull request, or the avatar and handle of a person. Bitbucket bodies leave
   references plain, matching Bitbucket itself, and a reference inside a code
   span or fence stays plain text.
+- **Images open fullscreen**: click a screenshot in a rendered description,
+  comment, or discussion (or either side of an image diff) to fill the window
+  over a dimmed backdrop, with its label and pixel dimensions, a
+  **Fit** / **100%** toggle, and **Open in browser** for one loaded from the
+  web. Arrow keys walk the rest of the set (the other images in that body, or
+  the diff's old and new sides) and Esc closes. Every image the viewer opens
+  takes the keyboard too: Tab to it and press Enter.
 - **Collapsible comment box**: fold the comment box down to a one-line strip to
   read more of the thread, on every conversation surface — pull requests and
   issues (local, on the forge, and Jira), discussions, and commits. Approve,

--- a/README.md
+++ b/README.md
@@ -885,7 +885,8 @@ review via its subscription login. The full list is under
   web. In **Fit** view the arrow keys walk the rest of the set (the other
   images in that body, or the diff's old and new sides); at **100%** they
   scroll the zoomed image instead, and Esc closes either way. Every image the
-  viewer opens takes the keyboard too: Tab to it and press Enter.
+  viewer opens takes the keyboard too: Tab to it and press Enter. A linked image
+  still follows its link, and badges and icons stay put.
 - **Collapsible comment box**: fold the comment box down to a one-line strip to
   read more of the thread, on every conversation surface — pull requests and
   issues (local, on the forge, and Jira), discussions, and commits. Approve,

--- a/README.md
+++ b/README.md
@@ -882,9 +882,9 @@ review via its subscription login. The full list is under
   comment, or discussion (or either side of an image diff) to fill the window
   over a dimmed backdrop, with its label and pixel dimensions, a
   **Fit** / **100%** toggle, and **Open in browser** for one loaded from the
-  web. In **Fit** view the arrow keys walk the rest of the set (the other
-  images in that body, or the diff's old and new sides); at **100%** they
-  scroll the zoomed image instead, and Esc closes either way. Every image the
+  web. In **Fit** view ← and → walk the rest of the set (the other images in
+  that body, or the diff's old and new sides); at **100%** the arrow keys pan
+  the zoomed image instead, and Esc closes either way. Every image the
   viewer opens takes the keyboard too: Tab to it and press Enter. A linked image
   still follows its link, and badges and icons stay put.
 - **Collapsible comment box**: fold the comment box down to a one-line strip to

--- a/README.md
+++ b/README.md
@@ -882,9 +882,10 @@ review via its subscription login. The full list is under
   comment, or discussion (or either side of an image diff) to fill the window
   over a dimmed backdrop, with its label and pixel dimensions, a
   **Fit** / **100%** toggle, and **Open in browser** for one loaded from the
-  web. Arrow keys walk the rest of the set (the other images in that body, or
-  the diff's old and new sides) and Esc closes. Every image the viewer opens
-  takes the keyboard too: Tab to it and press Enter.
+  web. In **Fit** view the arrow keys walk the rest of the set (the other
+  images in that body, or the diff's old and new sides); at **100%** they
+  scroll the zoomed image instead, and Esc closes either way. Every image the
+  viewer opens takes the keyboard too: Tab to it and press Enter.
 - **Collapsible comment box**: fold the comment box down to a one-line strip to
   read more of the thread, on every conversation surface — pull requests and
   issues (local, on the forge, and Jira), discussions, and commits. Approve,

--- a/changelog.d/added-image-lightbox.md
+++ b/changelog.d/added-image-lightbox.md
@@ -1,6 +1,6 @@
 - **Images open fullscreen.** Click a screenshot in a rendered description, comment, or
   discussion, or either side of an image diff, and it fills the window with its label and
   pixel dimensions, a **Fit** / **100%** toggle, and **Open in browser** for an image
-  loaded from the web. Fit to the window, ← and → step through the other images in
-  the same body; at **100%** they scroll the zoomed image. Esc closes, and every image
-  the viewer opens is reachable by Tab and Enter.
+  loaded from the web. In **Fit** view ← and → step through the other images in the
+  same body; at **100%** they scroll the zoomed image instead. Esc closes, and every
+  image the viewer opens is reachable by Tab and Enter.

--- a/changelog.d/added-image-lightbox.md
+++ b/changelog.d/added-image-lightbox.md
@@ -2,5 +2,5 @@
   discussion, or either side of an image diff, and it fills the window with its label and
   pixel dimensions, a **Fit** / **100%** toggle, and **Open in browser** for an image
   loaded from the web. In **Fit** view ← and → step through the other images in the
-  same body; at **100%** they scroll the zoomed image instead. Esc closes, and every
+  same body; at **100%** the arrow keys pan the zoomed image instead. Esc closes, and every
   image the viewer opens is reachable by Tab and Enter.

--- a/changelog.d/added-image-lightbox.md
+++ b/changelog.d/added-image-lightbox.md
@@ -1,5 +1,6 @@
 - **Images open fullscreen.** Click a screenshot in a rendered description, comment, or
   discussion, or either side of an image diff, and it fills the window with its label and
   pixel dimensions, a **Fit** / **100%** toggle, and **Open in browser** for an image
-  loaded from the web. ← and → step through the other images in the same body, Esc
-  closes, and every image the viewer opens is reachable by Tab and Enter.
+  loaded from the web. Fit to the window, ← and → step through the other images in
+  the same body; at **100%** they scroll the zoomed image. Esc closes, and every image
+  the viewer opens is reachable by Tab and Enter.

--- a/changelog.d/added-image-lightbox.md
+++ b/changelog.d/added-image-lightbox.md
@@ -1,0 +1,5 @@
+- **Images open fullscreen.** Click a screenshot in a rendered description, comment, or
+  discussion, or either side of an image diff, and it fills the window with its label and
+  pixel dimensions, a **Fit** / **100%** toggle, and **Open in browser** for an image
+  loaded from the web. ← and → step through the other images in the same body, Esc
+  closes, and every image the viewer opens is reachable by Tab and Enter.

--- a/changelog.d/added-reference-hovercards.md
+++ b/changelog.d/added-reference-hovercards.md
@@ -1,0 +1,4 @@
+- **Reference previews.** Hover a `#123`, `!123`, or `@user` in any rendered body, or
+  land on one with Tab, and a card shows what you'd be opening: state (Open, Merged,
+  Closed, or Draft) beside the number, then the title and author, or the avatar and
+  handle for a person. Esc dismisses it.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -516,7 +516,7 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
-      "Reference preview cards — hover or Tab to a #123, !123, or @user and read its state, title & author in place",
+      "Reference preview cards — hover or Tab to a #123 or !123 for its state, title & author, or to an @user for their avatar & handle",
   },
   {
     group: "Keyboard & Markdown",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -511,7 +511,12 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
-      "Reference autolinks — #123, @user, and GitLab's !123 open the issue, pull request, or profile they name",
+      "Reference autolinks — #123, @user, and GitLab's !123 open the issue, pull request, or profile they name, and preview its state, title & author on hover",
+  },
+  {
+    group: "Keyboard & Markdown",
+    label:
+      "Fullscreen image viewer — screenshots in any rendered body and both sides of an image diff, with fit/100% zoom and arrow-key stepping",
   },
 
   // — AI · generate & review —

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -511,12 +511,17 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
-      "Reference autolinks — #123, @user, and GitLab's !123 open the issue, pull request, or profile they name, and preview its state, title & author on hover",
+      "Reference autolinks — #123, @user, and GitLab's !123 open the issue, pull request, or profile they name",
   },
   {
     group: "Keyboard & Markdown",
     label:
-      "Fullscreen image viewer — screenshots in any rendered body and both sides of an image diff, with fit/100% zoom and arrow-key stepping",
+      "Reference preview cards — hover or Tab to a #123, !123, or @user and read its state, title & author in place",
+  },
+  {
+    group: "Keyboard & Markdown",
+    label:
+      "Fullscreen image viewer — screenshots in any rendered body and both sides of an image diff, with fit/100% zoom and arrow-key stepping in fit view",
   },
 
   // — AI · generate & review —

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -93,6 +93,32 @@ grep -n 'available-width' src/components/ui/popover.tsx
 No match means that file's width delta is gone. `popover.tsx` carries the
 panel-portal delta too, so check both of its markers.
 
+## Anchor forwarding
+
+A third set, again sharing no code with the two above. Base UI positions a
+popup against its `*Trigger` by default; a caller that renders no trigger has
+to hand the positioner an element itself, through the `anchor` prop these
+wrappers otherwise swallow.
+
+- **`combobox.tsx`**, **`hover-card.tsx`** — the `*Content` component's `Pick`
+  from its `Positioner.Props` includes `anchor`, and it forwards the prop to
+  the `Positioner`. Without it the chip-anchored combobox and the markdown
+  reference card — one card per rendered body, positioned at whichever
+  injected `<a>` the pointer is on — have no way to place their popup.
+  `hover-card.tsx` forwards `positionMethod` from the same `Pick` as well: that
+  card portals into the surrounding panel and anchors to an element in another
+  subtree, so it asks for viewport coordinates rather than resolving an
+  offsetParent it does not share.
+
+Grep each file after regenerating it:
+
+```sh
+grep -n '"anchor"' src/components/ui/combobox.tsx src/components/ui/hover-card.tsx
+```
+
+No match means that file's anchor delta is gone. Both files carry the
+panel-portal delta too, so check both of their markers.
+
 ## Check before re-applying
 
 If one of these has to be re-created, confirm it is still needed. Verify

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -95,29 +95,28 @@ panel-portal delta too, so check both of its markers.
 
 ## Anchor forwarding
 
-A third set, again sharing no code with the two above. Base UI positions a
-popup against its `*Trigger` by default; a caller that renders no trigger has
-to hand the positioner an element itself, through the `anchor` prop these
-wrappers otherwise swallow.
+A third delta, again sharing no code with the two above. Base UI positions a
+popup against its `*Trigger`; a caller whose trigger is not the element the
+popup should line up with hands the positioner an element itself, through the
+`anchor` prop the wrapper otherwise swallows.
 
-- **`combobox.tsx`**, **`hover-card.tsx`** — the `*Content` component's `Pick`
-  from its `Positioner.Props` includes `anchor`, and it forwards the prop to
-  the `Positioner`. Without it the chip-anchored combobox and the markdown
-  reference card — one card per rendered body, positioned at whichever
-  injected `<a>` the pointer is on — have no way to place their popup.
-  `hover-card.tsx` forwards `positionMethod` from the same `Pick` as well: that
-  card portals into the surrounding panel and anchors to an element in another
-  subtree, so it asks for viewport coordinates rather than resolving an
-  offsetParent it does not share.
+- **`combobox.tsx`** — `ComboboxContent`'s `Pick` from its `Positioner.Props`
+  includes `anchor`, forwards it to the `Positioner`, and stamps the popup's
+  `data-chips={!!anchor}`. A chips-shaped combobox types into a small input
+  inside the chip row, so its list belongs against the whole field, not that
+  input; the `data-chips` flag is what then drops the popup's `--anchor-width`
+  plus `--spacing(7)` floor so it can match that field exactly. No call site
+  passes `anchor` today, so the app demonstrates neither half — weigh that
+  under *Check before re-applying* below.
 
-Grep each file after regenerating it:
+Grep the file after regenerating it:
 
 ```sh
-grep -n '"anchor"' src/components/ui/combobox.tsx src/components/ui/hover-card.tsx
+grep -n '"anchor"' src/components/ui/combobox.tsx
 ```
 
-No match means that file's anchor delta is gone. Both files carry the
-panel-portal delta too, so check both of their markers.
+No match means the anchor delta is gone. That file carries the panel-portal
+delta too, so check both of its markers.
 
 ## Check before re-applying
 

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -19,18 +19,11 @@ function HoverCardContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 4,
-  anchor,
-  positionMethod,
   ...props
 }: PreviewCardPrimitive.Popup.Props &
   Pick<
     PreviewCardPrimitive.Positioner.Props,
-    | "align"
-    | "alignOffset"
-    | "anchor"
-    | "positionMethod"
-    | "side"
-    | "sideOffset"
+    "align" | "alignOffset" | "side" | "sideOffset"
   >) {
   const container = usePanelPortalContainer();
   return (
@@ -41,8 +34,6 @@ function HoverCardContent({
       <PreviewCardPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
-        anchor={anchor}
-        positionMethod={positionMethod}
         side={side}
         sideOffset={sideOffset}
         className="isolate z-50"

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -19,11 +19,18 @@ function HoverCardContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 4,
+  anchor,
+  positionMethod,
   ...props
 }: PreviewCardPrimitive.Popup.Props &
   Pick<
     PreviewCardPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
+    | "align"
+    | "alignOffset"
+    | "anchor"
+    | "positionMethod"
+    | "side"
+    | "sideOffset"
   >) {
   const container = usePanelPortalContainer();
   return (
@@ -34,6 +41,8 @@ function HoverCardContent({
       <PreviewCardPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
+        anchor={anchor}
+        positionMethod={positionMethod}
         side={side}
         sideOffset={sideOffset}
         className="isolate z-50"

--- a/src/components/ui/image-lightbox.tsx
+++ b/src/components/ui/image-lightbox.tsx
@@ -1,0 +1,296 @@
+import {
+  ArrowSquareOutIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
+  type Icon,
+  ImageBrokenIcon,
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { type KeyboardEvent, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { clipTitleFromText } from "@/lib/clip-title";
+import { toastError } from "@/lib/toast";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
+import { cn } from "@/lib/utils";
+
+/** One image the viewer can show. */
+export interface LightboxImage {
+  /** Image URL or data: URI — whatever the inline <img> renders. */
+  src: string;
+  /** Accessible name + caption line; "" allowed. */
+  alt: string;
+  /** Caption context: a pane label ("Old"/"New") or a filename. */
+  label?: string;
+  /** Natural dimensions when the host already knows them. */
+  naturalWidth?: number;
+  naturalHeight?: number;
+}
+
+type ZoomMode = "fit" | "actual";
+
+/** Each mode's control describes the mode it switches TO. */
+const ZOOM_TOGGLE = {
+  fit: {
+    Glyph: MagnifyingGlassPlusIcon,
+    text: "100%",
+    label: "Zoom to 100%",
+  },
+  actual: {
+    Glyph: MagnifyingGlassMinusIcon,
+    text: "Fit",
+    label: "Fit to window",
+  },
+} satisfies Record<ZoomMode, { Glyph: Icon; text: string; label: string }>;
+
+const ARROW_STEP: Record<string, number> = { ArrowLeft: -1, ArrowRight: 1 };
+
+/** Case-insensitive and un-flagged, so `.test` stays stateless for callers. */
+export const HTTP_SRC = /^https?:\/\//i;
+
+// The field is dark in both themes, so its controls carry their own light-on-
+// dark palette rather than the theme-following defaults of the ghost variant.
+const FIELD_BUTTON =
+  "shrink-0 text-white/85 hover:bg-white/15 hover:text-white focus-visible:border-white/80 focus-visible:ring-white/80 disabled:opacity-40";
+
+/** The trailing path segment of an http(s) src, for images with no label. */
+export function fileNameFromSrc(src: string): string {
+  if (!HTTP_SRC.test(src)) return "";
+  try {
+    const { pathname } = new URL(src);
+    return decodeURIComponent(pathname.slice(pathname.lastIndexOf("/") + 1));
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Fullscreen viewer for one or more images, with a fit/100% toggle and
+ * (for a set) prev/next navigation. Hosts render it nested in their own React
+ * tree — Base UI suppresses a parent dialog's Escape only for a nested one, so
+ * a sibling-mounted instance would close the surface underneath it too.
+ */
+export function ImageLightbox({
+  images,
+  index,
+  onIndexChange,
+  open,
+  onOpenChange,
+}: {
+  images: LightboxImage[];
+  index: number;
+  onIndexChange: (index: number) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  // Zoom, measured size, and load failure are all keyed by the shown image, so
+  // moving to another one resets them during render instead of via an effect.
+  const [zoomedKey, setZoomedKey] = useState<string | null>(null);
+  const [measured, setMeasured] = useState<{
+    key: string;
+    w: number;
+    h: number;
+  } | null>(null);
+  const [failedKey, setFailedKey] = useState<string | null>(null);
+
+  // Clearing the failure is what gives a reopen its retry: the <img> remounts
+  // and fetches again, so a transient 401 or dropped connection isn't permanent.
+  useSeedOnOpen(open, () => {
+    setZoomedKey(null);
+    setMeasured(null);
+    setFailedKey(null);
+  });
+
+  const image = images[index];
+  if (!image) return null;
+
+  const key = `${index}:${image.src}`;
+  const zoomed = zoomedKey === key;
+  const failed = failedKey === key;
+  const mode: ZoomMode = zoomed ? "actual" : "fit";
+  const toggle = ZOOM_TOGGLE[mode];
+
+  const loaded = measured?.key === key ? measured : null;
+  const width = image.naturalWidth ?? loaded?.w;
+  const height = image.naturalHeight ?? loaded?.h;
+  const caption =
+    image.label || image.alt || fileNameFromSrc(image.src) || "Image";
+  const webUrl = HTTP_SRC.test(image.src) ? image.src : null;
+  const hasNav = images.length > 1;
+
+  async function openInBrowser() {
+    if (webUrl === null) return;
+    try {
+      await openUrl(webUrl);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    // Fit mode only: at 100% the arrows belong to the scroll field, and a
+    // mode-dependent rule beats one that changes meaning at the end-stops.
+    if (!hasNav || zoomed) return;
+    const step = ARROW_STEP[e.key];
+    if (step === undefined) return;
+    const next = index + step;
+    if (next < 0 || next >= images.length) return;
+    e.preventDefault();
+    onIndexChange(next);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* ph-no-capture: user image content — block from session replay. */}
+      <DialogContent
+        className="ph-no-capture flex h-[92vh] w-[96vw] max-w-[96vw] flex-col gap-0 overflow-hidden bg-black/95 p-0 text-white ring-white/15 sm:max-w-[96vw]"
+        overlayClassName="bg-black/70"
+        onKeyDown={onKeyDown}
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{caption}</DialogTitle>
+        <div className="flex min-h-0 flex-1 overflow-auto">
+          {failed ? (
+            <div className="m-auto flex flex-col items-center gap-3 px-6 py-10 text-center">
+              <ImageBrokenIcon
+                aria-hidden="true"
+                className="size-8 text-white/50"
+              />
+              <p className="text-xs text-white/85">Couldn't load this image.</p>
+              {webUrl !== null && (
+                <Button
+                  className={FIELD_BUTTON}
+                  onClick={openInBrowser}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <ArrowSquareOutIcon />
+                  Open in browser
+                </Button>
+              )}
+            </div>
+          ) : (
+            <button
+              aria-label={toggle.label}
+              // `m-auto` centers without `justify-center`, which would make the
+              // overflowing edges unreachable once the image is at 100%.
+              className={cn(
+                "m-auto outline-none focus-visible:ring-2 focus-visible:ring-white/80",
+                zoomed ? "cursor-zoom-out" : "cursor-zoom-in",
+              )}
+              onClick={() => setZoomedKey(zoomed ? null : key)}
+              type="button"
+            >
+              <img
+                alt={image.alt}
+                // A percentage cap can't cross the shrink-wrapped button, so the
+                // fit size restates the dialog's own height minus the caption
+                // strip (h-11 plus its border) — keep the three in sync.
+                className={cn(
+                  "block",
+                  zoomed
+                    ? "max-h-none max-w-none"
+                    : "max-h-[calc(92vh-3rem)] max-w-[96vw]",
+                )}
+                key={key}
+                onError={() => setFailedKey(key)}
+                onLoad={(e) =>
+                  setMeasured({
+                    key,
+                    w: e.currentTarget.naturalWidth,
+                    h: e.currentTarget.naturalHeight,
+                  })
+                }
+                src={image.src}
+              />
+            </button>
+          )}
+        </div>
+        <div className="flex h-11 shrink-0 items-center gap-1 border-t border-white/15 bg-black px-2">
+          <p
+            className="min-w-0 flex-1 truncate text-xs text-white/85"
+            onMouseEnter={clipTitleFromText}
+          >
+            {caption}
+          </p>
+          {!failed && width !== undefined && height !== undefined && (
+            <p className="shrink-0 px-1 text-xs text-white/70 tabular-nums">
+              {width} × {height}
+            </p>
+          )}
+          {hasNav && (
+            <>
+              <Button
+                aria-label="Previous image"
+                className={FIELD_BUTTON}
+                disabled={index === 0}
+                onClick={() => onIndexChange(index - 1)}
+                size="icon-sm"
+                variant="ghost"
+              >
+                <CaretLeftIcon />
+              </Button>
+              <span className="shrink-0 px-0.5 text-xs text-white/85 tabular-nums">
+                <span aria-hidden="true">
+                  {index + 1} / {images.length}
+                </span>
+                <span className="sr-only">
+                  Image {index + 1} of {images.length}
+                </span>
+              </span>
+              <Button
+                aria-label="Next image"
+                className={FIELD_BUTTON}
+                disabled={index === images.length - 1}
+                onClick={() => onIndexChange(index + 1)}
+                size="icon-sm"
+                variant="ghost"
+              >
+                <CaretRightIcon />
+              </Button>
+            </>
+          )}
+          {!failed && (
+            <Button
+              aria-label={toggle.label}
+              className={FIELD_BUTTON}
+              onClick={() => setZoomedKey(zoomed ? null : key)}
+              size="sm"
+              variant="ghost"
+            >
+              <toggle.Glyph />
+              {toggle.text}
+            </Button>
+          )}
+          {webUrl !== null && (
+            <Button
+              className={FIELD_BUTTON}
+              onClick={openInBrowser}
+              size="sm"
+              variant="ghost"
+            >
+              <ArrowSquareOutIcon />
+              Open in browser
+            </Button>
+          )}
+          <DialogClose
+            render={
+              <Button className={FIELD_BUTTON} size="icon-sm" variant="ghost" />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/image-lightbox.tsx
+++ b/src/components/ui/image-lightbox.tsx
@@ -92,7 +92,9 @@ export function ImageLightbox({
   onOpenChange: (open: boolean) => void;
 }) {
   // Zoom, measured size, and load failure are all keyed by the shown image, so
-  // moving to another one resets them during render instead of via an effect.
+  // moving to another one suppresses them during render instead of via an
+  // effect — and stepping back to it restores what it had, which is what makes
+  // arrowing through a set and returning feel like the same viewer.
   const [zoomedKey, setZoomedKey] = useState<string | null>(null);
   const [measured, setMeasured] = useState<{
     key: string;

--- a/src/components/ui/image-lightbox.tsx
+++ b/src/components/ui/image-lightbox.tsx
@@ -54,7 +54,7 @@ const ZOOM_TOGGLE = {
 const ARROW_STEP: Record<string, number> = { ArrowLeft: -1, ArrowRight: 1 };
 
 /** Case-insensitive and un-flagged, so `.test` stays stateless for callers. */
-export const HTTP_SRC = /^https?:\/\//i;
+const HTTP_SRC = /^https?:\/\//i;
 
 // The field is dark in both themes, so its controls carry their own light-on-
 // dark palette rather than the theme-following defaults of the ghost variant.

--- a/src/components/ui/image-lightbox.tsx
+++ b/src/components/ui/image-lightbox.tsx
@@ -9,7 +9,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -52,6 +52,19 @@ const ZOOM_TOGGLE = {
 } satisfies Record<ZoomMode, { Glyph: Icon; text: string; label: string }>;
 
 const ARROW_STEP: Record<string, number> = { ArrowLeft: -1, ArrowRight: 1 };
+
+/** How far one arrow press pans the zoomed image, in px. Roughly a line of the
+ *  footer's height — small enough to aim with, large enough to cross a
+ *  screenshot without holding the key down. */
+const PAN_STEP = 80;
+
+/** Each arrow's pan direction at 100%, in `PAN_STEP` units. */
+const ARROW_PAN: Record<string, { x: number; y: number } | undefined> = {
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+};
 
 /** Case-insensitive and un-flagged, so `.test` stays stateless for callers. */
 const HTTP_SRC = /^https?:\/\//i;
@@ -102,6 +115,9 @@ export function ImageLightbox({
     h: number;
   } | null>(null);
   const [failedKey, setFailedKey] = useState<string | null>(null);
+  // The scrolling field, so the arrows can pan it at 100% without depending on
+  // where focus happens to be.
+  const field = useRef<HTMLDivElement>(null);
 
   // Clearing the failure is what gives a reopen its retry: the <img> remounts
   // and fetches again, so a transient 401 or dropped connection isn't permanent.
@@ -138,9 +154,23 @@ export function ImageLightbox({
   }
 
   function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    // Fit mode only: at 100% the arrows belong to the scroll field, and a
-    // mode-dependent rule beats one that changes meaning at the end-stops.
-    if (!hasNav || zoomed) return;
+    if (zoomed) {
+      // Panning is driven from here rather than left to the browser, which
+      // scrolls only when focus already sits inside the field — pressing the
+      // footer's 100% button leaves it on a button whose scrollable ancestor is
+      // the clipped popup, and the arrows would do nothing.
+      const pan = ARROW_PAN[e.key];
+      if (!pan) return;
+      e.preventDefault();
+      field.current?.scrollBy({
+        left: pan.x * PAN_STEP,
+        top: pan.y * PAN_STEP,
+      });
+      return;
+    }
+    // Fit view walks the set instead — a mode-dependent rule beats one that
+    // changes meaning at the end-stops.
+    if (!hasNav) return;
     const step = ARROW_STEP[e.key];
     if (step === undefined) return;
     const next = index + step;
@@ -159,7 +189,7 @@ export function ImageLightbox({
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">{caption}</DialogTitle>
-        <div className="flex min-h-0 flex-1 overflow-auto">
+        <div className="flex min-h-0 flex-1 overflow-auto" ref={field}>
           {failed ? (
             <div className="m-auto flex flex-col items-center gap-3 px-6 py-10 text-center">
               <ImageBrokenIcon

--- a/src/components/ui/image-lightbox.tsx
+++ b/src/components/ui/image-lightbox.tsx
@@ -53,9 +53,8 @@ const ZOOM_TOGGLE = {
 
 const ARROW_STEP: Record<string, number> = { ArrowLeft: -1, ArrowRight: 1 };
 
-/** How far one arrow press pans the zoomed image, in px. Roughly a line of the
- *  footer's height — small enough to aim with, large enough to cross a
- *  screenshot without holding the key down. */
+/** How far one arrow press pans the zoomed image, in px — small enough to aim
+ *  with, large enough to cross a screenshot without holding the key down. */
 const PAN_STEP = 80;
 
 /** Each arrow's pan direction at 100%, in `PAN_STEP` units. */

--- a/src/components/ui/markdown-ref-card.tsx
+++ b/src/components/ui/markdown-ref-card.tsx
@@ -2,6 +2,7 @@ import {
   CheckCircleIcon,
   CircleDashedIcon,
   GitMergeIcon,
+  GitPullRequestIcon,
   type Icon,
 } from "@phosphor-icons/react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
@@ -16,13 +17,12 @@ import {
 } from "@/components/ui/hover-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useForgeGhHost } from "@/lib/git/host";
-import { issueDetailsOptions, prDetailsOptions } from "@/lib/git/queries";
-import type {
-  ForgeUserRef,
-  IssueDetails,
-  PrDetails,
-  RemoteLens,
-} from "@/lib/git/types";
+import {
+  issueDetailsOptions,
+  prDetailsOptions,
+  useAssignableUsers,
+} from "@/lib/git/queries";
+import type { IssueDetails, PrDetails, RemoteLens } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
@@ -77,6 +77,9 @@ export function isPullRefUrl(url: string): boolean {
 /** The calm card's whole payload. `createdAt` is present only where the resolved
  *  shape carries one — pull request details have no creation timestamp. */
 interface RefItem {
+  /** Which shape answered. A GitHub `#N` can be either, and the two read CLOSED
+   *  differently, so the pill needs the answer the resolve already had. */
+  flavor: "issue" | "pr";
   state: string;
   title: string;
   author: string;
@@ -85,6 +88,7 @@ interface RefItem {
 
 function issueItem(issue: IssueDetails): RefItem {
   return {
+    flavor: "issue",
     state: issue.state,
     title: issue.title,
     author: issue.author,
@@ -96,6 +100,7 @@ function issueItem(issue: IssueDetails): RefItem {
  *  its own state even where `isDraft` lingers. */
 function prItem(pr: PrDetails): RefItem {
   return {
+    flavor: "pr",
     state: pr.isDraft && pr.state === "OPEN" ? "DRAFT" : pr.state,
     title: pr.title,
     author: pr.author,
@@ -104,8 +109,10 @@ function prItem(pr: PrDetails): RefItem {
 
 /**
  * Resolve a number reference under the body's own lens, matching what a click on
- * it would open. Every fetch is cache-first, so a warm list or a second hover
- * costs nothing.
+ * it would open. Reads are cache-first within each query's staleTime, and a warm
+ * list settles the kind without the classifying read — but a cold GitHub `#N`
+ * still costs two reads, so the caller's open delay is what keeps a pointer
+ * crossing a body of references from resolving every one of them.
  */
 async function resolveRefItem(
   queryClient: QueryClient,
@@ -155,20 +162,30 @@ async function resolveRefItem(
   }
 }
 
-/** Glyph and tone per state, following the related-issue `StateIcon` pairing.
- *  The word beside the glyph is what actually carries the state — color never
- *  does — so an unrecognized state (wire drift) falls through to the neutral
- *  dot without losing meaning. */
-const STATE_PILL: Record<
-  string,
-  { Icon: Icon; className: string } | undefined
-> = {
+interface StatePill {
+  Icon: Icon;
+  className: string;
+}
+
+/** Glyph and tone per state, shared by both shapes. The word beside the glyph is
+ *  what actually carries the state — color never does — so an unrecognized state
+ *  (wire drift) falls through to the neutral dot without losing meaning. */
+const STATE_PILL: Record<string, StatePill | undefined> = {
   OPEN: { Icon: CircleDashedIcon, className: "text-success" },
-  CLOSED: { Icon: CheckCircleIcon, className: "text-merged" },
   MERGED: { Icon: GitMergeIcon, className: "text-merged" },
   DRAFT: { Icon: CircleDashedIcon, className: "text-muted-foreground" },
 };
-const NEUTRAL_PILL = {
+
+/** CLOSED is the one state the app's two conventions part on: a closed issue is
+ *  resolved (the related-issue `StateIcon`), a closed pull request is abandoned
+ *  (`prPresentation` in IssueDevelopment), and a card that borrowed one for the
+ *  other would name the right state beside the wrong glyph. */
+const CLOSED_PILL: Record<RefItem["flavor"], StatePill> = {
+  issue: { Icon: CheckCircleIcon, className: "text-merged" },
+  pr: { Icon: GitPullRequestIcon, className: "text-destructive" },
+};
+
+const NEUTRAL_PILL: StatePill = {
   Icon: CircleDashedIcon,
   className: "text-muted-foreground",
 };
@@ -195,14 +212,14 @@ function RefUserCard({
   lens: RemoteLens;
   login: string;
 }) {
-  const queryClient = useQueryClient();
   const ghHost = useForgeGhHost(repoPath);
-  // A one-shot cache read: the popup mounts fresh per open, so a later fill can
-  // never leave a stale URL behind. GitLab populates `avatarUrl`; GitHub leaves
-  // it empty and `ForgeUserAvatar` derives the login's `.png` from `ghHost`.
-  const avatarUrl = queryClient
-    .getQueryData<ForgeUserRef[]>(["repo", repoPath, "assignable-users", lens])
-    ?.find((u) => u.id === login)?.avatarUrl;
+  // Whatever the pickers have already fetched, read through the same hook they
+  // use so the card repaints if the list lands under it — disabled, because a
+  // preview must never be what pulls the repo's whole user list. GitLab
+  // populates `avatarUrl`; GitHub leaves it empty and `ForgeUserAvatar` derives
+  // the login's `.png` from `ghHost`.
+  const { data: users } = useAssignableUsers(repoPath, false, lens);
+  const avatarUrl = users?.find((u) => u.id === login)?.avatarUrl;
   return (
     <div className="flex items-center gap-2">
       <ForgeUserAvatar
@@ -242,7 +259,10 @@ function RefCardBody({
   if (item === null) {
     return <p className="text-muted-foreground">{`Couldn't load ${label}`}</p>;
   }
-  const pill = STATE_PILL[item.state] ?? NEUTRAL_PILL;
+  const pill =
+    (item.state === "CLOSED"
+      ? CLOSED_PILL[item.flavor]
+      : STATE_PILL[item.state]) ?? NEUTRAL_PILL;
   const { createdAt } = item;
   return (
     <div className="flex flex-col gap-1.5">
@@ -304,8 +324,9 @@ export function MarkdownRefCard({
   // forms alike) while a store-registered trigger in the same build measured
   // correctly. So the card rides the trigger path instead: an inert invisible
   // span pinned to the active anchor's rect registers as the reference exactly
-  // the way a real trigger does. Read once per anchor — the card closes before
-  // anything can move it.
+  // the way a real trigger does. Read once per anchor: the caller closes the
+  // card on the first scroll or resize, so the rect it opened at is the only one
+  // it is ever shown at.
   const rect = useMemo(() => anchor?.getBoundingClientRect() ?? null, [anchor]);
   // Keyed by WHICH reference it answers, so a card switching targets reads as
   // resolving rather than painting the previous reference's content under the
@@ -355,7 +376,10 @@ export function MarkdownRefCard({
       }}
     >
       {/* Kept mounted through the close fade — an unmounting active trigger
-          force-closes the card mid-animation. */}
+          force-closes the card mid-animation. A transformed ancestor (a
+          `DialogContent`'s `-translate-x-1/2`) would become this fixed span's
+          containing block and displace the card by that offset — a refs-passing
+          body hosted inside one has to re-anchor or portal the span. */}
       <HoverCardTrigger
         render={
           <span
@@ -382,8 +406,12 @@ export function MarkdownRefCard({
         // link, and a popup edge that close can capture it.
         sideOffset={8}
         className="w-72"
-        // The skeleton is the sighted busy signal; this is its twin for anyone
-        // reading the card through the anchor's `aria-describedby`.
+        // The card opens empty and fills in, but `aria-describedby` resolves
+        // once, at focus — so the popup is a polite live region and the resolved
+        // state, title and author announce themselves as they land. `aria-busy`
+        // is the skeleton's twin for the same reader, and holds the announcement
+        // until the swap is done.
+        role="status"
         aria-busy={
           shown !== null && shown.kind !== "user" && item === undefined
         }

--- a/src/components/ui/markdown-ref-card.tsx
+++ b/src/components/ui/markdown-ref-card.tsx
@@ -6,7 +6,7 @@ import {
   type Icon,
 } from "@phosphor-icons/react";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { isUserDismissal } from "@/components/panel-portal";
 import { RelativeTime } from "@/components/relative-time";
@@ -37,11 +37,19 @@ export type MarkdownRefTarget =
 /** What a reference IS, independent of the object carrying it — the dispatch
  *  mints a fresh target per pointer event, so resolved content is matched on
  *  this rather than identity, and a re-hover paints from cache without a
- *  skeleton in between. */
-function refKey(target: MarkdownRefTarget): string {
-  return target.kind === "user"
-    ? `user:${target.user}`
-    : `${target.kind}:${target.number}`;
+ *  skeleton in between. All three axes the resolve reads: the same number under
+ *  the other repo or lens is a different item, and a key blind to them would
+ *  paint the previous scope's title under the new scope's number. */
+function refKey(
+  repoPath: string,
+  lens: RemoteLens,
+  target: MarkdownRefTarget,
+): string {
+  const ref =
+    target.kind === "user"
+      ? `user:${target.user}`
+      : `${target.kind}:${target.number}`;
+  return `${repoPath}|${lens}|${ref}`;
 }
 
 /**
@@ -69,7 +77,9 @@ export function cachedRefKind(
 /** Whether a resolved item's web URL addresses a pull request. The issues
  *  endpoint answers for PR numbers too, and the URL's resource segment
  *  (…/pull/N vs …/issues/N) tells the two apart; a substring test would misfire
- *  on a repo named `pull`. */
+ *  on a repo named `pull`.
+ *  A malformed or empty URL throws here by design — both callers contain it: the
+ *  card's resolve `.catch` paints "Couldn't load", and `openRef`'s try toasts. */
 export function isPullRefUrl(url: string): boolean {
   return new URL(url).pathname.split("/").at(-2) === "pull";
 }
@@ -291,15 +301,15 @@ function RefCardBody({
  *
  * One instance serves a whole body: the caller owns which anchor is active (and
  * every open/close delay, since a card with no `PreviewCard.Trigger` gets none of
- * Base UI's hover machinery), and hands the element in as the positioner's
- * anchor. Resolving a number reference warms exactly the queries its destination
- * view reads, so the click after a hover lands on a primed cache.
+ * Base UI's hover machinery), and hands in the rect it measured at open.
+ * Resolving a number reference warms exactly the queries its destination view
+ * reads, so the click after a hover lands on a primed cache.
  */
 export function MarkdownRefCard({
   id,
   refs,
   target,
-  anchor,
+  rect,
   onOpenChange,
   onPointerEnter,
   onPointerLeave,
@@ -310,8 +320,8 @@ export function MarkdownRefCard({
   refs: MarkdownRefs;
   /** The reference to show, or null to close. */
   target: MarkdownRefTarget | null;
-  /** The anchor to position against. */
-  anchor: HTMLElement | null;
+  /** Viewport geometry of the active anchor, measured when the card opened. */
+  rect: DOMRect | null;
   /** Base UI's own dismissals (Escape, outside press) arrive here. */
   onOpenChange: (open: boolean) => void;
   onPointerEnter: () => void;
@@ -324,10 +334,9 @@ export function MarkdownRefCard({
   // forms alike) while a store-registered trigger in the same build measured
   // correctly. So the card rides the trigger path instead: an inert invisible
   // span pinned to the active anchor's rect registers as the reference exactly
-  // the way a real trigger does. Read once per anchor: the caller closes the
+  // the way a real trigger does. The caller measures at each open and closes the
   // card on the first scroll or resize, so the rect it opened at is the only one
   // it is ever shown at.
-  const rect = useMemo(() => anchor?.getBoundingClientRect() ?? null, [anchor]);
   // Keyed by WHICH reference it answers, so a card switching targets reads as
   // resolving rather than painting the previous reference's content under the
   // new one's number — and so re-hovering a resolved one paints straight from
@@ -340,11 +349,13 @@ export function MarkdownRefCard({
   // close animation doesn't play over an emptied card.
   const shown = useRetained(target);
   const item =
-    shown && resolved?.key === refKey(shown) ? resolved.item : undefined;
+    shown && resolved?.key === refKey(repoPath, lens, shown)
+      ? resolved.item
+      : undefined;
 
   useEffect(() => {
     if (!target || target.kind === "user") return;
-    const key = refKey(target);
+    const key = refKey(repoPath, lens, target);
     let cancelled = false;
     resolveRefItem(queryClient, repoPath, lens, target)
       .then((resolvedItem) => {
@@ -376,10 +387,7 @@ export function MarkdownRefCard({
       }}
     >
       {/* Kept mounted through the close fade — an unmounting active trigger
-          force-closes the card mid-animation. A transformed ancestor (a
-          `DialogContent`'s `-translate-x-1/2`) would become this fixed span's
-          containing block and displace the card by that offset — a refs-passing
-          body hosted inside one has to re-anchor or portal the span. */}
+          force-closes the card mid-animation. */}
       <HoverCardTrigger
         render={
           <span

--- a/src/components/ui/markdown-ref-card.tsx
+++ b/src/components/ui/markdown-ref-card.tsx
@@ -1,0 +1,402 @@
+import {
+  CheckCircleIcon,
+  CircleDashedIcon,
+  GitMergeIcon,
+  type Icon,
+} from "@phosphor-icons/react";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import { isUserDismissal } from "@/components/panel-portal";
+import { RelativeTime } from "@/components/relative-time";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useForgeGhHost } from "@/lib/git/host";
+import { issueDetailsOptions, prDetailsOptions } from "@/lib/git/queries";
+import type {
+  ForgeUserRef,
+  IssueDetails,
+  PrDetails,
+  RemoteLens,
+} from "@/lib/git/types";
+import { parseableDate } from "@/lib/time";
+import { useRetained } from "@/lib/use-retained";
+import { cn } from "@/lib/utils";
+import type { MarkdownRefKind, MarkdownRefs } from "./markdown-refs";
+
+/** A reference that fully validated against the emitting renderer's grammar —
+ *  what both the click dispatch and this card route on. */
+export type MarkdownRefTarget =
+  | { kind: "user"; user: string }
+  | { kind: Exclude<MarkdownRefKind, "user">; number: number };
+
+/** What a reference IS, independent of the object carrying it — the dispatch
+ *  mints a fresh target per pointer event, so resolved content is matched on
+ *  this rather than identity, and a re-hover paints from cache without a
+ *  skeleton in between. */
+function refKey(target: MarkdownRefTarget): string {
+  return target.kind === "user"
+    ? `user:${target.user}`
+    : `${target.kind}:${target.number}`;
+}
+
+/**
+ * Which of the repo's cached lists already holds `number`, or null when neither
+ * does. GitHub's `#N` addresses one number space and its issue lists exclude
+ * pull requests, so a cached hit settles the kind with no request at all.
+ */
+export function cachedRefKind(
+  queryClient: QueryClient,
+  repoPath: string,
+  lens: RemoteLens,
+  number: number,
+): "pr" | "issue" | null {
+  const holds = (list: "pr-list" | "issue-list") =>
+    queryClient
+      .getQueriesData<{ number: number }[]>({
+        queryKey: ["repo", repoPath, list, lens],
+      })
+      .some(([, rows]) => rows?.some((row) => row.number === number));
+  if (holds("pr-list")) return "pr";
+  if (holds("issue-list")) return "issue";
+  return null;
+}
+
+/** Whether a resolved item's web URL addresses a pull request. The issues
+ *  endpoint answers for PR numbers too, and the URL's resource segment
+ *  (…/pull/N vs …/issues/N) tells the two apart; a substring test would misfire
+ *  on a repo named `pull`. */
+export function isPullRefUrl(url: string): boolean {
+  return new URL(url).pathname.split("/").at(-2) === "pull";
+}
+
+/** The calm card's whole payload. `createdAt` is present only where the resolved
+ *  shape carries one — pull request details have no creation timestamp. */
+interface RefItem {
+  state: string;
+  title: string;
+  author: string;
+  createdAt?: string;
+}
+
+function issueItem(issue: IssueDetails): RefItem {
+  return {
+    state: issue.state,
+    title: issue.title,
+    author: issue.author,
+    createdAt: issue.createdAt,
+  };
+}
+
+/** Draft qualifies an OPEN pull request only — a merged or closed one reports
+ *  its own state even where `isDraft` lingers. */
+function prItem(pr: PrDetails): RefItem {
+  return {
+    state: pr.isDraft && pr.state === "OPEN" ? "DRAFT" : pr.state,
+    title: pr.title,
+    author: pr.author,
+  };
+}
+
+/**
+ * Resolve a number reference under the body's own lens, matching what a click on
+ * it would open. Every fetch is cache-first, so a warm list or a second hover
+ * costs nothing.
+ */
+async function resolveRefItem(
+  queryClient: QueryClient,
+  repoPath: string,
+  lens: RemoteLens,
+  target: Extract<MarkdownRefTarget, { number: number }>,
+): Promise<RefItem> {
+  const { number } = target;
+  if (target.kind === "mr") {
+    return prItem(
+      await queryClient.fetchQuery(prDetailsOptions(repoPath, number, lens)),
+    );
+  }
+  if (target.kind === "issue") {
+    return issueItem(
+      await queryClient.fetchQuery(issueDetailsOptions(repoPath, number, lens)),
+    );
+  }
+  let kind = cachedRefKind(queryClient, repoPath, lens, number);
+  // Kept when the classifying read is what answered: it already describes this
+  // number, so it can stand in below if the PR read then fails.
+  let issue: IssueDetails | null = null;
+  if (kind === null) {
+    issue = await queryClient.fetchQuery(
+      issueDetailsOptions(repoPath, number, lens),
+    );
+    if (!isPullRefUrl(issue.url)) return issueItem(issue);
+    kind = "pr";
+  }
+  if (kind === "issue") {
+    // Only a cached hit lands here — a classifying read that says "issue" has
+    // already returned above — so there is nothing kept to reuse.
+    return issueItem(
+      await queryClient.fetchQuery(issueDetailsOptions(repoPath, number, lens)),
+    );
+  }
+  try {
+    // Only the PR shape carries the real merged/draft state.
+    return prItem(
+      await queryClient.fetchQuery(prDetailsOptions(repoPath, number, lens)),
+    );
+  } catch (e) {
+    // The reference DID resolve; only the merged/draft distinction is lost, so
+    // the issue read stands in rather than the card claiming a failure.
+    if (issue) return issueItem(issue);
+    throw e;
+  }
+}
+
+/** Glyph and tone per state, following the related-issue `StateIcon` pairing.
+ *  The word beside the glyph is what actually carries the state — color never
+ *  does — so an unrecognized state (wire drift) falls through to the neutral
+ *  dot without losing meaning. */
+const STATE_PILL: Record<
+  string,
+  { Icon: Icon; className: string } | undefined
+> = {
+  OPEN: { Icon: CircleDashedIcon, className: "text-success" },
+  CLOSED: { Icon: CheckCircleIcon, className: "text-merged" },
+  MERGED: { Icon: GitMergeIcon, className: "text-merged" },
+  DRAFT: { Icon: CircleDashedIcon, className: "text-muted-foreground" },
+};
+const NEUTRAL_PILL = {
+  Icon: CircleDashedIcon,
+  className: "text-muted-foreground",
+};
+
+/** Bars sized like the rows they stand in for, so the card doesn't resize under
+ *  the pointer when the content lands. */
+function RefCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Skeleton className="h-3.5 w-20" />
+      <Skeleton className="h-3.5 w-full" />
+      <Skeleton className="h-3.5 w-4/5" />
+      <Skeleton className="h-3.5 w-24" />
+    </div>
+  );
+}
+
+function RefUserCard({
+  repoPath,
+  lens,
+  login,
+}: {
+  repoPath: string;
+  lens: RemoteLens;
+  login: string;
+}) {
+  const queryClient = useQueryClient();
+  const ghHost = useForgeGhHost(repoPath);
+  // A one-shot cache read: the popup mounts fresh per open, so a later fill can
+  // never leave a stale URL behind. GitLab populates `avatarUrl`; GitHub leaves
+  // it empty and `ForgeUserAvatar` derives the login's `.png` from `ghHost`.
+  const avatarUrl = queryClient
+    .getQueryData<ForgeUserRef[]>(["repo", repoPath, "assignable-users", lens])
+    ?.find((u) => u.id === login)?.avatarUrl;
+  return (
+    <div className="flex items-center gap-2">
+      <ForgeUserAvatar
+        login={login}
+        avatarUrl={avatarUrl}
+        ghHost={ghHost}
+        decorative
+      />
+      <div className="min-w-0">
+        <p className="truncate font-medium">@{login}</p>
+        <p className="text-muted-foreground">Opens profile in browser</p>
+      </div>
+    </div>
+  );
+}
+
+function RefCardBody({
+  repoPath,
+  lens,
+  target,
+  item,
+}: {
+  repoPath: string;
+  lens: RemoteLens;
+  target: MarkdownRefTarget | null;
+  /** `undefined` while the reference is still resolving, `null` once it failed. */
+  item: RefItem | null | undefined;
+}) {
+  if (!target) return null;
+  if (target.kind === "user") {
+    return <RefUserCard repoPath={repoPath} lens={lens} login={target.user} />;
+  }
+  // GitLab numbers merge requests in their own space, so `!5` and `#5` are two
+  // different items — the card has to spell the one the body linked.
+  const label = `${target.kind === "mr" ? "!" : "#"}${target.number}`;
+  if (item === undefined) return <RefCardSkeleton />;
+  if (item === null) {
+    return <p className="text-muted-foreground">{`Couldn't load ${label}`}</p>;
+  }
+  const pill = STATE_PILL[item.state] ?? NEUTRAL_PILL;
+  const { createdAt } = item;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="flex items-center gap-1.5">
+        <pill.Icon className={cn("size-3.5 shrink-0", pill.className)} />
+        <span className="capitalize">{item.state.toLowerCase()}</span>
+        <span className="text-muted-foreground tabular-nums">{label}</span>
+      </p>
+      <p className="line-clamp-2 font-medium break-words">{item.title}</p>
+      <p className="text-muted-foreground">
+        {item.author}
+        {createdAt && parseableDate(createdAt) ? (
+          <>
+            {" · "}
+            <RelativeTime date={createdAt} />
+          </>
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The preview a rendered `#N` / `!N` / `@user` opens on hover or keyboard focus,
+ * so the user can judge the reference without spending a view switch on it.
+ *
+ * One instance serves a whole body: the caller owns which anchor is active (and
+ * every open/close delay, since a card with no `PreviewCard.Trigger` gets none of
+ * Base UI's hover machinery), and hands the element in as the positioner's
+ * anchor. Resolving a number reference warms exactly the queries its destination
+ * view reads, so the click after a hover lands on a primed cache.
+ */
+export function MarkdownRefCard({
+  id,
+  refs,
+  target,
+  anchor,
+  onOpenChange,
+  onPointerEnter,
+  onPointerLeave,
+}: {
+  /** The popup's element id, so the open card's anchor can point an
+   *  `aria-describedby` at it. */
+  id: string;
+  refs: MarkdownRefs;
+  /** The reference to show, or null to close. */
+  target: MarkdownRefTarget | null;
+  /** The anchor to position against. */
+  anchor: HTMLElement | null;
+  /** Base UI's own dismissals (Escape, outside press) arrive here. */
+  onOpenChange: (open: boolean) => void;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { repoPath, lens } = refs;
+  // The positioner's `anchor` prop never yields a measurable reference here —
+  // probed live: the popup positioned against a 0×0 rect (element and virtual
+  // forms alike) while a store-registered trigger in the same build measured
+  // correctly. So the card rides the trigger path instead: an inert invisible
+  // span pinned to the active anchor's rect registers as the reference exactly
+  // the way a real trigger does. Read once per anchor — the card closes before
+  // anything can move it.
+  const rect = useMemo(() => anchor?.getBoundingClientRect() ?? null, [anchor]);
+  // Keyed by WHICH reference it answers, so a card switching targets reads as
+  // resolving rather than painting the previous reference's content under the
+  // new one's number — and so re-hovering a resolved one paints straight from
+  // this state.
+  const [resolved, setResolved] = useState<{
+    key: string;
+    item: RefItem | null;
+  } | null>(null);
+  // The live target gates `open`; the retained one drives the content, so the
+  // close animation doesn't play over an emptied card.
+  const shown = useRetained(target);
+  const item =
+    shown && resolved?.key === refKey(shown) ? resolved.item : undefined;
+
+  useEffect(() => {
+    if (!target || target.kind === "user") return;
+    const key = refKey(target);
+    let cancelled = false;
+    resolveRefItem(queryClient, repoPath, lens, target)
+      .then((resolvedItem) => {
+        if (!cancelled) setResolved({ key, item: resolvedItem });
+      })
+      .catch(() => {
+        // Quiet by design: the card opens either way, and a toast for a preview
+        // the user only hovered would be louder than the miss.
+        if (!cancelled) setResolved({ key, item: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [target, repoPath, lens, queryClient]);
+
+  return (
+    <HoverCard
+      open={target !== null}
+      // The inert trigger's own hover machinery can never see the pointer over
+      // it (pointer-events: none), so ~300ms after every open it schedules a
+      // hover close — measured as a metronomic open/close flicker. The caller
+      // owns hover; only a real dismissal may close the card.
+      onOpenChange={(open, eventDetails) => {
+        if (!open && !isUserDismissal(eventDetails.reason)) {
+          eventDetails.cancel();
+          return;
+        }
+        onOpenChange(open);
+      }}
+    >
+      {/* Kept mounted through the close fade — an unmounting active trigger
+          force-closes the card mid-animation. */}
+      <HoverCardTrigger
+        render={
+          <span
+            aria-hidden
+            className="pointer-events-none fixed"
+            style={
+              rect
+                ? {
+                    left: rect.left,
+                    top: rect.top,
+                    width: rect.width,
+                    height: rect.height,
+                  }
+                : { display: "none" }
+            }
+          />
+        }
+      />
+      <HoverCardContent
+        id={id}
+        align="start"
+        alignOffset={0}
+        // Wider than a row-anchored card's 4px: the pointer rests ON a `#123`
+        // link, and a popup edge that close can capture it.
+        sideOffset={8}
+        className="w-72"
+        // The skeleton is the sighted busy signal; this is its twin for anyone
+        // reading the card through the anchor's `aria-describedby`.
+        aria-busy={
+          shown !== null && shown.kind !== "user" && item === undefined
+        }
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
+      >
+        <RefCardBody
+          repoPath={repoPath}
+          lens={lens}
+          target={shown}
+          item={item}
+        />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -14,6 +14,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   fileNameFromSrc,
   ImageLightbox,
@@ -127,11 +128,17 @@ const LIGHTBOX_MIN_PX = 48;
 
 /** Whether an embedded image is worth opening fullscreen. A linked image belongs
  *  to its link whatever the href — badges are near-universally wrapped in one —
- *  one inside a collapsed `<details>` isn't on screen to be opened or navigated
- *  past, and an image that hasn't loaded (or failed) reports 0 for both axes,
- *  which the floor rejects on its own. */
+ *  one in a `<summary>` belongs to the disclosure, whose toggle the viewer's own
+ *  `preventDefault` would swallow, one inside a collapsed `<details>` isn't on
+ *  screen to be opened or navigated past, and an image that hasn't loaded (or
+ *  failed) reports 0 for both axes, which the floor rejects on its own. */
 function isLightboxImage(img: HTMLImageElement): boolean {
-  if (img.closest("a") || img.closest("details:not([open])")) return false;
+  if (
+    img.closest("a") ||
+    img.closest("summary") ||
+    img.closest("details:not([open])")
+  )
+    return false;
   return (
     img.naturalWidth >= LIGHTBOX_MIN_PX && img.naturalHeight >= LIGHTBOX_MIN_PX
   );
@@ -235,12 +242,15 @@ export function Markdown({
   // `resolving`: hovering a reference must never flip the body's cursors — the
   // card's skeleton is the whole busy affordance for a hover.
   const [cardTarget, setCardTarget] = useState<MarkdownRefTarget | null>(null);
-  // The anchor is state rather than a ref because the positioner re-resolves only
-  // when the value it was handed changes: a switch straight from one reference to
-  // another (a Tab between two, which batches the close and the open into one
-  // commit) would otherwise leave the card sitting at the first anchor. It
-  // survives a close so the exit animation keeps its position.
+  // Which anchor the card belongs to: the pointer routes compare against it, and
+  // the `aria-describedby` effect writes to it. Never the card's geometry —
+  // reopening on the SAME element is a state no-op, so a rect derived from it
+  // would survive a scroll the reference has already moved under.
   const [cardAnchor, setCardAnchor] = useState<HTMLAnchorElement | null>(null);
+  // Measured at each open instead (a fresh DOMRect every time, so the positioner
+  // always re-resolves), and kept through the close so the exit animation plays
+  // where the card was.
+  const [cardRect, setCardRect] = useState<DOMRect | null>(null);
   const cardTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The pointer's claim on the card — resting on a reference, or inside the
   // popup. Read by the blur path, which must not close a card the mouse owns.
@@ -259,9 +269,9 @@ export function Markdown({
   // A re-parse replaces every injected anchor (a fence's lazy highlight.js
   // upgrade re-runs it), so an open card would track a detached node, and a
   // viewer opened from the old body no longer describes what's on screen.
-  // `cardAnchor` deliberately survives: only the positioner reads it, and
-  // clearing it here would drop the closing card to the origin mid-fade — the
-  // next `showCard` overwrites it before it can be read again.
+  // The anchor and its rect deliberately survive: both are read only while a
+  // target is set, and clearing the rect here would drop the closing card to the
+  // origin mid-fade — the next `showCard` overwrites both anyway.
   // `html` is the trigger, not a value this reads — same shape as the parse memo.
   // biome-ignore lint/correctness/useExhaustiveDependencies: html is the intentional reset trigger
   useEffect(() => {
@@ -358,6 +368,7 @@ export function Markdown({
   function showCard(anchor: HTMLAnchorElement, target: MarkdownRefTarget) {
     cancelTimer(cardTimer);
     setCardAnchor(anchor);
+    setCardRect(anchor.getBoundingClientRect());
     setCardTarget(target);
   }
 
@@ -402,15 +413,16 @@ export function Markdown({
     // has to race, and losing that race reopens from the anchor and cycles.
     if ((e.relatedTarget as Element | null)?.closest?.(CARD_POPUP_SELECTOR))
       return;
+    // The pointer has left a reference for something that isn't the popup, so it
+    // holds no claim on any card — including one it never opened, a sweep across
+    // a reference too brief to beat the open delay.
+    cardHovered.current = false;
     cancelTimer(cardTimer);
     // Only the anchor the card belongs to may close it. A card opened by
-    // keyboard on another reference is neither this pointer's to close nor its
-    // to have claimed — closing it here would leave it with no way back, the
-    // keyboard route reopening only on a fresh focus.
-    if (cardTarget && anchor === cardAnchor) {
-      cardHovered.current = false;
-      scheduleCardClose();
-    }
+    // keyboard on another reference is not this pointer's to close — doing so
+    // would leave it with no way back, the keyboard route reopening only on a
+    // fresh focus.
+    if (cardTarget && anchor === cardAnchor) scheduleCardClose();
   }
 
   function onFocusCapture(e: React.FocusEvent) {
@@ -643,28 +655,36 @@ export function Markdown({
         )}
         dangerouslySetInnerHTML={htmlProp}
       />
-      {refs ? (
-        <MarkdownRefCard
-          id={cardId}
-          refs={refs}
-          target={cardTarget}
-          anchor={cardAnchor}
-          onOpenChange={(open) => {
-            if (open) return;
-            cancelTimer(cardTimer);
-            cardHovered.current = false;
-            setCardTarget(null);
-          }}
-          onPointerEnter={() => {
-            cardHovered.current = true;
-            cancelTimer(cardTimer);
-          }}
-          onPointerLeave={() => {
-            cardHovered.current = false;
-            scheduleCardClose();
-          }}
-        />
-      ) : null}
+      {/* Portalled so the body div above stays its parent's ONLY in-flow child:
+          the card's trigger span is always mounted, and a `space-y-*` parent
+          (Tailwind compiles it to `> :not(:last-child)`) would otherwise hang a
+          phantom margin off the body. Context crosses a portal, so the popup's
+          own `usePanelPortalContainer()` still scopes it to the panel. */}
+      {refs
+        ? createPortal(
+            <MarkdownRefCard
+              id={cardId}
+              refs={refs}
+              target={cardTarget}
+              rect={cardRect}
+              onOpenChange={(open) => {
+                if (open) return;
+                cancelTimer(cardTimer);
+                cardHovered.current = false;
+                setCardTarget(null);
+              }}
+              onPointerEnter={() => {
+                cardHovered.current = true;
+                cancelTimer(cardTimer);
+              }}
+              onPointerLeave={() => {
+                cardHovered.current = false;
+                scheduleCardClose();
+              }}
+            />,
+            document.body,
+          )
+        : null}
       <ImageLightbox
         images={shownLightbox?.images ?? NO_IMAGES}
         index={shownLightbox?.index ?? 0}

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -6,7 +6,19 @@ import DOMPurify from "dompurify";
 // build (see markdown-hljs.ts), which registers into this same core singleton.
 import hljs from "highlight.js/lib/common";
 import { Marked } from "marked";
-import { useMemo, useState, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import {
+  fileNameFromSrc,
+  ImageLightbox,
+  type LightboxImage,
+} from "@/components/ui/image-lightbox";
 import { diffLang } from "@/features/diff/diff-lang";
 import { forgeRepoUrl } from "@/lib/git/api";
 import { issueDetailsOptions } from "@/lib/git/queries";
@@ -14,8 +26,15 @@ import type { RemoteLens } from "@/lib/git/types";
 import { lensKey } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
+import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import { hljsUpgradeStore, upgradeToFullHljs } from "./markdown-hljs";
+import {
+  cachedRefKind,
+  isPullRefUrl,
+  MarkdownRefCard,
+  type MarkdownRefTarget,
+} from "./markdown-ref-card";
 import {
   forgeRefExtension,
   isEmittableRefKind,
@@ -79,6 +98,80 @@ md.use({
 // active context names a provider (see markdown-refs.ts).
 md.use({ extensions: [forgeRefExtension] });
 
+// The preview card renders without a `PreviewCard.Trigger` — one card serves a
+// whole body, positioned at whichever anchor is active — so none of Base UI's
+// hover machinery applies and the delays are hand-rolled from its own constants.
+const CARD_OPEN_DELAY = 600;
+const CARD_CLOSE_DELAY = 300;
+
+/** The card's own subtree, for telling "the pointer left the anchor" apart from
+ *  "the pointer moved into the card" — which the DOM reports identically, the
+ *  popup being portaled out of the body. Both slots: `hover-card.tsx` stamps the
+ *  popup, and the portal wrapper covers the positioner between them. */
+const CARD_POPUP_SELECTOR =
+  '[data-slot="hover-card-content"],[data-slot="hover-card-portal"]';
+
+function cancelTimer(
+  ref: React.RefObject<ReturnType<typeof setTimeout> | null>,
+) {
+  if (ref.current !== null) {
+    clearTimeout(ref.current);
+    ref.current = null;
+  }
+}
+
+/** Natural-size floor, both axes, for an image the viewer will open: it clears
+ *  shields-style badges (~120×20) and emoji (~20×20) while any screenshot passes.
+ *  One knob — widen or narrow it here. */
+const LIGHTBOX_MIN_PX = 48;
+
+/** Whether an embedded image is worth opening fullscreen. A linked image belongs
+ *  to its link whatever the href — badges are near-universally wrapped in one —
+ *  one inside a collapsed `<details>` isn't on screen to be opened or navigated
+ *  past, and an image that hasn't loaded (or failed) reports 0 for both axes,
+ *  which the floor rejects on its own. */
+function isLightboxImage(img: HTMLImageElement): boolean {
+  if (img.closest("a") || img.closest("details:not([open])")) return false;
+  return (
+    img.naturalWidth >= LIGHTBOX_MIN_PX && img.naturalHeight >= LIGHTBOX_MIN_PX
+  );
+}
+
+/** Every qualifying image in a body, in document order — the set the viewer's
+ *  prev/next walks, whichever one was clicked. */
+function lightboxImagesIn(root: Element): HTMLImageElement[] {
+  return Array.from(root.querySelectorAll("img")).filter(isLightboxImage);
+}
+
+/** Make a loaded, qualifying image reachable without a pointer. Non-qualifying
+ *  images are left exactly as the body wrote them. The zoom cursor and focus
+ *  ring hang off `data-lightbox` rather than class tokens added here — the
+ *  wrapper's own `[&_img[data-lightbox]]:` rules then carry them, in the same
+ *  cascade layer and at a higher specificity than its `[&_img]:` block. */
+function markLightboxImage(img: HTMLImageElement) {
+  if (!isLightboxImage(img)) return;
+  // The viewer's own caption fallback, so the two name an image identically.
+  // It carries its own http(s) guard, so a data: URI resolves to "" here.
+  const name = img.alt || fileNameFromSrc(img.src);
+  img.tabIndex = 0;
+  img.setAttribute("role", "button");
+  img.setAttribute("aria-label", name ? `View image: ${name}` : "View image");
+  img.dataset.lightbox = "";
+}
+
+function toLightboxImage(img: HTMLImageElement): LightboxImage {
+  // `label` stays unset so the viewer falls back to alt, then the filename.
+  return {
+    src: img.src,
+    alt: img.alt,
+    naturalWidth: img.naturalWidth,
+    naturalHeight: img.naturalHeight,
+  };
+}
+
+/** Stable empty set for a viewer that has never been opened. */
+const NO_IMAGES: LightboxImage[] = [];
+
 /**
  * Renders GitHub-flavored Markdown (PR descriptions, comments, AI output).
  *
@@ -131,6 +224,173 @@ export function Markdown({
       setActiveMarkdownRefs(null);
     }
   }, [children, hljsVersion, refs?.provider, refs?.repoPath, refs?.lens]);
+  // React 19 diffs `dangerouslySetInnerHTML` by the WRAPPER OBJECT's identity,
+  // not the string inside (probed live: commitUpdate re-set an equal-content
+  // innerHTML on every re-render, replacing every injected node — which
+  // detached the hovercard's anchor and cycled it closed). One object per parse
+  // keeps the body's DOM stable across unrelated state changes.
+  const htmlProp = useMemo(() => ({ __html: html }), [html]);
+
+  // The preview card's own state, deliberately apart from the click path's
+  // `resolving`: hovering a reference must never flip the body's cursors — the
+  // card's skeleton is the whole busy affordance for a hover.
+  const [cardTarget, setCardTarget] = useState<MarkdownRefTarget | null>(null);
+  // The anchor is state rather than a ref because the positioner re-resolves only
+  // when the value it was handed changes: a switch straight from one reference to
+  // another (a Tab between two, which batches the close and the open into one
+  // commit) would otherwise leave the card sitting at the first anchor. It
+  // survives a close so the exit animation keeps its position.
+  const [cardAnchor, setCardAnchor] = useState<HTMLAnchorElement | null>(null);
+  const cardTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The pointer's claim on the card — resting on a reference, or inside the
+  // popup. Read by the blur path, which must not close a card the mouse owns.
+  const cardHovered = useRef(false);
+  const cardId = useId();
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // Null is closed. The viewer copies src strings rather than nodes, so this
+  // holds nothing a re-parse could detach; retaining the last set keeps the
+  // close fade from playing over an empty field.
+  const [lightbox, setLightbox] = useState<{
+    images: LightboxImage[];
+    index: number;
+  } | null>(null);
+  const shownLightbox = useRetained(lightbox);
+
+  // A re-parse replaces every injected anchor (a fence's lazy highlight.js
+  // upgrade re-runs it), so an open card would track a detached node, and a
+  // viewer opened from the old body no longer describes what's on screen.
+  // `cardAnchor` deliberately survives: only the positioner reads it, and
+  // clearing it here would drop the closing card to the origin mid-fade — the
+  // next `showCard` overwrites it before it can be read again.
+  // `html` is the trigger, not a value this reads — same shape as the parse memo.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: html is the intentional reset trigger
+  useEffect(() => {
+    cancelTimer(cardTimer);
+    cardHovered.current = false;
+    setCardTarget(null);
+    setLightbox(null);
+    return () => cancelTimer(cardTimer);
+  }, [html]);
+
+  // The open card describes its anchor. Set on the node rather than rendered:
+  // the anchor is injected HTML, same as the image affordances below. The
+  // cleanup covers both a close and a swap to another anchor.
+  useEffect(() => {
+    if (!cardAnchor || !cardTarget) return;
+    cardAnchor.setAttribute("aria-describedby", cardId);
+    return () => cardAnchor.removeAttribute("aria-describedby");
+  }, [cardAnchor, cardTarget, cardId]);
+
+  // Qualifying images become focus targets in place. Natural size is only known
+  // once an image has loaded, so every image gets a `load` listener AND an
+  // immediate attempt: the two orders (already decoded, or decoding past this
+  // commit) both have to land, and marking is idempotent, so the overlap is
+  // free. The listeners come off with the body that owns them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: html is the intentional re-walk trigger
+  useEffect(() => {
+    const root = bodyRef.current;
+    if (!root) return;
+    const offs: (() => void)[] = [];
+    for (const img of root.querySelectorAll("img")) {
+      const onLoad = () => markLightboxImage(img);
+      img.addEventListener("load", onLoad);
+      offs.push(() => img.removeEventListener("load", onLoad));
+      markLightboxImage(img);
+    }
+    return () => {
+      for (const off of offs) off();
+    };
+  }, [html]);
+
+  /** Open the viewer on `img`, with every other qualifying image in the body
+   *  behind its prev/next. Any hover intent in flight is dropped: a card opening
+   *  over the viewer would be positioned against a body the user can't see. */
+  function openLightbox(img: HTMLImageElement) {
+    const root = bodyRef.current;
+    if (!root) return;
+    const imgs = lightboxImagesIn(root);
+    const index = imgs.indexOf(img);
+    if (index < 0) return;
+    cancelTimer(cardTimer);
+    cardHovered.current = false;
+    setCardTarget(null);
+    setLightbox({ images: imgs.map(toLightboxImage), index });
+  }
+
+  function showCard(anchor: HTMLAnchorElement, target: MarkdownRefTarget) {
+    cancelTimer(cardTimer);
+    setCardAnchor(anchor);
+    setCardTarget(target);
+  }
+
+  /** The grace period before an open card goes: re-entering either the anchor or
+   *  the popup cancels it. */
+  function scheduleCardClose() {
+    cancelTimer(cardTimer);
+    cardTimer.current = setTimeout(() => {
+      cardTimer.current = null;
+      setCardTarget(null);
+    }, CARD_CLOSE_DELAY);
+  }
+
+  function onPointerOver(e: React.PointerEvent) {
+    const anchor = (e.target as HTMLElement).closest("a");
+    const target = anchor && refTarget(anchor);
+    if (!anchor || !target) return;
+    cardHovered.current = true;
+    // Cancels the close armed on the way out — of the anchor itself, or of the
+    // popup the pointer is coming back from.
+    cancelTimer(cardTimer);
+    // Re-entering the anchor a card already tracks is the whole job; reopening
+    // would only restart its resolve.
+    if (cardTarget && anchor === cardAnchor) return;
+    // A card belonging to some OTHER anchor describes a reference the pointer
+    // has already left, and it sits at that anchor — so it goes now rather than
+    // lingering misplaced for the length of this one's open delay.
+    if (cardTarget) setCardTarget(null);
+    cardTimer.current = setTimeout(() => {
+      cardTimer.current = null;
+      showCard(anchor, target);
+    }, CARD_OPEN_DELAY);
+  }
+
+  function onPointerOut(e: React.PointerEvent) {
+    const anchor = (e.target as HTMLElement).closest("a");
+    if (!anchor || !refTarget(anchor)) return;
+    // Crossing into the card is not leaving it. The popup portals outside this
+    // wrapper, so the browser reports the move as a plain pointerout on the
+    // anchor; treating that as a close would arm a timer the popup's own enter
+    // has to race, and losing that race reopens from the anchor and cycles.
+    if ((e.relatedTarget as Element | null)?.closest?.(CARD_POPUP_SELECTOR))
+      return;
+    cardHovered.current = false;
+    cancelTimer(cardTimer);
+    if (cardTarget) scheduleCardClose();
+  }
+
+  function onFocusCapture(e: React.FocusEvent) {
+    const anchor = (e.target as HTMLElement).closest("a");
+    const target = anchor && refTarget(anchor);
+    if (!anchor || !target) return;
+    // Keyboard arrival only. Landing on a reference by Tab is already the
+    // deliberate ask the hover delay waits for, but a click focuses the anchor
+    // too — and popping a card under the pointer there reads as a misfire,
+    // worst on `@user`, where the browser takes over and the view never changes.
+    if (!anchor.matches(":focus-visible")) return;
+    showCard(anchor, target);
+  }
+
+  function onBlurCapture(e: React.FocusEvent) {
+    const anchor = (e.target as HTMLElement).closest("a");
+    if (!anchor || !refTarget(anchor)) return;
+    // The keyboard's claim on the card ends here — card content is
+    // non-interactive, so focus cannot have moved into it. The pointer may still
+    // hold a claim of its own, on a reference or inside the popup, and a mouse
+    // user's card must not close because focus went somewhere unrelated.
+    if (cardHovered.current) return;
+    cancelTimer(cardTimer);
+    setCardTarget(null);
+  }
 
   /**
    * The reference this anchor addresses, or null when it isn't one this body can
@@ -139,7 +399,7 @@ export function Markdown({
    * row and every value against the grammar the renderer emits. Synchronous
    * because the click handler decides whether to claim the event on its answer.
    */
-  function refTarget(anchor: HTMLAnchorElement) {
+  function refTarget(anchor: HTMLAnchorElement): MarkdownRefTarget | null {
     if (!refs) return null;
     const kind = anchor.dataset.ref;
     if (!isEmittableRefKind(refs.provider, kind)) return null;
@@ -154,7 +414,7 @@ export function Markdown({
   }
 
   /** Navigate to whatever a validated reference target points at. */
-  async function openRef(target: NonNullable<ReturnType<typeof refTarget>>) {
+  async function openRef(target: MarkdownRefTarget) {
     if (!refs) return;
     const { repoPath, lens } = refs;
     const { kind } = target;
@@ -217,22 +477,14 @@ export function Markdown({
       }
       return;
     }
-    // GitHub's `#N` addresses one number space, so the kind resolves here: a
-    // cached list that already holds the number answers for free (its issue
-    // lists exclude PRs), and otherwise the issues endpoint answers for PR
-    // numbers too — the URL's resource segment (…/pull/N vs …/issues/N) tells
-    // the two apart; a substring test would misfire on a repo named `pull`.
-    const cachedHas = (list: "pr-list" | "issue-list") =>
-      queryClient
-        .getQueriesData<{ number: number }[]>({
-          queryKey: ["repo", repoPath, list, lens],
-        })
-        .some(([, rows]) => rows?.some((row) => row.number === number));
-    if (cachedHas("pr-list")) {
+    // GitHub's `#N` addresses one number space, so the kind resolves here — by
+    // the same two steps the preview card takes, off the same helpers.
+    const cached = cachedRefKind(queryClient, repoPath, lens, number);
+    if (cached === "pr") {
       openPr();
       return;
     }
-    if (cachedHas("issue-list")) {
+    if (cached === "issue") {
       openIssue();
       return;
     }
@@ -241,7 +493,7 @@ export function Markdown({
       const issue = await queryClient.fetchQuery(
         issueDetailsOptions(repoPath, number, lens),
       );
-      if (new URL(issue.url).pathname.split("/").at(-2) === "pull") openPr();
+      if (isPullRefUrl(issue.url)) openPr();
       else openIssue();
     } catch (e) {
       toastError(e);
@@ -252,66 +504,132 @@ export function Markdown({
 
   // Event delegation over the rendered body, most specific target first: a forge
   // reference navigates in-app, then any external link opens in the system browser
-  // rather than navigating the embedded webview, and the fall-through past both is
-  // the seam a future image branch slots into. The in-app branch claims the event
-  // only for a target that fully validates, so a `data-ref` this renderer didn't
-  // emit keeps whatever behavior its href already gives it.
+  // rather than navigating the embedded webview, and an unlinked image big enough
+  // to be worth seeing opens fullscreen. The anchor branches claim the event only
+  // for a target that fully validates, so a `data-ref` this renderer didn't emit
+  // keeps whatever behavior its href already gives it — and an image under an
+  // anchor stays that anchor's, which is what makes the image branch last.
   function onClick(e: React.MouseEvent) {
-    const anchor = (e.target as HTMLElement).closest("a");
-    if (!anchor) return;
-    const target = refTarget(anchor);
-    if (target) {
-      e.preventDefault();
-      void openRef(target);
+    const el = e.target as HTMLElement;
+    const anchor = el.closest("a");
+    if (anchor) {
+      const target = refTarget(anchor);
+      if (target) {
+        e.preventDefault();
+        void openRef(target);
+        return;
+      }
+      const href = anchor.getAttribute("href");
+      if (href && /^(https?:|mailto:)/.test(href)) {
+        e.preventDefault();
+        openUrl(href);
+      }
       return;
     }
-    const href = anchor.getAttribute("href");
-    if (href && /^(https?:|mailto:)/.test(href)) {
+    const img = el.closest("img");
+    if (img && isLightboxImage(img)) {
       e.preventDefault();
-      openUrl(href);
+      openLightbox(img);
     }
   }
 
+  /** The image branch's keyboard twin — the anchors above are real links and
+   *  already answer Enter themselves. */
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const img = (e.target as HTMLElement).closest("img");
+    if (!img || !isLightboxImage(img)) return;
+    // Space would scroll the pane out from under the image otherwise.
+    e.preventDefault();
+    openLightbox(img);
+  }
+
   return (
-    <div
-      onClick={onClick}
-      // The cursor can't reach a keyboard or screen-reader user; aria-busy is
-      // the same signal for them.
-      aria-busy={resolving}
-      className={cn(
-        "markdown-body text-xs/relaxed break-words",
-        // Margins collapse at the edges so previews/comments have no leading or
-        // trailing gap (matches GitHub's rendered-markdown reset).
-        "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-        // Heading scale with GitHub-style underlines on h1/h2 for clear hierarchy.
-        "[&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:border-b [&_h1]:border-border [&_h1]:pb-1.5 [&_h1]:font-heading [&_h1]:text-xl [&_h1]:font-semibold",
-        "[&_h2]:mt-5 [&_h2]:mb-3 [&_h2]:border-b [&_h2]:border-border [&_h2]:pb-1.5 [&_h2]:font-heading [&_h2]:text-lg [&_h2]:font-semibold",
-        "[&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-heading [&_h3]:text-base [&_h3]:font-semibold",
-        "[&_h4]:mt-4 [&_h4]:mb-2 [&_h4]:font-heading [&_h4]:text-sm [&_h4]:font-semibold",
-        "[&_h5]:mt-4 [&_h5]:mb-2 [&_h5]:font-heading [&_h5]:text-xs [&_h5]:font-semibold",
-        "[&_h6]:mt-4 [&_h6]:mb-2 [&_h6]:font-heading [&_h6]:text-xs [&_h6]:font-semibold [&_h6]:text-muted-foreground",
-        "[&_p]:my-2.5 [&_ul]:my-2.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1",
-        // Nested lists hug their parent item rather than opening a full gap.
-        "[&_li_ul]:my-1 [&_li_ol]:my-1",
-        "[&_a]:cursor-pointer [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-foreground",
-        // AFTER the anchor block, not before: tw-merge keeps the later of two
-        // `[&_a]:cursor-*` classes, so listing this first leaves the anchor on
-        // cursor-pointer and the busy state invisible where the pointer actually is.
-        resolving && "cursor-progress [&_a]:cursor-progress",
-        "[&_code]:rounded-none [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]",
-        "[&_pre]:my-2.5 [&_pre]:overflow-x-auto [&_pre]:border [&_pre]:border-border [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-[0.85em] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[1em]",
-        "[&_blockquote]:my-2.5 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
-        "[&_hr]:my-4 [&_hr]:border-border [&_strong]:font-semibold [&_em]:italic",
-        "[&_table]:my-2.5 [&_table]:block [&_table]:overflow-x-auto [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-semibold [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-1.5",
-        // Task lists (`- [ ]`) render as checkboxes with no bullet, like GitHub.
-        "[&_input[type=checkbox]]:mr-1.5 [&_input[type=checkbox]]:align-middle [&_li:has(input[type=checkbox])]:list-none [&_li:has(input[type=checkbox])]:-ml-5",
-        // Collapsible details blocks (release notes, changelogs, command lists)
-        "[&_details]:my-2.5 [&_summary]:cursor-pointer [&_summary]:py-1 [&_summary]:font-medium [&_summary]:select-none",
-        // Inline badges (compatibility score) and embedded previews (QR codes)
-        "[&_img]:my-1 [&_img]:inline-block [&_img]:max-w-full",
-        className,
-      )}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <>
+      <div
+        ref={bodyRef}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        onPointerOver={onPointerOver}
+        onPointerOut={onPointerOut}
+        onFocusCapture={onFocusCapture}
+        onBlurCapture={onBlurCapture}
+        // The cursor can't reach a keyboard or screen-reader user; aria-busy is
+        // the same signal for them.
+        aria-busy={resolving}
+        className={cn(
+          "markdown-body text-xs/relaxed break-words",
+          // Margins collapse at the edges so previews/comments have no leading or
+          // trailing gap (matches GitHub's rendered-markdown reset).
+          "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          // Heading scale with GitHub-style underlines on h1/h2 for clear hierarchy.
+          "[&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:border-b [&_h1]:border-border [&_h1]:pb-1.5 [&_h1]:font-heading [&_h1]:text-xl [&_h1]:font-semibold",
+          "[&_h2]:mt-5 [&_h2]:mb-3 [&_h2]:border-b [&_h2]:border-border [&_h2]:pb-1.5 [&_h2]:font-heading [&_h2]:text-lg [&_h2]:font-semibold",
+          "[&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-heading [&_h3]:text-base [&_h3]:font-semibold",
+          "[&_h4]:mt-4 [&_h4]:mb-2 [&_h4]:font-heading [&_h4]:text-sm [&_h4]:font-semibold",
+          "[&_h5]:mt-4 [&_h5]:mb-2 [&_h5]:font-heading [&_h5]:text-xs [&_h5]:font-semibold",
+          "[&_h6]:mt-4 [&_h6]:mb-2 [&_h6]:font-heading [&_h6]:text-xs [&_h6]:font-semibold [&_h6]:text-muted-foreground",
+          "[&_p]:my-2.5 [&_ul]:my-2.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-1",
+          // Nested lists hug their parent item rather than opening a full gap.
+          "[&_li_ul]:my-1 [&_li_ol]:my-1",
+          "[&_a]:cursor-pointer [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-foreground",
+          // AFTER the anchor block, not before: tw-merge keeps the later of two
+          // `[&_a]:cursor-*` classes, so listing this first leaves the anchor on
+          // cursor-pointer and the busy state invisible where the pointer actually is.
+          resolving && "cursor-progress [&_a]:cursor-progress",
+          "[&_code]:rounded-none [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em]",
+          "[&_pre]:my-2.5 [&_pre]:overflow-x-auto [&_pre]:border [&_pre]:border-border [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-[0.85em] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[1em]",
+          "[&_blockquote]:my-2.5 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
+          "[&_hr]:my-4 [&_hr]:border-border [&_strong]:font-semibold [&_em]:italic",
+          "[&_table]:my-2.5 [&_table]:block [&_table]:overflow-x-auto [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-semibold [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-1.5",
+          // Task lists (`- [ ]`) render as checkboxes with no bullet, like GitHub.
+          "[&_input[type=checkbox]]:mr-1.5 [&_input[type=checkbox]]:align-middle [&_li:has(input[type=checkbox])]:list-none [&_li:has(input[type=checkbox])]:-ml-5",
+          // Collapsible details blocks (release notes, changelogs, command lists)
+          "[&_details]:my-2.5 [&_summary]:cursor-pointer [&_summary]:py-1 [&_summary]:font-medium [&_summary]:select-none",
+          // Inline badges (compatibility score) and embedded previews (QR codes)
+          "[&_img]:my-1 [&_img]:inline-block [&_img]:max-w-full",
+          // The zoom affordance for an image the viewer will open, keyed on the
+          // attribute the marking effect sets. Authored here rather than added to
+          // the element's own class list so it shares a layer with the rules
+          // above and outranks the `[&_img]:` block instead of tying with it.
+          "[&_img[data-lightbox]]:cursor-zoom-in [&_img[data-lightbox]]:outline-none",
+          "[&_img[data-lightbox]:focus-visible]:ring-1 [&_img[data-lightbox]:focus-visible]:ring-ring/50",
+          className,
+        )}
+        dangerouslySetInnerHTML={htmlProp}
+      />
+      {refs ? (
+        <MarkdownRefCard
+          id={cardId}
+          refs={refs}
+          target={cardTarget}
+          anchor={cardAnchor}
+          onOpenChange={(open) => {
+            if (open) return;
+            cancelTimer(cardTimer);
+            setCardTarget(null);
+          }}
+          onPointerEnter={() => {
+            cardHovered.current = true;
+            cancelTimer(cardTimer);
+          }}
+          onPointerLeave={() => {
+            cardHovered.current = false;
+            scheduleCardClose();
+          }}
+        />
+      ) : null}
+      <ImageLightbox
+        images={shownLightbox?.images ?? NO_IMAGES}
+        index={shownLightbox?.index ?? 0}
+        onIndexChange={(index) =>
+          setLightbox((shown) => (shown ? { ...shown, index } : shown))
+        }
+        open={lightbox !== null}
+        onOpenChange={(open) => {
+          if (!open) setLightbox(null);
+        }}
+      />
+    </>
   );
 }

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -263,9 +263,11 @@ export function Markdown({
   // The focus route's pending open, held so a blur or a re-parse can cancel it
   // rather than measuring an anchor that is gone or no longer where it was.
   const cardFrame = useRef<number | null>(null);
-  // The pointer's claim on the card — resting on a reference, or inside the
-  // popup. Read by the blur path, which must not close a card the mouse owns.
-  const cardHovered = useRef(false);
+  // WHICH reference the pointer claims: the anchor it rests on, or the open
+  // card's own anchor while it rests inside the popup. Null is no claim. The
+  // blur path must not close a card the mouse owns, and only the anchor's
+  // identity can tell that apart from a claim on some unrelated reference.
+  const cardPointerAnchor = useRef<HTMLAnchorElement | null>(null);
   const cardId = useId();
   const bodyRef = useRef<HTMLDivElement>(null);
   // Null is closed. The viewer copies src strings rather than nodes, so this
@@ -288,7 +290,7 @@ export function Markdown({
   useEffect(() => {
     cancelTimer(cardTimer);
     cancelFrame(cardFrame);
-    cardHovered.current = false;
+    cardPointerAnchor.current = null;
     setCardTarget(null);
     setLightbox(null);
     return () => {
@@ -310,9 +312,9 @@ export function Markdown({
     let subscribed = false;
     const close = () => {
       cancelTimer(cardTimer);
-      // The claim describes the card that just closed; a lingering true would
+      // The claim describes the card that just closed; a lingering one would
       // block the blur path from closing the NEXT card (pointerover re-arms it).
-      cardHovered.current = false;
+      cardPointerAnchor.current = null;
       setCardTarget(null);
     };
     const raf = requestAnimationFrame(() => {
@@ -377,7 +379,7 @@ export function Markdown({
     if (index < 0) return;
     cancelTimer(cardTimer);
     cancelFrame(cardFrame);
-    cardHovered.current = false;
+    cardPointerAnchor.current = null;
     setCardTarget(null);
     setLightbox({ images: imgs.map(toLightboxImage), index });
   }
@@ -395,7 +397,7 @@ export function Markdown({
     cancelTimer(cardTimer);
     cardTimer.current = setTimeout(() => {
       cardTimer.current = null;
-      cardHovered.current = false;
+      cardPointerAnchor.current = null;
       setCardTarget(null);
     }, CARD_CLOSE_DELAY);
   }
@@ -404,7 +406,7 @@ export function Markdown({
     const anchor = (e.target as HTMLElement).closest("a");
     const target = anchor && refTarget(anchor);
     if (!anchor || !target) return;
-    cardHovered.current = true;
+    cardPointerAnchor.current = anchor;
     // Cancels the close armed on the way out — of the anchor itself, or of the
     // popup the pointer is coming back from.
     cancelTimer(cardTimer);
@@ -433,7 +435,7 @@ export function Markdown({
     // The pointer has left a reference for something that isn't the popup, so it
     // holds no claim on any card — including one it never opened, a sweep across
     // a reference too brief to beat the open delay.
-    cardHovered.current = false;
+    cardPointerAnchor.current = null;
     cancelTimer(cardTimer);
     // Only the anchor the card belongs to may close it. A card opened by
     // keyboard on another reference is not this pointer's to close — doing so
@@ -465,13 +467,19 @@ export function Markdown({
   function onBlurCapture(e: React.FocusEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
     if (!anchor || !refTarget(anchor)) return;
-    // The keyboard's claim on the card ends here — card content is
-    // non-interactive, so focus cannot have moved into it. The pointer may still
-    // hold a claim of its own, on a reference or inside the popup, and a mouse
-    // user's card must not close because focus went somewhere unrelated.
-    if (cardHovered.current) return;
-    cancelTimer(cardTimer);
+    // A pending focus-open belongs to the anchor being blurred, so it dies here
+    // whatever the pointer is doing — otherwise it would open a card for a
+    // reference the keyboard has already left.
     cancelFrame(cardFrame);
+    // The keyboard's claim on the card ends here — card content is
+    // non-interactive, so focus cannot have moved into it. What survives is a
+    // pointer claim on THIS card: the pointer resting on the card's own anchor,
+    // or inside the popup (which claims that same anchor). A claim on some other
+    // reference is not a reason to keep this card, which is how a keyboard card
+    // on B closes while the mouse sits on A.
+    const claim = cardPointerAnchor.current;
+    if (claim !== null && claim === cardAnchor) return;
+    cancelTimer(cardTimer);
     setCardTarget(null);
   }
 
@@ -696,15 +704,17 @@ export function Markdown({
               onOpenChange={(open) => {
                 if (open) return;
                 cancelTimer(cardTimer);
-                cardHovered.current = false;
+                cardPointerAnchor.current = null;
                 setCardTarget(null);
               }}
               onPointerEnter={() => {
-                cardHovered.current = true;
+                // Inside the popup the pointer claims the card, so it claims the
+                // anchor the card belongs to — the blur path compares identities.
+                cardPointerAnchor.current = cardAnchor;
                 cancelTimer(cardTimer);
               }}
               onPointerLeave={() => {
-                cardHovered.current = false;
+                cardPointerAnchor.current = null;
                 scheduleCardClose();
               }}
             />,

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -272,6 +272,36 @@ export function Markdown({
     return () => cancelTimer(cardTimer);
   }, [html]);
 
+  // The card is pinned to the rect its anchor had when it opened, so anything
+  // that moves the reference strands it: the hover routes end at the pointer
+  // leaving, but a focused one would sit at stale coordinates while its
+  // reference scrolls away. Capture-phase, since a pane's scroll doesn't bubble.
+  // The listeners go on a frame late: tabbing to an off-screen reference scrolls
+  // it into view first, and that scroll lands after the focus that opened the
+  // card (scroll steps run before animation-frame callbacks).
+  useEffect(() => {
+    if (cardTarget === null) return;
+    let subscribed = false;
+    const close = () => {
+      cancelTimer(cardTimer);
+      // The claim describes the card that just closed; a lingering true would
+      // block the blur path from closing the NEXT card (pointerover re-arms it).
+      cardHovered.current = false;
+      setCardTarget(null);
+    };
+    const raf = requestAnimationFrame(() => {
+      subscribed = true;
+      window.addEventListener("scroll", close, true);
+      window.addEventListener("resize", close);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      if (!subscribed) return;
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [cardTarget]);
+
   // The open card describes its anchor. Set on the node rather than rendered:
   // the anchor is injected HTML, same as the image affordances below. The
   // cleanup covers both a close and a swap to another anchor.
@@ -297,6 +327,14 @@ export function Markdown({
       offs.push(() => img.removeEventListener("load", onLoad));
       markLightboxImage(img);
     }
+    // Expanding a `<details>` qualifies the images inside it, which nothing else
+    // re-evaluates — a click would open one the keyboard could never reach.
+    // `toggle` doesn't bubble, so the root only sees it in capture.
+    const onToggle = () => {
+      for (const img of root.querySelectorAll("img")) markLightboxImage(img);
+    };
+    root.addEventListener("toggle", onToggle, true);
+    offs.push(() => root.removeEventListener("toggle", onToggle, true));
     return () => {
       for (const off of offs) off();
     };
@@ -329,6 +367,7 @@ export function Markdown({
     cancelTimer(cardTimer);
     cardTimer.current = setTimeout(() => {
       cardTimer.current = null;
+      cardHovered.current = false;
       setCardTarget(null);
     }, CARD_CLOSE_DELAY);
   }
@@ -363,9 +402,15 @@ export function Markdown({
     // has to race, and losing that race reopens from the anchor and cycles.
     if ((e.relatedTarget as Element | null)?.closest?.(CARD_POPUP_SELECTOR))
       return;
-    cardHovered.current = false;
     cancelTimer(cardTimer);
-    if (cardTarget) scheduleCardClose();
+    // Only the anchor the card belongs to may close it. A card opened by
+    // keyboard on another reference is neither this pointer's to close nor its
+    // to have claimed — closing it here would leave it with no way back, the
+    // keyboard route reopening only on a fresh focus.
+    if (cardTarget && anchor === cardAnchor) {
+      cardHovered.current = false;
+      scheduleCardClose();
+    }
   }
 
   function onFocusCapture(e: React.FocusEvent) {
@@ -607,6 +652,7 @@ export function Markdown({
           onOpenChange={(open) => {
             if (open) return;
             cancelTimer(cardTimer);
+            cardHovered.current = false;
             setCardTarget(null);
           }}
           onPointerEnter={() => {

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -121,6 +121,13 @@ function cancelTimer(
   }
 }
 
+function cancelFrame(ref: React.RefObject<number | null>) {
+  if (ref.current !== null) {
+    cancelAnimationFrame(ref.current);
+    ref.current = null;
+  }
+}
+
 /** Natural-size floor, both axes, for an image the viewer will open: it clears
  *  shields-style badges (~120×20) and emoji (~20×20) while any screenshot passes.
  *  One knob — widen or narrow it here. */
@@ -249,9 +256,13 @@ export function Markdown({
   const [cardAnchor, setCardAnchor] = useState<HTMLAnchorElement | null>(null);
   // Measured at each open instead (a fresh DOMRect every time, so the positioner
   // always re-resolves), and kept through the close so the exit animation plays
-  // where the card was.
+  // where the card was. The focus route measures a frame late — see the pending
+  // frame below — because Tab scrolls its target into view after firing focus.
   const [cardRect, setCardRect] = useState<DOMRect | null>(null);
   const cardTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The focus route's pending open, held so a blur or a re-parse can cancel it
+  // rather than measuring an anchor that is gone or no longer where it was.
+  const cardFrame = useRef<number | null>(null);
   // The pointer's claim on the card — resting on a reference, or inside the
   // popup. Read by the blur path, which must not close a card the mouse owns.
   const cardHovered = useRef(false);
@@ -269,26 +280,31 @@ export function Markdown({
   // A re-parse replaces every injected anchor (a fence's lazy highlight.js
   // upgrade re-runs it), so an open card would track a detached node, and a
   // viewer opened from the old body no longer describes what's on screen.
-  // The anchor and its rect deliberately survive: both are read only while a
-  // target is set, and clearing the rect here would drop the closing card to the
-  // origin mid-fade — the next `showCard` overwrites both anyway.
+  // The anchor and its rect deliberately survive: clearing the rect here would
+  // drop the closing card to the origin mid-fade, and the next `showCard`
+  // overwrites both anyway.
   // `html` is the trigger, not a value this reads — same shape as the parse memo.
   // biome-ignore lint/correctness/useExhaustiveDependencies: html is the intentional reset trigger
   useEffect(() => {
     cancelTimer(cardTimer);
+    cancelFrame(cardFrame);
     cardHovered.current = false;
     setCardTarget(null);
     setLightbox(null);
-    return () => cancelTimer(cardTimer);
+    return () => {
+      cancelTimer(cardTimer);
+      cancelFrame(cardFrame);
+    };
   }, [html]);
 
   // The card is pinned to the rect its anchor had when it opened, so anything
   // that moves the reference strands it: the hover routes end at the pointer
   // leaving, but a focused one would sit at stale coordinates while its
   // reference scrolls away. Capture-phase, since a pane's scroll doesn't bubble.
-  // The listeners go on a frame late: tabbing to an off-screen reference scrolls
-  // it into view first, and that scroll lands after the focus that opened the
-  // card (scroll steps run before animation-frame callbacks).
+  // The listeners go on a frame late even though the focus route already opens a
+  // frame late: Tab's scroll-into-view can land in that same frame, and closing
+  // on the very scroll the rect was measured after would shut the card on
+  // arrival.
   useEffect(() => {
     if (cardTarget === null) return;
     let subscribed = false;
@@ -360,6 +376,7 @@ export function Markdown({
     const index = imgs.indexOf(img);
     if (index < 0) return;
     cancelTimer(cardTimer);
+    cancelFrame(cardFrame);
     cardHovered.current = false;
     setCardTarget(null);
     setLightbox({ images: imgs.map(toLightboxImage), index });
@@ -434,7 +451,15 @@ export function Markdown({
     // too — and popping a card under the pointer there reads as a misfire,
     // worst on `@user`, where the browser takes over and the view never changes.
     if (!anchor.matches(":focus-visible")) return;
-    showCard(anchor, target);
+    // A frame late, so the rect is measured after the browser has scrolled this
+    // anchor into view — Tab fires focus first and scrolls during the update
+    // that follows, and scroll steps run before animation-frame callbacks.
+    // Harmless on an engine that scrolls first, and on an anchor already in view.
+    cancelFrame(cardFrame);
+    cardFrame.current = requestAnimationFrame(() => {
+      cardFrame.current = null;
+      showCard(anchor, target);
+    });
   }
 
   function onBlurCapture(e: React.FocusEvent) {
@@ -446,6 +471,7 @@ export function Markdown({
     // user's card must not close because focus went somewhere unrelated.
     if (cardHovered.current) return;
     cancelTimer(cardTimer);
+    cancelFrame(cardFrame);
     setCardTarget(null);
   }
 

--- a/src/features/diff/ImageDiff.tsx
+++ b/src/features/diff/ImageDiff.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import {
+  ImageLightbox,
+  type LightboxImage,
+} from "@/components/ui/image-lightbox";
 import { useFileAtRev } from "@/lib/git/queries";
 
 const IMAGE_MIME: Record<string, string> = {
@@ -25,16 +29,31 @@ export interface ImageRevs {
   new: string | null;
 }
 
+interface Size {
+  w: number;
+  h: number;
+}
+
+type PaneKey = "old" | "new";
+
+interface Pane {
+  key: PaneKey;
+  label: string;
+  src: string;
+}
+
 function ImageSide({
   label,
-  base64,
-  mime,
+  src,
+  onOpen,
+  onMeasure,
 }: {
   label: string;
-  base64: string;
-  mime: string;
+  src: string;
+  onOpen: () => void;
+  onMeasure: (size: Size) => void;
 }) {
-  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+  const [size, setSize] = useState<Size | null>(null);
   return (
     <figure className="min-w-0 max-w-[45%] space-y-1.5 text-center">
       <figcaption className="text-xs font-medium text-muted-foreground">
@@ -49,17 +68,26 @@ function ImageSide({
           backgroundSize: "16px 16px",
         }}
       >
-        <img
-          alt={label}
-          src={`data:${mime};base64,${base64}`}
-          className="max-h-[60vh] max-w-full"
-          onLoad={(e) =>
-            setSize({
-              w: e.currentTarget.naturalWidth,
-              h: e.currentTarget.naturalHeight,
-            })
-          }
-        />
+        <button
+          aria-label={`View ${label} image fullscreen`}
+          className="block cursor-zoom-in outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+          onClick={onOpen}
+          type="button"
+        >
+          <img
+            alt={label}
+            className="max-h-[60vh] max-w-full"
+            onLoad={(e) => {
+              const next = {
+                w: e.currentTarget.naturalWidth,
+                h: e.currentTarget.naturalHeight,
+              };
+              setSize(next);
+              onMeasure(next);
+            }}
+            src={src}
+          />
+        </button>
       </div>
       {size && (
         <p className="text-[11px] text-muted-foreground tabular-nums">
@@ -68,6 +96,14 @@ function ImageSide({
       )}
     </figure>
   );
+}
+
+/** Measured sides and the open viewer, scoped to the pair they belong to. */
+interface PanesState {
+  id: string;
+  old?: Size;
+  new?: Size;
+  viewing?: number;
 }
 
 /**
@@ -86,6 +122,9 @@ export function ImagePanes({
   const mime = imageMime(filePath) ?? "application/octet-stream";
   const oldFile = useFileAtRev(repoPath, revs.old, filePath, true);
   const newFile = useFileAtRev(repoPath, revs.new, filePath, true);
+  // Keyed by the pair being shown, so a switch to another file drops the
+  // previous one's measurements and viewer index during render.
+  const [state, setState] = useState<PanesState>({ id: "" });
 
   const pending = oldFile.isPending || newFile.isPending;
   const oldB64 = oldFile.data ?? null;
@@ -94,27 +133,67 @@ export function ImagePanes({
   if (pending) {
     return null;
   }
+
+  const id = [filePath, revs.old, revs.new].join("|");
+  const current = state.id === id ? state : null;
+  const patch = (next: Partial<PanesState>) =>
+    setState((prev) =>
+      prev.id === id ? { ...prev, ...next } : { id, ...next },
+    );
+
+  const panes: Pane[] = [];
+  if (oldB64 !== null) {
+    panes.push({
+      key: "old",
+      label: newB64 === null ? "Deleted" : "Old",
+      src: `data:${mime};base64,${oldB64}`,
+    });
+  }
+  if (newB64 !== null) {
+    panes.push({
+      key: "new",
+      label: oldB64 === null ? "Added" : "New",
+      src: `data:${mime};base64,${newB64}`,
+    });
+  }
+
+  const images: LightboxImage[] = panes.map((pane) => ({
+    src: pane.src,
+    alt: pane.label,
+    label: pane.label,
+    naturalWidth: current?.[pane.key]?.w,
+    naturalHeight: current?.[pane.key]?.h,
+  }));
+  const viewing = current?.viewing ?? null;
+
   return (
     <div className="flex items-start justify-center gap-8 p-6">
-      {oldB64 !== null && (
+      {panes.map((pane, i) => (
         <ImageSide
-          label={newB64 === null ? "Deleted" : "Old"}
-          base64={oldB64}
-          mime={mime}
+          key={pane.key}
+          label={pane.label}
+          onMeasure={(size) => patch({ [pane.key]: size })}
+          onOpen={() => patch({ viewing: i })}
+          src={pane.src}
         />
-      )}
-      {newB64 !== null && (
-        <ImageSide
-          label={oldB64 === null ? "Added" : "New"}
-          base64={newB64}
-          mime={mime}
-        />
-      )}
-      {oldB64 === null && newB64 === null && (
+      ))}
+      {panes.length === 0 && (
         <p className="py-8 text-xs text-muted-foreground">
           Could not load this image.
         </p>
       )}
+      {/* Nested here rather than at a shared host: Base UI suppresses a parent
+          dialog's Escape only for a dialog inside its React tree, and these
+          panes render inside StashesDialog on one of their routes. */}
+      <ImageLightbox
+        images={images}
+        index={viewing ?? 0}
+        onIndexChange={(next) => patch({ viewing: next })}
+        onOpenChange={(open) => {
+          if (!open) patch({ viewing: undefined });
+        }}
+        open={viewing !== null}
+      />
     </div>
   );
 }

--- a/src/features/diff/ImageDiff.tsx
+++ b/src/features/diff/ImageDiff.tsx
@@ -170,7 +170,10 @@ export function ImagePanes({
     <div className="flex items-start justify-center gap-8 p-6">
       {panes.map((pane, i) => (
         <ImageSide
-          key={pane.key}
+          // Keyed by the pair as well as the slot: a side that kept its element
+          // across a file switch would caption the new image with the previous
+          // one's dimensions until the new one decodes.
+          key={`${id}|${pane.key}`}
           label={pane.label}
           onMeasure={(size) => patch({ [pane.key]: size })}
           onOpen={() => patch({ viewing: i })}

--- a/src/features/diff/ImageDiff.tsx
+++ b/src/features/diff/ImageDiff.tsx
@@ -44,16 +44,19 @@ interface Pane {
 
 function ImageSide({
   label,
+  size,
   src,
   onOpen,
   onMeasure,
 }: {
   label: string;
+  /** The parent's record of this side's measurement — the caption's only
+   *  source, so the two can't disagree about which file is on screen. */
+  size: Size | undefined;
   src: string;
   onOpen: () => void;
   onMeasure: (size: Size) => void;
 }) {
-  const [size, setSize] = useState<Size | null>(null);
   return (
     <figure className="min-w-0 max-w-[45%] space-y-1.5 text-center">
       <figcaption className="text-xs font-medium text-muted-foreground">
@@ -77,19 +80,17 @@ function ImageSide({
           <img
             alt={label}
             className="max-h-[60vh] max-w-full"
-            onLoad={(e) => {
-              const next = {
+            onLoad={(e) =>
+              onMeasure({
                 w: e.currentTarget.naturalWidth,
                 h: e.currentTarget.naturalHeight,
-              };
-              setSize(next);
-              onMeasure(next);
-            }}
+              })
+            }
             src={src}
           />
         </button>
       </div>
-      {size && (
+      {size !== undefined && (
         <p className="text-[11px] text-muted-foreground tabular-nums">
           {size.w} × {size.h}
         </p>
@@ -170,13 +171,13 @@ export function ImagePanes({
     <div className="flex items-start justify-center gap-8 p-6">
       {panes.map((pane, i) => (
         <ImageSide
-          // Keyed by the pair as well as the slot: a side that kept its element
-          // across a file switch would caption the new image with the previous
-          // one's dimensions until the new one decodes.
+          // Keyed by the pair as well as the slot: an `<img>` kept across a file
+          // switch paints the previous file until the new src decodes.
           key={`${id}|${pane.key}`}
           label={pane.label}
           onMeasure={(size) => patch({ [pane.key]: size })}
           onOpen={() => patch({ viewing: i })}
+          size={current?.[pane.key]}
           src={pane.src}
         />
       ))}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -402,7 +402,11 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   file is detected wrong (or turn highlighting off). A narrow pane drops the override's
   button from the toolbar; *Change diff language…* in the command palette (palette-only
   by default — bind a key in **Settings → Keyboard**) still opens the picker.
-- **Image diffs** render side by side.
+- **Image diffs** render side by side. Click a side, or Tab to it and press Enter, to
+  open it fullscreen: the image over a dimmed backdrop, its label and pixel dimensions
+  along the bottom, a **Fit** / **100%** toggle, ← and → between the old and new sides,
+  and Esc to close. The **SVG** preview above a text diff and the image diffs inside the
+  stashes dialog open the same viewer.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
 - Files that look **generated or minified** (one enormous line — bundles, source maps,
@@ -936,10 +940,19 @@ pull request or issue right here in the app — GitHub numbers issues and pull r
 one sequence, so GitDesktop works out which of the two you meant and takes you to the
 matching tab (a body you're viewing under a fork's other remote opens the item on the
 forge instead, so the number always lands where it belongs); on GitLab, **#123** is an
-issue and **!123** a merge request. **@user**
-opens that person's profile in your browser. **Bitbucket** bodies leave references plain,
-matching Bitbucket itself, and a reference inside backticks or a fenced code block stays
-plain text everywhere.
+issue and **!123** a merge request. **@user** opens that person's profile in your
+browser. Hover a reference, or land on it with Tab, and a preview card names what you'd
+be opening: an issue, pull request, or merge request shows its state (Open, Merged,
+Closed, or Draft) beside its number, then its title and author, while **@user** shows
+that person's avatar and handle. Esc dismisses the card. **Bitbucket** bodies leave
+references plain, matching Bitbucket itself, and a reference inside backticks or a fenced
+code block stays plain text everywhere.
+
+Images in a rendered body open fullscreen too. Click a screenshot in a description,
+comment, or discussion (or Tab to it and press Enter) and it fills the window over a
+dimmed backdrop, with its name and pixel dimensions along the bottom, a **Fit** /
+**100%** toggle, and **Open in browser** for an image the body loaded from the web.
+← and → step through the other images in the same body, and Esc closes the viewer.
 
 ## Conflicts with the base branch
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -404,9 +404,10 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   by default — bind a key in **Settings → Keyboard**) still opens the picker.
 - **Image diffs** render side by side. Click a side, or Tab to it and press Enter, to
   open it fullscreen: the image over a dimmed backdrop, its label and pixel dimensions
-  along the bottom, a **Fit** / **100%** toggle, ← and → between the old and new sides,
-  and Esc to close. The **SVG** preview above a text diff and the image diffs inside the
-  stashes dialog open the same viewer.
+  along the bottom, and a **Fit** / **100%** toggle. Fit to the window, ← and → move
+  between the old and new sides; at **100%** they scroll the zoomed image instead, and
+  Esc closes either way. The **SVG** preview above a text diff and the image diffs
+  inside the stashes dialog open the same viewer.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
 - Files that look **generated or minified** (one enormous line — bundles, source maps,
@@ -952,7 +953,8 @@ Images in a rendered body open fullscreen too. Click a screenshot in a descripti
 comment, or discussion (or Tab to it and press Enter) and it fills the window over a
 dimmed backdrop, with its name and pixel dimensions along the bottom, a **Fit** /
 **100%** toggle, and **Open in browser** for an image the body loaded from the web.
-← and → step through the other images in the same body, and Esc closes the viewer.
+Fit to the window, ← and → step through the other images in the same body; at
+**100%** they scroll the zoomed image instead. Esc closes the viewer.
 
 ## Conflicts with the base branch
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -404,7 +404,7 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   by default — bind a key in **Settings → Keyboard**) still opens the picker.
 - **Image diffs** render side by side. Click a side, or Tab to it and press Enter, to
   open it fullscreen: the image over a dimmed backdrop, its label and pixel dimensions
-  along the bottom, and a **Fit** / **100%** toggle. Fit to the window, ← and → move
+  along the bottom, and a **Fit** / **100%** toggle. In **Fit** view ← and → move
   between the old and new sides; at **100%** they scroll the zoomed image instead, and
   Esc closes either way. The **SVG** preview above a text diff and the image diffs
   inside the stashes dialog open the same viewer.
@@ -953,8 +953,9 @@ Images in a rendered body open fullscreen too. Click a screenshot in a descripti
 comment, or discussion (or Tab to it and press Enter) and it fills the window over a
 dimmed backdrop, with its name and pixel dimensions along the bottom, a **Fit** /
 **100%** toggle, and **Open in browser** for an image the body loaded from the web.
-Fit to the window, ← and → step through the other images in the same body; at
-**100%** they scroll the zoomed image instead. Esc closes the viewer.
+In **Fit** view ← and → step through the other images in the same body; at **100%**
+they scroll the zoomed image instead, and Esc closes the viewer. A linked image still
+follows its link, and badges and icons stay put.
 
 ## Conflicts with the base branch
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -405,7 +405,7 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **Image diffs** render side by side. Click a side, or Tab to it and press Enter, to
   open it fullscreen: the image over a dimmed backdrop, its label and pixel dimensions
   along the bottom, and a **Fit** / **100%** toggle. In **Fit** view ← and → move
-  between the old and new sides; at **100%** they scroll the zoomed image instead, and
+  between the old and new sides; at **100%** the arrow keys pan the zoomed image, and
   Esc closes either way. The **SVG** preview above a text diff and the image diffs
   inside the stashes dialog open the same viewer.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
@@ -954,7 +954,7 @@ comment, or discussion (or Tab to it and press Enter) and it fills the window ov
 dimmed backdrop, with its name and pixel dimensions along the bottom, a **Fit** /
 **100%** toggle, and **Open in browser** for an image the body loaded from the web.
 In **Fit** view ← and → step through the other images in the same body; at **100%**
-they scroll the zoomed image instead, and Esc closes the viewer. A linked image still
+the arrow keys pan the zoomed image, and Esc closes the viewer. A linked image still
 follows its link, and badges and icons stay put.
 
 ## Conflicts with the base branch

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -1103,7 +1103,11 @@ export function useRepoLabels(
 // Shared definitions so the hook and the prefetch path stay in sync. A short
 // stale window makes a hover-prefetched PR open with no extra round-trip; the
 // window-focus refetch still keeps an open PR current.
-const prDetailsOptions = (repo: string, number: number, lens: RemoteLens) =>
+export const prDetailsOptions = (
+  repo: string,
+  number: number,
+  lens: RemoteLens,
+) =>
   queryOptions({
     queryKey: ["repo", repo, "pr", lens, number] as const,
     queryFn: () => api.forgePrView(repo, number, lens),


### PR DESCRIPTION
Rendered bodies now answer two questions in place instead of spending a view switch on them: what a `#123` / `!123` / `@user` reference actually points at, and what a screenshot actually shows. Hovering or tabbing to a reference opens a preview card with its state, title, and author; clicking an image in a rendered body — or either side of an image diff — opens it fullscreen with zoom, arrow-key stepping, and keyboard access.

### Reference preview cards

- Adds `src/components/ui/markdown-ref-card.tsx`. `MarkdownRefCard` serves one card per body, positioned at whichever anchor is active; `RefCardBody` branches to `RefUserCard` (avatar and handle via `ForgeUserAvatar`, with the avatar URL read once from the cached assignable-users list) or to the state / title / author rows, and `RefCardSkeleton` matches those row sizes so the card doesn't resize under the pointer.
- `resolveRefItem` resolves a number under the body's own lens, cache-first through `fetchQuery`: `cachedRefKind` settles GitHub's shared `#N` space from a warm PR or issue list, otherwise the issues read classifies through `isPullRefUrl`, and a failed PR read falls back to the kept issue payload rather than claiming the reference didn't resolve. `prItem` reports `DRAFT` only for an open pull request.
- `STATE_PILL` pairs a glyph and tone per state with the state word beside it, so nothing is carried by color alone, and an unrecognized state falls through to `NEUTRAL_PILL`.
- Because the card renders without a `PreviewCard.Trigger`, it registers an inert `pointer-events-none` span pinned to the active anchor's rect and cancels every close reason `isUserDismissal` doesn't recognize — Base UI would otherwise schedule a hover close ~300ms after each open. `useRetained` keeps the previous target painting through the exit animation.
- Wires the lifecycle in `src/components/ui/markdown.tsx`: pointer delegation with hand-rolled `CARD_OPEN_DELAY` / `CARD_CLOSE_DELAY`, `CARD_POPUP_SELECTOR` to tell "left the anchor" apart from "moved into the portaled card", `:focus-visible`-gated keyboard opens so a click doesn't pop a card under the pointer, and an effect pointing the anchor's `aria-describedby` at the card's `useId`.
- Exports `prDetailsOptions` from `src/lib/git/queries.ts` so a hover warms exactly the queries the destination view reads, and reuses `cachedRefKind` / `isPullRefUrl` in the existing click path so both routes classify a number the same way.

### Fullscreen image viewer

- Adds `src/components/ui/image-lightbox.tsx`. `ImageLightbox` fills the window over a dimmed backdrop with the caption and pixel dimensions, the `ZOOM_TOGGLE` Fit/100% control, prev/next for a set, **Open in browser** for an `HTTP_SRC` image, and a broken-image state; `fileNameFromSrc` supplies the caption fallback. Zoom, measurement, and load failure are keyed by the shown image, and `useSeedOnOpen` clears them so a reopen retries a transient failure. The dialog carries `ph-no-capture` to keep user image content out of session replay.
- `ARROW_STEP` navigation applies in fit mode only, leaving the arrows to the scroll field at 100%.
- Makes body images openable in `markdown.tsx`: `isLightboxImage` gates on the `LIGHTBOX_MIN_PX` natural-size floor and skips linked images and ones inside a collapsed `<details>`; `markLightboxImage` gives qualifying images `tabIndex`, `role="button"`, a label, and `data-lightbox`, with the zoom cursor and focus ring authored in the wrapper's own `[&_img[data-lightbox]]:` rules so they outrank its `[&_img]:` block. Click, Enter, and Space open the viewer over every qualifying image in the body, and a `load` listener plus an immediate attempt cover both decode orders.
- Memoizes the `dangerouslySetInnerHTML` wrapper as `htmlProp`: React 19 diffs it by object identity, so a re-render was replacing every injected node and detaching the card's anchor.

### Image diff panes

- Reworks `src/features/diff/ImageDiff.tsx` around a `panes` array. `ImageSide` now takes a ready `src` plus `onOpen` / `onMeasure`, and each side is a zoom-cursor button reachable by Tab and Enter.
- `PanesState` keys measured sizes and the open index by file path plus revs, so switching files drops the previous pair's state during render. The `ImageLightbox` is nested inside the panes because Base UI suppresses a parent dialog's Escape only for a dialog in its React tree, and these panes render inside `StashesDialog` on one route.

### Vendored primitive delta

- `src/components/ui/hover-card.tsx` adds `anchor` and `positionMethod` to the `Positioner.Props` `Pick` and forwards both, so a caller that renders no trigger can place the popup and ask for viewport coordinates across a portal boundary.
- Records this as a third sanctioned delta set, "Anchor forwarding", in `src/components/ui/README.md`, covering `combobox.tsx` and `hover-card.tsx` with the grep to re-check after a re-vendor.

### Documentation

- `README.md` extends the reference-autolinks bullet with the preview card and adds an "Images open fullscreen" bullet.
- `site/src/data/capabilities.ts` extends the reference-autolinks capability and adds a fullscreen-image-viewer capability under *Keyboard & Markdown*.
- `src/features/help/content.ts` updates the image-diff bullet and the references section with the card's contents, Esc dismissal, and the in-body image viewer.
- Adds `changelog.d/added-reference-hovercards.md` and `changelog.d/added-image-lightbox.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen viewing for rendered images and image diffs with Fit/100% zoom, dimensions, navigation, keyboard controls, and browser opening.
  * Added hover- and keyboard-accessible preview cards for issue, pull request, and person references, showing relevant status, title, author, avatar, or handle details.
  * Preserved linked-image navigation while keeping badges and icons in place.
* **Documentation**
  * Updated the README, in-app help, capability guide, and component documentation with details about these features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->