### PR TITLE
feat(ui,repository): add a rail header slot, fix collapse-toggle focus

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -176,9 +176,10 @@ separators.
   not a call-site component.
 - A file rail's header content (a count, a filter summary) rides `DetailRail`'s
   `header` prop (`src/components/detail-rail.tsx`), which places it in the h-7
-  caret strip — never a first-child band inside `children`: a second bordered
-  band breaks the collapse toggle's no-shift invariant (both branches pin the
-  caret in the same h-7 box, so the caret must not move as the rail toggles).
+  caret strip — never a first-child band inside `children`: the strip is already
+  a bordered row, so a band under it stacks a second border and spends vertical
+  space the list wants. Keep that content to one short line; the strip's h-7 is
+  what pins the caret at the same height in both branches, so it must not grow.
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -174,6 +174,11 @@ separators.
   cold load doesn't shift the list as rows arrive. It carries the group's
   `aria-busy` + sr-only status; `ListRowSkeleton` is the single row it wraps,
   not a call-site component.
+- A file rail's header content (a count, a filter summary) rides `DetailRail`'s
+  `header` prop (`src/components/detail-rail.tsx`), which places it in the h-7
+  caret strip — never a first-child band inside `children`: a second bordered
+  band breaks the collapse toggle's no-shift invariant (both branches pin the
+  caret in the same h-7 box, so the caret must not move as the rail toggles).
 - Avatars: vendored `Avatar`/`AvatarImage`/`AvatarFallback` (canonical:
   `AuthorAvatar` in `src/features/conversations/Thread.tsx`) — never
   hand-rolled `<img>`/background divs. Biome-ignore comments use `/*`, not `/**`.

--- a/changelog.d/fixed-composer-collapse-focus.md
+++ b/changelog.d/fixed-composer-collapse-focus.md
@@ -1,3 +1,3 @@
-- When saving the **comment box**'s collapsed state doesn't stick, the box now
-  returns to its previous state in the same frame and keeps keyboard focus on
-  the restored control (the peek line or the editor) instead of dropping it.
+- When saving the **comment box**'s collapsed state doesn't stick, the box
+  returns to its previous state immediately and keeps keyboard focus on the
+  restored control (the one-line strip or the editor).

--- a/changelog.d/fixed-composer-collapse-focus.md
+++ b/changelog.d/fixed-composer-collapse-focus.md
@@ -1,0 +1,3 @@
+- When saving the **comment box**'s collapsed state doesn't stick, the box now
+  returns to its previous state in the same frame and keeps keyboard focus on
+  the restored control (the peek line or the editor) instead of dropping it.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -336,8 +336,13 @@ const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 // buys the reverse, which matters more: the patch and the mutation it guards may
 // sit in different functions of the same hook file, and a proximity pair would
 // miss that. The reported line is the `onError`, which is the site to rewrite.
+// The optional type-argument group uses the same `<[^(]*?>` class as
+// SET_QUERY_DATA_RE above, for the same reason: a `<[^>]*>` group stops at the
+// INNER `>` of a nested generic (`setQueryData<Record<string, Foo>>`), and the
+// lazy run bounded by the call's own paren resolves it. Missing a typed spelling
+// here would turn this file's whole gate off, not just skip one line.
 const OPTIMISTIC_SETTINGS_PATCH_RE =
-  /setQueryData\s*\(\s*settingsKeys\.settings\b/;
+  /setQueryData\s*(?:<[^(]*?>)?\s*\(\s*settingsKeys\.settings\b/;
 const ONERROR_SETTINGS_REFETCH_RE = new RegExp(
   `\\bonError\\b[\\s\\S]{0,${PAIR_GAP}}?invalidateQueries\\s*\\(\\s*\\{\\s*` +
     `queryKey:\\s*settingsKeys\\.settings\\b`,

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -146,9 +146,13 @@ const anyOf = (scans) => (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
 
 /** Scanner: `scan`'s hits, but only in files whose whole-file view also matches
  *  `gate` — a file-scoped AND for a class where each half is legitimate alone,
- *  so only their co-presence is the defect. `gate` must not carry `g`: `test`
- *  is stateful with it and would alternate between files. */
-const onlyWhen = (gate, scan) => (v) => (gate.test(v.text) ? scan(v) : []);
+ *  so only their co-presence is the defect. The `lastIndex` reset is what makes
+ *  a `g`-flagged `gate` safe: `test` is stateful with one, so it would otherwise
+ *  resume mid-file and alternate between hit and miss down the file list. */
+const onlyWhen = (gate, scan) => (v) => {
+  gate.lastIndex = 0;
+  return gate.test(v.text) ? scan(v) : [];
+};
 
 /** Scanner: the union of several `nearPair`s — one check, one allowlist, every
  *  Tailwind spelling of the same idiom. */
@@ -319,13 +323,19 @@ const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 // restoring by REFETCH rather than by writing the snapshot back, which lands the
 // restore a commit or more later — too late for a focus hand-off armed on the
 // flip, so focus drops to <body> on a refused write.
-// Co-presence is the whole check: three files invalidate the settings key from
-// an onError with nothing optimistic to roll back (DangerZone, RepoList,
-// useRepoVisibilityProbe), and settings/queries.ts patches optimistically while
-// its own invalidates are all onSuccess — neither half alone is the class.
-// File-scoped rather than a proximity pair: the patch and the mutation it guards
-// can sit in different functions of the same hook file. The reported line is the
-// invalidate's `onError`, which is the site to rewrite.
+// Co-presence is the class, and the gate is FORWARD-looking: nothing trips the
+// onError half today — every settings invalidate under src/ is success-path, and
+// settings/queries.ts's lone `onError` sits 467 normalized chars from the next
+// one, well past PAIR_GAP (measured while sizing this check). What the gate buys
+// is that a file which legitimately refetches settings from an `onError` with
+// nothing optimistic to roll back (DangerZone, RepoList, useRepoVisibilityProbe
+// are each one edit from that shape) can never read as a violation.
+// The cost of file-scoping, accepted: one file that patches the settings cache
+// for its own feature AND refetches settings from an unrelated mutation's
+// onError pairs them anyway — a loud false positive, allowlist as remedy. It
+// buys the reverse, which matters more: the patch and the mutation it guards may
+// sit in different functions of the same hook file, and a proximity pair would
+// miss that. The reported line is the `onError`, which is the site to rewrite.
 const OPTIMISTIC_SETTINGS_PATCH_RE =
   /setQueryData\s*\(\s*settingsKeys\.settings\b/;
 const ONERROR_SETTINGS_REFETCH_RE = new RegExp(

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -144,6 +144,12 @@ const nearPair = (a, b) => {
  *  views: `perLine` for a token, `perFile` for one that can wrap). */
 const anyOf = (scans) => (v) => [...new Set(scans.flatMap((scan) => scan(v)))];
 
+/** Scanner: `scan`'s hits, but only in files whose whole-file view also matches
+ *  `gate` — a file-scoped AND for a class where each half is legitimate alone,
+ *  so only their co-presence is the defect. `gate` must not carry `g`: `test`
+ *  is stateful with it and would alternate between files. */
+const onlyWhen = (gate, scan) => (v) => (gate.test(v.text) ? scan(v) : []);
+
 /** Scanner: the union of several `nearPair`s — one check, one allowlist, every
  *  Tailwind spelling of the same idiom. */
 const anyPair = (pairs) => anyOf(pairs.map(([a, b]) => nearPair(a, b)));
@@ -307,6 +313,27 @@ const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
 // converted site had.
 const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 
+// The two halves of an async settings rollback. The gate: an OPTIMISTIC patch of
+// the settings cache — the file flips the preference itself so the UI can commit
+// before the store write resolves. The hit: that file's mutation `onError`
+// restoring by REFETCH rather than by writing the snapshot back, which lands the
+// restore a commit or more later — too late for a focus hand-off armed on the
+// flip, so focus drops to <body> on a refused write.
+// Co-presence is the whole check: three files invalidate the settings key from
+// an onError with nothing optimistic to roll back (DangerZone, RepoList,
+// useRepoVisibilityProbe), and settings/queries.ts patches optimistically while
+// its own invalidates are all onSuccess — neither half alone is the class.
+// File-scoped rather than a proximity pair: the patch and the mutation it guards
+// can sit in different functions of the same hook file. The reported line is the
+// invalidate's `onError`, which is the site to rewrite.
+const OPTIMISTIC_SETTINGS_PATCH_RE =
+  /setQueryData\s*\(\s*settingsKeys\.settings\b/;
+const ONERROR_SETTINGS_REFETCH_RE = new RegExp(
+  `\\bonError\\b[\\s\\S]{0,${PAIR_GAP}}?invalidateQueries\\s*\\(\\s*\\{\\s*` +
+    `queryKey:\\s*settingsKeys\\.settings\\b`,
+  "g",
+);
+
 export const CHECKS = [
   {
     name: "hover-reveal",
@@ -385,6 +412,18 @@ export const CHECKS = [
     allowlist: [],
     message:
       "setQueryData(key, undefined) is a silent no-op in TanStack v5 — snapshot and restore the previous value instead",
+  },
+  {
+    name: "async-settings-rollback",
+    // Not a UI idiom — it applies wherever the settings cache is patched.
+    appliesTo: () => true,
+    scan: onlyWhen(
+      OPTIMISTIC_SETTINGS_PATCH_RE,
+      perFile(ONERROR_SETTINGS_REFETCH_RE),
+    ),
+    allowlist: [],
+    message:
+      "an optimistically patched settings write rolls back SYNCHRONOUSLY — snapshot the previous value and setQueryData it back under a latest-write guard (useApplyTheme, src/lib/settings/queries.ts), never invalidateQueries: the refetch restores a commit or more later, so a collapse toggle's focus hand-off has nothing to ride and focus drops to <body>",
   },
   {
     name: "bare-mutate-in-converted-trees",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -351,6 +351,26 @@ test("async-settings-rollback flags an optimistic patch whose onError refetches"
   assert.deepEqual(settingsRollback(block), [3]);
 });
 
+test("async-settings-rollback gates on a TYPED optimistic patch too", () => {
+  // The gate is all-or-nothing per file: a spelling it can't see turns the whole
+  // check off there. The repo already types the sibling read
+  // (`getQueryData<AppSettings>`), so the typed write is a plausible next edit —
+  // including the nested-generic form a `<[^>]*>` group would stop short of.
+  for (const call of [
+    "queryClient.setQueryData<AppSettings>(settingsKeys.settings, updated);",
+    "queryClient.setQueryData<Record<string, AppSettings>>(settingsKeys.settings, u);",
+  ]) {
+    const source = [
+      call,
+      "saveSettings.mutate(updated, {",
+      "  onError: () =>",
+      "    queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),",
+      "});",
+    ].join("\n");
+    assert.deepEqual(settingsRollback(source), [3], `should gate on ${call}`);
+  }
+});
+
 test("async-settings-rollback pairs across functions, not just adjacent code", () => {
   // The property `onlyWhen` exists for: the gating patch and the mutation it
   // guards can live in different functions of the same hook file, far outside

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -351,10 +351,34 @@ test("async-settings-rollback flags an optimistic patch whose onError refetches"
   assert.deepEqual(settingsRollback(block), [3]);
 });
 
+test("async-settings-rollback pairs across functions, not just adjacent code", () => {
+  // The property `onlyWhen` exists for: the gating patch and the mutation it
+  // guards can live in different functions of the same hook file, far outside
+  // any proximity window. Padding is deliberately >PAIR_GAP (160).
+  const source = [
+    "export function useSomethingCollapsed() {",
+    "  function apply(next) {",
+    "    queryClient.setQueryData(settingsKeys.settings, updated);",
+    "  }",
+    "  const pad1 = someHelper(alpha, beta, gamma, delta, epsilon, zeta, eta);",
+    "  const pad2 = someHelper(alpha, beta, gamma, delta, epsilon, zeta, eta);",
+    "  const pad3 = someHelper(alpha, beta, gamma, delta, epsilon, zeta, eta);",
+    "  const pad4 = someHelper(alpha, beta, gamma, delta, epsilon, zeta, eta);",
+    "  function persist(updated) {",
+    "    saveSettings.mutate(updated, {",
+    "      onError: () =>",
+    "        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),",
+    "    });",
+    "  }",
+    "}",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(source), [11]);
+});
+
 test("async-settings-rollback needs BOTH halves, in the same file", () => {
-  // A settings invalidate from an onError with nothing optimistic to roll back
-  // is the shape three live files have (DangerZone, RepoList,
-  // useRepoVisibilityProbe) — the gate is what keeps them clean.
+  // No live file trips the onError half today — every settings invalidate under
+  // src/ is success-path. The gate is forward-looking: a file that refetches
+  // settings from an onError with nothing optimistic to roll back stays clean.
   const noPatch = [
     "remove.mutate(path, {",
     "  onError: () =>",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -46,6 +46,7 @@ const modKey = scanner("hand-rolled-mod-key");
 const inlineClipTitle = scanner("inline-clip-title");
 const selectItemClipTitle = scanner("select-item-clip-title");
 const setQueryData = scanner("setQueryData-noop");
+const settingsRollback = scanner("async-settings-rollback");
 const bareMutate = scanner("bare-mutate-in-converted-trees");
 const menuSuppression = scanner("context-menu-suppression");
 const loneActivity = scanner("lone-activity-boundary");
@@ -325,6 +326,69 @@ test("setQueryData-noop does not reach across a `;` statement boundary", () => {
     "logger.debug(label, undefined);",
   ].join("\n");
   assert.deepEqual(setQueryData(source), []);
+});
+
+test("async-settings-rollback flags an optimistic patch whose onError refetches", () => {
+  // The pre-fix shape, in both its bodies: the arrow the two settings hooks
+  // used, and the block detail-rail used to clear its focus arm in.
+  const arrow = [
+    "queryClient.setQueryData(settingsKeys.settings, updated);",
+    "saveSettings.mutate(updated, {",
+    "  onError: () =>",
+    "    queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),",
+    "});",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(arrow), [3]);
+  const block = [
+    "queryClient.setQueryData(settingsKeys.settings, updated);",
+    "saveSettings.mutate(updated, {",
+    "  onError: () => {",
+    "    refocus.current = null;",
+    "    queryClient.invalidateQueries({ queryKey: settingsKeys.settings });",
+    "  },",
+    "});",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(block), [3]);
+});
+
+test("async-settings-rollback needs BOTH halves, in the same file", () => {
+  // A settings invalidate from an onError with nothing optimistic to roll back
+  // is the shape three live files have (DangerZone, RepoList,
+  // useRepoVisibilityProbe) — the gate is what keeps them clean.
+  const noPatch = [
+    "remove.mutate(path, {",
+    "  onError: () =>",
+    "    queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),",
+    "});",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(noPatch), []);
+  // The happy-path reconcile every settings mutation carries is onSuccess, so
+  // the patch alone never pairs with it.
+  const onSuccess = [
+    "queryClient.setQueryData(settingsKeys.settings, updated);",
+    "return useMutation({",
+    "  mutationFn: saveSettingsMerged,",
+    "  onSuccess: () =>",
+    "    queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),",
+    "});",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(onSuccess), []);
+});
+
+test("async-settings-rollback leaves the guarded synchronous restore alone", () => {
+  // The useApplyTheme shape this check exists to hold: latest-write guard, then
+  // the snapshot written straight back.
+  const fixed = [
+    "queryClient.setQueryData(settingsKeys.settings, updated);",
+    "saveSettings.mutate(updated, {",
+    "  onError: () => {",
+    "    const latest = queryClient.getQueryData(settingsKeys.settings);",
+    "    if (latest?.theme !== next) return;",
+    "    queryClient.setQueryData(settingsKeys.settings, current);",
+    "  },",
+    "});",
+  ].join("\n");
+  assert.deepEqual(settingsRollback(fixed), []);
 });
 
 test("bare-mutate-in-converted-trees flags every way a call reaches its callbacks", () => {

--- a/src/components/detail-rail.tsx
+++ b/src/components/detail-rail.tsx
@@ -5,6 +5,7 @@ import {
   createContext,
   type ReactNode,
   useContext,
+  useEffectEvent,
   useLayoutEffect,
   useRef,
   useState,
@@ -12,6 +13,7 @@ import {
 import { usePanelActive } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import type { AppSettings } from "@/lib/settings/api";
 import {
   settingsKeys,
   useSaveSettings,
@@ -55,11 +57,15 @@ export function DetailRailRow({ children }: { children: ReactNode }) {
 export function DetailRail({
   ariaLabel,
   className,
+  header,
   role,
   children,
 }: {
   ariaLabel: string;
   className?: string;
+  /** Rendered start-aligned in the expanded caret strip (e.g. a file count),
+   *  which owns the row's height — it must not grow past one short line. */
+  header?: ReactNode;
   role?: AriaRole;
   children: ReactNode;
 }) {
@@ -73,10 +79,11 @@ export function DetailRail({
   const toggleRef = useRef<HTMLButtonElement>(null);
   // The expanded-ness a focus-carrying toggle asked for, or null when nothing is
   // pending: each branch renders a different button node, so without the move
-  // focus drops to <body>. Single-shot — armed only on a committed flip, cleared
-  // the moment it fires, and cleared again if the write is refused. An arm that
-  // outlived its own flip would fire on the next width crossing instead, pulling
-  // focus into a rail the user never touched.
+  // focus drops to <body>. Armed on a committed flip, and on a rejected write's
+  // rollback only while the rail holds focus AND the row is still wide (a narrow
+  // rollback can't produce the transition the arm waits for). Every expanded
+  // transition consumes the arm, so it can't linger to fire on a later width
+  // crossing, pulling focus into a rail the user never touched.
   const refocus = useRef<boolean | null>(null);
 
   const narrow = rowWidth !== null && rowWidth < RAIL_MIN_CONTAINER_PX;
@@ -87,6 +94,29 @@ export function DetailRail({
   const expanded = narrow
     ? transientExpand
     : !settings.data?.diffFileListCollapsed;
+
+  // Rejected-write rollback as an effect event so `narrow` is read at rejection
+  // time, not capture time: a rollback landing while the row is narrow can't
+  // transition `expanded` (the strip is width-forced), so arming there would
+  // leave a live arm for a later width crossing to fire as a focus steal.
+  const rollbackCollapsePref = useEffectEvent(
+    (previous: AppSettings, attempted: AppSettings) => {
+      // Only roll back if this call's change is still the latest: otherwise a
+      // late-failing earlier write would stomp a newer successful one.
+      const latest = queryClient.getQueryData<AppSettings>(
+        settingsKeys.settings,
+      );
+      if (latest?.diffFileListCollapsed !== attempted.diffFileListCollapsed)
+        return;
+      // Re-armed for the rollback's own commit, only while the rail still holds
+      // focus — a user who has moved on must not have it stolen back.
+      refocus.current =
+        !narrow && railRef.current?.contains(document.activeElement)
+          ? !previous.diffFileListCollapsed
+          : null;
+      queryClient.setQueryData(settingsKeys.settings, previous);
+    },
+  );
 
   const toggle = () => {
     const held = Boolean(railRef.current?.contains(document.activeElement));
@@ -108,10 +138,7 @@ export function DetailRail({
     // so a second press reads the new value instead of re-issuing the old flip.
     queryClient.setQueryData(settingsKeys.settings, updated);
     saveSettings.mutate(updated, {
-      onError: () => {
-        refocus.current = null;
-        queryClient.invalidateQueries({ queryKey: settingsKeys.settings });
-      },
+      onError: () => rollbackCollapsePref(current, updated),
     });
   };
   // Only the visible tab's rail answers the action: <Activity> keeps hidden
@@ -121,9 +148,10 @@ export function DetailRail({
   // Rides the commit that actually renders the new branch — a frame scheduled
   // from the handler could still beat react-query's notify-batched re-render.
   useLayoutEffect(() => {
-    if (refocus.current !== expanded) return;
+    if (refocus.current === null) return;
+    const matched = refocus.current === expanded;
     refocus.current = null;
-    toggleRef.current?.focus();
+    if (matched) toggleRef.current?.focus();
   }, [expanded]);
 
   if (!expanded) {
@@ -162,7 +190,12 @@ export function DetailRail({
       aria-label={role ? LANDMARK_LABEL : ariaLabel}
       className={cn("flex w-72 shrink-0 flex-col border-r", className)}
     >
-      <div className="flex h-7 shrink-0 items-center justify-end border-b px-0.5">
+      <div className="flex h-7 shrink-0 items-center justify-end gap-2 border-b px-0.5">
+        {/* `pl-2.5` on top of the row's `px-0.5` puts the header's text column on
+            the same 12px inset as the `px-3` rows below it. */}
+        {header !== undefined && (
+          <div className="mr-auto min-w-0 pl-2.5">{header}</div>
+        )}
         <Button
           ref={toggleRef}
           type="button"

--- a/src/components/detail-rail.tsx
+++ b/src/components/detail-rail.tsx
@@ -81,9 +81,9 @@ export function DetailRail({
   // pending: each branch renders a different button node, so without the move
   // focus drops to <body>. Armed on a committed flip, and on a rejected write's
   // rollback only while the rail holds focus AND the row is still wide (a narrow
-  // rollback can't produce the transition the arm waits for). Every expanded
-  // transition consumes the arm, so it can't linger to fire on a later width
-  // crossing, pulling focus into a rail the user never touched.
+  // rollback can't produce the transition the arm waits for). Every `expanded`
+  // or `narrow` commit consumes the arm, so it can't linger to fire on a later
+  // width crossing, pulling focus into a rail the user never touched.
   const refocus = useRef<boolean | null>(null);
 
   const narrow = rowWidth !== null && rowWidth < RAIL_MIN_CONTAINER_PX;
@@ -147,12 +147,16 @@ export function DetailRail({
 
   // Rides the commit that actually renders the new branch — a frame scheduled
   // from the handler could still beat react-query's notify-batched re-render.
+  // `narrow` is a trigger, not a read: a ResizeObserver width update can batch
+  // with the flip, leaving `expanded` still, and an arm left unconsumed there
+  // would fire on the next widening instead.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `narrow` is the trigger — a width crossing must consume a pending arm even when `expanded` holds still.
   useLayoutEffect(() => {
     if (refocus.current === null) return;
     const matched = refocus.current === expanded;
     refocus.current = null;
     if (matched) toggleRef.current?.focus();
-  }, [expanded]);
+  }, [expanded, narrow]);
 
   if (!expanded) {
     return (
@@ -193,9 +197,7 @@ export function DetailRail({
       <div className="flex h-7 shrink-0 items-center justify-end gap-2 border-b px-0.5">
         {/* `pl-2.5` on top of the row's `px-0.5` puts the header's text column on
             the same 12px inset as the `px-3` rows below it. */}
-        {header !== undefined && (
-          <div className="mr-auto min-w-0 pl-2.5">{header}</div>
-        )}
+        {header ? <div className="mr-auto min-w-0 pl-2.5">{header}</div> : null}
         <Button
           ref={toggleRef}
           type="button"

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -95,11 +95,12 @@ export function CommentComposer({
   const editorRef = useRef<MarkdownEditorHandle>(null);
   const editorWrapRef = useRef<HTMLDivElement>(null);
   const peekRef = useRef<HTMLButtonElement>(null);
-  // The scroll region measured at expand time, when the reader was sitting at
-  // its bottom — null otherwise. The ELEMENT is held rather than re-walked on
-  // the commit: un-hiding the editor changes which containers overflow, so a
-  // second walk can answer with a different element than the one the pin
-  // decision was made against.
+  // The scroll region measured before the box grows (an expand, or the rollback
+  // of a refused collapse), when the reader was sitting at its bottom; null
+  // otherwise. The ELEMENT is held rather than re-walked on the commit:
+  // un-hiding the editor changes which containers overflow, so a second walk can
+  // answer with a different element than the one the pin decision was made
+  // against.
   const repinRef = useRef<HTMLElement | null>(null);
   // What the expanded/collapsed render owes the user once it commits. The
   // un-hide rides a react-query cache notify, whose batching can land after any

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -107,6 +107,10 @@ export function CommentComposer({
   // that actually flipped `collapsed` — never on wall clock.
   const pendingRef = useRef<"focus" | "preview" | null>(null);
   const pendingPeekRef = useRef(false);
+  // A hand-off frame is scheduled but hasn't landed. Focus sits on <body> for
+  // that whole window (longer still if the window is backgrounded, where rAF is
+  // suspended), so a rejection arriving inside it must read as "focus is ours".
+  const handoffRef = useRef(false);
 
   const { collapsed, setCollapsed, toggle } = useComposerCollapsed(
     () => expand("focus"),
@@ -114,21 +118,27 @@ export function CommentComposer({
     rollback,
   );
 
-  /** Reveal the box, and record what the expanded render owes: focus, or the
-   *  Preview tab. */
-  function expand(then: "focus" | "preview") {
-    // Growing the box shrinks the scroll region above it, which would carry the
-    // last comment off-screen for a reader sitting at the bottom.
+  /** The scroll region an about-to-grow box owes a re-pin, or null when the
+   *  reader isn't sitting at its bottom. Call BEFORE the flip: growing the box
+   *  shrinks the region above it, carrying the last comment off-screen. */
+  function measurePinRegion(): HTMLElement | null {
     const region = findScrollRegion(
       rootRef.current?.previousElementSibling ?? null,
     );
-    const pinned =
-      !!region &&
+    if (!region) return null;
+    const atBottom =
       region.scrollHeight - region.scrollTop - region.clientHeight <= 8;
+    return atBottom ? region : null;
+  }
+
+  /** Reveal the box, and record what the expanded render owes: focus, or the
+   *  Preview tab. */
+  function expand(then: "focus" | "preview") {
+    const pinned = measurePinRegion();
     // Arm follow-ups only on a real transition: a write the hook declined leaves
     // no commit to consume them, and a stale flag would fire on a later expand.
     const changed = setCollapsed(false);
-    repinRef.current = changed && pinned ? region : null;
+    repinRef.current = changed ? pinned : null;
     pendingRef.current = changed ? then : null;
   }
 
@@ -141,12 +151,21 @@ export function CommentComposer({
 
   /** A refused write is restoring the box to `restoredCollapsed`: arm whatever
    *  that commit's effect owes, since it unmounts (peek button) or hides
-   *  (editor) the control focus is on. Gated on focus still being in the
-   *  composer — a user who moved on must not be yanked back. */
+   *  (editor) the control focus is on. Gated on focus being in the composer, or
+   *  on its way there in a scheduled hand-off — a user who moved on must not be
+   *  yanked back. */
   function rollback(restoredCollapsed: boolean) {
-    if (!rootRef.current?.contains(document.activeElement)) return;
-    if (restoredCollapsed) pendingPeekRef.current = true;
-    else pendingRef.current = "focus";
+    if (
+      !handoffRef.current &&
+      !rootRef.current?.contains(document.activeElement)
+    )
+      return;
+    if (restoredCollapsed) {
+      pendingPeekRef.current = true;
+      return;
+    }
+    repinRef.current = measurePinRegion();
+    pendingRef.current = "focus";
   }
 
   // No dependency list: the handle closes over `collapsed` and over locals the
@@ -181,7 +200,11 @@ export function CommentComposer({
     pendingPeekRef.current = false;
     // One frame, inside the commit that mounted the strip: the palette dialog
     // returns focus to its trigger as it closes, and would otherwise win.
-    requestAnimationFrame(() => peekRef.current?.focus());
+    handoffRef.current = true;
+    requestAnimationFrame(() => {
+      handoffRef.current = false;
+      peekRef.current?.focus();
+    });
   }, [collapsed]);
 
   // The expand commit. Re-pin before focusing — and the two can't fight anyway:
@@ -199,7 +222,9 @@ export function CommentComposer({
     pendingRef.current = null;
     // One frame, inside the commit that revealed the editor: a quote reply fires
     // from a Base UI menu whose close-time focus-return would otherwise steal it.
+    handoffRef.current = true;
     requestAnimationFrame(() => {
+      handoffRef.current = false;
       if (pending === "preview") editorRef.current?.showPreview();
       else editorRef.current?.focus();
     });

--- a/src/features/conversations/CommentComposer.tsx
+++ b/src/features/conversations/CommentComposer.tsx
@@ -111,6 +111,7 @@ export function CommentComposer({
   const { collapsed, setCollapsed, toggle } = useComposerCollapsed(
     () => expand("focus"),
     collapse,
+    rollback,
   );
 
   /** Reveal the box, and record what the expanded render owes: focus, or the
@@ -136,6 +137,16 @@ export function CommentComposer({
     // unmounts with the expanded row; the palette closes), so focus would fall to
     // <body> without re-homing it on the peek strip.
     pendingPeekRef.current = setCollapsed(true);
+  }
+
+  /** A refused write is restoring the box to `restoredCollapsed`: arm whatever
+   *  that commit's effect owes, since it unmounts (peek button) or hides
+   *  (editor) the control focus is on. Gated on focus still being in the
+   *  composer — a user who moved on must not be yanked back. */
+  function rollback(restoredCollapsed: boolean) {
+    if (!rootRef.current?.contains(document.activeElement)) return;
+    if (restoredCollapsed) pendingPeekRef.current = true;
+    else pendingRef.current = "focus";
   }
 
   // No dependency list: the handle closes over `collapsed` and over locals the

--- a/src/features/conversations/useComposerCollapsed.ts
+++ b/src/features/conversations/useComposerCollapsed.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import type { AppSettings } from "@/lib/settings/api";
 import {
   settingsKeys,
   useSaveSettings,
@@ -35,11 +36,19 @@ export function useComposerCollapsed(
     const updated = { ...current, commentComposerCollapsed: next };
     // Patch the cache before persisting: an expand focuses the editor one frame
     // later, which the settings round-trip would not have landed in time for. A
-    // failed write refetches the stored truth back over the patch.
+    // failed write restores the previous value synchronously, in one commit.
     queryClient.setQueryData(settingsKeys.settings, updated);
     saveSettings.mutate(updated, {
-      onError: () =>
-        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+      onError: () => {
+        // Only roll back if this call's change is still the latest: otherwise a
+        // late-failing earlier write would stomp a newer successful one (two
+        // fast toggles where the first write rejects after the second lands).
+        const latest = queryClient.getQueryData<AppSettings>(
+          settingsKeys.settings,
+        );
+        if (latest?.commentComposerCollapsed !== next) return;
+        queryClient.setQueryData(settingsKeys.settings, current);
+      },
     });
     return true;
   }

--- a/src/features/conversations/useComposerCollapsed.ts
+++ b/src/features/conversations/useComposerCollapsed.ts
@@ -17,10 +17,14 @@ import {
  * @param onExpand run when the box is expanded
  * @param onCollapse run when it collapses. Both directions re-home focus, but to
  *   different controls, so the hook delegates rather than picking one.
+ * @param onRollback run with the collapsed value a refused write is restoring —
+ *   the same re-homing decision for a transition the user never asked for, whose
+ *   commit would otherwise unmount the focused control and strand focus.
  */
 export function useComposerCollapsed(
   onExpand: () => void,
   onCollapse: () => void,
+  onRollback: (restoredCollapsed: boolean) => void,
 ) {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
@@ -36,7 +40,8 @@ export function useComposerCollapsed(
     const updated = { ...current, commentComposerCollapsed: next };
     // Patch the cache before persisting: an expand focuses the editor one frame
     // later, which the settings round-trip would not have landed in time for. A
-    // failed write restores the previous value synchronously, in one commit.
+    // refused write restores the previous value synchronously, so the caller's
+    // re-homing has that one commit to ride.
     queryClient.setQueryData(settingsKeys.settings, updated);
     saveSettings.mutate(updated, {
       onError: () => {
@@ -47,6 +52,8 @@ export function useComposerCollapsed(
           settingsKeys.settings,
         );
         if (latest?.commentComposerCollapsed !== next) return;
+        // Armed before the restore, so the commit it rides is the very next one.
+        onRollback(current.commentComposerCollapsed);
         queryClient.setQueryData(settingsKeys.settings, current);
       },
     });

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -413,10 +413,13 @@ export function CommitDetailView({
         <DetailRail
           ariaLabel="Changed files"
           className={cn(PLACEHOLDER_FADE, staleDim)}
+          header={
+            <p className="truncate text-xs text-muted-foreground">
+              {files.data.length} changed file
+              {files.data.length === 1 ? "" : "s"}
+            </p>
+          }
         >
-          <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
-            {files.data.length} changed file{files.data.length === 1 ? "" : "s"}
-          </p>
           {/* overflow-hidden contains the list's natural height (vendored Root is
               `relative`-only) so a long file list can't leak a window scrollbar. */}
           <ScrollArea className="min-h-0 flex-1 overflow-hidden">

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -212,10 +212,14 @@ export function PrCommitDetail({
         <DiffPlaceholder message="Could not load this commit's changes" />
       ) : (
         <DetailRailRow>
-          <DetailRail ariaLabel="Changed files">
-            <p className="border-b px-3 py-1.5 text-xs text-muted-foreground">
-              {files.length} changed file{files.length === 1 ? "" : "s"}
-            </p>
+          <DetailRail
+            ariaLabel="Changed files"
+            header={
+              <p className="truncate text-xs text-muted-foreground">
+                {files.length} changed file{files.length === 1 ? "" : "s"}
+              </p>
+            }
+          >
             {/* overflow-hidden contains the list's natural height (vendored Root
                 is `relative`-only) so a long file list can't leak a window scrollbar. */}
             <ScrollArea className="min-h-0 flex-1 overflow-hidden">

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -90,6 +90,7 @@ import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useLensGate, useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useScripts } from "@/lib/scripts/queries";
+import type { AppSettings } from "@/lib/settings/api";
 import {
   settingsKeys,
   useAiEnabled,
@@ -510,11 +511,23 @@ export function RepositoryView() {
     const updated = { ...current, sidebarCollapsed: next };
     // Patch the cache before persisting: the flip has to land this render, or a
     // fast double-press reads the stale value and re-issues it — one flip, not
-    // two. A failed write refetches the stored truth back over the patch.
+    // two. A failed write restores the previous value synchronously, so the
+    // hand-off can ride the rollback's own commit.
     queryClient.setQueryData(settingsKeys.settings, updated);
     saveSettings.mutate(updated, {
-      onError: () =>
-        queryClient.invalidateQueries({ queryKey: settingsKeys.settings }),
+      onError: () => {
+        // Only roll back if this call's change is still the latest: otherwise a
+        // late-failing earlier write would stomp a newer successful one (two
+        // fast presses where the first write rejects after the second lands).
+        const latest = queryClient.getQueryData<AppSettings>(
+          settingsKeys.settings,
+        );
+        if (latest?.sidebarCollapsed !== next) return;
+        if (sidebarRef.current?.contains(document.activeElement)) {
+          refocusToggleRef.current = !next;
+        }
+        queryClient.setQueryData(settingsKeys.settings, current);
+      },
     });
     return true;
   }
@@ -650,12 +663,13 @@ export function RepositoryView() {
       .catch(() => undefined);
   }, [repoName, alias, headLabel]);
   useLayoutEffect(() => {
-    if (refocusToggleRef.current !== sidebarCollapsed) return;
+    if (refocusToggleRef.current === null) return;
+    const matched = refocusToggleRef.current === sidebarCollapsed;
     refocusToggleRef.current = null;
     // One frame, inside the commit that rendered the new mode's toggle: a Base
     // UI menu returns focus to its (now unmounted) trigger as it closes and
     // would otherwise win.
-    requestAnimationFrame(() => sidebarToggleRef.current?.focus());
+    if (matched) requestAnimationFrame(() => sidebarToggleRef.current?.focus());
   }, [sidebarCollapsed]);
 
   // Reset to the bare title only when the repo view unmounts (repo closed).

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -677,10 +677,10 @@ export function RepositoryView() {
     if (refocusToggleRef.current === null) return;
     const matched = refocusToggleRef.current === sidebarCollapsed;
     refocusToggleRef.current = null;
+    if (!matched) return;
     // One frame, inside the commit that rendered the new mode's toggle: a Base
     // UI menu returns focus to its (now unmounted) trigger as it closes and
     // would otherwise win.
-    if (!matched) return;
     handoffRef.current = true;
     requestAnimationFrame(() => {
       handoffRef.current = false;

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -476,6 +476,10 @@ export function RepositoryView() {
   // rather than from a frame scheduled in the handler, because the preference
   // lives in react-query, whose notify-batched re-render can land after one.
   const refocusToggleRef = useRef<boolean | null>(null);
+  // A hand-off frame is scheduled but hasn't landed. Focus sits on <body> for
+  // that whole window (longer still if the window is backgrounded, where rAF is
+  // suspended), so a rejection arriving inside it must read as "focus is ours".
+  const handoffRef = useRef(false);
 
   // OS notifications for PR/check and workflow-run events while this repo is open.
   usePrNotifications(repoPath ?? "");
@@ -501,11 +505,15 @@ export function RepositoryView() {
   function setSidebarCollapsed(next: boolean): boolean {
     const current = settings.data;
     if (!current || current.sidebarCollapsed === next) return false;
-    // Focus sitting in the sidebar is about to be hidden (the panels) or
-    // unmounted (this mode's toggle, the rail), so it can't be re-homed until
-    // the new mode has rendered its own toggle — arm the hand-off for that
-    // commit rather than focusing a node this flip is about to take away.
-    if (sidebarRef.current?.contains(document.activeElement)) {
+    // Focus sitting in the sidebar (or in flight to it, mid hand-off) is about
+    // to be hidden (the panels) or unmounted (this mode's toggle, the rail), so
+    // it can't be re-homed until the new mode has rendered its own toggle — arm
+    // the hand-off for that commit rather than focusing a node this flip is
+    // about to take away.
+    if (
+      handoffRef.current ||
+      sidebarRef.current?.contains(document.activeElement)
+    ) {
       refocusToggleRef.current = next;
     }
     const updated = { ...current, sidebarCollapsed: next };
@@ -523,7 +531,10 @@ export function RepositoryView() {
           settingsKeys.settings,
         );
         if (latest?.sidebarCollapsed !== next) return;
-        if (sidebarRef.current?.contains(document.activeElement)) {
+        if (
+          handoffRef.current ||
+          sidebarRef.current?.contains(document.activeElement)
+        ) {
           refocusToggleRef.current = !next;
         }
         queryClient.setQueryData(settingsKeys.settings, current);
@@ -669,7 +680,12 @@ export function RepositoryView() {
     // One frame, inside the commit that rendered the new mode's toggle: a Base
     // UI menu returns focus to its (now unmounted) trigger as it closes and
     // would otherwise win.
-    if (matched) requestAnimationFrame(() => sidebarToggleRef.current?.focus());
+    if (!matched) return;
+    handoffRef.current = true;
+    requestAnimationFrame(() => {
+      handoffRef.current = false;
+      sidebarToggleRef.current?.focus();
+    });
   }, [sidebarCollapsed]);
 
   // Reset to the bare title only when the repo view unmounts (repo closed).


### PR DESCRIPTION
Moves the file rails' "N changed files" line out of the rail body and into a new header slot in the collapse strip, so the caret stays pinned in the same `h-7` box whether the rail is expanded or collapsed. Fixing the strip surfaced a second defect on the same path: a refused settings write rolled back by refetch, which lands a commit or more after the toggle flips, so the focus hand-off had nothing to ride and focus dropped to `<body>`.

### Rail header slot

- `DetailRail` in `src/components/detail-rail.tsx` gains an optional `header` prop rendered start-aligned inside the expanded caret strip: the row picks up `gap-2` and the header sits in a `mr-auto min-w-0 pl-2.5` box so its text column lands on the same 12px inset as the `px-3` rows below it.
- `src/features/history/CommitDetailView.tsx` and `src/features/pulls/PrCommitDetail.tsx` pass their changed-file count through `header` (now `truncate text-xs text-muted-foreground`) instead of rendering it as a bordered `border-b px-3 py-1.5` first child.
- `.claude/skills/gd-conventions/SKILL.md` records the rule: rail header content rides the `header` prop, never a first-child band, because a second bordered band breaks the collapse toggle's no-shift invariant.

### Synchronous rollback for refused settings writes

- `detail-rail.tsx` replaces the `onError` invalidate with `rollbackCollapsePref`, a `useEffectEvent` that verifies the settings cache still holds this call's `diffFileListCollapsed` before writing the previous `AppSettings` back via `setQueryData`. The effect-event form is what lets it read `narrow` at rejection time, so a rollback landing on a narrow row does not arm a hand-off that only a later width crossing could fire.
- The rollback re-arms `refocus` only while `railRef` still contains `document.activeElement`, so a user who has moved on does not get focus pulled back.
- `src/features/repository/RepositoryView.tsx` applies the same shape to `sidebarCollapsed`: latest-write guard, re-arm `refocusToggleRef` when the sidebar holds focus, then restore the snapshot.
- `src/features/conversations/useComposerCollapsed.ts` gets the guarded synchronous restore for `commentComposerCollapsed` (no focus arm on that path).
- Both layout effects (`detail-rail.tsx`, `RepositoryView.tsx`) now clear the arm on any transition and focus only when the arm matches the new value, so a stale arm cannot survive to fire on an unrelated later flip.

### Banned-pattern check

- Adds an `async-settings-rollback` check to `scripts/check-banned-patterns.mjs`, built on a new `onlyWhen(gate, scan)` combinator that ANDs a whole-file gate with a scan. It flags an `onError` invalidating `settingsKeys.settings` only in files that also patch that key optimistically, since neither half alone is the defect: `DangerZone`, `RepoList`, and `useRepoVisibilityProbe` invalidate with nothing optimistic to roll back, and `settings/queries.ts` patches optimistically but invalidates from `onSuccess`.
- `scripts/checks.test.mjs` covers the check with three cases: the pre-fix arrow and block `onError` bodies are both flagged, a file carrying only one half stays clean, and the guarded snapshot-restore shape is left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed comment composer state restoration when saving a collapse/expand preference fails.
  - Preserved keyboard focus when the composer or sidebar returns to its previous state.
  - Prevented stale preference-save errors from overriding newer changes.
  - Improved sidebar toggle behavior during rapid updates and mode changes.

- **UI Improvements**
  - Added aligned, concise headers to changed-files sidebars.
  - Improved header spacing and truncation to keep caret strips compact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->