### PR TITLE
feat(worktrees,git): split repo lock domains and archive branch after worktree removal

### DIFF
--- a/changelog.d/added-archive-branch-after-worktree-removal.md
+++ b/changelog.d/added-archive-branch-after-worktree-removal.md
@@ -1,0 +1,3 @@
+- Deleting a worktree can archive its branch automatically once the removal
+  finishes — a checkbox in the delete dialog, so a branch you're done with tidies
+  itself away without a second trip to the branch menu.

--- a/changelog.d/added-archive-branch-after-worktree-removal.md
+++ b/changelog.d/added-archive-branch-after-worktree-removal.md
@@ -1,3 +1,4 @@
 - Deleting a worktree can archive its branch automatically once the removal
-  finishes — a checkbox in the delete dialog, so a branch you're done with tidies
-  itself away without a second trip to the branch menu.
+  finishes — a checkbox in the delete dialog, offered for branches other than
+  the default one, so a branch you're done with tidies itself away without a
+  second trip to the branch menu.

--- a/changelog.d/fixed-worktree-removal-lock-contention.md
+++ b/changelog.d/fixed-worktree-removal-lock-contention.md
@@ -1,0 +1,3 @@
+- Staging, committing and branch actions keep working while a worktree is being
+  removed, and while a fetch or push runs. An action that does still have to
+  wait says what it is waiting for instead of hanging.

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -130,7 +130,7 @@ const REFSPEC_ALLOWLIST = [
   },
   {
     file: "git/worktree.rs",
-    fn: "branch_tip",
+    fn: "validated_branch_tip",
     rationale:
       "read-only rev-parse tip probe gating the removal's best-effort branch delete (never a refspec); validates with validate_ref_name at fn entry",
   },

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -129,6 +129,12 @@ const REFSPEC_ALLOWLIST = [
     rationale: "#[cfg(test)] fixture — the branch name is a test literal",
   },
   {
+    file: "git/worktree.rs",
+    fn: "branch_tip",
+    rationale:
+      "read-only rev-parse tip probe gating the removal's best-effort branch delete (never a refspec); validates with validate_ref_name at fn entry",
+  },
+  {
     file: "github/pr.rs",
     fn: "gh_delete_remote_head_branch",
     rationale:

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -21,6 +21,10 @@ pub enum AppError {
     /// would push every `AppResult` in the crate past clippy's `result_large_err`.
     #[error("{}", .0.message)]
     PullRebaseWouldDrop(Box<crate::git::pull_guard::WouldDrop>),
+    /// A bounded wait for one of a repo's locks expired. `holder` names what was
+    /// running in the user's terms ("a worktree removal"), never the lock itself.
+    #[error("{}", busy_message(holder))]
+    Busy { holder: String },
     #[error("not a git repository: {0}")]
     NotARepo(String),
     #[error("git executable not found")]
@@ -62,6 +66,22 @@ fn git_message(code: i32, stderr: &str) -> String {
     }
 }
 
+/// One complete sentence, because the frontend takes line 1 verbatim as the toast
+/// title (`firstMeaningfulLine`, `src/lib/error-summary.ts`). An empty holder falls
+/// back to the generic phrasing rather than emitting a headless sentence.
+fn busy_message(holder: &str) -> String {
+    let mut chars = holder.chars();
+    let Some(first) = chars.next() else {
+        return "Another Git operation is still running — try again when it finishes."
+            .to_string();
+    };
+    format!(
+        "{}{} is still running — try again when it finishes.",
+        first.to_uppercase(),
+        chars.as_str()
+    )
+}
+
 /// The frontend renders a conflict from `op`/`report`, so this is what the
 /// non-presenting readers get: `Display` feeds `to_string()` embeds (the oplog
 /// entry, the compound funnels' wrapped messages). A report can only be empty if
@@ -85,6 +105,7 @@ impl Serialize for AppError {
             // Stable serialized kind — the frontend branches on it to open the
             // keep-or-drop decision instead of presenting an error.
             AppError::PullRebaseWouldDrop(_) => "pullRebaseWouldDrop",
+            AppError::Busy { .. } => "busy",
             AppError::NotARepo(_) => "notARepo",
             AppError::GitNotFound => "gitNotFound",
             AppError::GhNotFound => "ghNotFound",
@@ -110,6 +131,9 @@ impl Serialize for AppError {
             AppError::Git { code, stderr } => {
                 map.serialize_entry("code", code)?;
                 map.serialize_entry("stderr", stderr)?;
+            }
+            AppError::Busy { holder } => {
+                map.serialize_entry("holder", holder)?;
             }
             AppError::Conflict { op, paths, report } => {
                 map.serialize_entry("op", op)?;
@@ -218,6 +242,19 @@ mod tests {
             ))
             .unwrap(),
             r#"{"kind":"pullRebaseWouldDrop","message":"Pulling with rebase would drop 2 commits that origin/main no longer contains.","branch":"main","upstream":"origin/main","branchTip":"1111111111111111111111111111111111111111","newTip":"3333333333333333333333333333333333333333","mergeBase":"4444444444444444444444444444444444444444","forkPoint":"1111111111111111111111111111111111111111","commits":[{"sha":"1111111111111111111111111111111111111111","subject":"V the victim","author":"Ada","authorDate":"2026-08-28T23:37:38-04:00"},{"sha":"2222222222222222222222222222222222222222","subject":"also doomed","author":"Bob","authorDate":"2026-08-27T10:00:00+00:00"}]}"#
+        );
+    }
+
+    /// The frontend renders line 1 of `message` as the toast title, so the whole
+    /// sentence is the contract — not just the `holder` key beside it.
+    #[test]
+    fn busy_serializes_to_the_pinned_wire_shape() {
+        let err = AppError::Busy {
+            holder: "a worktree removal".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_string(&err).unwrap(),
+            r#"{"kind":"busy","message":"A worktree removal is still running — try again when it finishes.","holder":"a worktree removal"}"#
         );
     }
 

--- a/src-tauri/src/forge/bitbucket.rs
+++ b/src-tauri/src/forge/bitbucket.rs
@@ -3058,9 +3058,14 @@ pub async fn create_pr(
     let push_args =
         crate::git::remote::with_credentials(&cred, &["push", "-u", "origin", &spec]);
     let push_refs: Vec<&str> = push_args.iter().map(String::as_str).collect();
-    crate::git::runner::run_git_mutating(
+    // The NETWORK domain: a transfer runs for minutes on a large branch, and the
+    // working-tree lock must stay free for staging and commits meanwhile. Empty
+    // `cred` because the argv above already carries the entries — that also keeps the
+    // ambient-auth retry (gated on a non-empty slice) off, as this funnel expects.
+    crate::git::remote::run_git_mutating_with_creds(
         state,
         repo_path,
+        &[],
         &push_refs,
         crate::git::runner::NETWORK_TIMEOUT,
     )
@@ -5016,9 +5021,12 @@ pub async fn publish_repo(
     }
 
     let spec = crate::git::remote::publish_refspec(&branch);
-    if let Err(e) = crate::git::runner::run_git_mutating(
+    // NETWORK domain (see `create_pr`'s push): the credentials ride the argv, so the
+    // empty `cred` slice leaves both the command and the ambient retry unchanged.
+    if let Err(e) = crate::git::remote::run_git_mutating_with_creds(
         state,
         repo_path,
+        &[],
         &["-c", "credential.interactive=false", "push", "-u", "origin", &spec],
         crate::git::runner::NETWORK_TIMEOUT,
     )

--- a/src-tauri/src/forge/gitlab.rs
+++ b/src-tauri/src/forge/gitlab.rs
@@ -5413,9 +5413,14 @@ pub async fn publish_repo(
     }
     let spec = crate::git::remote::publish_refspec(&branch);
     push_args.extend(["push", "-u", "origin", &spec]);
-    crate::git::runner::run_git_mutating(
+    // The NETWORK domain: a transfer runs for minutes on a large branch, and the
+    // working-tree lock must stay free for staging and commits meanwhile. Empty
+    // `cred` because `push_args` already carries the `-c` entries — that also keeps
+    // the ambient-auth retry (gated on a non-empty slice) off.
+    crate::git::remote::run_git_mutating_with_creds(
         state,
         repo_path,
+        &[],
         &push_args,
         crate::git::runner::NETWORK_TIMEOUT,
     )
@@ -5553,9 +5558,12 @@ pub async fn create_mr(
     }
     let spec = crate::git::remote::publish_refspec(head);
     push_args.extend(["push", "-u", "origin", &spec]);
-    crate::git::runner::run_git_mutating(
+    // NETWORK domain (see `publish_repo`'s push): the `-c` entries ride `push_args`,
+    // so the empty `cred` slice changes neither the command nor the ambient retry.
+    crate::git::remote::run_git_mutating_with_creds(
         state,
         repo_path,
+        &[],
         &push_args,
         crate::git::runner::NETWORK_TIMEOUT,
     )

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -206,17 +206,15 @@ pub(crate) async fn git_pull_autostash_core(
     let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
-    let stashed = autostash_push(&repo_path).await?;
     // The transfer serializes with the network domain (the auto-fetch runs there),
-    // released the moment the pull returns. A refusal to wait is settled exactly like
-    // a failed git invocation, so the stash still comes back.
+    // and the hold is taken BEFORE the stash so it spans stash → pull → settle: a
+    // refusal to wait must precede the first tree mutation, or the user's work is
+    // stashed and popped back purely to report that something else was running.
     let network = state.network_lock(&repo_path).await;
-    let op = match acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await {
-        Ok(_net) => {
-            run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await
-        }
-        Err(busy) => Err(busy),
-    };
+    let _net_guard = acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await?;
+
+    let stashed = autostash_push(&repo_path).await?;
+    let op = run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await;
     settle(&repo_path, paused, stashed, true, op).await
 }
 

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -1,17 +1,23 @@
 //! App-level stash → op → reapply compounds for pull, merge, rebase and switch.
 //!
-//! Each command acquires `repo_lock` ONCE and uses only the lock-free runners
-//! while holding it — `run_git_mutating` re-acquires the same non-reentrant
-//! mutex and deadlocks (precedent: `git_stash_paths_core`). The inner steps
-//! therefore lose `run_git_mutating`'s one-shot index.lock retry, the same
-//! trade-off that compound accepts.
+//! Each command acquires the repo's WORKING-TREE lock ONCE and uses only the
+//! lock-free runners while holding it — `run_git_mutating` re-acquires the same
+//! non-reentrant mutex and deadlocks (precedent: `git_stash_paths_core`). The inner
+//! steps therefore lose `run_git_mutating`'s one-shot index.lock retry, the same
+//! trade-off that compound accepts. The pull compound's transfer additionally takes
+//! the NETWORK lock around its one network call, so it still serializes against the
+//! background auto-fetch; that nesting direction is the only one allowed (see
+//! `run_git_mutating`).
 
 use tauri::State;
 
 use crate::error::AppResult;
 use crate::git::branches::validate_ref_name;
 use crate::git::remote::run_git_with_creds_once;
-use crate::git::runner::{run_git, run_git_raw, GitOutput, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
+use crate::git::runner::{
+    acquire_repo_lock, run_git, run_git_raw, GitOutput, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    NETWORK_LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// How a stash → op → reapply compound ended. Every failure mode is reportable —
@@ -196,12 +202,21 @@ pub(crate) async fn git_pull_autostash_core(
     // A read that shells out to git itself — resolve it BEFORE taking the lock.
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
-    let op = run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await;
+    // The transfer serializes with the network domain (the auto-fetch runs there),
+    // released the moment the pull returns. A refusal to wait is settled exactly like
+    // a failed git invocation, so the stash still comes back.
+    let network = state.network_lock(&repo_path).await;
+    let op = match acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await {
+        Ok(_net) => {
+            run_git_with_creds_once(&repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await
+        }
+        Err(busy) => Err(busy),
+    };
     settle(&repo_path, paused, stashed, true, op).await
 }
 
@@ -223,8 +238,8 @@ pub(crate) async fn git_merge_autostash_core(
 ) -> AppResult<AutostashOutcome> {
     validate_ref_name(&branch)?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a merge").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
@@ -257,8 +272,8 @@ pub(crate) async fn git_rebase_autostash_core(
 ) -> AppResult<AutostashOutcome> {
     validate_ref_name(&branch)?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a rebase").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
@@ -295,8 +310,8 @@ pub(crate) async fn git_rebase_onto_autostash_core(
     validate_ref_name(&new_base)?;
     validate_ref_name(&old_base)?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a rebase").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;
@@ -344,8 +359,8 @@ pub(crate) async fn git_switch_autostash_core(
     }
     let tracking = remote.map(|remote| format!("{remote}/{name}"));
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a checkout").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
     let stashed = autostash_push(&repo_path).await?;

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -2,8 +2,8 @@ use tauri::State;
 
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT,
-    WORKTREE_OP_TIMEOUT,
+    acquire_repo_lock, run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{Branch, BranchDivergence, RemoteBranch};
 use crate::state::AppState;
@@ -1078,9 +1078,9 @@ pub(crate) async fn update_branch_from(
         ));
     }
 
-    // Mutating refs — serialize against other writes to this repo.
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    // Mutating refs — serialize against other writes to this repo's working tree.
+    let domain = state.working_tree_lock(repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a branch update").await?;
 
     let current = run_git(
         Some(repo_path),

--- a/src-tauri/src/git/conflict.rs
+++ b/src-tauri/src/git/conflict.rs
@@ -12,7 +12,9 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
-use crate::git::runner::{run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT};
+use crate::git::runner::{
+    acquire_repo_lock, run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// Cap on a conflicted file's working-tree size for AI resolution. Past this the
@@ -225,8 +227,8 @@ pub(crate) async fn git_checkout_conflict_side_core(
     // stage or discard can rewrite the working-tree file, and the `add` would then
     // stage THAT content as the user's chosen side. Lock-free runners only while
     // held (see `run_git_mutating`).
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a conflict resolution").await?;
 
     // A side that removed the file (deleted it, or renamed it away) has no stage
     // entry, and `checkout --ours|--theirs` then exits 1 ("does not have our

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -7,8 +7,9 @@ use crate::error::{AppError, AppResult};
 use crate::git::diff::parse_numstat_z;
 use crate::git::history::validate_hash;
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_mutating_raw, run_git_raw, run_git_raw_input,
-    DEFAULT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
+    acquire_repo_lock, run_git, run_git_mutating, run_git_mutating_raw, run_git_raw,
+    run_git_raw_input, run_git_worktree_admin, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT,
+    WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{FileDiff, RepoOpState, RewriteStep, StashEntry, TagInfo};
 use crate::state::AppState;
@@ -454,8 +455,8 @@ fn remove_lines(content: &str, drop: &std::collections::HashSet<u32>) -> String 
 /// the dirty check alone would let a reset strand those markers and leave the
 /// repo claiming an operation whose commits have moved out from under it.
 ///
-/// Both `--hard` guards and the reset itself run under ONE `repo_lock` hold, so
-/// no other caller in THIS PROCESS can dirty the tree or start a merge between the
+/// Both `--hard` guards and the reset itself run under ONE working-tree-lock hold,
+/// so no other caller in THIS PROCESS can dirty the tree or start a merge between the
 /// checks and a rewrite that has no stash and no reflog to recover from. The hold
 /// is why the reset runs on the lock-free `run_git`: `run_git_mutating` re-acquires
 /// the same non-reentrant mutex and deadlocks, so this trades away its one-shot
@@ -508,8 +509,8 @@ pub(crate) async fn git_reset_core(
     }
     // One hold across both guards and the rewrite — see this function's doc for
     // why the runner inside it must be the lock-free one.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a reset").await?;
     ensure_clean_tree(&repo_path).await?;
     if op_state(&repo_path).await?.mid_op() {
         return Err(AppError::InvalidArgument(
@@ -697,8 +698,8 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
     // `target` to the `target_tip` captured up here, so a commit another caller lands
     // in between would be destroyed by a reset to a tip that predates it. Lock-free
     // runners only while held (see `run_git_mutating`).
-    let lock = state.repo_lock(repo_path).await;
-    let guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo_path).await;
+    let guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a cherry-pick").await?;
 
     // Ahead of the tree check because it can't stand in for this one: a pick paused
     // with its conflicts staged has a CLEAN tree, so the only refusal left would be
@@ -804,7 +805,7 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
         let mut failure: Option<(String, AppError)> = None;
         'picks: for hash in hashes {
             // Raw plus an explicit code check, never a mutating runner: this loop
-            // runs inside the compound's own `repo_lock` hold. A conflicted pick
+            // runs inside the compound's own working-tree hold. A conflicted pick
             // splits its report — `could not apply` on stderr, the `CONFLICT (…`
             // file list on stdout — so the rollback verdict below needs both.
             let out = match run_git_raw(Some(repo_path), &["cherry-pick", hash], pick_timeout).await
@@ -1046,8 +1047,8 @@ pub(crate) async fn git_stash_all_core(state: &AppState, repo_path: String) -> A
     // between the check and the push. That means the lock-free `run_git` for the
     // push itself — `run_git_mutating` re-acquires this non-reentrant lock and
     // deadlocks — trading away its one-shot index.lock retry (as autostash does).
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a stash operation").await?;
     refuse_mid_op(&repo_path).await?;
 
     run_git(
@@ -1155,10 +1156,10 @@ pub(crate) async fn git_stash_paths_core(
     // the stash's index-commit (`^2`), so any OTHER staged file rides along and can
     // resurrect on `pop --index`. To capture only the selection, hold the per-repo
     // lock across the whole compound sequence and use the lock-free `run_git` for
-    // every step while holding it — `repo_lock` is a non-reentrant
+    // every step while holding it — the working-tree domain is a non-reentrant
     // `tokio::sync::Mutex`, so `run_git_mutating` would re-acquire it and deadlock.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a stash operation").await?;
 
     // Refuse mid-operation, before any mutation: an unmerged index blocks both a
     // native `git stash push` and the slow path's `write-tree` snapshot, and a
@@ -1619,11 +1620,11 @@ pub(crate) async fn replace_file_lines(
     // Hold the repo's mutating lock across the WHOLE dirty-check → read → verify →
     // write → stage sequence, not just the final `git add`: otherwise two concurrent
     // Apply calls on different ranges of one file interleave and the second silently
-    // overwrites the first's write. `repo_lock` is a `tokio::sync::Mutex` (safe to
-    // hold across `.await`) but non-reentrant — use the lock-free `run_git` below,
-    // never `run_git_mutating`, which would deadlock.
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    // overwrites the first's write. The working-tree domain is a `tokio::sync::Mutex`
+    // (safe to hold across `.await`) but non-reentrant — use the lock-free `run_git`
+    // below, never `run_git_mutating`, which would deadlock.
+    let domain = state.working_tree_lock(repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a file edit").await?;
 
     let repo_root = std::path::Path::new(repo_path);
     let target = repo_root.join(rel);
@@ -2447,7 +2448,7 @@ pub(crate) async fn unmerged_paths(repo_path: &str) -> Vec<String> {
 /// `report` must be [`GitOutput::full_failure_text`]: the conflict families split
 /// ONE report across both streams, so either half alone is silent data loss.
 /// Lock-free (the probe uses `run_git_raw`), so compounds may call it while
-/// holding `repo_lock`.
+/// holding any domain's lock.
 pub(crate) async fn classify_failure(
     repo_path: &str,
     op: &str,
@@ -2499,14 +2500,15 @@ fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf> {
 /// `git worktree prune`, both in the MAIN repo, both best-effort (a resolve
 /// worktree is detached and holds no branch, so nothing else needs cleanup).
 async fn remove_resolve_worktree(state: &AppState, repo_path: &str, worktree_path: &str) {
-    let _ = run_git_mutating(
+    let _ = run_git_worktree_admin(
         state,
         repo_path,
         &["worktree", "remove", "--force", worktree_path],
         WORKTREE_OP_TIMEOUT,
     )
     .await;
-    let _ = run_git_mutating(state, repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    let _ =
+        run_git_worktree_admin(state, repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
 }
 
 /// Parses `git worktree list --porcelain` into the checked-out branch name of
@@ -2828,7 +2830,7 @@ pub(crate) async fn merge_local_pr(
         crate::oplog::finish(repo_path, &op_id, Some(e.to_string())).await;
         return Err(AppError::Io(e));
     }
-    let add = run_git_mutating(
+    let add = run_git_worktree_admin(
         state,
         repo_path,
         &["worktree", "add", "--detach", &worktree_path, &base_tip],
@@ -3518,7 +3520,7 @@ pub(crate) async fn merge_remote_pr(
     ));
     let worktree_path = worktree_path.to_string_lossy().into_owned();
     std::fs::create_dir_all(root).map_err(AppError::Io)?;
-    run_git_mutating(
+    run_git_worktree_admin(
         state,
         repo_path,
         &["worktree", "add", "--detach", &worktree_path, &head_tip],
@@ -3997,8 +3999,8 @@ pub(crate) async fn rewrite_commits_with_timeouts(
     // destroyed, and between `reset --hard base` and the picks the branch sits rewound
     // where a concurrent read sees a truncated history. Lock-free runners only while
     // held (see `run_git_mutating`).
-    let lock = state.repo_lock(repo_path).await;
-    let guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo_path).await;
+    let guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a history rewrite").await?;
 
     // reset --hard would destroy uncommitted work — refuse instead.
     let status = run_git(
@@ -4086,7 +4088,7 @@ pub(crate) async fn rewrite_commits_with_timeouts(
         let rewound = failure.is_none();
         if failure.is_none() {
             // Raw plus `check_code`, never a mutating runner: this loop runs inside
-            // the compound's own `repo_lock` hold. Failures land on either stream —
+            // the compound's own working-tree hold. Failures land on either stream —
             // a conflicted pick splits `could not apply` (stderr) from its `CONFLICT (…`
             // file list (stdout), and `commit` reports a squash that left nothing to
             // commit on stdout alone — so a stderr-only error would carry half a
@@ -4574,6 +4576,8 @@ pub async fn git_list_tags(repo_path: String) -> AppResult<Vec<TagInfo>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Test-only: the interleave control queues on the lock WITHOUT a wait bound.
+    use crate::git::runner::acquire_repo_lock_unbounded;
 
     fn dropping(content: &str, lines: &[u32]) -> String {
         remove_lines(content, &lines.iter().copied().collect())
@@ -5327,18 +5331,22 @@ mod tests {
             let state = state.clone();
             let repo = repo.clone();
             tokio::spawn(async move {
-                let lock = state.repo_lock(&repo).await;
+                let domain = state.working_tree_lock(&repo).await;
                 // Bounded wait: if the compound somehow finished first we still
                 // commit, and the assertions below stay meaningful either way.
                 for _ in 0..500 {
-                    if lock.try_lock().is_err() {
+                    if domain.lock().try_lock().is_err() {
                         break;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(2)).await;
                 }
-                run_git_mutating(
-                    &state,
-                    &repo,
+                // The same queue an ordinary mutating caller joins, minus the wait
+                // bound: this test pins the compound's ATOMICITY, so a compound that
+                // outran `LOCK_WAIT_TIMEOUT` on a loaded runner must not turn it into
+                // a Busy failure. Lock-free runner, since the hold is ours.
+                let _guard = acquire_repo_lock_unbounded(&domain, "a commit").await;
+                run_git(
+                    Some(&repo),
                     &["commit", "--allow-empty", "-m", "concurrent"],
                     DEFAULT_TIMEOUT,
                 )

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -15,7 +15,10 @@ use crate::error::{AppError, AppResult};
 use crate::git::autostash::{autostash_push, settle, AutostashOutcome};
 use crate::git::history::validate_hash;
 use crate::git::remote::run_git_with_creds_once;
-use crate::git::runner::{run_git, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT};
+use crate::git::runner::{
+    acquire_repo_lock, run_git, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    NETWORK_LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT,
+};
 use crate::state::AppState;
 
 /// One commit the fork-point verdict would rewrite away, as the decision UI names
@@ -491,9 +494,13 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// pull that bare git refuses outright ("no such ref was fetched"). Pruned, the
 /// upstream ref stops resolving and that refusal is what the user sees.
 ///
-/// The caller must already hold the repo lock, so every step here uses the
-/// lock-free runners — `run_git_mutating*` would re-acquire it and deadlock.
+/// The caller must already hold the repo's working-tree lock, so every step here
+/// uses the lock-free runners — `run_git_mutating*` would re-acquire it and
+/// deadlock. The fetch below takes the NETWORK lock for its own duration (that
+/// nesting direction only), which is what keeps it from racing the background
+/// auto-fetch at the ref level.
 pub(crate) async fn probe(
+    state: &AppState,
     repo: &str,
     target: &PullTarget,
     cred: &[String],
@@ -504,6 +511,9 @@ pub(crate) async fn probe(
         return Ok(None);
     }
     if target.remote != "." {
+        let network = state.network_lock(repo).await;
+        let _net_guard =
+            acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a fetch").await?;
         let out = run_git_with_creds_once(
             repo,
             cred,
@@ -570,14 +580,14 @@ pub(crate) async fn guarded_pull(state: &AppState, repo: &str) -> AppResult<bool
     // autostash compounds do.
     let cred = credentials(repo, &target).await?;
 
-    let lock = state.repo_lock(repo).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     // Re-read under the lock: `resolve` saw the tree before it, and another window
     // pausing a rebase in that gap would leave this one rebasing onto a conflict.
     if mid_op(repo).await {
         return Ok(false);
     }
-    let Some(plan) = probe(repo, &target, &cred).await? else {
+    let Some(plan) = probe(state, repo, &target, &cred).await? else {
         return Ok(false);
     };
     if !plan.dropped().is_empty() {
@@ -619,10 +629,10 @@ pub(crate) async fn guarded_pull_autostash(
     };
     let cred = credentials(repo, &target).await?;
 
-    let lock = state.repo_lock(repo).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     crate::git::ops::refuse_mid_op(repo).await?;
-    let Some(plan) = probe(repo, &target, &cred).await? else {
+    let Some(plan) = probe(state, repo, &target, &cred).await? else {
         return Ok(None);
     };
     if !plan.dropped().is_empty() {
@@ -855,8 +865,8 @@ pub(crate) async fn git_pull_rebase_decided_core(
         &expected_tip,
     )?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     // Names what the user asked for: this arm stashes nothing, so `refuse_mid_op`'s
     // "Can't stash …" would describe an operation that isn't happening.
     crate::git::ops::refuse_mid_op_for(&repo_path, "pull").await?;
@@ -955,8 +965,8 @@ pub(crate) async fn git_pull_rebase_decided_autostash_core(
         &expected_tip,
     )?;
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
     ensure_on_expected_commit(&repo_path, &decided.branch, &expected_tip).await?;
 

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -496,9 +496,10 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 ///
 /// The caller must already hold the repo's working-tree lock, so every step here
 /// uses the lock-free runners — `run_git_mutating*` would re-acquire it and
-/// deadlock. The fetch below takes the NETWORK lock for its own duration (that
-/// nesting direction only), which is what keeps it from racing the background
-/// auto-fetch at the ref level.
+/// deadlock. The NETWORK lock is taken around the fetch and held through the plan's
+/// reads (that nesting direction only), so the whole verdict rests on ONE snapshot
+/// of the tracking refs: the background auto-fetch shares that domain and would
+/// otherwise be free to move them between the fetch and the revs read off it.
 pub(crate) async fn probe(
     state: &AppState,
     repo: &str,
@@ -510,24 +511,33 @@ pub(crate) async fn probe(
     if current_branch(repo).await.as_deref() != Some(target.branch.as_str()) {
         return Ok(None);
     }
-    if target.remote != "." {
-        let network = state.network_lock(repo).await;
-        let _net_guard =
-            acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a fetch").await?;
-        let out = run_git_with_creds_once(
-            repo,
-            cred,
-            &["fetch", "--prune", &target.remote],
-            NETWORK_TIMEOUT,
-        )
-        .await?;
-        if out.code != 0 {
-            return Err(AppError::Git {
-                code: out.code,
-                stderr: out.full_failure_text(),
-            });
+    // ONE network hold spanning the fetch AND every read below it: the verdict is
+    // only sound on the refs this fetch produced, and the background auto-fetch runs
+    // in this same domain — released in between, it can move
+    // `refs/remotes/<remote>/<branch>` under the four reads and the plan then mixes
+    // two snapshots. `None` for a local upstream, which reads no remote-tracking ref.
+    let _net_guard = match target.remote.as_str() {
+        "." => None,
+        remote => {
+            let network = state.network_lock(repo).await;
+            let guard =
+                acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a fetch").await?;
+            let out = run_git_with_creds_once(
+                repo,
+                cred,
+                &["fetch", "--prune", remote],
+                NETWORK_TIMEOUT,
+            )
+            .await?;
+            if out.code != 0 {
+                return Err(AppError::Git {
+                    code: out.code,
+                    stderr: out.full_failure_text(),
+                });
+            }
+            Some(guard)
         }
-    }
+    };
 
     // The local side of every rev below is HEAD, not the branch NAME: rev-parse
     // resolves `refs/tags/<n>` ahead of `refs/heads/<n>`, so a tag sharing the

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -6,7 +6,8 @@ use tauri::State;
 
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_raw, GitOutput, DEFAULT_TIMEOUT, NETWORK_TIMEOUT,
+    acquire_repo_lock, holder_label, run_git, run_git_mutating, run_git_raw, subcommand_of,
+    GitOutput, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT, NETWORK_LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT,
 };
 use crate::state::AppState;
 
@@ -60,8 +61,9 @@ fn is_auth_class_failure(stderr: &str) -> bool {
 }
 
 /// Run a git network op with one-shot credential `-c` entries prefixed, taking NO
-/// lock — so it is callable from inside a held `repo_lock` (the autostash
-/// compounds). Returns the raw output: a non-zero exit is not an error here.
+/// lock — so it is callable from inside a held working-tree lock (the autostash
+/// compounds, which take the network lock around it themselves). Returns the raw
+/// output: a non-zero exit is not an error here.
 ///
 /// When `cred` is non-empty and the injected run fails with an auth-class git error
 /// ([`is_auth_class_failure`]), retries EXACTLY ONCE with NO injected config (the
@@ -100,9 +102,15 @@ pub(crate) async fn run_git_with_creds_once(
     Ok(out)
 }
 
-/// [`run_git_with_creds_once`] under the per-repo lock, surfacing a non-zero exit
-/// as [`AppError::Git`] — the mutating-command contract every network caller
+/// [`run_git_with_creds_once`] under the repo's NETWORK lock, surfacing a non-zero
+/// exit as [`AppError::Git`] — the mutating-command contract every network caller
 /// (fetch/pull/push) is written against.
+///
+/// The network domain rather than the working tree: a transfer runs for up to
+/// `NETWORK_TIMEOUT` and must not stall staging or a commit for that long. A caller
+/// whose command also touches the working tree (`git_pull_core`) takes the
+/// working-tree lock around this call — that direction only (see
+/// `run_git_mutating`).
 pub(crate) async fn run_git_mutating_with_creds(
     state: &AppState,
     repo_path: &str,
@@ -110,8 +118,13 @@ pub(crate) async fn run_git_mutating_with_creds(
     sub: &[&str],
     timeout: Duration,
 ) -> AppResult<GitOutput> {
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.network_lock(repo_path).await;
+    let _guard = acquire_repo_lock(
+        &domain,
+        NETWORK_LOCK_WAIT_TIMEOUT,
+        holder_label(subcommand_of(sub)),
+    )
+    .await?;
 
     // index.lock contention from an external tool (editor, other client) is
     // transient — retry once. Expressed here rather than via `run_git_mutating`
@@ -481,6 +494,12 @@ pub(crate) async fn git_pull_core(
         return Ok(());
     }
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
+    // Bare `git pull` is a transfer AND a merge in one command, so it needs both
+    // domains: the working tree here, the network inside `run_git_mutating_with_creds`
+    // — that order only (see `run_git_mutating`). The guarded rebase path above takes
+    // the working-tree lock itself and must stay outside this hold.
+    let wt = state.working_tree_lock(&repo_path).await;
+    let _wt_guard = acquire_repo_lock(&wt, LOCK_WAIT_TIMEOUT, "a pull").await?;
     let already_unmerged = crate::git::ops::unmerged_paths(&repo_path).await;
     if let Err(err) =
         run_git_mutating_with_creds(state, &repo_path, &cred, &["pull", flag], NETWORK_TIMEOUT).await

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -110,8 +110,9 @@ pub(crate) fn try_acquire_repo_lock(
 pub(crate) fn holder_label(subcommand: &str) -> &'static str {
     match subcommand {
         "commit" => "a commit",
-        "add" => "a staging operation",
-        "apply" => "a patch apply",
+        // `apply` reaches this runner only as diff.rs's hunk stage/unstage/discard,
+        // which the user knows as staging — never as a standalone patch tool.
+        "add" | "apply" => "a staging operation",
         "restore" => "a file restore",
         // The one `submodule` argv reaching this runner is `submodule update`
         // (git::submodule's other paths hold the lock themselves and label it).

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -110,6 +110,9 @@ pub(crate) fn try_acquire_repo_lock(
 pub(crate) fn holder_label(subcommand: &str) -> &'static str {
     match subcommand {
         "commit" => "a commit",
+        "add" => "a staging operation",
+        "apply" => "a patch apply",
+        "restore" => "a file restore",
         // The one `submodule` argv reaching this runner is `submodule update`
         // (git::submodule's other paths hold the lock themselves and label it).
         "submodule" => "a submodule update",

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
-use crate::state::AppState;
+use crate::state::{AppState, HolderSlot, LockDomain};
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const NETWORK_TIMEOUT: Duration = Duration::from_secs(600);
@@ -16,6 +16,133 @@ pub const NETWORK_TIMEOUT: Duration = Duration::from_secs(600);
 /// lands mid-materialize or mid-delete — leaving exactly the half-state the
 /// registered/prunable reconciliation in `git::worktree` then has to clean up.
 pub const WORKTREE_OP_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// How long a caller waits for the working-tree or worktree-admin lock before
+/// reporting [`AppError::Busy`]. Short on purpose: the ops holding those domains
+/// are local index/ref work, so a wait this long already means the user should be
+/// told what they are queued behind rather than watching a spinner.
+pub(crate) const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The same bound for the network domain, where a legitimate holder is a transfer
+/// whose own budget is `NETWORK_TIMEOUT` — a wait of a minute is still ordinary.
+pub(crate) const NETWORK_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The holder label for a hold whose operation has no better name.
+pub(crate) const DEFAULT_HOLDER: &str = "another Git operation";
+
+/// A held domain lock, which publishes its holder's label for as long as it lives
+/// so a waiter that times out can name what it lost to.
+#[derive(Debug)]
+pub(crate) struct RepoLockGuard {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+    holder: HolderSlot,
+}
+
+impl Drop for RepoLockGuard {
+    fn drop(&mut self) {
+        *self.holder.lock().unwrap_or_else(|p| p.into_inner()) = None;
+    }
+}
+
+/// Publish `label` as the domain's holder and wrap the guard, so the label is
+/// cleared on every release path.
+fn hold(
+    domain: &LockDomain,
+    guard: tokio::sync::OwnedMutexGuard<()>,
+    label: &'static str,
+) -> RepoLockGuard {
+    let holder = domain.holder_slot();
+    *holder.lock().unwrap_or_else(|p| p.into_inner()) = Some(label);
+    RepoLockGuard {
+        _guard: guard,
+        holder,
+    }
+}
+
+/// Wait up to `bound` for `domain`, labelling the hold `label`. On expiry the
+/// CURRENT holder's label rides the error, so the user reads what they are waiting
+/// for instead of watching an unbounded hang.
+///
+/// `bound` is a parameter rather than a constant so tests can pass
+/// `Duration::ZERO`: `tokio::time::timeout` polls its inner future first, so a zero
+/// budget still succeeds against a FREE lock and fails immediately against a held
+/// one — free/held is decided by the lock, never by scheduling.
+pub(crate) async fn acquire_repo_lock(
+    domain: &LockDomain,
+    bound: Duration,
+    label: &'static str,
+) -> AppResult<RepoLockGuard> {
+    match tokio::time::timeout(bound, domain.lock().lock_owned()).await {
+        Ok(guard) => Ok(hold(domain, guard, label)),
+        Err(_) => Err(AppError::Busy {
+            holder: domain.holder_label().unwrap_or(DEFAULT_HOLDER).to_string(),
+        }),
+    }
+}
+
+/// Wait indefinitely for `domain`. For the holds a user never initiated (agent
+/// session turns) and the ones that ARE the long operation: erroring there would
+/// only move the failure, so they queue.
+pub(crate) async fn acquire_repo_lock_unbounded(
+    domain: &LockDomain,
+    label: &'static str,
+) -> RepoLockGuard {
+    let guard = domain.lock().lock_owned().await;
+    hold(domain, guard, label)
+}
+
+/// Take `domain` only if it is free right now. `None` means someone else holds it
+/// and the caller's work is skippable — never a queue.
+pub(crate) fn try_acquire_repo_lock(
+    domain: &LockDomain,
+    label: &'static str,
+) -> Option<RepoLockGuard> {
+    let guard = domain.lock().try_lock_owned().ok()?;
+    Some(hold(domain, guard, label))
+}
+
+/// How a git subcommand is named to the NEXT caller waiting on the same domain.
+/// The user's word for the operation, not git's — this text lands in a toast.
+///
+/// Compound holds pass their own label instead (`"a history rewrite"`,
+/// `"a submodule change"`), since the sequence is what the user did, not any one
+/// of its commands.
+pub(crate) fn holder_label(subcommand: &str) -> &'static str {
+    match subcommand {
+        "commit" => "a commit",
+        // The one `submodule` argv reaching this runner is `submodule update`
+        // (git::submodule's other paths hold the lock themselves and label it).
+        "submodule" => "a submodule update",
+        "checkout" | "switch" => "a checkout",
+        "stash" => "a stash operation",
+        "worktree" => "a worktree operation",
+        "branch" => "a branch update",
+        "merge" => "a merge",
+        "rebase" => "a rebase",
+        "cherry-pick" => "a cherry-pick",
+        "revert" => "a revert",
+        "reset" => "a reset",
+        "pull" => "a pull",
+        "push" => "a push",
+        "fetch" => "a fetch",
+        _ => DEFAULT_HOLDER,
+    }
+}
+
+/// The subcommand in an argv that may open with `-c key=value` config pairs
+/// (`op_continue`'s `core.editor`, the forge pushes' credential entries), which
+/// would otherwise label every one of those holds generically.
+pub(crate) fn subcommand_of<'a>(args: &[&'a str]) -> &'a str {
+    let mut rest = args.iter();
+    while let Some(arg) = rest.next() {
+        if *arg == "-c" {
+            rest.next();
+        } else if !arg.starts_with('-') {
+            return arg;
+        }
+    }
+    ""
+}
 
 pub struct GitOutput {
     pub stdout: Vec<u8>,
@@ -401,16 +528,22 @@ pub(crate) async fn worktree_toplevel(repo_path: &str) -> AppResult<String> {
     Ok(toplevel)
 }
 
-/// Runs a mutating git command under the per-repo lock, retrying once on
-/// index.lock contention caused by external tools (editors, other clients).
+/// Runs a mutating git command under the repo's WORKING-TREE lock, retrying once
+/// on index.lock contention caused by external tools (editors, other clients). The
+/// wait is bounded by [`LOCK_WAIT_TIMEOUT`] and reports [`AppError::Busy`] naming
+/// the current holder, so a caller is never queued behind a long op with no word.
 ///
-/// Compound sequences take `repo_lock` themselves, so their guards, anchors and
-/// rollback see one unbroken view — and must NOT call this from inside that hold,
-/// which re-acquires the same non-reentrant mutex and deadlocks. Use the lock-free
-/// runners there (`run_git`, `run_git_raw`, the `_input` pair,
+/// A repo has three independent domains — working-tree, worktree-admin
+/// (`run_git_worktree_admin`), network (`remote::run_git_mutating_with_creds`) —
+/// and every one of them is non-reentrant. Compound sequences take their domain's
+/// lock themselves, so their guards, anchors and rollback see one unbroken view,
+/// and must NOT call a mutating runner of THAT domain from inside the hold: use the
+/// lock-free runners (`run_git`, `run_git_raw`, the `_input` pair,
 /// `remote::run_git_with_creds_once`), accepting the loss of the retry above.
-/// Either way the lock serializes callers in THIS process: a separate MCP-server
-/// process has its own and is not covered.
+/// Crossing domains is allowed in ONE direction: a working-tree hold may take the
+/// network lock (a pull is a transfer plus a merge), never the reverse, which is
+/// what keeps the wait graph acyclic. Either way the locks serialize callers in
+/// THIS process: a separate MCP-server process has its own and is not covered.
 pub async fn run_git_mutating(
     state: &AppState,
     repo_path: &str,
@@ -431,8 +564,13 @@ pub async fn run_git_mutating_raw(
     args: &[&str],
     timeout: Duration,
 ) -> AppResult<GitOutput> {
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo_path).await;
+    let _guard = acquire_repo_lock(
+        &domain,
+        LOCK_WAIT_TIMEOUT,
+        holder_label(subcommand_of(args)),
+    )
+    .await?;
     let out = run_git_raw(Some(repo_path), args, timeout).await?;
     if out.code != 0 && out.stderr.contains("index.lock") {
         tokio::time::sleep(Duration::from_millis(300)).await;
@@ -449,14 +587,160 @@ pub async fn run_git_mutating_input(
     input: Option<&str>,
     timeout: Duration,
 ) -> AppResult<GitOutput> {
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(repo_path).await;
+    let _guard = acquire_repo_lock(
+        &domain,
+        LOCK_WAIT_TIMEOUT,
+        holder_label(subcommand_of(args)),
+    )
+    .await?;
     match run_git_input(Some(repo_path), args, input, timeout).await {
         Err(AppError::Git { ref stderr, .. }) if stderr.contains("index.lock") => {
             tokio::time::sleep(Duration::from_millis(300)).await;
             run_git_input(Some(repo_path), args, input, timeout).await
         }
         other => other,
+    }
+}
+
+/// Runs a `git worktree …` admin command under the repo's WORKTREE-ADMIN lock —
+/// the domain that keeps a multi-minute removal from stalling staging, commits and
+/// the worktree list. Same bounded wait and [`AppError::Busy`] contract as
+/// [`run_git_mutating`]; no index.lock retry, since these commands touch the admin
+/// registry rather than the index.
+pub(crate) async fn run_git_worktree_admin(
+    state: &AppState,
+    repo_path: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> AppResult<GitOutput> {
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a worktree operation").await?;
+    run_git(Some(repo_path), args, timeout).await
+}
+
+#[cfg(test)]
+mod lock_tests {
+    use super::*;
+
+    /// A zero budget is the deterministic seam for both verdicts: it resolves for a
+    /// FREE lock (timeout polls its inner future first) and expires immediately for
+    /// a held one, so neither arm rests on scheduling.
+    #[tokio::test]
+    async fn a_bounded_acquire_names_the_current_holder() {
+        let state = AppState::default();
+        let domain = state.worktree_admin_lock("C:/repos/busy").await;
+
+        let held = acquire_repo_lock(&domain, Duration::ZERO, "a worktree removal")
+            .await
+            .expect("a free lock is taken at a zero budget");
+
+        let err = acquire_repo_lock(&domain, Duration::ZERO, "a commit")
+            .await
+            .expect_err("a held lock refuses rather than queueing");
+        let AppError::Busy { holder } = &err else {
+            panic!("expected Busy, got {err:?}");
+        };
+        assert_eq!(holder, "a worktree removal");
+        assert_eq!(
+            err.to_string(),
+            "A worktree removal is still running — try again when it finishes."
+        );
+
+        // Released ⇒ free again, and the stale label is gone with it.
+        drop(held);
+        assert_eq!(domain.holder_label(), None);
+        acquire_repo_lock(&domain, Duration::ZERO, "a commit")
+            .await
+            .expect("the released lock is taken immediately");
+    }
+
+    /// An unlabeled holder still has to produce a sentence, so the waiter never
+    /// reads a headless one.
+    #[tokio::test]
+    async fn an_unlabeled_holder_falls_back_to_the_generic_name() {
+        let state = AppState::default();
+        let domain = state.working_tree_lock("C:/repos/unlabeled").await;
+        let raw = domain.lock();
+        let _held = raw.lock().await;
+
+        let err = acquire_repo_lock(&domain, Duration::ZERO, "a commit")
+            .await
+            .expect_err("the raw hold still blocks");
+        assert!(
+            matches!(&err, AppError::Busy { holder } if holder == DEFAULT_HOLDER),
+            "{err:?}"
+        );
+    }
+
+    /// The domains are independent by construction: a removal holding ADMIN must
+    /// not delay a commit, which is the whole point of the split.
+    #[tokio::test]
+    async fn the_three_domains_do_not_block_each_other() {
+        let state = AppState::default();
+        let repo = "C:/repos/domains";
+        let _admin = acquire_repo_lock(
+            &state.worktree_admin_lock(repo).await,
+            Duration::ZERO,
+            "a worktree removal",
+        )
+        .await
+        .expect("admin is free");
+
+        for domain in [
+            state.working_tree_lock(repo).await,
+            state.network_lock(repo).await,
+        ] {
+            acquire_repo_lock(&domain, Duration::ZERO, "a commit")
+                .await
+                .expect("another domain is unaffected by the admin hold");
+        }
+    }
+
+    /// Every accessor call for one repo path hands back the SAME mutex, and a
+    /// different path a different one. The whole scheme rests on this: a registry
+    /// that minted a fresh domain per call would serialize nothing while every
+    /// acquire still succeeded, and one that ignored the path would serialize every
+    /// repo against every other.
+    #[tokio::test]
+    async fn one_repo_path_shares_one_working_tree_mutex() {
+        let state = AppState::default();
+        let repo = "C:/repos/same-mutex";
+        let _held = state.working_tree_lock(repo).await.lock().lock_owned().await;
+
+        assert!(
+            state
+                .working_tree_lock(repo)
+                .await
+                .lock()
+                .try_lock()
+                .is_err(),
+            "a second lookup of the same path must find the held mutex"
+        );
+        assert!(
+            state
+                .working_tree_lock("C:/repos/other")
+                .await
+                .lock()
+                .try_lock()
+                .is_ok(),
+            "another repo path must be an independent mutex"
+        );
+    }
+
+    /// The label a waiter reads comes from the argv, and a leading `-c` pair must
+    /// not hide the subcommand behind it.
+    #[test]
+    fn the_holder_label_reads_past_leading_config_pairs() {
+        assert_eq!(subcommand_of(&["commit", "-m", "x"]), "commit");
+        assert_eq!(
+            subcommand_of(&["-c", "core.editor=true", "rebase", "--continue"]),
+            "rebase"
+        );
+        assert_eq!(subcommand_of(&["-c", "a=b", "-c", "c=d", "push"]), "push");
+        assert_eq!(subcommand_of(&[]), "");
+        assert_eq!(holder_label("cherry-pick"), "a cherry-pick");
+        assert_eq!(holder_label("bisect"), DEFAULT_HOLDER);
     }
 }
 

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -129,6 +129,8 @@ pub(crate) fn holder_label(subcommand: &str) -> &'static str {
         "pull" => "a pull",
         "push" => "a push",
         "fetch" => "a fetch",
+        // `remote set-head --auto` — a real network call holding the network domain.
+        "remote" => "a remote change",
         _ => DEFAULT_HOLDER,
     }
 }

--- a/src-tauri/src/git/submodule.rs
+++ b/src-tauri/src/git/submodule.rs
@@ -5,7 +5,8 @@ use tauri::State;
 
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
+    acquire_repo_lock, run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{Submodule, SubmoduleRemoveOutcome};
 use crate::state::AppState;
@@ -235,10 +236,12 @@ pub(crate) async fn git_submodule_update_core(
     // nested submodules to their own remote tips (measured, git 2.51.1). Only the
     // targeted level should follow its branch, so bump it un-recursively and then
     // settle its children on what it now records — two commands, one lock. Both are
-    // network steps, so the lock is deliberately held for minutes: the pair has to
-    // see one unbroken view, and blocking other mutations meanwhile is the point.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    // network steps, so the working-tree lock is deliberately held for minutes: the
+    // pair has to see one unbroken view, and blocking other mutations meanwhile is
+    // the point. Labelled because of that duration — a waiter that gives up has to be
+    // told it is queued behind a submodule update rather than left guessing.
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a submodule update").await?;
     crate::git::ops::refuse_mid_op_for(&repo_path, "update submodules").await?;
 
     let mut args = vec!["submodule", "update", "--init", "--remote"];
@@ -321,11 +324,11 @@ pub(crate) async fn git_submodule_add_core(
 
     // Lock-once rather than `run_git_mutating`, so the `.gitmodules` guard cannot be
     // raced by another in-process mutation between check and run — the same shape the
-    // other three `.gitmodules` writers use. The costs are deliberate: the lock is held
-    // across the clone, and the lock-free runner gives up `run_git_mutating`'s one-shot
-    // index.lock retry.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    // other three `.gitmodules` writers use. The costs are deliberate: the working-tree
+    // lock is held across the clone, and the lock-free runner gives up
+    // `run_git_mutating`'s one-shot index.lock retry.
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a submodule change").await?;
     crate::git::ops::refuse_mid_op_for(&repo_path, "add a submodule").await?;
     refuse_unsettled_gitmodules(&repo_path).await?;
     run_git(Some(&repo_path), &args, NETWORK_TIMEOUT).await?;
@@ -358,11 +361,11 @@ pub(crate) async fn git_submodule_remove_core(
     validate_repo_relative(&path, "submodule path")?;
     let spec = crate::git::pathspec::literal(&path);
 
-    // deinit → rm → module-data delete is one sequence: hold the per-repo lock
+    // deinit → rm → module-data delete is one sequence: hold the working-tree lock
     // across it and use the lock-free runners inside — `run_git_mutating` would
     // re-acquire the same non-reentrant mutex and deadlock.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a submodule change").await?;
     crate::git::ops::refuse_mid_op_for(&repo_path, "remove the submodule").await?;
     refuse_unsettled_gitmodules(&repo_path).await?;
 
@@ -501,8 +504,8 @@ pub(crate) async fn git_submodule_set_url_core(
     validate_option_value(&url, "submodule URL")?;
 
     // set-url + stage is one sequence — lock once, lock-free runners inside.
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a submodule change").await?;
     crate::git::ops::refuse_mid_op_for(&repo_path, "change the submodule URL").await?;
     refuse_unsettled_gitmodules(&repo_path).await?;
 
@@ -541,8 +544,9 @@ pub(crate) async fn git_submodule_set_branch_core(
         validate_option_value(branch, "submodule branch")?;
     }
 
-    let lock = state.repo_lock(&repo_path).await;
-    let _guard = lock.lock().await;
+    // set-branch + stage, same one-sequence shape as `set_url`.
+    let domain = state.working_tree_lock(&repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a submodule change").await?;
     crate::git::ops::refuse_mid_op_for(&repo_path, "change the submodule branch").await?;
     refuse_unsettled_gitmodules(&repo_path).await?;
 

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -10,7 +10,7 @@ use tauri::{AppHandle, Manager, State};
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
     acquire_repo_lock_unbounded, run_git, run_git_raw, run_git_worktree_admin,
-    try_acquire_repo_lock, DEFAULT_HOLDER, DEFAULT_TIMEOUT, WORKTREE_OP_TIMEOUT,
+    try_acquire_repo_lock, DEFAULT_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::state::AppState;
 
@@ -482,7 +482,7 @@ pub(crate) async fn remove_worktree(
     // server) anyway. An unreadable tip counts as absent, so the delete is skipped.
     let branch = branch.as_deref().filter(|b| !b.is_empty());
     let expected_tip = match branch {
-        Some(b) => branch_tip(repo_path, b).await,
+        Some(b) => validated_branch_tip(repo_path, b).await,
         None => None,
     };
 
@@ -541,7 +541,7 @@ pub(crate) async fn remove_worktree(
 /// would compare a tag's tip against a branch delete. The name is IPC-supplied and
 /// validated here, so an invalid name skips the whole delete rather than reaching
 /// this template or the `branch -D` argv downstream.
-async fn branch_tip(repo_path: &str, branch: &str) -> Option<String> {
+async fn validated_branch_tip(repo_path: &str, branch: &str) -> Option<String> {
     crate::git::branches::validate_ref_name(branch).ok()?;
     let out = run_git_raw(
         Some(repo_path),
@@ -565,7 +565,7 @@ async fn branch_tip(repo_path: &str, branch: &str) -> Option<String> {
 /// A moved or unreadable tip skips silently; the delete stays best-effort, since a
 /// refusal must never turn a completed removal into a reported failure.
 async fn delete_branch_if_unmoved(repo_path: &str, branch: &str, expected_tip: &str) {
-    if branch_tip(repo_path, branch).await.as_deref() != Some(expected_tip) {
+    if validated_branch_tip(repo_path, branch).await.as_deref() != Some(expected_tip) {
         return;
     }
     let _ = run_git(Some(repo_path), &["branch", "-D", branch], DEFAULT_TIMEOUT).await;
@@ -605,7 +605,7 @@ pub(crate) async fn worktree_commit_all(
     // The WORKTREE's own working-tree domain, and unbounded: a session turn is
     // background work that has to queue rather than fail the turn.
     let domain = state.working_tree_lock(worktree_path).await;
-    let _guard = acquire_repo_lock_unbounded(&domain, DEFAULT_HOLDER).await;
+    let _guard = acquire_repo_lock_unbounded(&domain, "an agent session commit").await;
 
     let status = run_git(
         Some(worktree_path),
@@ -659,7 +659,7 @@ pub async fn git_worktree_squash(
     // into the squash. Lock-free runners only while held (see `run_git_mutating`).
     // Unbounded for the same reason as `worktree_commit_all`.
     let domain = state.working_tree_lock(&worktree_path).await;
-    let _guard = acquire_repo_lock_unbounded(&domain, DEFAULT_HOLDER).await;
+    let _guard = acquire_repo_lock_unbounded(&domain, "a session squash").await;
 
     let head = run_git(
         Some(&worktree_path),
@@ -1601,7 +1601,7 @@ prunable gitdir file points to non-existent location
         let repo_dir = base.path().join("repo");
         run(&repo_s, &["branch", "unmoved"]).await;
         run(&repo_s, &["branch", "moved"]).await;
-        let tip = branch_tip(&repo_s, "moved")
+        let tip = validated_branch_tip(&repo_s, "moved")
             .await
             .expect("a fresh branch has a tip");
 
@@ -1621,7 +1621,7 @@ prunable gitdir file points to non-existent location
             "a branch that moved since the snapshot must survive"
         );
 
-        let unmoved_tip = branch_tip(&repo_s, "unmoved").await.unwrap();
+        let unmoved_tip = validated_branch_tip(&repo_s, "unmoved").await.unwrap();
         delete_branch_if_unmoved(&repo_s, "unmoved", &unmoved_tip).await;
         assert!(
             run(&repo_s, &["branch", "--list", "unmoved"])
@@ -1643,7 +1643,7 @@ prunable gitdir file points to non-existent location
         let wt = base.path().join("live-wt");
         let wt_s = wt.to_string_lossy().into_owned();
         run(&repo_s, &["worktree", "add", "-b", "feat-live", &wt_s, "HEAD"]).await;
-        let tip = branch_tip(&repo_s, "feat-live").await.unwrap();
+        let tip = validated_branch_tip(&repo_s, "feat-live").await.unwrap();
 
         delete_branch_if_unmoved(&repo_s, "feat-live", &tip).await;
         assert!(

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -538,8 +538,11 @@ pub(crate) async fn remove_worktree(
 /// the read fails — callers treat both as "don't touch it".
 ///
 /// Fully qualified: bare `rev-parse <name>` resolves a same-named TAG first, which
-/// would compare a tag's tip against a branch delete.
+/// would compare a tag's tip against a branch delete. The name is IPC-supplied and
+/// validated here, so an invalid name skips the whole delete rather than reaching
+/// this template or the `branch -D` argv downstream.
 async fn branch_tip(repo_path: &str, branch: &str) -> Option<String> {
+    crate::git::branches::validate_ref_name(branch).ok()?;
     let out = run_git_raw(
         Some(repo_path),
         &[

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -9,7 +9,8 @@ use tauri::{AppHandle, Manager, State};
 
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
-    run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, WORKTREE_OP_TIMEOUT,
+    acquire_repo_lock_unbounded, run_git, run_git_raw, run_git_worktree_admin,
+    try_acquire_repo_lock, DEFAULT_HOLDER, DEFAULT_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::state::AppState;
 
@@ -114,7 +115,7 @@ pub async fn git_worktree_create(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .unwrap_or("HEAD");
-    run_git_mutating(
+    run_git_worktree_admin(
         &state,
         &repo_path,
         &["worktree", "add", "-b", &branch, &path_str, base],
@@ -145,20 +146,35 @@ pub async fn git_worktree_list(repo_path: String) -> AppResult<Vec<WorktreeInfo>
     Ok(parse_worktree_list(&out.stdout_lossy()))
 }
 
+/// Prunes stale worktree admin entries ONLY IF the admin domain is free right now.
+/// Contended means an admin op (a removal) is in flight, and this prune is
+/// skippable: its result is discarded either way, a removal runs its own prune when
+/// it ends, and queueing would stall the list read behind a multi-minute hold.
+/// `true` when the prune ran.
+pub(crate) async fn prune_worktrees_if_free(state: &AppState, repo_path: &str) -> bool {
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let Some(_guard) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+        return false;
+    };
+    let _ = run_git(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    true
+}
+
 /// Lists the repo's **user** worktrees for the worktree manager — every checkout
 /// except the app-internal agent-session ones; the main worktree is always first
-/// and undeletable. Prunes first so stale admin entries (directory deleted
-/// out-of-band) self-heal — such an entry also holds a branch lock, and it's
-/// filtered from the list, so the manager could never clear it otherwise. Git never
-/// prunes a *locked* worktree, so one on a temporarily-disconnected drive is safe if
-/// the user locked it.
+/// and undeletable. Prunes first (when nothing else is doing admin work) so stale
+/// admin entries (directory deleted out-of-band) self-heal — such an entry also
+/// holds a branch lock, and it's filtered from the list, so the manager could never
+/// clear it otherwise. Git never prunes a *locked* worktree, so one on a
+/// temporarily-disconnected drive is safe if the user locked it. The list read
+/// itself is lock-free, so it still answers while a removal runs.
 #[tauri::command]
 pub async fn git_worktree_list_user(
     app: AppHandle,
     state: State<'_, AppState>,
     repo_path: String,
 ) -> AppResult<Vec<UserWorktree>> {
-    let _ = run_git_mutating(&state, &repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    prune_worktrees_if_free(&state, &repo_path).await;
     let out = run_git(
         Some(&repo_path),
         &["worktree", "list", "--porcelain"],
@@ -250,7 +266,7 @@ pub async fn git_worktree_add_user(
     } else {
         args.extend_from_slice(&[path, branch]);
     }
-    run_git_mutating(&state, &repo_path, &args, WORKTREE_OP_TIMEOUT).await?;
+    run_git_worktree_admin(&state, &repo_path, &args, WORKTREE_OP_TIMEOUT).await?;
     Ok(())
 }
 
@@ -285,7 +301,7 @@ pub async fn git_worktree_move(
             "{to} already exists — choose a new name"
         )));
     }
-    run_git_mutating(
+    run_git_worktree_admin(
         &state,
         &repo_path,
         &["worktree", "move", from, to],
@@ -326,7 +342,7 @@ pub async fn git_worktree_lock(
         args.push(r);
     }
     args.push(path);
-    run_git_mutating(&state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
+    run_git_worktree_admin(&state, &repo_path, &args, DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -348,7 +364,7 @@ pub async fn git_worktree_unlock(
             "path must not start with '-'".into(),
         ));
     }
-    run_git_mutating(
+    run_git_worktree_admin(
         &state,
         &repo_path,
         &["worktree", "unlock", path],
@@ -368,7 +384,7 @@ pub async fn git_worktree_repair(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> AppResult<()> {
-    run_git_mutating(
+    run_git_worktree_admin(
         &state,
         &repo_path,
         &["worktree", "repair"],
@@ -451,13 +467,24 @@ pub(crate) async fn remove_worktree(
     }
     args.push(path);
 
-    // One hold across remove → prune → `branch -D`: the delete is decided from state
-    // observed before the removal, so a concurrent checkout or commit in between would
-    // be destroyed by a `-D` that no longer reflects the repo. The `remove_dir_all`
-    // fallback stays under it — releasing around it reopens that window. Lock-free
-    // runners only while held (see `run_git_mutating`).
-    let lock = state.repo_lock(repo_path).await;
-    let _guard = lock.lock().await;
+    // The WORKTREE-ADMIN domain only, and unbounded: this hold spans a whole
+    // checkout's deletion (minutes on a large tree), so taking the working-tree lock
+    // with it would stall staging and committing for the duration — the bug the
+    // delete dialog's "you can close this and keep working" promise depends on.
+    // Nothing may error out of the wait: the removal IS the long operation.
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let _guard = acquire_repo_lock_unbounded(&domain, "a worktree removal").await;
+
+    // The branch delete is decided from the tip observed BEFORE the removal instead
+    // of from a working-tree hold: git itself refuses to delete a branch checked out
+    // in any worktree, and the equality check below covers the commit race the old
+    // whole-repo hold closed — a hold that never reached another process (the MCP
+    // server) anyway. An unreadable tip counts as absent, so the delete is skipped.
+    let branch = branch.as_deref().filter(|b| !b.is_empty());
+    let expected_tip = match branch {
+        Some(b) => branch_tip(repo_path, b).await,
+        None => None,
+    };
 
     // `git worktree remove` deletes the directory itself, but its recursive delete
     // mishandles Windows reparse points: a worktree with pnpm-installed deps
@@ -501,17 +528,51 @@ pub(crate) async fn remove_worktree(
     }
     // The branch can only be deleted once it's no longer checked out (i.e. after
     // the worktree is gone). Best-effort: a failure here shouldn't fail removal.
-    if let Some(branch) = branch.as_deref().filter(|b| !b.is_empty()) {
-        let _ = run_git(Some(repo_path), &["branch", "-D", branch], DEFAULT_TIMEOUT).await;
+    if let (Some(branch), Some(expected_tip)) = (branch, expected_tip.as_deref()) {
+        delete_branch_if_unmoved(repo_path, branch, expected_tip).await;
     }
     Ok(())
+}
+
+/// The commit `refs/heads/<branch>` points at. `None` when the branch is gone or
+/// the read fails — callers treat both as "don't touch it".
+///
+/// Fully qualified: bare `rev-parse <name>` resolves a same-named TAG first, which
+/// would compare a tag's tip against a branch delete.
+async fn branch_tip(repo_path: &str, branch: &str) -> Option<String> {
+    let out = run_git_raw(
+        Some(repo_path),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .ok()?;
+    (out.code == 0)
+        .then(|| out.stdout_lossy().trim().to_string())
+        .filter(|tip| !tip.is_empty())
+}
+
+/// Deletes `branch` ONLY IF its tip is still `expected_tip` — a commit that landed
+/// on it since would otherwise be discarded by a `-D` decided before it existed.
+/// A moved or unreadable tip skips silently; the delete stays best-effort, since a
+/// refusal must never turn a completed removal into a reported failure.
+async fn delete_branch_if_unmoved(repo_path: &str, branch: &str, expected_tip: &str) {
+    if branch_tip(repo_path, branch).await.as_deref() != Some(expected_tip) {
+        return;
+    }
+    let _ = run_git(Some(repo_path), &["branch", "-D", branch], DEFAULT_TIMEOUT).await;
 }
 
 /// Prunes stale worktree admin entries (a worktree whose directory was deleted
 /// out from under git, e.g. by an app crash). Safe to run on startup.
 #[tauri::command]
 pub async fn git_worktree_prune(state: State<'_, AppState>, repo_path: String) -> AppResult<()> {
-    run_git_mutating(&state, &repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await?;
+    run_git_worktree_admin(&state, &repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
 
@@ -538,8 +599,10 @@ pub(crate) async fn worktree_commit_all(
     // concurrent write lands between the check and `add -A` (sweeping files this
     // commit never meant to carry), and the HEAD read can report someone else's commit
     // as this one's. Lock-free runners only while held (see `run_git_mutating`).
-    let lock = state.repo_lock(worktree_path).await;
-    let _guard = lock.lock().await;
+    // The WORKTREE's own working-tree domain, and unbounded: a session turn is
+    // background work that has to queue rather than fail the turn.
+    let domain = state.working_tree_lock(worktree_path).await;
+    let _guard = acquire_repo_lock_unbounded(&domain, DEFAULT_HOLDER).await;
 
     let status = run_git(
         Some(worktree_path),
@@ -591,8 +654,9 @@ pub async fn git_worktree_squash(
     // commit the branch sits rewound with every turn's changes staged, so a concurrent
     // commit or discard there either loses the session's work or folds foreign changes
     // into the squash. Lock-free runners only while held (see `run_git_mutating`).
-    let lock = state.repo_lock(&worktree_path).await;
-    let _guard = lock.lock().await;
+    // Unbounded for the same reason as `worktree_commit_all`.
+    let domain = state.working_tree_lock(&worktree_path).await;
+    let _guard = acquire_repo_lock_unbounded(&domain, DEFAULT_HOLDER).await;
 
     let head = run_git(
         Some(&worktree_path),
@@ -639,8 +703,9 @@ pub async fn git_worktree_resume(
     path: String,
     branch: String,
 ) -> AppResult<()> {
-    let _ = run_git_mutating(&state, &repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
-    run_git_mutating(
+    let _ =
+        run_git_worktree_admin(&state, &repo_path, &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    run_git_worktree_admin(
         &state,
         &repo_path,
         &["worktree", "add", &path, &branch],
@@ -808,6 +873,9 @@ fn parse_worktree_list(porcelain: &str) -> Vec<WorktreeInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The module itself no longer calls the working-tree runner — the interleave
+    // tests below drive it as an ordinary caller would.
+    use crate::git::runner::run_git_mutating;
 
     #[test]
     fn repo_hash_is_stable_and_case_insensitive() {
@@ -1392,18 +1460,22 @@ prunable gitdir file points to non-existent location
             let state = state.clone();
             let repo = repo_s.clone();
             tokio::spawn(async move {
-                let lock = state.repo_lock(&repo).await;
+                let domain = state.working_tree_lock(&repo).await;
                 // Bounded wait: if the turn somehow finished first we still commit,
                 // and the assertions below stay meaningful either way.
                 for _ in 0..500 {
-                    if lock.try_lock().is_err() {
+                    if domain.lock().try_lock().is_err() {
                         break;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(2)).await;
                 }
-                run_git_mutating(
-                    &state,
-                    &repo,
+                // The same queue an ordinary mutating caller joins, minus the wait
+                // bound: this test pins the turn's ATOMICITY, so a turn that outran
+                // `LOCK_WAIT_TIMEOUT` on a loaded runner must not turn it into a Busy
+                // failure. Lock-free runner, since the hold is ours.
+                let _guard = acquire_repo_lock_unbounded(&domain, "a commit").await;
+                run_git(
+                    Some(&repo),
                     &["commit", "--allow-empty", "-m", "concurrent"],
                     DEFAULT_TIMEOUT,
                 )
@@ -1428,5 +1500,155 @@ prunable gitdir file points to non-existent location
         // And the turn's own output rode along in the turn's commit, not a later one.
         let files = run(&repo_s, &["show", "--name-only", "--format=", &hash]).await;
         assert!(files.contains("agent.txt"), "turn's output missing: {files}");
+    }
+
+    /// The bug this split fixes: while a removal holds the worktree-admin lock, a
+    /// commit must run to completion rather than queue behind it. Deterministic —
+    /// the admin lock is held outright for the whole call, no timing bet.
+    #[tokio::test]
+    async fn staging_runs_while_a_worktree_removal_holds_the_admin_lock() {
+        let (_base, repo_s) = setup_repo("admin-vs-commit").await;
+        let state = AppState::default();
+        let _admin = acquire_repo_lock_unbounded(
+            &state.worktree_admin_lock(&repo_s).await,
+            "a worktree removal",
+        )
+        .await;
+
+        run_git_mutating(
+            &state,
+            &repo_s,
+            &["commit", "--allow-empty", "-m", "during removal"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .expect("a commit must not wait on the worktree-admin domain");
+        assert!(run(&repo_s, &["log", "--format=%s"])
+            .await
+            .contains("during removal"));
+    }
+
+    /// The inverse direction, and the one the owner hit from the other side: a
+    /// removal must not wait on whatever holds the working tree.
+    #[tokio::test]
+    async fn a_worktree_removal_runs_while_the_working_tree_lock_is_held() {
+        let (base, repo_s) = setup_repo("commit-vs-removal").await;
+        let wt = base.path().join("busy-wt");
+        let wt_s = wt.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "-b", "feat-busy", &wt_s, "HEAD"]).await;
+
+        let state = AppState::default();
+        let working_tree = state.working_tree_lock(&repo_s).await;
+        let _held = working_tree.lock().lock_owned().await;
+
+        remove_worktree(&state, &repo_s, &wt_s, Some("feat-busy".into()), false)
+            .await
+            .expect("a removal must not wait on the working-tree domain");
+        assert!(!wt.exists(), "the checkout is gone");
+        assert!(
+            run(&repo_s, &["branch", "--list", "feat-busy"])
+                .await
+                .trim()
+                .is_empty(),
+            "and its branch went with it"
+        );
+    }
+
+    /// The opportunistic prune SKIPS rather than queues while an admin op runs, so
+    /// the worktree list still answers during a removal. The stale entry surviving
+    /// the contended call is what proves it was skipped and not merely slow.
+    #[tokio::test]
+    async fn the_opportunistic_prune_is_skipped_while_admin_work_runs() {
+        let (base, repo_s) = setup_repo("prune-if-free").await;
+        let wt = base.path().join("stale-wt");
+        let wt_s = wt.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "-b", "feat-stale", &wt_s, "HEAD"]).await;
+        std::fs::remove_dir_all(&wt).expect("drop the checkout behind git's back");
+
+        let state = AppState::default();
+        let contended = {
+            let _admin = acquire_repo_lock_unbounded(
+                &state.worktree_admin_lock(&repo_s).await,
+                "a worktree removal",
+            )
+            .await;
+            prune_worktrees_if_free(&state, &repo_s).await
+        };
+        assert!(!contended, "a held admin lock skips the prune");
+        assert!(
+            registry(&repo_s).await.contains("/stale-wt"),
+            "the stale entry survives a skipped prune"
+        );
+
+        assert!(
+            prune_worktrees_if_free(&state, &repo_s).await,
+            "a free admin lock runs it"
+        );
+        assert!(
+            !registry(&repo_s).await.contains("/stale-wt"),
+            "and the stale entry is gone"
+        );
+    }
+
+    /// The branch delete is now gated on the tip, not on a whole-repo hold: an
+    /// unmoved branch goes, one that gained a commit since stays.
+    #[tokio::test]
+    async fn delete_branch_if_unmoved_spares_a_branch_that_moved() {
+        let (base, repo_s) = setup_repo("tip-gate").await;
+        let repo_dir = base.path().join("repo");
+        run(&repo_s, &["branch", "unmoved"]).await;
+        run(&repo_s, &["branch", "moved"]).await;
+        let tip = branch_tip(&repo_s, "moved")
+            .await
+            .expect("a fresh branch has a tip");
+
+        // The branch gains a commit after the tip was recorded.
+        run(&repo_s, &["switch", "-q", "moved"]).await;
+        std::fs::write(repo_dir.join("later.txt"), "later\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "landed after the snapshot"]).await;
+        run(&repo_s, &["switch", "-q", "-"]).await;
+
+        delete_branch_if_unmoved(&repo_s, "moved", &tip).await;
+        assert!(
+            !run(&repo_s, &["branch", "--list", "moved"])
+                .await
+                .trim()
+                .is_empty(),
+            "a branch that moved since the snapshot must survive"
+        );
+
+        let unmoved_tip = branch_tip(&repo_s, "unmoved").await.unwrap();
+        delete_branch_if_unmoved(&repo_s, "unmoved", &unmoved_tip).await;
+        assert!(
+            run(&repo_s, &["branch", "--list", "unmoved"])
+                .await
+                .trim()
+                .is_empty(),
+            "an unmoved branch is deleted"
+        );
+
+        // A branch that never existed is a no-op, not a panic.
+        delete_branch_if_unmoved(&repo_s, "never-existed", &unmoved_tip).await;
+    }
+
+    /// git's own refusal is the third guard: a branch still checked out in a
+    /// worktree survives even at its recorded tip.
+    #[tokio::test]
+    async fn delete_branch_if_unmoved_defers_to_gits_checkout_refusal() {
+        let (base, repo_s) = setup_repo("tip-gate-checked-out").await;
+        let wt = base.path().join("live-wt");
+        let wt_s = wt.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "-b", "feat-live", &wt_s, "HEAD"]).await;
+        let tip = branch_tip(&repo_s, "feat-live").await.unwrap();
+
+        delete_branch_if_unmoved(&repo_s, "feat-live", &tip).await;
+        assert!(
+            !run(&repo_s, &["branch", "--list", "feat-live"])
+                .await
+                .trim()
+                .is_empty(),
+            "git refuses to delete a branch checked out in a worktree"
+        );
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -45,8 +45,46 @@ impl CancelEntry {
     }
 }
 
+/// The label of whatever currently holds a domain's lock, readable WITHOUT holding
+/// it — a waiter that times out reads this to name the operation it lost to. A
+/// blocking mutex because every critical section is one `Option` read or write.
+pub(crate) type HolderSlot = Arc<SyncMutex<Option<&'static str>>>;
+
+/// One lock domain for one repo path: the mutex plus its holder label. Cloning
+/// hands out the same two `Arc`s, so every caller shares one domain.
+#[derive(Clone, Default)]
+pub struct LockDomain {
+    lock: Arc<Mutex<()>>,
+    holder: HolderSlot,
+}
+
+impl LockDomain {
+    pub(crate) fn lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.lock)
+    }
+
+    pub(crate) fn holder_slot(&self) -> HolderSlot {
+        Arc::clone(&self.holder)
+    }
+
+    /// What holds this domain right now, or `None` when it is free (or held by an
+    /// unlabeled acquisition).
+    pub(crate) fn holder_label(&self) -> Option<&'static str> {
+        *self.holder.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// The three independent lock domains of one repo path. They are separate mutexes
+/// precisely so a multi-minute worktree removal can't stall staging or a commit.
+#[derive(Clone, Default)]
+struct RepoDomains {
+    working_tree: LockDomain,
+    worktree_admin: LockDomain,
+    network: LockDomain,
+}
+
 pub struct AppState {
-    repo_locks: Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
+    repo_domains: Mutex<HashMap<PathBuf, RepoDomains>>,
     pub git_info: OnceCell<GitInfo>,
     /// In-flight agent-CLI reviews and sessions keyed by a frontend-supplied id, so a
     /// separate cancel command can signal the streaming run to stop. A blocking mutex:
@@ -63,7 +101,7 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            repo_locks: Mutex::new(HashMap::new()),
+            repo_domains: Mutex::new(HashMap::new()),
             git_info: OnceCell::new(),
             agent_cancels: Arc::new(SyncMutex::new(HashMap::new())),
             close_to_tray: AtomicBool::new(true),
@@ -72,13 +110,39 @@ impl Default for AppState {
 }
 
 impl AppState {
-    /// Per-repo lock serializing mutating git operations so concurrent
-    /// invocations don't fight over .git/index.lock.
-    pub async fn repo_lock(&self, repo_path: &str) -> Arc<Mutex<()>> {
-        let mut map = self.repo_locks.lock().await;
-        map.entry(PathBuf::from(repo_path))
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
+    /// The three domains for `repo_path`, created on first use.
+    async fn domains(&self, repo_path: &str) -> RepoDomains {
+        let mut map = self.repo_domains.lock().await;
+        map.entry(PathBuf::from(repo_path)).or_default().clone()
+    }
+
+    /// The **working-tree** domain: index, HEAD and ref mutations of the checkout
+    /// at `repo_path` — the lock that keeps concurrent git invocations from
+    /// fighting over `.git/index.lock`.
+    ///
+    /// Lock ordering across domains, which keeps the wait graph acyclic: a task may
+    /// take NETWORK while holding WORKING-TREE (a pull is a transfer plus a merge)
+    /// and never the reverse; the ADMIN domain nests with neither, and no task takes
+    /// two locks of one domain.
+    pub(crate) async fn working_tree_lock(&self, repo_path: &str) -> LockDomain {
+        self.domains(repo_path).await.working_tree
+    }
+
+    /// The **worktree-admin** domain: every `git worktree
+    /// add/remove/prune/move/lock/unlock/repair` on the main repo path. Separate
+    /// from the working tree because a removal holds it for minutes while staging
+    /// and committing must keep working. Never nested with another domain (see
+    /// [`working_tree_lock`](Self::working_tree_lock) for the ordering rule).
+    pub(crate) async fn worktree_admin_lock(&self, repo_path: &str) -> LockDomain {
+        self.domains(repo_path).await.worktree_admin
+    }
+
+    /// The **network** domain: fetch, push, set-head and pull transfers, serialized
+    /// so a user pull's fetch can't race the background auto-fetch at the ref level.
+    /// May be taken while holding the working-tree lock, never the reverse (see
+    /// [`working_tree_lock`](Self::working_tree_lock)).
+    pub(crate) async fn network_lock(&self, repo_path: &str) -> LockDomain {
+        self.domains(repo_path).await.network
     }
 
     /// Register (or adopt) the cancellation handle for a run id and return it. The

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -520,13 +520,13 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
   it, collapsing it into an "Archived" section. The branch you're on, the default branch,
-  and a branch checked out in another worktree can't be archived; **Unarchive** has no such
-  limit — it works even on the branch you're checked out on. When creating, the
-  **Base it on** picker is a searchable list grouped into **Local** and **Remote** branches,
-  so you can start from *any* branch — not just the one you're on. Basing on a remote branch
-  (e.g. \`origin/epic/…\`) starts from the remote tip and leaves the new branch with
-  **no upstream**, so its first push publishes it under its own name — pairs with pushing a
-  branch without switching to it (below).
+  and a branch checked out in another worktree can't be archived (unless you're already
+  deleting that worktree); **Unarchive** has no such limit — it works even on the branch
+  you're checked out on. When creating, the **Base it on** picker is a searchable list
+  grouped into **Local** and **Remote** branches, so you can start from *any* branch — not
+  just the one you're on. Basing on a remote branch (e.g. \`origin/epic/…\`) starts from the
+  remote tip and leaves the new branch with **no upstream**, so its first push publishes it
+  under its own name — pairs with pushing a branch without switching to it (below).
 - **Clean up branches** — from the switcher's menu or the command palette — opens a bulk
   sweep of stale branches: those **merged** into the default branch — directly, or, where
   the repository's forge connection can supply them, through a recent pull request, so
@@ -538,7 +538,8 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   name, so it never pre-checks a row on its own — it badges one for you to confirm. Review
   the list, then **archive** them (reversible) or **delete** them together. The current
   branch, the default branch, and branches checked out in another worktree are never
-  included; deleting also skips protected branches.
+  included (archiving still offers one whose worktree you're already deleting); deleting
+  also skips protected branches.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
   or renaming one. Whenever the working tree can't describe the branch being named —
   it's clean, or you're renaming a branch you aren't on — it names it from that
@@ -665,14 +666,16 @@ so the ones you've finished with stand out.
 - **Lock** a worktree (with an optional reason) so it won't be pruned, renamed, or
   removed: renaming needs an unlock first, and deleting asks for a forced confirmation.
   Useful for one on a removable or network drive; **Unlock** to undo.
-- **Delete** a worktree to remove its folder; its branch is kept. A worktree with
-  uncommitted changes, or a locked one, asks before force-removing. Removing a worktree can
-  take a few minutes, and you can close the dialog and carry on: the removal keeps a line at
-  the top of the repository view until it finishes, its row here reads **Removing…**, and
-  the actions held while it runs say *removal in progress*. It runs to completion once
-  started, so there's nothing to cancel. The main worktree, and whichever one you're
-  currently in, can't be renamed or deleted — switch away first. A locked worktree can't be
-  renamed until you unlock it.
+- **Delete** a worktree to remove its folder; its branch is kept. The dialog offers to
+  **archive that branch after the worktree is removed**, so a branch you're finished with
+  drops into the "Archived" section on its own (offered whenever the worktree is on a
+  branch other than the default one). A worktree with uncommitted changes, or a locked
+  one, asks before force-removing. Removing a worktree can take a few minutes, and you can
+  close the dialog and carry on: the removal keeps a line at the top of the repository view
+  until it finishes, its row here reads **Removing…**, and the actions held while it runs
+  say *removal in progress*. It runs to completion once started, so there's nothing to
+  cancel. The main worktree, and whichever one you're currently in, can't be renamed or
+  deleted — switch away first. A locked worktree can't be renamed until you unlock it.
 - **Promote to main workspace** brings a worktree's branch into your main checkout: it
   removes the worktree (a branch can't be checked out in two at once) and checks that branch
   out in the main workspace. The worktree must be clean first; any uncommitted work in the

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1416,10 +1416,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // flight — the map is empty until it lands, which would offer Archive on a
     // branch the answer excludes. A FAILED read falls through to best-effort:
     // no answer is coming, and holding the item forever helps no one.
+    // A branch whose worktree is being removed is the one exception, and it
+    // comes from the removal store rather than the worktree read: that read can
+    // be starved while a removal runs, leaving the guard stuck on "checking".
+    // Promote entries are excluded by `promotePhase`: a promote removes the
+    // worktree to CHECK THAT BRANCH OUT here, so archiving it mid-flight would
+    // land the user on an archived current branch.
     const archiveBlockedReason = (() => {
       if (branch.archived) return null;
       if (branch.isCurrent) return "current branch";
       if (branch.name === defaultName) return "default branch";
+      if (removals.some((r) => r.branch === branch.name && !r.promotePhase))
+        return null;
       if (userWorktrees.data === undefined && !userWorktrees.isError)
         return "checking worktrees…";
       if (inWorktree) return "checked out in another worktree";
@@ -2427,6 +2435,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentBranch={currentName}
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
+        // From the removal store, not the worktree read: that read can be
+        // starved while a removal runs, so the exclusion above would hold a
+        // branch whose worktree is on its way out. A promote's removal
+        // (`promotePhase`) doesn't count — it frees the branch to check it out
+        // here, and archiving it would hide the branch you're about to land on.
+        isWorktreeRemoving={(name) =>
+          removals.some((r) => r.branch === name && !r.promotePhase)
+        }
         // The map is empty until the read lands and stays empty if it fails, so
         // the dialog is told which, and holds its list rather than acting on an
         // exclusion that isn't answering yet.

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1417,11 +1417,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // branch the answer excludes. A FAILED read falls through to best-effort:
     // no answer is coming, and holding the item forever helps no one.
     // A branch whose worktree is being removed is the one exception, and it
-    // comes from the removal store rather than the worktree read: that read can
-    // be starved while a removal runs, leaving the guard stuck on "checking".
-    // Promote entries are excluded by `promotePhase`: a promote removes the
-    // worktree to CHECK THAT BRANCH OUT here, so archiving it mid-flight would
-    // land the user on an archived current branch.
+    // reads the removal store, not the worktree list: git goes on listing a
+    // worktree until its removal finishes, and this query is gated on the menu
+    // or the cleanup dialog being open, so `inWorktree` refuses on an answer
+    // that is either still true or already stale. Promote entries are excluded
+    // by `promotePhase`: a promote removes the worktree to CHECK THAT BRANCH
+    // OUT here, so archiving it mid-flight would hide the branch you land on.
     const archiveBlockedReason = (() => {
       if (branch.archived) return null;
       if (branch.isCurrent) return "current branch";
@@ -2435,11 +2436,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentBranch={currentName}
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
         isInWorktree={(name) => worktreeByBranch.has(name)}
-        // From the removal store, not the worktree read: that read can be
-        // starved while a removal runs, so the exclusion above would hold a
-        // branch whose worktree is on its way out. A promote's removal
-        // (`promotePhase`) doesn't count — it frees the branch to check it out
-        // here, and archiving it would hide the branch you're about to land on.
+        // From the removal store, not the worktree read: `isInWorktree` still
+        // matches a worktree git lists until its removal finishes, and that
+        // read is gated on this menu or the dialog being open, so it can lag —
+        // either way the exclusion holds a branch already on its way out. A
+        // promote's removal (`promotePhase`) doesn't count: it frees the branch
+        // to check it out here, and archiving would hide what you land on.
         isWorktreeRemoving={(name) =>
           removals.some((r) => r.branch === name && !r.promotePhase)
         }

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -255,10 +255,11 @@ export function CleanupBranchesDialog({
    *  unless {@link isWorktreeRemoving} takes it back. */
   isInWorktree: (name: string) => boolean;
   /** True when the worktree holding this branch is already being removed, read
-   *  from the removal store rather than the worktree list (which can be starved
-   *  while a removal runs). Archive takes it back — the branch is on its way out
-   *  of use — while Delete keeps excluding it: git refuses `branch -D` on a
-   *  checked-out branch, and the removal can still fail. */
+   *  from the removal store rather than the worktree list, which goes on listing
+   *  that worktree until the removal finishes. Archive takes it back — the
+   *  branch is on its way out of use — while Delete keeps excluding it: git
+   *  refuses `branch -D` on a checked-out branch, and the removal can still
+   *  fail. */
   isWorktreeRemoving: (name: string) => boolean;
   /** Whether {@link isInWorktree} has an answer yet. An advisory read that would
    *  have refused an action must be held on, never acted around: while this is

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -218,8 +218,9 @@ function RowBadge({
  * past the selected age window** — and lets the user Archive (reversible hide via
  * the `gitdesktopArchived` flag) or Delete (`git branch -D`) the selected set in
  * one pass. The current branch, the default branch, `gd/session/*` branches, and
- * branches checked out in another worktree are never candidates; Archive also
- * skips already-archived branches, and Delete skips rule-protected ones.
+ * branches checked out in another worktree are never candidates — except that
+ * Archive takes back a branch whose worktree is already being removed; Archive
+ * also skips already-archived branches, and Delete skips rule-protected ones.
  *
  * Merged detection has two sources: branch divergence (`ahead === 0`, no extra
  * backend) and the switcher's PR map, which catches the squash and rebase merges
@@ -235,6 +236,7 @@ export function CleanupBranchesDialog({
   currentBranch,
   isProtected,
   isInWorktree,
+  isWorktreeRemoving,
   worktreeCheckState,
   prMergedByBranch,
   prCheckState,
@@ -249,8 +251,15 @@ export function CleanupBranchesDialog({
   /** True when a branch is blocked from deletion by an effective branch rule. */
   isProtected: (name: string) => boolean;
   /** True when a branch is checked out in another worktree — git can't delete it,
-   *  and archiving would hide a branch that's in use, so both modes drop it. */
+   *  and archiving would hide a branch that's in use, so both modes drop it
+   *  unless {@link isWorktreeRemoving} takes it back. */
   isInWorktree: (name: string) => boolean;
+  /** True when the worktree holding this branch is already being removed, read
+   *  from the removal store rather than the worktree list (which can be starved
+   *  while a removal runs). Archive takes it back — the branch is on its way out
+   *  of use — while Delete keeps excluding it: git refuses `branch -D` on a
+   *  checked-out branch, and the removal can still fail. */
+  isWorktreeRemoving: (name: string) => boolean;
   /** Whether {@link isInWorktree} has an answer yet. An advisory read that would
    *  have refused an action must be held on, never acted around: while this is
    *  `"pending"` the predicate is a stand-in that excludes nothing, so the list
@@ -338,13 +347,17 @@ export function CleanupBranchesDialog({
 
   // Mode-specific candidates. Archive hides — drop already-archived branches
   // (a no-op) and ones checked out in another worktree (in use; the row menu
-  // refuses those too). Delete is permanent — drop rule-protected branches
-  // (they'd fail anyway), but keep archived ones (a final sweep may want them).
+  // refuses those too), except where that worktree is already being removed.
+  // Delete is permanent — drop rule-protected branches (they'd fail anyway),
+  // but keep archived ones (a final sweep may want them).
   const candidates = useMemo(() => {
     const list =
       mode === "archive"
         ? stale.filter(
-            (c) => !c.branch.archived && !isInWorktree(c.branch.name),
+            (c) =>
+              !c.branch.archived &&
+              (!isInWorktree(c.branch.name) ||
+                isWorktreeRemoving(c.branch.name)),
           )
         : stale.filter(
             (c) => !isProtected(c.branch.name) && !isInWorktree(c.branch.name),
@@ -354,7 +367,7 @@ export function CleanupBranchesDialog({
       if (a.merged !== b.merged) return a.merged ? -1 : 1;
       return b.ageDays - a.ageDays;
     });
-  }, [stale, mode, isProtected, isInWorktree]);
+  }, [stale, mode, isProtected, isInWorktree, isWorktreeRemoving]);
 
   // Until the worktree read lands, `isInWorktree` excludes nothing, so every
   // candidate below is provisional — the list stays behind the skeleton and the

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -10,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useDefaultBranch } from "@/lib/git/queries";
 import type { UserWorktree } from "@/lib/git/worktree";
 import {
   registerRemovalListener,
@@ -18,6 +20,7 @@ import {
 } from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
 import { useLatestRef } from "@/lib/use-latest-ref";
+import { cn } from "@/lib/utils";
 
 /** Last path segment, tolerating both separators — what to call a detached
  *  worktree that has no branch name. */
@@ -49,6 +52,24 @@ export function DeleteWorktreeDialog({
   const removing = useIsRemovingWorktree(repoPath, worktree?.path);
   // A locked worktree always needs --force; a dirty one reveals it on first try.
   const [forceNeeded, setForceNeeded] = useState(worktree?.isLocked ?? false);
+  const [archiveAfter, setArchiveAfter] = useState(false);
+  // The intent the running removal actually recorded, so a dialog re-opened
+  // over one shows what it will do rather than this mount's fresh `false`.
+  const inFlightArchive = useWorktreeRemovalStore((s) =>
+    Boolean(worktree && s.byRepo[repoPath]?.[worktree.path]?.archiveWhenDone),
+  );
+  // Same query the branch switcher resolves its default branch from, so the two
+  // can't disagree about which branch Archive is refused for. Unresolved (still
+  // loading, or unreadable) leaves the offer up — the store re-checks at
+  // completion time, and that guard is the one that has to hold.
+  const defaultBranch = useDefaultBranch(repoPath);
+  // The branch the archive offer applies to, or null when there is none to
+  // offer: a detached worktree has no branch to put away, and the default
+  // branch is never archivable.
+  const archivableBranch =
+    worktree?.branch && worktree.branch !== defaultBranch.data
+      ? worktree.branch
+      : null;
 
   // Behind a ref because the store invokes these from its own async stack, long
   // after the render that wrote them: what gets registered is a plain object
@@ -88,6 +109,8 @@ export function DeleteWorktreeDialog({
       repoPath,
       path: worktree.path,
       name: worktree.branch || folderName(worktree.path),
+      branch: worktree.branch || null,
+      archiveWhenDone: archiveAfter && Boolean(worktree.branch),
       force,
     });
     if (refused) toast.info(refused);
@@ -112,6 +135,26 @@ export function DeleteWorktreeDialog({
         <p className="truncate rounded bg-muted px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
           {worktree?.path}
         </p>
+
+        {archivableBranch && (
+          <label
+            className={cn(
+              "flex items-start gap-2 text-xs text-muted-foreground",
+              removing ? "cursor-not-allowed opacity-70" : "cursor-pointer",
+            )}
+          >
+            <Checkbox
+              checked={removing ? inFlightArchive : archiveAfter}
+              disabled={removing}
+              onCheckedChange={(checked) => setArchiveAfter(checked === true)}
+            />
+            <span className="min-w-0">
+              Archive{" "}
+              <span className="font-mono break-all">{archivableBranch}</span>{" "}
+              after the worktree is removed
+            </span>
+          </label>
+        )}
 
         {worktree?.isLocked && (
           <p className="text-xs text-warning">

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -50,6 +50,9 @@ export function DeleteWorktreeDialog({
 }) {
   const startRemoval = useWorktreeRemovalStore((s) => s.startRemoval);
   const removing = useIsRemovingWorktree(repoPath, worktree?.path);
+  // Both reset per target only because every mount site keys this dialog by the
+  // target's path (WorktreesDialog, BranchSwitcher); an unkeyed third mount
+  // would carry one worktree's force escalation and archive intent to the next.
   // A locked worktree always needs --force; a dirty one reveals it on first try.
   const [forceNeeded, setForceNeeded] = useState(worktree?.isLocked ?? false);
   const [archiveAfter, setArchiveAfter] = useState(false);

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -20,6 +20,7 @@ const KIND_LABELS: Record<AppError["kind"], string> = {
   git: "Git error",
   conflict: "Merge conflict",
   pullRebaseWouldDrop: "Pull blocked",
+  busy: "Operation in progress",
   notARepo: "Not a Git repository",
   gitNotFound: "Git not found",
   ghNotFound: "GitHub CLI not found",

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -305,14 +305,29 @@ function settleRemoval(repoPath: string, path: string) {
  *  has settled. The removal itself has already succeeded here, so nothing in
  *  this step can turn it back into a failure — a refused archive reports itself
  *  and points at the branch menu, which can still do it. */
+/** The one recovery message for an archive that didn't happen, spelled once so
+ *  the two ways it can be refused can't drift apart. */
+function toastArchiveRefused(branch: string, e: unknown) {
+  toast.error(
+    `Removed the worktree, but couldn't archive ${branch} — you can archive it from the branch menu.`,
+    { description: errorMessage(e) },
+  );
+}
+
 async function archiveAfterRemoval(repoPath: string, branch: string) {
   // Re-resolved at completion time rather than trusted from the dialog: the
   // intent can be minutes old, and archiving the default branch would hide it
-  // from every branch surface. An unreadable default stays best-effort, the
-  // same posture the branch menu's own archive guard takes.
-  const isDefault = await gitDefaultBranch(repoPath)
-    .then((name) => name === branch)
-    .catch(() => false);
+  // from every branch surface. This write fails CLOSED — an unreadable default
+  // skips the archive and says so, because nobody is watching a deferred write
+  // that lands minutes later. The branch menu's guard stays best-effort on the
+  // same lookup: it answers a user who is right there to see the result.
+  let isDefault: boolean;
+  try {
+    isDefault = (await gitDefaultBranch(repoPath)) === branch;
+  } catch (e) {
+    toastArchiveRefused(branch, e);
+    return;
+  }
   if (isDefault) {
     toast.success("Worktree removed");
     toast.info(`Left ${branch} unarchived — it's the default branch.`);
@@ -327,10 +342,7 @@ async function archiveAfterRemoval(repoPath: string, branch: string) {
     });
     toast.success(`Worktree removed and ${branch} archived`);
   } catch (e) {
-    toast.error(
-      `Removed the worktree, but couldn't archive ${branch} — you can archive it from the branch menu.`,
-      { description: errorMessage(e) },
-    );
+    toastArchiveRefused(branch, e);
   }
 }
 

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -301,10 +301,6 @@ function settleRemoval(repoPath: string, path: string) {
   invalidateAfterRemoval(repoPath);
 }
 
-/** Honours the delete dialog's "archive when done" checkbox, once the removal
- *  has settled. The removal itself has already succeeded here, so nothing in
- *  this step can turn it back into a failure — a refused archive reports itself
- *  and points at the branch menu, which can still do it. */
 /** The one recovery message for an archive that didn't happen, spelled once so
  *  the two ways it can be refused can't drift apart. */
 function toastArchiveRefused(branch: string, e: unknown) {
@@ -314,6 +310,10 @@ function toastArchiveRefused(branch: string, e: unknown) {
   );
 }
 
+/** Honours the delete dialog's "archive when done" checkbox, once the removal
+ *  has settled. The removal itself has already succeeded here, so nothing in
+ *  this step can turn it back into a failure — a refused archive reports itself
+ *  and points at the branch menu, which can still do it. */
 async function archiveAfterRemoval(repoPath: string, branch: string) {
   // Re-resolved at completion time rather than trusted from the dialog: the
   // intent can be minutes old, and archiving the default branch would hide it

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,10 +1,17 @@
 import { toast } from "sonner";
 import { create } from "zustand";
-import { gitCheckoutBranch, gitStashAll, validateRepo } from "@/lib/git/api";
+import {
+  gitCheckoutBranch,
+  gitDefaultBranch,
+  gitSetBranchArchived,
+  gitStashAll,
+  validateRepo,
+} from "@/lib/git/api";
 import { normPath } from "@/lib/git/path";
 import { repoKeys, worktreeKey } from "@/lib/git/queries";
 import { pruneWorktrees, removeWorktree } from "@/lib/git/worktree";
 import { queryClient } from "@/lib/query-client";
+import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
 import { useUiStore } from "./ui";
 
@@ -14,6 +21,14 @@ export interface WorktreeRemoval {
   path: string;
   /** What to call it on screen — its branch, or the folder name when detached. */
   name: string;
+  /** The branch checked out in the worktree being removed, null when detached.
+   *  Distinct from {@link WorktreeRemoval.name}, whose folder-name fallback can
+   *  collide with an unrelated branch — match on this one. */
+  branch: string | null;
+  /** Archive {@link WorktreeRemoval.branch} once the removal succeeds. Held in
+   *  memory only: quitting mid-removal drops the intent while the backend
+   *  removal still completes, which is accepted over persisting it. */
+  archiveWhenDone: boolean;
   /** Epoch ms the removal started. */
   startedAt: number;
   /** Which step of a promote this entry is on. Set only by the promote path — a
@@ -46,7 +61,12 @@ interface WorktreeRemovalState {
   startRemoval: (args: {
     repoPath: string;
     path: string;
+    /** Display name; see {@link WorktreeRemoval.name}. */
     name: string;
+    /** The removed worktree's branch; see {@link WorktreeRemoval.branch}. */
+    branch: string | null;
+    /** Archive `branch` when the removal succeeds. */
+    archiveWhenDone: boolean;
     force: boolean;
   }) => string | null;
   /** Starts a promote — remove the worktree to free its branch, then check that
@@ -153,15 +173,22 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
   (_set, get) => ({
     byRepo: {},
 
-    startRemoval: ({ repoPath, path, name, force }) => {
+    startRemoval: ({
+      repoPath,
+      path,
+      name,
+      branch,
+      archiveWhenDone,
+      force,
+    }) => {
       // Matched on the directory, not the string: today's callers all spell it
       // the ui store's way, but the admission rule shouldn't depend on that.
       if (isRemovalInFlight(get().byRepo, repoPath, path))
         return WORKTREE_REMOVING_MESSAGE;
       if (promotingWorktrees.has(normPath(path)))
         return WORKTREE_PROMOTING_MESSAGE;
-      markRemoval(repoPath, path, name);
-      void run(repoPath, path, force);
+      markRemoval({ repoPath, path, name, branch, archiveWhenDone });
+      void run({ repoPath, path, force, branch, archiveWhenDone });
       return null;
     },
 
@@ -185,18 +212,37 @@ export const useWorktreeRemovalStore = create<WorktreeRemovalState>()(
   }),
 );
 
-function markRemoval(
-  repoPath: string,
-  path: string,
-  name: string,
-  promotePhase?: WorktreeRemoval["promotePhase"],
-) {
+/** Named arguments rather than positional: `name` and `branch` are both plain
+ *  strings that usually hold the same value, and a swap at a call site would
+ *  only surface on a detached worktree. */
+function markRemoval({
+  repoPath,
+  path,
+  name,
+  branch,
+  archiveWhenDone,
+  promotePhase,
+}: {
+  repoPath: string;
+  path: string;
+  name: string;
+  branch: string | null;
+  archiveWhenDone: boolean;
+  promotePhase?: WorktreeRemoval["promotePhase"];
+}) {
   useWorktreeRemovalStore.setState((s) => ({
     byRepo: {
       ...s.byRepo,
       [repoPath]: {
         ...s.byRepo[repoPath],
-        [path]: { path, name, startedAt: Date.now(), promotePhase },
+        [path]: {
+          path,
+          name,
+          branch,
+          archiveWhenDone,
+          startedAt: Date.now(),
+          promotePhase,
+        },
       },
     },
   }));
@@ -255,12 +301,57 @@ function settleRemoval(repoPath: string, path: string) {
   invalidateAfterRemoval(repoPath);
 }
 
+/** Honours the delete dialog's "archive when done" checkbox, once the removal
+ *  has settled. The removal itself has already succeeded here, so nothing in
+ *  this step can turn it back into a failure — a refused archive reports itself
+ *  and points at the branch menu, which can still do it. */
+async function archiveAfterRemoval(repoPath: string, branch: string) {
+  // Re-resolved at completion time rather than trusted from the dialog: the
+  // intent can be minutes old, and archiving the default branch would hide it
+  // from every branch surface. An unreadable default stays best-effort, the
+  // same posture the branch menu's own archive guard takes.
+  const isDefault = await gitDefaultBranch(repoPath)
+    .then((name) => name === branch)
+    .catch(() => false);
+  if (isDefault) {
+    toast.success("Worktree removed");
+    toast.info(`Left ${branch} unarchived — it's the default branch.`);
+    return;
+  }
+  try {
+    await gitSetBranchArchived(repoPath, branch, true);
+    // `settleRemoval` invalidated before the flag landed; branch surfaces read
+    // the archived state, so they need the pass that sees it.
+    void queryClient.invalidateQueries({
+      queryKey: repoKeys.branches(repoPath),
+    });
+    toast.success(`Worktree removed and ${branch} archived`);
+  } catch (e) {
+    toast.error(
+      `Removed the worktree, but couldn't archive ${branch} — you can archive it from the branch menu.`,
+      { description: errorMessage(e) },
+    );
+  }
+}
+
 /**
  * Runs one removal to completion. There is deliberately no cancel: the backend
  * removal is uninterruptible past its first steps, and killing it midway strands
  * a half-removed worktree with a live admin entry.
  */
-async function run(repoPath: string, path: string, force: boolean) {
+async function run({
+  repoPath,
+  path,
+  force,
+  branch,
+  archiveWhenDone,
+}: {
+  repoPath: string;
+  path: string;
+  force: boolean;
+  branch: string | null;
+  archiveWhenDone: boolean;
+}) {
   let failure: { error: unknown } | null = null;
   try {
     // branch=null: removing a worktree leaves its branch intact (deleting a
@@ -277,13 +368,23 @@ async function run(repoPath: string, path: string, force: boolean) {
   settleRemoval(repoPath, path);
 
   const listener = listeners.get(listenerKey(repoPath, path))?.at(-1);
-  if (!failure) {
+  if (failure) {
+    // A failed removal leaves the worktree — and so the branch's checkout —
+    // in place, so the archive intent is not acted on.
+    if (listener) listener.onError(failure.error, force);
+    else toastError(failure.error);
+    return;
+  }
+  if (!archiveWhenDone || !branch) {
     toast.success("Worktree removed");
     listener?.onSuccess();
     return;
   }
-  if (listener) listener.onError(failure.error, force);
-  else toastError(failure.error);
+  // Close the dialog before the archive rather than after: the entry has
+  // already settled, so one left open would re-offer Remove on a worktree that
+  // is gone. The archive reports its own outcome by toast either way.
+  listener?.onSuccess();
+  await archiveAfterRemoval(repoPath, branch);
 }
 
 /** Remove a worktree while keeping its branch, retrying once if the folder is
@@ -351,7 +452,16 @@ async function runPromote(
     useUiStore.getState().openRepo(info);
     await new Promise((resolve) => setTimeout(resolve, 80));
     // Main is the active repo now, so the removal is visible where the user is.
-    markRemoval(activeKey, worktreePath, branch, "removing");
+    // A promote is checking this branch out, not putting it away, so it never
+    // archives; the branch doubles as the display name (a promote has one).
+    markRemoval({
+      repoPath: activeKey,
+      path: worktreePath,
+      name: branch,
+      branch,
+      archiveWhenDone: false,
+      promotePhase: "removing",
+    });
     markedKey = activeKey;
     // Free the branch: remove the worktree but KEEP the branch (null) — we
     // check it out in main next. force=false: the clean-tree guard already ran.

--- a/src/lib/tauri/invoke.ts
+++ b/src/lib/tauri/invoke.ts
@@ -1,7 +1,7 @@
 import { getTransport } from "@/lib/transport";
 
 /** The kinds whose wire shape is kind + message alone (Rust `AppError`
- *  serializes a payload only for the three members below). */
+ *  serializes a payload only for the four members below). */
 type PlainErrorKind =
   | "notARepo"
   | "gitNotFound"
@@ -38,6 +38,10 @@ export type AppError =
    *  exclusively through `isPullWouldDrop`, which narrows to `PullWouldDrop`
    *  (lib/git/api.ts) — declaring it twice would let the two shapes drift. */
   | { kind: "pullRebaseWouldDrop"; message: string }
+  /** A bounded wait for one of a repo's locks expired. `holder` names what was
+   *  running in the user's terms ("a worktree removal"), never the lock itself;
+   *  `message` is already the complete sentence a toast shows. */
+  | { kind: "busy"; message: string; holder: string }
   | { kind: PlainErrorKind; message: string };
 
 export function isAppError(e: unknown): e is AppError {


### PR DESCRIPTION
Removing a worktree could take minutes, and because every mutating git command shared one per-repo mutex, that hold stalled staging, committing, branch actions and fetches for the whole duration — directly contradicting the delete dialog's "you can close this and keep working" promise. This splits the single `repo_lock` into three independent domains, makes waits bounded and self-describing, and adds an opt-in "archive that branch after the worktree is removed" checkbox to the delete dialog.

### Lock domains

- `src-tauri/src/state.rs`: replaces `AppState::repo_lock` with `RepoDomains` (`working_tree`, `worktree_admin`, `network`) behind `working_tree_lock` / `worktree_admin_lock` / `network_lock`. A `LockDomain` pairs the mutex with a `HolderSlot` label readable *without* holding the lock, and the ordering rule (network may nest inside working-tree, never the reverse; admin nests with neither) is documented on `working_tree_lock`.
- `src-tauri/src/git/runner.rs`: adds the acquisition helpers — `acquire_repo_lock` (bounded, fails with `AppError::Busy`), `acquire_repo_lock_unbounded` for holds that *are* the long operation, and `try_acquire_repo_lock` for skippable work. All hand back a `RepoLockGuard` that publishes the holder label and clears it on every release path.
- Adds `LOCK_WAIT_TIMEOUT` (10s, working-tree/admin) and `NETWORK_LOCK_WAIT_TIMEOUT` (60s, sized against `NETWORK_TIMEOUT`), plus `holder_label` (git subcommand → the user's word for it) and `subcommand_of`, which skips leading `-c key=value` pairs so credential-injected and editor-configured runs still get a real label.
- Adds `run_git_worktree_admin` as the admin-domain counterpart to `run_git_mutating`.

### Call-site migration

- Working-tree domain with explicit labels across the compounds: `git/autostash.rs`, `git/ops.rs` (reset, cherry-pick, stash, `replace_file_lines`), `git/pull_guard.rs`, `git/branches.rs::update_branch_from`, `git/conflict.rs`, `git/submodule.rs`.
- `git/remote.rs`: `run_git_mutating_with_creds` moves to the **network** domain so a transfer can't hold up a commit for `NETWORK_TIMEOUT`; `git_pull_core` takes the working-tree lock around it, since bare `git pull` is a transfer *and* a merge. `git/pull_guard.rs::probe` now takes `&AppState` and holds the network lock around its fetch.
- `git/worktree.rs`: every `worktree add/move/lock/unlock/repair` goes through `run_git_worktree_admin`; `remove_worktree` holds only the admin domain, unbounded, and derives its `branch -D` decision from the tip observed before removal. New `prune_worktrees_if_free` try-locks the admin domain so `git_worktree_list_user` answers instead of queueing behind an in-flight removal.

### Busy error surface

- `src-tauri/src/error.rs`: new `AppError::Busy { holder }`, whose `busy_message` builds one complete sentence (the frontend uses line 1 verbatim as the toast title) with a generic fallback for an empty holder. Pinned by `busy_serializes_to_the_pinned_wire_shape`.
- `src/lib/tauri/invoke.ts` adds the `busy` variant to the `AppError` union; `src/lib/error-summary.ts` maps it to "Operation in progress".

### Archive the branch after removal

- `src/features/repository/DeleteWorktreeDialog.tsx`: adds the checkbox, shown only when `archivableBranch` resolves (worktree has a branch, and it isn't the default per `useDefaultBranch`). While a removal runs the control is disabled and reflects the intent the running removal actually recorded.
- `src/lib/stores/worktree-removal.ts`: `WorktreeRemoval` gains `branch` and `archiveWhenDone`; `markRemoval` switches to named arguments (`name` and `branch` are interchangeable-looking strings); new `archiveAfterRemoval` re-resolves the default branch at completion time, calls `gitSetBranchArchived`, invalidates `repoKeys.branches`, and reports a refusal without turning a succeeded removal into a failure.
- `src/features/repository/BranchSwitcher.tsx`: a branch whose worktree is being removed is no longer archive-blocked, read from the removal store rather than the worktree query (which can be starved during a removal). Promote-driven removals (`promotePhase`) are excluded — that removal exists to check the branch out.
- `src/features/repository/CleanupBranchesDialog.tsx`: new `isWorktreeRemoving` prop — Archive takes such branches back into its candidate set, Delete keeps excluding them since `branch -D` still refuses a checked-out branch.

### Documentation

- `src/features/help/content.ts`: updates the branch switcher and Clean up branches sections for the new archive exception, and rewrites the Delete worktree bullet to cover the checkbox.
- Adds `changelog.d/added-archive-branch-after-worktree-removal.md` and `changelog.d/fixed-worktree-removal-lock-contention.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree deletion can now automatically archive the associated branch after removal, with an option in the confirmation dialog.
  * Branch cleanup can include branches whose worktrees are currently being removed, while protecting checked-out and default branches.
* **Bug Fixes**
  * Git operations no longer block unnecessarily during worktree removal, fetches, or pushes.
  * Operations waiting too long now show a clear busy message identifying what is in progress.
* **Documentation**
  * Updated help content to explain worktree removal, branch archiving, and deletion protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->