### PR TITLE
feat(markdown,insights): add link preview cards on hover and focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,13 @@ review via its subscription login. The full list is under
   pull request, or the avatar and handle of a person. Bitbucket bodies leave
   references plain, matching Bitbucket itself, and a reference inside a code
   span or fence stays plain text.
+- **Link previews**: hover a web or `mailto:` link in a rendered body, or reach
+  it with Tab, and a card names its destination right away: the domain and
+  the full URL. For a web link it then fills in the page's title, description,
+  and image where the site publishes them, and a `mailto:` link shows the
+  address. **Fetch link previews** (Settings → General) turns that lookup off
+  when you want the destination alone, and pages on private or local network
+  addresses are never fetched.
 - **Images open fullscreen**: click a screenshot in a rendered description,
   comment, or discussion (or either side of an image diff) to fill the window
   over a dimmed backdrop, with its label and pixel dimensions, a

--- a/README.md
+++ b/README.md
@@ -884,12 +884,12 @@ review via its subscription login. The full list is under
   references plain, matching Bitbucket itself, and a reference inside a code
   span or fence stays plain text.
 - **Link previews**: hover a web or `mailto:` link in a rendered body, or reach
-  it with Tab, and a card names its destination right away: the domain and
-  the full URL. For a web link it then fills in the page's title, description,
-  and image where the site publishes them, and a `mailto:` link shows the
-  address. **Fetch link previews** (Settings → General) turns that lookup off
-  when you want the destination alone, and pages on private or local network
-  addresses are never fetched.
+  it with Tab, and a card names its destination right away: a web link's domain
+  and full URL, or the address a `mailto:` link would write to. For a web link
+  it then fills in the page's title, description, and image where the site
+  publishes them. **Fetch link previews** (Settings → General) turns that
+  lookup off when you want the destination alone, and pages on private or
+  local network addresses are never fetched.
 - **Images open fullscreen**: click a screenshot in a rendered description,
   comment, or discussion (or either side of an image diff) to fill the window
   over a dimmed backdrop, with its label and pixel dimensions, a

--- a/changelog.d/added-link-previews.md
+++ b/changelog.d/added-link-previews.md
@@ -1,0 +1,6 @@
+- **Link previews.** Hover a link in any rendered description, comment, or release
+  note, or land on it with Tab, and a card shows where it goes: a web link gives you
+  the domain and the full URL right away, then the page's title, description, and
+  image where the site publishes them, while a `mailto:` link shows the address.
+  **Fetch link previews** under **Settings → General** turns that lookup off when
+  you want the destination alone.

--- a/changelog.d/changed-insights-hovercard-cursor.md
+++ b/changelog.d/changed-insights-hovercard-cursor.md
@@ -1,0 +1,2 @@
+- Dependency hovercards on the **Insights** page open at your cursor, and Tab
+  reaches them from the keyboard.

--- a/changelog.d/changed-insights-hovercard-cursor.md
+++ b/changelog.d/changed-insights-hovercard-cursor.md
@@ -1,2 +1,2 @@
 - Dependency hovercards on the **Insights** page open at your cursor, and Tab
-  reaches them from the keyboard.
+  to a package's name opens its card from the keyboard.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -462,6 +462,9 @@ export const CHECKS = [
       "src/features/repository/BranchSwitcher.tsx",
       // Registers the open dialog with the native-menu gate; add/remove pair.
       "src/lib/hotkeys/modal-gate.ts",
+      // Scroll/resize-close listeners for the open hovercard; add/remove pair,
+      // and re-subscribing after an Activity re-show is the wanted behavior.
+      "src/features/repository/insights/DependenciesCard.tsx",
     ],
     message:
       "an open-transition reset must ride useSeedOnOpen (src/lib/use-seed-on-open.ts) — a hidden <Activity> tab re-mounts its effects on show, so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires and wipes the user's draft; a data-arrival or otherwise idempotent seed needs an allowlist entry with rationale",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -523,6 +523,11 @@ export const capabilities: Capability[] = [
   {
     group: "Keyboard & Markdown",
     label:
+      "Link previews — hover or Tab to a link for its domain & full URL, plus the page's title, description & image",
+  },
+  {
+    group: "Keyboard & Markdown",
+    label:
       "Fullscreen image viewer — screenshots in any rendered body and both sides of an image diff, with fit/100% zoom and arrow-key stepping in fit view",
   },
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["windows-native", "apple-native", "sync-secret-service"] }
 trash = "5"
-tokio = { version = "1", features = ["process", "time", "macros", "sync", "rt-multi-thread", "io-std"] }
+tokio = { version = "1", features = ["process", "time", "macros", "sync", "rt-multi-thread", "io-std", "net"] }
 thiserror = "2"
 base64 = "0.23.1"
 tauri-plugin-notification = "2.3.3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod hooks;
 mod instructions;
 mod jira_field_maps;
 mod jira_links;
+mod link_preview;
 mod local_issues;
 mod local_prs;
 mod mcp;
@@ -590,6 +591,7 @@ pub fn run() {
             dependabot::dependabot_get,
             dependabot::dependabot_set,
             dependabot::dependabot_delete,
+            link_preview::fetch_link_preview,
             github::insights::gh_community_insights,
             github::insights::gh_repo_traffic,
             github::insights::gh_repo_dependencies,

--- a/src-tauri/src/link_preview.rs
+++ b/src-tauri/src/link_preview.rs
@@ -1542,13 +1542,25 @@ mod tests {
         }
     }
 
-    /// The image fetch's first act is to `guard_hop` its target, and that is the whole
-    /// private-network refusal — nothing reaches the network before it. IP literals need
-    /// no DNS, which is what makes these arms testable offline.
+    /// Three layers, because the outer two can each pass for the wrong reason. The
+    /// `guard_hop` arm is the precise "why". The shared loop must then fail with a
+    /// REFUSAL (`InvalidArgument`) and not a transport error (`Command`) — that is what
+    /// distinguishes "the guard rejected it" from "the request was attempted and
+    /// failed", and it is the arm that catches a guard moved after the send. The public
+    /// entry's `None` pins the chain the command actually calls, but a bypass would
+    /// still yield `None` once the doomed request errored, so the elapsed bound below is
+    /// what gives that arm teeth.
+    ///
+    /// Every arm resolves offline: a blocked literal never reaches DNS, `localhost` is
+    /// name-blocked before the lookup, `file://` fails the scheme check, and an
+    /// unparseable candidate is dropped before any of it.
     #[tokio::test]
     async fn a_private_network_image_url_is_refused_before_any_request() {
+        let started = std::time::Instant::now();
         for candidate in [
-            "http://192.168.1.1/setup.cgi?reboot=1",
+            // Inert paths on purpose: if a regression ever lets one of these through,
+            // the suite must not be the thing that acts on the developer's own LAN.
+            "http://192.168.1.1/cover.png",
             "http://127.0.0.1:8080/x.png",
             "http://169.254.169.254/latest/meta-data",
             "http://[::1]/x.png",
@@ -1561,13 +1573,33 @@ mod tests {
                 guard_hop(&target).await.is_err(),
                 "{candidate} must be refused before any request"
             );
+            match fetch_following_redirects(target).await {
+                Err(AppError::InvalidArgument(_)) => {}
+                Err(other) => panic!("{candidate} failed in transit, not at the guard: {other}"),
+                Ok(_) => panic!("{candidate} must never be requested"),
+            }
+            assert!(
+                fetch_image_data(candidate).await.is_none(),
+                "{candidate} must not be fetched"
+            );
         }
         // A public literal clears the guard, again without touching DNS.
         assert!(guard_hop(&url("https://93.184.216.34/cover.png"))
             .await
             .is_ok());
-        // An unparseable candidate never reaches the guard: the fetch drops it first.
+        // An unparseable candidate is dropped before the guard is ever consulted.
         assert!(Url::parse("not a url").is_err());
+        assert!(fetch_image_data("not a url").await.is_none());
+
+        // Refusals are decided in memory, so the whole loop is sub-millisecond work. A
+        // path that reached the network would spend seconds here failing to connect
+        // (6.64s measured with the guard removed), which is the only way the `None`
+        // assertions above can be caught passing for the wrong reason.
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "refusals took {:?} — something attempted a connection",
+            started.elapsed()
+        );
     }
 
     /// The examined-tag bound is what makes the scan linear regardless of body shape;

--- a/src-tauri/src/link_preview.rs
+++ b/src-tauri/src/link_preview.rs
@@ -4,10 +4,13 @@
 //! against a private-network blocklist, a 3-hop redirect cap, and a 512 KiB body cap
 //! parsed by a bounded hand-rolled scan rather than a full HTML parser.
 //!
-//! The returned `og:image` clears that same blocklist before it crosses IPC: the
-//! webview loads it with `<img src>` outside this module's client, under a null CSP,
-//! so an unvetted image URL would hand a hostile page the LAN probe the rest of this
-//! module exists to prevent.
+//! The `og:image` is fetched HERE, through the same client and the same per-hop
+//! validation, and crosses IPC as a `data:` URI rather than a URL. Handing the webview
+//! a URL is not enough: `<img>` follows redirects with no validation of its own, so a
+//! page could point its `og:image` at a host that passes the blocklist and 302 the
+//! webview into the user's LAN. Delivering bytes means the webview issues no
+//! third-party request at all, which also closes that redirect gap and the `Referer`
+//! leak, and leaves no DNS-rebinding window for images.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::OnceLock;
@@ -35,6 +38,10 @@ const MAX_REDIRECTS: usize = 3;
 /// so this is generous, and the cap is what keeps a hostile page from exhausting memory.
 const MAX_BODY_BYTES: usize = 512 * 1024;
 
+/// Ceiling on a proxied `og:image`. Over it the image is dropped rather than cut: a
+/// truncated image is a corrupt one, and the encoded copy also has to cross IPC.
+const MAX_IMAGE_BYTES: usize = 2 * 1024 * 1024;
+
 /// How far [`tag_end`] scans for a tag's `>`, and how many `<meta` occurrences are
 /// examined at all. Together they bound the harvest at ~4 MB of scanning whatever the
 /// body contains: the window alone is not enough, because a document ending in a single
@@ -51,12 +58,25 @@ const MAX_IMAGE_URL_CHARS: usize = 2048;
 
 /// The Open Graph summary a hover card renders. Every field is optional: a page with
 /// no metadata is a valid answer, not an error.
+///
+/// `image_data` is a complete `data:<content-type>;base64,<payload>` URI, not a URL —
+/// see the module doc for why the bytes travel instead of a link.
 #[derive(Debug, Default, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkPreview {
     pub title: Option<String>,
     pub description: Option<String>,
-    pub image_url: Option<String>,
+    pub image_data: Option<String>,
+}
+
+/// What the HTML scan produced. Separate from [`LinkPreview`] because its image is
+/// still a URL at this stage — the type the frontend receives can only ever hold the
+/// fetched bytes, so the two states cannot be confused.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ParsedPreview {
+    title: Option<String>,
+    description: Option<String>,
+    image_url: Option<String>,
 }
 
 /// The preview client, deliberately separate from [`crate::forge::http`]'s: it sends no
@@ -269,34 +289,56 @@ fn next_hop(
     Ok(Some(next))
 }
 
-/// Append `chunk` under [`MAX_BODY_BYTES`], returning `false` once the cap is reached
-/// and reading must stop. Split out from the async read so the cap itself is testable
-/// without a server.
-fn push_capped(buf: &mut Vec<u8>, chunk: &[u8]) -> bool {
-    let room = MAX_BODY_BYTES - buf.len();
-    if chunk.len() >= room {
-        buf.extend_from_slice(&chunk[..room]);
-        return false;
-    }
-    buf.extend_from_slice(chunk);
-    true
+/// Accumulates a response body under a byte cap. One byte past `cap` is read so a body
+/// sitting exactly ON the cap is distinguishable from one exceeding it — the page path
+/// parses a truncated body, but an oversized image has to be dropped. Split from the
+/// async read so tests drive the same accumulator the reader does.
+struct CappedBody {
+    buf: Vec<u8>,
+    cap: usize,
 }
 
-/// Read at most [`MAX_BODY_BYTES`] of the body, chunk by chunk — `.text()` on an
-/// attacker-chosen page would be unbounded. A cut mid-sequence is absorbed by the
-/// lossy decode.
-async fn read_body_capped(mut resp: Response) -> AppResult<String> {
-    let mut buf: Vec<u8> = Vec::new();
+impl CappedBody {
+    fn new(cap: usize) -> Self {
+        Self {
+            buf: Vec::new(),
+            cap,
+        }
+    }
+
+    /// `false` once enough has been read that no further chunk can change the outcome.
+    fn push(&mut self, chunk: &[u8]) -> bool {
+        let room = self.cap.saturating_add(1) - self.buf.len();
+        if chunk.len() >= room {
+            self.buf.extend_from_slice(&chunk[..room]);
+            return false;
+        }
+        self.buf.extend_from_slice(chunk);
+        true
+    }
+
+    /// The bytes trimmed to `cap`, plus whether the source ran past it.
+    fn finish(mut self) -> (Vec<u8>, bool) {
+        let over_cap = self.buf.len() > self.cap;
+        self.buf.truncate(self.cap);
+        (self.buf, over_cap)
+    }
+}
+
+/// Read at most `cap` bytes of the body, chunk by chunk — `.text()` on an
+/// attacker-chosen response would be unbounded.
+async fn read_body_capped(mut resp: Response, cap: usize) -> AppResult<(Vec<u8>, bool)> {
+    let mut body = CappedBody::new(cap);
     while let Some(chunk) = resp
         .chunk()
         .await
         .map_err(|e| AppError::Command(format!("link preview: could not read response: {e}")))?
     {
-        if !push_capped(&mut buf, &chunk) {
+        if !body.push(&chunk) {
             break;
         }
     }
-    Ok(String::from_utf8_lossy(&buf).into_owned())
+    Ok(body.finish())
 }
 
 /// XHTML carries og tags as routinely as HTML does, so both types are parsed; an absent
@@ -311,19 +353,78 @@ fn is_html(headers: &header::HeaderMap) -> bool {
         })
 }
 
-/// Clear an `og:image` for the frontend, which loads it in the webview outside this
-/// module's client. A refusal drops the image rather than failing the preview — the
-/// card renders fine without one, and the page's own text is still trustworthy output.
+/// RFC 7230 token characters, less `#`. `#` is a valid token character but a fragment
+/// delimiter in the data URI this feeds, so it would truncate the media type there the
+/// same way a comma does.
+fn is_media_token(part: &str) -> bool {
+    !part.is_empty()
+        && part
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"!$%&'*+-.^_`|~".contains(&b))
+}
+
+/// The media type to embed in an image data URI, or `None` when the response is not an
+/// image this preview will carry. Pure, so the gate is testable without a response.
+///
+/// The header is attacker-chosen — the page names the `og:image` host — so the value is
+/// validated as `image/<token>` rather than by substring: `image/svg+xml,x` is not equal
+/// to `image/svg+xml`, so it would slip past the refusal below, and a data URI's media
+/// type ends at its first comma, which would also strip the `;base64` flag. SVG is
+/// refused despite being an image type: it is an active document (script, external
+/// references), and og images are raster in practice.
+fn image_media_type(content_type: &str) -> Option<String> {
+    let media_type = content_type.split(';').next()?.trim().to_ascii_lowercase();
+    let (top_level, subtype) = media_type.split_once('/')?;
+    if top_level != "image" || !is_media_token(subtype) {
+        return None;
+    }
+    // Sound only because the token check above rules out the decorated spellings.
+    if media_type == "image/svg+xml" {
+        return None;
+    }
+    Some(media_type)
+}
+
+/// Pre-filter an `og:image` URL before any request: the cheap half of the image guard,
+/// rejecting a private-network target without spending a fetch on it.
 async fn vet_image_url(candidate: &str) -> Option<String> {
     let url = Url::parse(candidate).ok()?;
     guard_hop(&url).await.ok()?;
     Some(candidate.to_string())
 }
 
+/// Compose the `data:` URI the frontend renders as an `<img src>`.
+fn image_data_uri(media_type: &str, bytes: &[u8]) -> String {
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{media_type};base64,{payload}")
+}
+
+/// Fetch a vetted `og:image` through this module's client and return it as a complete
+/// `data:` URI, so the webview never contacts the third-party host. Every failure —
+/// refused hop, non-2xx, wrong media type, oversized or empty body — yields `None`: a
+/// preview without an image is a valid preview, never an error.
+async fn fetch_image_data(url: Url) -> Option<String> {
+    let (_, resp) = fetch_following_redirects(url).await.ok()?;
+    if !(200..300).contains(&resp.status().as_u16()) {
+        return None;
+    }
+    let media_type = image_media_type(
+        resp.headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())?,
+    )?;
+    let (bytes, over_cap) = read_body_capped(resp, MAX_IMAGE_BYTES).await.ok()?;
+    if over_cap || bytes.is_empty() {
+        return None;
+    }
+    Some(image_data_uri(&media_type, &bytes))
+}
+
 /// Fetch a page's Open Graph metadata for the link hover card.
 ///
-/// A page with no metadata, or one that isn't HTML, is `Ok` with every field `None` —
-/// only refused URLs and transport failures are `Err`.
+/// A page with no metadata, or one that isn't HTML, is `Ok` with every field
+/// `None` — only refused URLs and transport failures are `Err`.
 #[tauri::command]
 pub async fn fetch_link_preview(url: String) -> AppResult<LinkPreview> {
     // One deadline over the whole thing: each hop's timeouts are per-request, so four
@@ -333,9 +434,16 @@ pub async fn fetch_link_preview(url: String) -> AppResult<LinkPreview> {
         .map_err(|_| AppError::Command("link preview: timed out".into()))?
 }
 
-async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
-    let mut current = Url::parse(url.trim())
-        .map_err(|_| AppError::InvalidArgument("link preview: not a valid URL".into()))?;
+/// GET `start`, following redirects by hand so [`guard_hop`] clears every hop — the
+/// first one included — before it is requested. Returns the URL that finally served the
+/// response and the response itself, whatever its status; gating the status is the
+/// caller's half.
+///
+/// The page fetch and the image fetch both go through here, so the hop counting,
+/// `Location` resolution, and per-hop validation that [`next_hop`]'s tests cover apply
+/// to both paths — there is only one loop to get right.
+async fn fetch_following_redirects(start: Url) -> AppResult<(Url, Response)> {
+    let mut current = start;
     let mut hops = 0usize;
     loop {
         guard_hop(&current).await?;
@@ -350,24 +458,45 @@ async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
             .get(header::LOCATION)
             .and_then(|v| v.to_str().ok())
             .map(str::to_string);
-        if let Some(next) = next_hop(&current, status, location.as_deref(), hops)? {
-            hops += 1;
-            current = next;
-            continue;
+        match next_hop(&current, status, location.as_deref(), hops)? {
+            Some(next) => {
+                hops += 1;
+                current = next;
+            }
+            None => return Ok((current, resp)),
         }
-        if !(200..300).contains(&status) {
-            return Err(AppError::Command(format!("link preview: HTTP {status}")));
-        }
-        if !is_html(resp.headers()) {
-            return Ok(LinkPreview::default());
-        }
-        let body = read_body_capped(resp).await?;
-        let mut preview = preview_from_html(&body, &current);
-        if let Some(candidate) = preview.image_url.take() {
-            preview.image_url = vet_image_url(&candidate).await;
-        }
-        return Ok(preview);
     }
+}
+
+async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
+    let start = Url::parse(url.trim())
+        .map_err(|_| AppError::InvalidArgument("link preview: not a valid URL".into()))?;
+    let (final_url, resp) = fetch_following_redirects(start).await?;
+    let status = resp.status().as_u16();
+    if !(200..300).contains(&status) {
+        return Err(AppError::Command(format!("link preview: HTTP {status}")));
+    }
+    if !is_html(resp.headers()) {
+        return Ok(LinkPreview::default());
+    }
+    let (body, _) = read_body_capped(resp, MAX_BODY_BYTES).await?;
+    let parsed = preview_from_html(&String::from_utf8_lossy(&body), &final_url);
+    let mut preview = LinkPreview {
+        title: parsed.title,
+        description: parsed.description,
+        image_data: None,
+    };
+    // Vet the URL, then fetch it here rather than handing it to the webview. Both
+    // layers stay: the vet refuses a private target without spending a request, and the
+    // fetch is what survives a redirect the webview would have followed unchecked.
+    if let Some(candidate) = parsed.image_url {
+        if let Some(vetted) = vet_image_url(&candidate).await {
+            if let Ok(url) = Url::parse(&vetted) {
+                preview.image_data = fetch_image_data(url).await;
+            }
+        }
+    }
+    Ok(preview)
 }
 
 // ---------------------------------------------------------------------------
@@ -665,11 +794,12 @@ fn resolve_image(base: &Url, raw: &str) -> Option<String> {
     (text.chars().count() <= MAX_IMAGE_URL_CHARS).then_some(text)
 }
 
-/// Build a preview from a page body and the URL that finally served it.
-fn preview_from_html(html: &str, final_url: &Url) -> LinkPreview {
+/// Build a parse result from a page body and the URL that finally served it. The image
+/// is still a URL here; [`fetch_image_data`] turns it into the bytes that ship.
+fn preview_from_html(html: &str, final_url: &Url) -> ParsedPreview {
     let h = harvest(html);
     let first = |sources: Vec<Option<String>>| sources.into_iter().flatten().next();
-    LinkPreview {
+    ParsedPreview {
         title: first(vec![h.og_title, h.tw_title, h.title_element])
             .and_then(|v| normalize(&v, MAX_TITLE_CHARS)),
         description: first(vec![h.og_description, h.tw_description, h.meta_description])
@@ -688,18 +818,19 @@ mod tests {
         Url::parse(s).expect("test URL parses")
     }
 
-    fn preview(html: &str) -> LinkPreview {
+    fn preview(html: &str) -> ParsedPreview {
         preview_from_html(html, &url("https://example.com/page"))
     }
 
-    /// The frontend reads `imageUrl` off this record; `rename_all` is a rename trap the
-    /// repo has been bitten by, so the wire shape is pinned rather than assumed.
+    /// The frontend reads `imageData` off this record — a data URI, not a URL, and no
+    /// `imageUrl` key at all. `rename_all` is a rename trap the repo has been bitten by,
+    /// so the wire shape is pinned rather than assumed.
     #[test]
     fn link_preview_serializes_to_the_pinned_wire_shape() {
         let value = serde_json::to_value(LinkPreview {
             title: Some("T".into()),
             description: Some("D".into()),
-            image_url: Some("https://example.com/i.png".into()),
+            image_data: Some("data:image/png;base64,AAAA".into()),
         })
         .unwrap();
         assert_eq!(
@@ -707,13 +838,15 @@ mod tests {
             json!({
                 "title": "T",
                 "description": "D",
-                "imageUrl": "https://example.com/i.png",
+                "imageData": "data:image/png;base64,AAAA",
             })
         );
         assert_eq!(
             serde_json::to_value(LinkPreview::default()).unwrap(),
-            json!({ "title": null, "description": null, "imageUrl": null })
+            json!({ "title": null, "description": null, "imageData": null })
         );
+        // The old key is gone, not merely renamed alongside.
+        assert!(value.get("imageUrl").is_none());
     }
 
     #[test]
@@ -1137,18 +1270,18 @@ mod tests {
     fn a_page_without_metadata_yields_all_none() {
         assert_eq!(
             preview("<html><body>Nothing here</body></html>"),
-            LinkPreview::default()
+            ParsedPreview::default()
         );
-        assert_eq!(preview(""), LinkPreview::default());
+        assert_eq!(preview(""), ParsedPreview::default());
         // A meta tag with no `content` contributes nothing.
         assert_eq!(
             preview(r#"<meta property="og:title">"#),
-            LinkPreview::default()
+            ParsedPreview::default()
         );
         // An empty `content` normalizes away rather than becoming an empty string.
         assert_eq!(
             preview(r#"<meta property="og:title" content="  ">"#),
-            LinkPreview::default()
+            ParsedPreview::default()
         );
     }
 
@@ -1202,37 +1335,67 @@ mod tests {
         assert!(!is_html(&headers_with(None)));
     }
 
-    /// Drive the cap the way the async reader does, over an explicit chunk sequence.
-    fn collect_capped(chunks: &[&[u8]]) -> Vec<u8> {
-        let mut buf = Vec::new();
+    /// Drive the accumulator the async reader uses, over an explicit chunk sequence.
+    fn collect_capped(chunks: &[&[u8]], cap: usize) -> (Vec<u8>, bool) {
+        let mut body = CappedBody::new(cap);
         for chunk in chunks {
-            if !push_capped(&mut buf, chunk) {
+            if !body.push(chunk) {
                 break;
             }
         }
-        buf
+        body.finish()
     }
 
     #[test]
     fn the_body_cap_stops_at_exactly_max_body_bytes() {
-        // Well under the cap: everything is kept.
-        let small = collect_capped(&[b"abc", b"def"]);
+        // Well under the cap: everything is kept, and nothing is reported over it.
+        let (small, over) = collect_capped(&[b"abc", b"def"], MAX_BODY_BYTES);
         assert_eq!(small, b"abcdef");
+        assert!(!over);
 
-        // A chunk landing exactly on the cap fills it and stops the read, so a chunk
-        // after it is never appended.
+        // A body landing exactly ON the cap is complete, not over it — the distinction
+        // the image path needs.
         let exact = vec![b'x'; MAX_BODY_BYTES];
-        let filled = collect_capped(&[&exact, b"never"]);
+        let (filled, over) = collect_capped(&[&exact], MAX_BODY_BYTES);
         assert_eq!(filled.len(), MAX_BODY_BYTES);
-        assert!(!filled.ends_with(b"never"));
+        assert!(!over, "a body exactly at the cap is not over it");
 
-        // An overflowing chunk is cut at the cap.
-        let over = vec![b'y'; MAX_BODY_BYTES + 4096];
-        assert_eq!(collect_capped(&[&over]).len(), MAX_BODY_BYTES);
+        // One byte past the cap is over it, and the bytes come back trimmed to the cap.
+        let one_over = vec![b'x'; MAX_BODY_BYTES + 1];
+        let (trimmed, over) = collect_capped(&[&one_over], MAX_BODY_BYTES);
+        assert_eq!(trimmed.len(), MAX_BODY_BYTES);
+        assert!(over, "one byte past the cap is over it");
+
+        // A chunk after the cap is reached is never appended.
+        let (filled, _) = collect_capped(&[&exact, b"never"], MAX_BODY_BYTES);
+        assert!(!filled.ends_with(b"never"));
 
         // The cap counts across chunks, not per chunk.
         let half = vec![b'z'; MAX_BODY_BYTES / 2];
-        assert_eq!(collect_capped(&[&half, &half, &half]).len(), MAX_BODY_BYTES);
+        let (all, over) = collect_capped(&[&half, &half, &half], MAX_BODY_BYTES);
+        assert_eq!(all.len(), MAX_BODY_BYTES);
+        assert!(over);
+    }
+
+    /// The image cap is the same accumulator at a different ceiling, and its boundary is
+    /// what decides drop-vs-keep rather than truncate-vs-keep.
+    #[test]
+    fn the_image_cap_separates_exactly_full_from_oversized() {
+        let exact = vec![0u8; MAX_IMAGE_BYTES];
+        let (bytes, over) = collect_capped(&[&exact], MAX_IMAGE_BYTES);
+        assert_eq!(bytes.len(), MAX_IMAGE_BYTES);
+        assert!(!over, "a 2 MiB image is at the cap, not over it");
+
+        let too_big = vec![0u8; MAX_IMAGE_BYTES + 1];
+        let (_, over) = collect_capped(&[&too_big], MAX_IMAGE_BYTES);
+        assert!(over, "2 MiB + 1 byte is over the cap and gets dropped");
+
+        // Split across chunks the verdict is the same.
+        let chunk = vec![0u8; MAX_IMAGE_BYTES / 2];
+        let (_, over) = collect_capped(&[&chunk, &chunk], MAX_IMAGE_BYTES);
+        assert!(!over);
+        let (_, over) = collect_capped(&[&chunk, &chunk, b"x"], MAX_IMAGE_BYTES);
+        assert!(over);
     }
 
     #[test]
@@ -1240,11 +1403,89 @@ mod tests {
         // Cap-1 ASCII bytes then a 2-byte char: the cut lands between its bytes.
         let mut body = vec![b'a'; MAX_BODY_BYTES - 1];
         body.extend_from_slice("é".as_bytes());
-        let truncated = collect_capped(&[&body]);
+        let (truncated, over) = collect_capped(&[&body], MAX_BODY_BYTES);
         assert_eq!(truncated.len(), MAX_BODY_BYTES);
+        assert!(over);
         let text = String::from_utf8_lossy(&truncated);
         assert!(text.ends_with('\u{fffd}'), "the split char became U+FFFD");
         assert_eq!(text.chars().count(), MAX_BODY_BYTES);
+    }
+
+    #[test]
+    fn image_media_type_accepts_raster_images_only() {
+        for (raw, expected) in [
+            ("image/png", "image/png"),
+            ("IMAGE/PNG", "image/png"),
+            ("image/jpeg; charset=binary", "image/jpeg"),
+            ("  image/webp  ", "image/webp"),
+            ("image/gif", "image/gif"),
+        ] {
+            assert_eq!(image_media_type(raw).as_deref(), Some(expected), "{raw}");
+        }
+        for raw in [
+            "text/html",
+            "application/json",
+            "application/octet-stream",
+            // SVG is an image type but an active document — refused deliberately.
+            "image/svg+xml",
+            "IMAGE/SVG+XML; charset=utf-8",
+            "",
+            "notimage/png",
+            "image",
+            "image/",
+            "/png",
+        ] {
+            assert_eq!(image_media_type(raw), None, "{raw} must not be carried");
+        }
+    }
+
+    /// The header comes from the attacker-chosen image host. A comma ends the media type
+    /// when a data URI is parsed and a `#` starts its fragment, so either one both
+    /// dodges the exact-match SVG refusal and strips the `;base64` flag off the URI the
+    /// frontend receives — the whole reason the subtype is token-validated.
+    #[test]
+    fn image_media_type_rejects_decorated_subtypes() {
+        for raw in [
+            "image/svg+xml,x",
+            "image/svg+xml,",
+            "image/png,x",
+            "image/svg+xml#x",
+            "image/png#",
+            "image/png x",
+            "image/pn g",
+            "image/svg/x",
+            "image/png\"",
+            "image/png\\x",
+        ] {
+            assert_eq!(
+                image_media_type(raw),
+                None,
+                "{raw} must not reach a data URI"
+            );
+        }
+    }
+
+    /// The frontend renders this string directly as an `<img src>`, so both halves of
+    /// the URI have to be exactly right.
+    #[test]
+    fn an_image_data_uri_carries_the_type_and_round_trips_the_bytes() {
+        use base64::Engine;
+
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let uri = image_data_uri("image/png", &bytes);
+        let payload = uri
+            .strip_prefix("data:image/png;base64,")
+            .expect("the prefix names the media type and the encoding");
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(payload)
+                .expect("the payload is valid base64"),
+            bytes,
+            "every byte survives the round trip"
+        );
+        // Empty input still produces a well-formed (empty-payload) URI; the fetch path
+        // rejects empty bodies before reaching here.
+        assert_eq!(image_data_uri("image/gif", &[]), "data:image/gif;base64,");
     }
 
     #[test]
@@ -1253,11 +1494,11 @@ mod tests {
         assert_eq!(preview(cut_mid_tag).title.as_deref(), Some("Good"));
 
         let unclosed_quote = r#"<meta property="og:title" content="never closed"#;
-        assert_eq!(preview(unclosed_quote), LinkPreview::default());
+        assert_eq!(preview(unclosed_quote), ParsedPreview::default());
 
         // A bare `<meta` at the very end is not a tag and must not panic.
-        assert_eq!(preview("<meta"), LinkPreview::default());
-        assert_eq!(preview("<title"), LinkPreview::default());
+        assert_eq!(preview("<meta"), ParsedPreview::default());
+        assert_eq!(preview("<title"), ParsedPreview::default());
         // A `<title>` with no `</title>` has no determinate text, so it yields nothing
         // rather than swallowing the rest of the document.
         assert_eq!(preview("<title>unterminated element").title, None);
@@ -1282,7 +1523,7 @@ mod tests {
             let started = std::time::Instant::now();
             let got = preview_from_html(&body, &base);
             let elapsed = started.elapsed();
-            assert_eq!(got, LinkPreview::default());
+            assert_eq!(got, ParsedPreview::default());
             assert!(
                 elapsed < Duration::from_secs(5),
                 "harvest took {elapsed:?} — the scan is not linear"
@@ -1290,9 +1531,10 @@ mod tests {
         }
     }
 
-    /// The image URL crosses IPC and is loaded by the webview under a null CSP, outside
-    /// this module's client — so it clears the blocklist here or it is not returned.
-    /// IP literals need no DNS, which is what makes both arms testable offline.
+    /// The cheap half of the image guard: refusing a private target here costs no
+    /// request, while the enforcement that matters is the per-hop check inside the fetch
+    /// (a URL cleared here can still redirect). IP literals need no DNS, which is what
+    /// makes both arms testable offline.
     #[tokio::test]
     async fn a_private_network_image_url_is_dropped_not_returned() {
         for candidate in [
@@ -1323,5 +1565,15 @@ mod tests {
         let filler = r#"<meta name="x" content="y">"#.repeat(MAX_META_TAGS - 1);
         let html = format!(r#"{filler}<meta property="og:title" content="Found">"#);
         assert_eq!(preview(&html).title.as_deref(), Some("Found"));
+    }
+
+    /// The mirror of the arm above, pinning the boundary from the far side: without it
+    /// nothing fails if the bound stops biting, since the pathological bodies stay
+    /// inside the hang bound on the tag window alone.
+    #[test]
+    fn metadata_past_the_examined_tag_bound_is_dropped() {
+        let filler = r#"<meta name="x" content="y">"#.repeat(MAX_META_TAGS);
+        let html = format!(r#"{filler}<meta property="og:title" content="Too late">"#);
+        assert_eq!(preview(&html).title, None);
     }
 }

--- a/src-tauri/src/link_preview.rs
+++ b/src-tauri/src/link_preview.rs
@@ -27,9 +27,15 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A hostile authoritative nameserver can stall `getaddrinfo` for the resolver's own
 /// timeout (~30s), once per hop, so the wait is bounded here; [`PREVIEW_DEADLINE`]
-/// then bounds the whole preview so hops cannot stack their budgets.
+/// then bounds the page half and [`IMAGE_DEADLINE`] the image step, so hops cannot
+/// stack their budgets past those two ceilings.
 const DNS_TIMEOUT: Duration = Duration::from_secs(5);
 const PREVIEW_DEADLINE: Duration = Duration::from_secs(15);
+
+/// The image's own best-effort budget, outside [`PREVIEW_DEADLINE`]. Deliberately tight —
+/// below its own constituent timeouts ([`DNS_TIMEOUT`] alone can consume it): exceeding
+/// it costs the card its picture, never its text.
+const IMAGE_DEADLINE: Duration = Duration::from_secs(5);
 
 /// Redirects followed manually (see [`next_hop`]); the 4th is an error.
 const MAX_REDIRECTS: usize = 3;
@@ -223,12 +229,12 @@ fn validate_url(url: &Url) -> AppResult<FetchTarget> {
 }
 
 /// Clear one hop for fetching: [`validate_url`], then DNS when the host is a name. Used
-/// for the page's hops and for the `og:image` the frontend will load.
+/// for the page's hops and for the proxied `og:image` fetch.
 ///
-/// Accepted residual: whoever connects afterwards re-resolves the name — reqwest for a
-/// page hop, the webview for an image — so a DNS-rebinding TOCTOU between this check and
-/// that connection remains open. Tolerable for a hover preview in a desktop app, where
-/// the attacker already needs the user to hover a link they control.
+/// Accepted residual: reqwest re-resolves the name when it connects afterwards, so a
+/// DNS-rebinding TOCTOU between this check and that connection remains open. Tolerable
+/// for a hover preview in a desktop app, where the attacker already needs the user to
+/// hover a link they control.
 async fn guard_hop(url: &Url) -> AppResult<()> {
     let (host, port) = match validate_url(url)? {
         FetchTarget::Literal => return Ok(()),
@@ -385,14 +391,6 @@ fn image_media_type(content_type: &str) -> Option<String> {
     Some(media_type)
 }
 
-/// Pre-filter an `og:image` URL before any request: the cheap half of the image guard,
-/// rejecting a private-network target without spending a fetch on it.
-async fn vet_image_url(candidate: &str) -> Option<String> {
-    let url = Url::parse(candidate).ok()?;
-    guard_hop(&url).await.ok()?;
-    Some(candidate.to_string())
-}
-
 /// Compose the `data:` URI the frontend renders as an `<img src>`.
 fn image_data_uri(media_type: &str, bytes: &[u8]) -> String {
     use base64::Engine;
@@ -400,11 +398,23 @@ fn image_data_uri(media_type: &str, bytes: &[u8]) -> String {
     format!("data:{media_type};base64,{payload}")
 }
 
-/// Fetch a vetted `og:image` through this module's client and return it as a complete
-/// `data:` URI, so the webview never contacts the third-party host. Every failure —
-/// refused hop, non-2xx, wrong media type, oversized or empty body — yields `None`: a
-/// preview without an image is a valid preview, never an error.
-async fn fetch_image_data(url: Url) -> Option<String> {
+/// Fetch an `og:image` through this module's client and return it as a complete `data:`
+/// URI, so the webview never contacts the third-party host. Every failure — unparseable
+/// URL, refused hop, transport failure, non-2xx, a missing or unreadable content type,
+/// wrong media type, oversized or empty body, or [`IMAGE_DEADLINE`] elapsing — yields
+/// `None`: a preview without an image is a valid preview, never an error.
+async fn fetch_image_data(candidate: &str) -> Option<String> {
+    let url = Url::parse(candidate).ok()?;
+    // Its own budget, so a slow image host cannot spend the page's deadline. The first
+    // thing the loop does is `guard_hop` this URL, which is the whole private-network
+    // refusal — no separate pre-check earns its extra DNS lookup.
+    tokio::time::timeout(IMAGE_DEADLINE, load_image_data_uri(url))
+        .await
+        .ok()
+        .flatten()
+}
+
+async fn load_image_data_uri(url: Url) -> Option<String> {
     let (_, resp) = fetch_following_redirects(url).await.ok()?;
     if !(200..300).contains(&resp.status().as_u16()) {
         return None;
@@ -424,14 +434,26 @@ async fn fetch_image_data(url: Url) -> Option<String> {
 /// Fetch a page's Open Graph metadata for the link hover card.
 ///
 /// A page with no metadata, or one that isn't HTML, is `Ok` with every field
-/// `None` — only refused URLs and transport failures are `Err`.
+/// `None` — only refused URLs, transport failures, non-2xx pages, and the page
+/// half's deadline are `Err`. The image step never is.
 #[tauri::command]
 pub async fn fetch_link_preview(url: String) -> AppResult<LinkPreview> {
-    // One deadline over the whole thing: each hop's timeouts are per-request, so four
-    // hops plus DNS plus the image check could otherwise stack into a minute.
-    tokio::time::timeout(PREVIEW_DEADLINE, fetch_preview(url))
+    // The deadline bounds the PAGE fetch, whose hops each carry their own per-request
+    // timeouts and would otherwise stack. The image is deliberately outside it: it has
+    // its own budget and can only ever be absent, so a slow image host cannot discard a
+    // preview whose text already arrived.
+    let parsed = tokio::time::timeout(PREVIEW_DEADLINE, fetch_page(url))
         .await
-        .map_err(|_| AppError::Command("link preview: timed out".into()))?
+        .map_err(|_| AppError::Command("link preview: timed out".into()))??;
+    let image_data = match &parsed.image_url {
+        Some(candidate) => fetch_image_data(candidate).await,
+        None => None,
+    };
+    Ok(LinkPreview {
+        title: parsed.title,
+        description: parsed.description,
+        image_data,
+    })
 }
 
 /// GET `start`, following redirects by hand so [`guard_hop`] clears every hop — the
@@ -468,7 +490,9 @@ async fn fetch_following_redirects(start: Url) -> AppResult<(Url, Response)> {
     }
 }
 
-async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
+/// The page half: everything under [`PREVIEW_DEADLINE`], ending at the parsed metadata.
+/// The image it names is fetched separately so its cost is not charged to this budget.
+async fn fetch_page(url: String) -> AppResult<ParsedPreview> {
     let start = Url::parse(url.trim())
         .map_err(|_| AppError::InvalidArgument("link preview: not a valid URL".into()))?;
     let (final_url, resp) = fetch_following_redirects(start).await?;
@@ -477,26 +501,13 @@ async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
         return Err(AppError::Command(format!("link preview: HTTP {status}")));
     }
     if !is_html(resp.headers()) {
-        return Ok(LinkPreview::default());
+        return Ok(ParsedPreview::default());
     }
     let (body, _) = read_body_capped(resp, MAX_BODY_BYTES).await?;
-    let parsed = preview_from_html(&String::from_utf8_lossy(&body), &final_url);
-    let mut preview = LinkPreview {
-        title: parsed.title,
-        description: parsed.description,
-        image_data: None,
-    };
-    // Vet the URL, then fetch it here rather than handing it to the webview. Both
-    // layers stay: the vet refuses a private target without spending a request, and the
-    // fetch is what survives a redirect the webview would have followed unchecked.
-    if let Some(candidate) = parsed.image_url {
-        if let Some(vetted) = vet_image_url(&candidate).await {
-            if let Ok(url) = Url::parse(&vetted) {
-                preview.image_data = fetch_image_data(url).await;
-            }
-        }
-    }
-    Ok(preview)
+    Ok(preview_from_html(
+        &String::from_utf8_lossy(&body),
+        &final_url,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1531,12 +1542,11 @@ mod tests {
         }
     }
 
-    /// The cheap half of the image guard: refusing a private target here costs no
-    /// request, while the enforcement that matters is the per-hop check inside the fetch
-    /// (a URL cleared here can still redirect). IP literals need no DNS, which is what
-    /// makes both arms testable offline.
+    /// The image fetch's first act is to `guard_hop` its target, and that is the whole
+    /// private-network refusal — nothing reaches the network before it. IP literals need
+    /// no DNS, which is what makes these arms testable offline.
     #[tokio::test]
-    async fn a_private_network_image_url_is_dropped_not_returned() {
+    async fn a_private_network_image_url_is_refused_before_any_request() {
         for candidate in [
             "http://192.168.1.1/setup.cgi?reboot=1",
             "http://127.0.0.1:8080/x.png",
@@ -1545,17 +1555,19 @@ mod tests {
             "http://[::ffff:10.0.0.1]/x.png",
             "http://localhost/x.png",
             "file:///etc/passwd",
-            "not a url",
         ] {
-            assert_eq!(
-                vet_image_url(candidate).await,
-                None,
-                "{candidate} must not reach the webview"
+            let target = Url::parse(candidate).expect("the candidate is a parseable URL");
+            assert!(
+                guard_hop(&target).await.is_err(),
+                "{candidate} must be refused before any request"
             );
         }
-        // A public literal passes through byte-for-byte.
-        let public = "https://93.184.216.34/cover.png";
-        assert_eq!(vet_image_url(public).await, Some(public.to_string()));
+        // A public literal clears the guard, again without touching DNS.
+        assert!(guard_hop(&url("https://93.184.216.34/cover.png"))
+            .await
+            .is_ok());
+        // An unparseable candidate never reaches the guard: the fetch drops it first.
+        assert!(Url::parse("not a url").is_err());
     }
 
     /// The examined-tag bound is what makes the scan linear regardless of body shape;

--- a/src-tauri/src/link_preview.rs
+++ b/src-tauri/src/link_preview.rs
@@ -1,0 +1,1327 @@
+//! Open Graph previews for links in third-party text (PR and issue bodies), for the
+//! frontend's hover card. The URL comes from content the user did not write, so this
+//! is a hardened surface: no credentials, no cookies, every redirect hop re-validated
+//! against a private-network blocklist, a 3-hop redirect cap, and a 512 KiB body cap
+//! parsed by a bounded hand-rolled scan rather than a full HTML parser.
+//!
+//! The returned `og:image` clears that same blocklist before it crosses IPC: the
+//! webview loads it with `<img src>` outside this module's client, under a null CSP,
+//! so an unvetted image URL would hand a hostile page the LAN probe the rest of this
+//! module exists to prevent.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tauri_plugin_http::reqwest::{header, redirect, Client, Response, Url};
+
+use crate::error::{AppError, AppResult};
+
+/// An unreachable host must fail fast, and a hover preview that outlives the hover is
+/// wasted work — both budgets are far tighter than the forge clients'.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A hostile authoritative nameserver can stall `getaddrinfo` for the resolver's own
+/// timeout (~30s), once per hop, so the wait is bounded here; [`PREVIEW_DEADLINE`]
+/// then bounds the whole preview so hops cannot stack their budgets.
+const DNS_TIMEOUT: Duration = Duration::from_secs(5);
+const PREVIEW_DEADLINE: Duration = Duration::from_secs(15);
+
+/// Redirects followed manually (see [`next_hop`]); the 4th is an error.
+const MAX_REDIRECTS: usize = 3;
+
+/// How much response body is read before parsing stops. Metadata lives in `<head>`,
+/// so this is generous, and the cap is what keeps a hostile page from exhausting memory.
+const MAX_BODY_BYTES: usize = 512 * 1024;
+
+/// How far [`tag_end`] scans for a tag's `>`, and how many `<meta` occurrences are
+/// examined at all. Together they bound the harvest at ~4 MB of scanning whatever the
+/// body contains: the window alone is not enough, because a document ending in a single
+/// `>` makes every earlier occurrence scan its full window. Real pages sit orders of
+/// magnitude under both.
+const MAX_TAG_BYTES: usize = 4 * 1024;
+const MAX_META_TAGS: usize = 1024;
+
+const MAX_TITLE_CHARS: usize = 300;
+const MAX_DESCRIPTION_CHARS: usize = 500;
+/// The conventional URL ceiling. An over-long image URL is dropped rather than cut —
+/// a truncated URL is a different URL, and would be a request to somewhere else.
+const MAX_IMAGE_URL_CHARS: usize = 2048;
+
+/// The Open Graph summary a hover card renders. Every field is optional: a page with
+/// no metadata is a valid answer, not an error.
+#[derive(Debug, Default, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkPreview {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub image_url: Option<String>,
+}
+
+/// The preview client, deliberately separate from [`crate::forge::http`]'s: it sends no
+/// credentials and installs no cookie store, and its redirect policy is NONE so no hop
+/// can be requested before [`guard_hop`] has cleared it. `None` when the TLS backend is
+/// unavailable — never falls back to `Client::new()`, whose default policy would follow
+/// redirects past that check.
+static CLIENT: OnceLock<Option<Client>> = OnceLock::new();
+
+fn client() -> AppResult<&'static Client> {
+    CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .user_agent(concat!("GitDesktop/", env!("CARGO_PKG_VERSION")))
+                .connect_timeout(CONNECT_TIMEOUT)
+                .timeout(REQUEST_TIMEOUT)
+                .redirect(redirect::Policy::none())
+                .build()
+                .ok()
+        })
+        .as_ref()
+        .ok_or_else(|| AppError::Command("link preview: HTTP client unavailable".into()))
+}
+
+// ---------------------------------------------------------------------------
+// Address blocklist
+// ---------------------------------------------------------------------------
+
+/// Whether `ip` is anything other than a publicly routable address. Hand-rolled
+/// because `IpAddr::is_global` is nightly-only, and deliberately over-broad: a hovered
+/// link must never become a probe of the user's own network.
+fn ip_is_blocked(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => ipv4_is_blocked(v4),
+        IpAddr::V6(v6) => ipv6_is_blocked(v6),
+    }
+}
+
+fn ipv4_is_blocked(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    ip.is_loopback()            // 127.0.0.0/8
+        || ip.is_private()      // 10/8, 172.16/12, 192.168/16
+        || ip.is_link_local()   // 169.254.0.0/16
+        || ip.is_unspecified()  // 0.0.0.0
+        || ip.is_broadcast()    // 255.255.255.255
+        || ip.is_multicast()    // 224.0.0.0/4
+        // 100.64.0.0/10 — carrier-grade NAT, routable inside an ISP but never public.
+        || (octets[0] == 100 && (64..128).contains(&octets[1]))
+}
+
+/// The IPv4 address an IPv6 address carries, for every form that reaches a v4 network.
+/// Judging these as ordinary v6 addresses would wave the embedded target straight
+/// through the v4 arms, so each is unwrapped and re-checked.
+fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let seg = ip.segments();
+    let from_halves = |hi: u16, lo: u16| Ipv4Addr::from(((hi as u32) << 16) | lo as u32);
+    // ::ffff:a.b.c.d — IPv4-mapped.
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return Some(v4);
+    }
+    // ::a.b.c.d — IPv4-compatible: deprecated, but still translated by some stacks.
+    // `::` and `::1` are their own arms below, not embeddings.
+    if seg[..6] == [0, 0, 0, 0, 0, 0] && !(seg[6] == 0 && seg[7] <= 1) {
+        return Some(from_halves(seg[6], seg[7]));
+    }
+    // 64:ff9b::/96 — the NAT64 well-known prefix.
+    if seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2..6] == [0, 0, 0, 0] {
+        return Some(from_halves(seg[6], seg[7]));
+    }
+    // 2002:a.b.c.d::/48 — 6to4 carries its v4 endpoint in the second and third groups.
+    if seg[0] == 0x2002 {
+        return Some(from_halves(seg[1], seg[2]));
+    }
+    None
+}
+
+fn ipv6_is_blocked(ip: Ipv6Addr) -> bool {
+    if let Some(v4) = embedded_ipv4(ip) {
+        return ipv4_is_blocked(v4);
+    }
+    let first = ip.segments()[0];
+    ip.is_loopback()                  // ::1
+        || ip.is_unspecified()        // ::
+        || ip.is_multicast()          // ff00::/8
+        || (first & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+        || (first & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        || (first & 0xffc0) == 0xfec0 // fec0::/10 deprecated site-local
+}
+
+// ---------------------------------------------------------------------------
+// Per-hop validation
+// ---------------------------------------------------------------------------
+
+/// What a validated URL still needs before it can be requested.
+#[derive(Debug, PartialEq, Eq)]
+enum FetchTarget {
+    /// The host is an IP literal that already cleared [`ip_is_blocked`].
+    Literal,
+    /// The host is a name; every address it resolves to must clear the blocklist too.
+    Resolve { host: String, port: u16 },
+}
+
+fn blocked(host: &str) -> AppError {
+    AppError::InvalidArgument(format!("link preview refused: {host} is not a public host"))
+}
+
+/// Validate one hop's URL — scheme, host presence, and the name/IP blocklist — before
+/// it is requested. Pure: DNS is the caller's half (see [`guard_hop`]).
+fn validate_url(url: &Url) -> AppResult<FetchTarget> {
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(AppError::InvalidArgument(format!(
+            "link preview supports http and https only, not {scheme}"
+        )));
+    }
+    let host = url
+        .host_str()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| AppError::InvalidArgument("link preview: URL has no host".into()))?;
+    // `host_str` brackets IPv6 literals; strip them before parsing.
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = bare.parse::<IpAddr>() {
+        return if ip_is_blocked(ip) {
+            Err(blocked(host))
+        } else {
+            Ok(FetchTarget::Literal)
+        };
+    }
+    let lower = host.to_ascii_lowercase();
+    // The trailing root dot resolves identically, so it is stripped before matching.
+    let name = lower.trim_end_matches('.');
+    if name == "localhost" || name.ends_with(".localhost") || name.ends_with(".local") {
+        return Err(blocked(host));
+    }
+    // `port()` is `None` exactly when the URL uses the scheme's default, which the
+    // scheme check above has already narrowed to these two.
+    let port = url
+        .port()
+        .unwrap_or(if scheme == "https" { 443 } else { 80 });
+    Ok(FetchTarget::Resolve { host: lower, port })
+}
+
+/// Clear one hop for fetching: [`validate_url`], then DNS when the host is a name. Used
+/// for the page's hops and for the `og:image` the frontend will load.
+///
+/// Accepted residual: whoever connects afterwards re-resolves the name — reqwest for a
+/// page hop, the webview for an image — so a DNS-rebinding TOCTOU between this check and
+/// that connection remains open. Tolerable for a hover preview in a desktop app, where
+/// the attacker already needs the user to hover a link they control.
+async fn guard_hop(url: &Url) -> AppResult<()> {
+    let (host, port) = match validate_url(url)? {
+        FetchTarget::Literal => return Ok(()),
+        FetchTarget::Resolve { host, port } => (host, port),
+    };
+    // The timeout bounds OUR wait, not the OS resolver's thread: tokio runs the blocking
+    // `getaddrinfo` on its blocking pool, and that task runs on to its own completion.
+    let addrs = tokio::time::timeout(DNS_TIMEOUT, tokio::net::lookup_host((host.as_str(), port)))
+        .await
+        .map_err(|_| AppError::Command(format!("link preview: DNS timed out for {host}")))?
+        .map_err(|_| AppError::Command(format!("link preview: could not resolve {host}")))?;
+    let mut resolved_any = false;
+    for addr in addrs {
+        resolved_any = true;
+        if ip_is_blocked(addr.ip()) {
+            return Err(blocked(&host));
+        }
+    }
+    if !resolved_any {
+        return Err(AppError::Command(format!(
+            "link preview: could not resolve {host}"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Redirect loop
+// ---------------------------------------------------------------------------
+
+/// Decide one step of the redirect loop from a hop's status and `Location`: `Ok(None)`
+/// for a terminal status, `Ok(Some(next))` for the hop to take, `Err` past the cap or
+/// on an unusable `Location`. Pure, so hop counting and `Location` resolution are
+/// testable without a server.
+fn next_hop(
+    current: &Url,
+    status: u16,
+    location: Option<&str>,
+    hops_taken: usize,
+) -> AppResult<Option<Url>> {
+    if !matches!(status, 301 | 302 | 303 | 307 | 308) {
+        return Ok(None);
+    }
+    if hops_taken >= MAX_REDIRECTS {
+        return Err(AppError::Command("link preview: too many redirects".into()));
+    }
+    let location = location
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .ok_or_else(|| {
+            AppError::Command(format!("link preview: HTTP {status} without a Location"))
+        })?;
+    // Relative and protocol-relative Locations are both real, so joining against the
+    // URL that produced the redirect is the only correct resolution.
+    let next = current
+        .join(location)
+        .map_err(|_| AppError::Command("link preview: redirect target is not a URL".into()))?;
+    Ok(Some(next))
+}
+
+/// Append `chunk` under [`MAX_BODY_BYTES`], returning `false` once the cap is reached
+/// and reading must stop. Split out from the async read so the cap itself is testable
+/// without a server.
+fn push_capped(buf: &mut Vec<u8>, chunk: &[u8]) -> bool {
+    let room = MAX_BODY_BYTES - buf.len();
+    if chunk.len() >= room {
+        buf.extend_from_slice(&chunk[..room]);
+        return false;
+    }
+    buf.extend_from_slice(chunk);
+    true
+}
+
+/// Read at most [`MAX_BODY_BYTES`] of the body, chunk by chunk — `.text()` on an
+/// attacker-chosen page would be unbounded. A cut mid-sequence is absorbed by the
+/// lossy decode.
+async fn read_body_capped(mut resp: Response) -> AppResult<String> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| AppError::Command(format!("link preview: could not read response: {e}")))?
+    {
+        if !push_capped(&mut buf, &chunk) {
+            break;
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// XHTML carries og tags as routinely as HTML does, so both types are parsed; an absent
+/// or any other content type is not.
+fn is_html(headers: &header::HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| {
+            let v = v.to_ascii_lowercase();
+            v.contains("text/html") || v.contains("application/xhtml+xml")
+        })
+}
+
+/// Clear an `og:image` for the frontend, which loads it in the webview outside this
+/// module's client. A refusal drops the image rather than failing the preview — the
+/// card renders fine without one, and the page's own text is still trustworthy output.
+async fn vet_image_url(candidate: &str) -> Option<String> {
+    let url = Url::parse(candidate).ok()?;
+    guard_hop(&url).await.ok()?;
+    Some(candidate.to_string())
+}
+
+/// Fetch a page's Open Graph metadata for the link hover card.
+///
+/// A page with no metadata, or one that isn't HTML, is `Ok` with every field `None` —
+/// only refused URLs and transport failures are `Err`.
+#[tauri::command]
+pub async fn fetch_link_preview(url: String) -> AppResult<LinkPreview> {
+    // One deadline over the whole thing: each hop's timeouts are per-request, so four
+    // hops plus DNS plus the image check could otherwise stack into a minute.
+    tokio::time::timeout(PREVIEW_DEADLINE, fetch_preview(url))
+        .await
+        .map_err(|_| AppError::Command("link preview: timed out".into()))?
+}
+
+async fn fetch_preview(url: String) -> AppResult<LinkPreview> {
+    let mut current = Url::parse(url.trim())
+        .map_err(|_| AppError::InvalidArgument("link preview: not a valid URL".into()))?;
+    let mut hops = 0usize;
+    loop {
+        guard_hop(&current).await?;
+        let resp = client()?
+            .get(current.clone())
+            .send()
+            .await
+            .map_err(|e| AppError::Command(format!("link preview request failed: {e}")))?;
+        let status = resp.status().as_u16();
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        if let Some(next) = next_hop(&current, status, location.as_deref(), hops)? {
+            hops += 1;
+            current = next;
+            continue;
+        }
+        if !(200..300).contains(&status) {
+            return Err(AppError::Command(format!("link preview: HTTP {status}")));
+        }
+        if !is_html(resp.headers()) {
+            return Ok(LinkPreview::default());
+        }
+        let body = read_body_capped(resp).await?;
+        let mut preview = preview_from_html(&body, &current);
+        if let Some(candidate) = preview.image_url.take() {
+            preview.image_url = vet_image_url(&candidate).await;
+        }
+        return Ok(preview);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/// The raw (still entity-encoded) values a scan found, one slot per source so
+/// precedence is decided once in [`preview_from_html`] rather than by document order.
+#[derive(Default)]
+struct Harvest {
+    og_title: Option<String>,
+    og_description: Option<String>,
+    og_image: Option<String>,
+    og_image_url: Option<String>,
+    tw_title: Option<String>,
+    tw_description: Option<String>,
+    tw_image: Option<String>,
+    tw_image_src: Option<String>,
+    meta_description: Option<String>,
+    title_element: Option<String>,
+}
+
+/// Index of the `>` that closes a tag opened at `from`, skipping quoted attribute values
+/// (a `>` inside one does not end the tag). `None` when none appears within
+/// [`MAX_TAG_BYTES`] — an unwindowed scan is what made a page of unterminated tags cost
+/// O(n²), since every one of them would rescan to the end of the document.
+fn tag_end(bytes: &[u8], from: usize) -> Option<usize> {
+    let limit = bytes.len().min(from.saturating_add(MAX_TAG_BYTES));
+    let mut i = from;
+    let mut quote: Option<u8> = None;
+    while i < limit {
+        let c = bytes[i];
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some(_) => {}
+            None if c == b'"' || c == b'\'' => quote = Some(c),
+            None if c == b'>' => return Some(i),
+            None => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether [`tag_end`]'s `None` means the document itself ran out (rather than the tag
+/// merely being longer than the window).
+fn window_reached_end(bytes: &[u8], from: usize) -> bool {
+    from.saturating_add(MAX_TAG_BYTES) >= bytes.len()
+}
+
+/// Attribute pairs of a tag body, names lowercased and values raw. Handles single-,
+/// double-, and un-quoted values in any order, and tolerates valueless attributes.
+/// Every index advanced past is ASCII, so the slices stay on char boundaries.
+fn parse_attributes(tag: &str) -> Vec<(String, String)> {
+    let bytes = tag.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        while i < bytes.len() && (bytes[i].is_ascii_whitespace() || bytes[i] == b'/') {
+            i += 1;
+        }
+        let name_start = i;
+        while i < bytes.len()
+            && !bytes[i].is_ascii_whitespace()
+            && bytes[i] != b'='
+            && bytes[i] != b'/'
+        {
+            i += 1;
+        }
+        let name = tag[name_start..i].to_ascii_lowercase();
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let mut value = String::new();
+        if i < bytes.len() && bytes[i] == b'=' {
+            i += 1;
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i < bytes.len() && (bytes[i] == b'"' || bytes[i] == b'\'') {
+                let quote = bytes[i];
+                i += 1;
+                let start = i;
+                while i < bytes.len() && bytes[i] != quote {
+                    i += 1;
+                }
+                value.push_str(&tag[start..i]);
+                if i < bytes.len() {
+                    i += 1;
+                }
+            } else {
+                let start = i;
+                while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                    i += 1;
+                }
+                value.push_str(&tag[start..i]);
+            }
+        }
+        if name.is_empty() {
+            // No name and no progress would spin; the delimiter skip above guarantees
+            // one of the two.
+            if i < bytes.len() && bytes[i] != b'=' {
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        out.push((name, value));
+    }
+    out
+}
+
+/// Whether the byte at `at` ends an HTML tag name (so `<metadata>` isn't a `<meta>`).
+fn ends_tag_name(bytes: &[u8], at: usize) -> bool {
+    matches!(bytes.get(at), Some(c) if c.is_ascii_whitespace() || *c == b'/' || *c == b'>')
+}
+
+fn harvest(html: &str) -> Harvest {
+    // ASCII-lowercasing preserves byte length, so indices found here slice `html`.
+    let lower = html.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+    let mut h = Harvest::default();
+
+    let mut examined = 0usize;
+    for (start, _) in lower.match_indices("<meta") {
+        let after = start + "<meta".len();
+        if !ends_tag_name(bytes, after) {
+            continue;
+        }
+        examined += 1;
+        if examined > MAX_META_TAGS {
+            break;
+        }
+        let Some(end) = tag_end(bytes, after) else {
+            if window_reached_end(bytes, after) {
+                // The document ends inside this tag, so everything after it is inside it
+                // too and no later `<meta` can close either. Stopping here is what keeps
+                // a body of unterminated tags linear instead of quadratic.
+                break;
+            }
+            // Merely absurd rather than unterminated — skip this one and keep scanning.
+            continue;
+        };
+        let attrs = parse_attributes(&html[after..end]);
+        let Some(content) = attrs.iter().find(|(n, _)| n == "content").map(|(_, v)| v) else {
+            continue;
+        };
+        // Pages disagree about which attribute names a key (`property` for og, `name`
+        // for twitter — but both spellings occur for both), so either one is read.
+        for (attr, key) in &attrs {
+            if attr != "property" && attr != "name" {
+                continue;
+            }
+            let slot = match key.trim().to_ascii_lowercase().as_str() {
+                "og:title" => &mut h.og_title,
+                "og:description" => &mut h.og_description,
+                "og:image" => &mut h.og_image,
+                "og:image:url" => &mut h.og_image_url,
+                "twitter:title" => &mut h.tw_title,
+                "twitter:description" => &mut h.tw_description,
+                "twitter:image" => &mut h.tw_image,
+                "twitter:image:src" => &mut h.tw_image_src,
+                "description" => &mut h.meta_description,
+                _ => continue,
+            };
+            if slot.is_none() {
+                *slot = Some(content.clone());
+            }
+        }
+    }
+
+    h.title_element = lower
+        .match_indices("<title")
+        .find(|(i, _)| ends_tag_name(bytes, i + "<title".len()))
+        .and_then(|(start, _)| {
+            let open_end = tag_end(bytes, start + "<title".len())?;
+            let text_start = open_end.checked_add(1).filter(|s| *s <= bytes.len())?;
+            let rel = lower[text_start..].find("</title")?;
+            Some(html[text_start..text_start + rel].to_string())
+        });
+
+    h
+}
+
+/// Decode the HTML entities that actually appear in page metadata: numeric (`&#123;`,
+/// `&#x1f;`) plus the common named set. An unknown or unterminated entity is copied
+/// through verbatim — a preview renders text, so a miss is cosmetic.
+fn decode_entities(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        let after = &rest[amp + 1..];
+        // Bounded lookahead so a bare `&` in prose costs a few chars, not a full scan.
+        let terminator = after
+            .char_indices()
+            .take(12)
+            .find(|(_, c)| *c == ';')
+            .map(|(i, _)| i);
+        match terminator.and_then(|end| decode_entity(&after[..end]).map(|d| (d, end))) {
+            Some((decoded, end)) => {
+                out.push_str(&decoded);
+                rest = &after[end + 1..];
+            }
+            None => {
+                out.push('&');
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn decode_entity(body: &str) -> Option<String> {
+    if let Some(digits) = body.strip_prefix('#') {
+        let hex = digits
+            .strip_prefix('x')
+            .or_else(|| digits.strip_prefix('X'));
+        let code = match hex {
+            Some(h) => u32::from_str_radix(h, 16).ok()?,
+            None => digits.parse::<u32>().ok()?,
+        };
+        return char::from_u32(code).map(String::from);
+    }
+    let named = match body {
+        "amp" => "&",
+        "lt" => "<",
+        "gt" => ">",
+        "quot" => "\"",
+        "apos" => "'",
+        "nbsp" => "\u{a0}",
+        "mdash" => "\u{2014}",
+        "ndash" => "\u{2013}",
+        "hellip" => "\u{2026}",
+        "lsquo" => "\u{2018}",
+        "rsquo" => "\u{2019}",
+        "ldquo" => "\u{201c}",
+        "rdquo" => "\u{201d}",
+        "copy" => "\u{a9}",
+        "reg" => "\u{ae}",
+        "trade" => "\u{2122}",
+        "deg" => "\u{b0}",
+        "middot" => "\u{b7}",
+        "bull" => "\u{2022}",
+        _ => return None,
+    };
+    Some(named.to_string())
+}
+
+/// Decode, collapse whitespace runs (control characters counted as whitespace — the
+/// card renders text, never markup), trim, and drop an empty result.
+fn collapse(raw: &str) -> Option<String> {
+    let decoded = decode_entities(raw);
+    let mut collapsed = String::with_capacity(decoded.len());
+    let mut pending_space = false;
+    for c in decoded.chars() {
+        if c.is_whitespace() || c.is_control() {
+            pending_space = !collapsed.is_empty();
+        } else {
+            if pending_space {
+                collapsed.push(' ');
+                pending_space = false;
+            }
+            collapsed.push(c);
+        }
+    }
+    let trimmed = collapsed.trim_end();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// [`collapse`] plus a `max_chars` cap for prose fields, cut on a char boundary.
+fn normalize(raw: &str, max_chars: usize) -> Option<String> {
+    let text = collapse(raw)?;
+    let capped = if text.chars().count() > max_chars {
+        text.chars().take(max_chars).collect::<String>()
+    } else {
+        text
+    };
+    let trimmed = capped.trim_end();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Resolve an `og:image` against the page's FINAL (post-redirect) URL — the value is
+/// routinely relative or protocol-relative. A result that isn't http(s) (a `data:` URI,
+/// say) or that exceeds [`MAX_IMAGE_URL_CHARS`] is dropped: unlike prose, a URL cannot
+/// be truncated without becoming a different URL.
+fn resolve_image(base: &Url, raw: &str) -> Option<String> {
+    let value = collapse(raw)?;
+    let resolved = base.join(&value).ok()?;
+    if !matches!(resolved.scheme(), "http" | "https") {
+        return None;
+    }
+    let text = resolved.to_string();
+    (text.chars().count() <= MAX_IMAGE_URL_CHARS).then_some(text)
+}
+
+/// Build a preview from a page body and the URL that finally served it.
+fn preview_from_html(html: &str, final_url: &Url) -> LinkPreview {
+    let h = harvest(html);
+    let first = |sources: Vec<Option<String>>| sources.into_iter().flatten().next();
+    LinkPreview {
+        title: first(vec![h.og_title, h.tw_title, h.title_element])
+            .and_then(|v| normalize(&v, MAX_TITLE_CHARS)),
+        description: first(vec![h.og_description, h.tw_description, h.meta_description])
+            .and_then(|v| normalize(&v, MAX_DESCRIPTION_CHARS)),
+        image_url: first(vec![h.og_image, h.og_image_url, h.tw_image, h.tw_image_src])
+            .and_then(|v| resolve_image(final_url, &v)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).expect("test URL parses")
+    }
+
+    fn preview(html: &str) -> LinkPreview {
+        preview_from_html(html, &url("https://example.com/page"))
+    }
+
+    /// The frontend reads `imageUrl` off this record; `rename_all` is a rename trap the
+    /// repo has been bitten by, so the wire shape is pinned rather than assumed.
+    #[test]
+    fn link_preview_serializes_to_the_pinned_wire_shape() {
+        let value = serde_json::to_value(LinkPreview {
+            title: Some("T".into()),
+            description: Some("D".into()),
+            image_url: Some("https://example.com/i.png".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "title": "T",
+                "description": "D",
+                "imageUrl": "https://example.com/i.png",
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(LinkPreview::default()).unwrap(),
+            json!({ "title": null, "description": null, "imageUrl": null })
+        );
+    }
+
+    #[test]
+    fn ip_is_blocked_covers_every_private_range() {
+        let blocked = [
+            "127.0.0.1",
+            "127.255.255.254",
+            "10.0.0.1",
+            "10.255.255.255",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.0.1",
+            "192.168.255.255",
+            "169.254.169.254",
+            "100.64.0.0",
+            "100.127.255.255",
+            "0.0.0.0",
+            "255.255.255.255",
+            "::1",
+            "::",
+            "fc00::1",
+            "fd12:3456::1",
+            "fdff:ffff::1",
+            "fe80::1",
+            "febf::1",
+            // Deprecated site-local, and multicast in both families.
+            "fec0::1",
+            "feff::1",
+            "ff02::1",
+            "224.0.0.1",
+            "239.255.255.250",
+        ];
+        for raw in blocked {
+            let ip: IpAddr = raw.parse().unwrap();
+            assert!(ip_is_blocked(ip), "{raw} should be blocked");
+        }
+    }
+
+    #[test]
+    fn ip_is_blocked_allows_the_neighbours_of_each_range() {
+        let allowed = [
+            "126.255.255.255",
+            "128.0.0.1",
+            "9.255.255.255",
+            "11.0.0.1",
+            "172.15.255.255",
+            "172.32.0.1",
+            "192.167.255.255",
+            "192.169.0.1",
+            "169.253.255.255",
+            "169.255.0.1",
+            "100.63.255.255",
+            "100.128.0.0",
+            "0.0.0.1",
+            "255.255.255.254",
+            "8.8.8.8",
+            "223.255.255.255",
+            "240.0.0.1",
+            "2606:4700:4700::1111",
+            "fbff:ffff::1",
+            "fe00::1",
+        ];
+        for raw in allowed {
+            let ip: IpAddr = raw.parse().unwrap();
+            assert!(!ip_is_blocked(ip), "{raw} should be allowed");
+        }
+    }
+
+    /// `::ffff:a.b.c.d` reaches the embedded v4 network, so it must be judged by the v4
+    /// arms — treating it as an ordinary v6 address would wave 127.0.0.1 straight through.
+    #[test]
+    fn ip_is_blocked_unwraps_ipv4_mapped_addresses() {
+        for raw in [
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::ffff:169.254.169.254",
+        ] {
+            let ip: IpAddr = raw.parse().unwrap();
+            assert!(ip_is_blocked(ip), "{raw} should be blocked");
+        }
+        let public: IpAddr = "::ffff:8.8.8.8".parse().unwrap();
+        assert!(!ip_is_blocked(public));
+    }
+
+    /// Three more v6 spellings reach a v4 network without being IPv4-MAPPED, so each has
+    /// to be unwrapped too: IPv4-compatible, NAT64, and 6to4. Every one of them cleared
+    /// the blocklist before this arm existed.
+    #[test]
+    fn ip_is_blocked_unwraps_the_other_v4_embeddings() {
+        let blocked = [
+            "::127.0.0.1",        // IPv4-compatible (::7f00:1)
+            "::192.168.1.1",      // IPv4-compatible
+            "64:ff9b::127.0.0.1", // NAT64 well-known prefix
+            "64:ff9b::10.0.0.1",  // NAT64
+            "2002:7f00:0001::1",  // 6to4 wrapping 127.0.0.1
+            "2002:c0a8:0101::1",  // 6to4 wrapping 192.168.1.1
+        ];
+        for raw in blocked {
+            let ip: IpAddr = raw.parse().unwrap();
+            assert!(ip_is_blocked(ip), "{raw} should be blocked");
+        }
+        // Unwrapping re-checks rather than blanket-blocks: the same forms around a
+        // public v4 address stay allowed.
+        let allowed = ["::8.8.8.8", "64:ff9b::8.8.8.8", "2002:0808:0808::1"];
+        for raw in allowed {
+            let ip: IpAddr = raw.parse().unwrap();
+            assert!(!ip_is_blocked(ip), "{raw} should be allowed");
+        }
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http_schemes() {
+        for raw in [
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "data:text/html,x",
+        ] {
+            assert!(validate_url(&url(raw)).is_err(), "{raw} should be refused");
+        }
+    }
+
+    #[test]
+    fn validate_url_rejects_loopback_names() {
+        for raw in [
+            "http://localhost/x",
+            "https://LOCALHOST:8080/x",
+            "http://localhost./x",
+            "http://api.localhost/x",
+            "http://printer.local/x",
+        ] {
+            assert!(validate_url(&url(raw)).is_err(), "{raw} should be refused");
+        }
+    }
+
+    #[test]
+    fn validate_url_rejects_blocked_ip_literals() {
+        for raw in [
+            "http://127.0.0.1/x",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]/x",
+            "http://[fe80::1]/x",
+            "http://[::ffff:127.0.0.1]/x",
+            // The url crate normalizes IPv4 shorthands, so the decimal spelling of
+            // 127.0.0.1 is caught by the same literal check.
+            "http://2130706433/x",
+        ] {
+            assert!(validate_url(&url(raw)).is_err(), "{raw} should be refused");
+        }
+    }
+
+    #[test]
+    fn validate_url_defers_names_to_dns_with_the_right_port() {
+        assert_eq!(
+            validate_url(&url("https://Example.COM/page")).unwrap(),
+            FetchTarget::Resolve {
+                host: "example.com".into(),
+                port: 443
+            }
+        );
+        assert_eq!(
+            validate_url(&url("http://example.com/page")).unwrap(),
+            FetchTarget::Resolve {
+                host: "example.com".into(),
+                port: 80
+            }
+        );
+        assert_eq!(
+            validate_url(&url("http://example.com:8443/page")).unwrap(),
+            FetchTarget::Resolve {
+                host: "example.com".into(),
+                port: 8443
+            }
+        );
+        assert_eq!(
+            validate_url(&url("https://93.184.216.34/page")).unwrap(),
+            FetchTarget::Literal
+        );
+    }
+
+    /// Hrefs reach the command with their author's casing (`HTTPS://…`), so the scheme
+    /// comparison rides on the WHATWG parser lowercasing it. Pinned against the crate
+    /// rather than the standard.
+    #[test]
+    fn an_uppercase_scheme_is_lowercased_before_the_scheme_check() {
+        let parsed = url("HTTPS://EXAMPLE.COM/p");
+        assert_eq!(parsed.scheme(), "https");
+        assert_eq!(
+            validate_url(&parsed).unwrap(),
+            FetchTarget::Resolve {
+                host: "example.com".into(),
+                port: 443
+            }
+        );
+        assert_eq!(url("HTTP://Example.com/p").scheme(), "http");
+        // The same normalization must not rescue a refused scheme.
+        assert!(validate_url(&url("FILE:///etc/passwd")).is_err());
+    }
+
+    #[test]
+    fn next_hop_returns_none_for_a_terminal_status() {
+        let current = url("https://example.com/a");
+        assert_eq!(next_hop(&current, 200, None, 0).unwrap(), None);
+        assert_eq!(next_hop(&current, 404, Some("/b"), 0).unwrap(), None);
+        // 304/305 are not redirects we follow.
+        assert_eq!(next_hop(&current, 304, Some("/b"), 0).unwrap(), None);
+    }
+
+    #[test]
+    fn next_hop_resolves_relative_and_protocol_relative_locations() {
+        let current = url("https://example.com/dir/page?q=1");
+        assert_eq!(
+            next_hop(&current, 302, Some("other"), 0).unwrap(),
+            Some(url("https://example.com/dir/other"))
+        );
+        assert_eq!(
+            next_hop(&current, 301, Some("/root"), 0).unwrap(),
+            Some(url("https://example.com/root"))
+        );
+        assert_eq!(
+            next_hop(&current, 308, Some("//cdn.example.net/x"), 0).unwrap(),
+            Some(url("https://cdn.example.net/x"))
+        );
+        assert_eq!(
+            next_hop(&current, 307, Some("  https://other.example/y  "), 0).unwrap(),
+            Some(url("https://other.example/y"))
+        );
+    }
+
+    #[test]
+    fn next_hop_follows_three_redirects_and_refuses_the_fourth() {
+        let current = url("https://example.com/a");
+        for hops_taken in 0..MAX_REDIRECTS {
+            assert!(
+                next_hop(&current, 302, Some("/next"), hops_taken)
+                    .unwrap()
+                    .is_some(),
+                "hop {hops_taken} should be followed"
+            );
+        }
+        let err = next_hop(&current, 302, Some("/next"), MAX_REDIRECTS).unwrap_err();
+        assert!(err.to_string().contains("too many redirects"));
+    }
+
+    #[test]
+    fn next_hop_errors_on_an_unusable_location() {
+        let current = url("https://example.com/a");
+        assert!(next_hop(&current, 302, None, 0).is_err());
+        assert!(next_hop(&current, 302, Some("   "), 0).is_err());
+        assert!(next_hop(&current, 302, Some("http://"), 0).is_err());
+    }
+
+    #[test]
+    fn meta_parser_reads_both_attribute_orders() {
+        let content_last = r#"<meta property="og:title" content="Order A">"#;
+        assert_eq!(preview(content_last).title.as_deref(), Some("Order A"));
+        let content_first = r#"<meta content="Order B" property="og:title">"#;
+        assert_eq!(preview(content_first).title.as_deref(), Some("Order B"));
+        // Other attributes on the tag must not confuse the scan.
+        let noisy = r#"<meta charset="utf-8" data-x content = 'Order C' property = "og:title" />"#;
+        assert_eq!(preview(noisy).title.as_deref(), Some("Order C"));
+    }
+
+    #[test]
+    fn meta_parser_reads_single_and_double_quoted_values() {
+        let single = "<meta property='og:description' content='Single quoted'>";
+        assert_eq!(
+            preview(single).description.as_deref(),
+            Some("Single quoted")
+        );
+        let double = r#"<meta property="og:description" content="Double quoted">"#;
+        assert_eq!(
+            preview(double).description.as_deref(),
+            Some("Double quoted")
+        );
+        // A `>` inside a quoted value does not end the tag.
+        let angled = r#"<meta property="og:title" content="A > B"><meta property="og:description" content="After">"#;
+        let p = preview(angled);
+        assert_eq!(p.title.as_deref(), Some("A > B"));
+        assert_eq!(p.description.as_deref(), Some("After"));
+    }
+
+    #[test]
+    fn og_beats_twitter_which_beats_the_title_element() {
+        let all = r#"<title>Element</title>
+            <meta name="twitter:title" content="Twitter">
+            <meta property="og:title" content="OpenGraph">"#;
+        assert_eq!(preview(all).title.as_deref(), Some("OpenGraph"));
+
+        let twitter_only = r#"<title>Element</title>
+            <meta name="twitter:title" content="Twitter">"#;
+        assert_eq!(preview(twitter_only).title.as_deref(), Some("Twitter"));
+    }
+
+    #[test]
+    fn title_element_is_the_last_title_fallback() {
+        let html = "<html><head><title>  Just the element  </title></head></html>";
+        assert_eq!(preview(html).title.as_deref(), Some("Just the element"));
+        // `<titlebar>` is not `<title>`.
+        assert_eq!(preview("<titlebar>nope</titlebar>").title, None);
+    }
+
+    #[test]
+    fn name_description_is_the_last_description_fallback() {
+        let plain = r#"<meta name="description" content="Plain meta">"#;
+        assert_eq!(preview(plain).description.as_deref(), Some("Plain meta"));
+
+        let with_twitter = r#"<meta name="description" content="Plain meta">
+            <meta name="twitter:description" content="Twitter meta">"#;
+        assert_eq!(
+            preview(with_twitter).description.as_deref(),
+            Some("Twitter meta")
+        );
+    }
+
+    #[test]
+    fn entities_are_decoded_named_and_numeric() {
+        let html = r#"<meta property="og:title" content="Tom &amp; Jerry &mdash; &#8220;quoted&#x201d; &hellip;">"#;
+        assert_eq!(
+            preview(html).title.as_deref(),
+            Some("Tom & Jerry \u{2014} \u{201c}quoted\u{201d} \u{2026}")
+        );
+        // `&nbsp;` decodes to a non-breaking space, which the collapse folds to a plain one.
+        let nbsp = r#"<meta property="og:title" content="A&nbsp;B">"#;
+        assert_eq!(preview(nbsp).title.as_deref(), Some("A B"));
+        // An unterminated or unknown entity is copied through, not dropped.
+        let literal = r#"<meta property="og:title" content="Q&A and &notreal; and 5 &lt; 6">"#;
+        assert_eq!(
+            preview(literal).title.as_deref(),
+            Some("Q&A and &notreal; and 5 < 6")
+        );
+    }
+
+    #[test]
+    fn og_image_resolves_against_the_final_url() {
+        let base = url("https://example.com/blog/post?x=1");
+        let relative = r#"<meta property="og:image" content="cover.png">"#;
+        assert_eq!(
+            preview_from_html(relative, &base).image_url.as_deref(),
+            Some("https://example.com/blog/cover.png")
+        );
+        let rooted = r#"<meta property="og:image" content="/img/cover.png">"#;
+        assert_eq!(
+            preview_from_html(rooted, &base).image_url.as_deref(),
+            Some("https://example.com/img/cover.png")
+        );
+        let protocol_relative = r#"<meta property="og:image" content="//cdn.example.net/c.png">"#;
+        assert_eq!(
+            preview_from_html(protocol_relative, &base)
+                .image_url
+                .as_deref(),
+            Some("https://cdn.example.net/c.png")
+        );
+        let absolute =
+            r#"<meta property="og:image" content="http://other.example/c.png?a=1&amp;b=2">"#;
+        assert_eq!(
+            preview_from_html(absolute, &base).image_url.as_deref(),
+            Some("http://other.example/c.png?a=1&b=2")
+        );
+    }
+
+    #[test]
+    fn a_non_http_og_image_is_dropped() {
+        let data_uri = r#"<meta property="og:image" content="data:image/png;base64,AAAA">"#;
+        assert_eq!(preview(data_uri).image_url, None);
+        let empty = r#"<meta property="og:image" content="   ">"#;
+        assert_eq!(preview(empty).image_url, None);
+    }
+
+    #[test]
+    fn og_image_url_and_twitter_image_are_the_image_fallbacks() {
+        let base = url("https://example.com/p");
+        let og_url_only = r#"<meta property="og:image:url" content="/a.png">"#;
+        assert_eq!(
+            preview_from_html(og_url_only, &base).image_url.as_deref(),
+            Some("https://example.com/a.png")
+        );
+        let twitter_src = r#"<meta name="twitter:image:src" content="/b.png">"#;
+        assert_eq!(
+            preview_from_html(twitter_src, &base).image_url.as_deref(),
+            Some("https://example.com/b.png")
+        );
+        // og:image wins over every fallback regardless of document order.
+        let mixed = r#"<meta name="twitter:image" content="/t.png">
+            <meta property="og:image:url" content="/u.png">
+            <meta property="og:image" content="/o.png">"#;
+        assert_eq!(
+            preview_from_html(mixed, &base).image_url.as_deref(),
+            Some("https://example.com/o.png")
+        );
+    }
+
+    #[test]
+    fn whitespace_runs_collapse_to_single_spaces() {
+        let html = "<meta property=\"og:description\" content=\"  lots\n\n of \t\t space  \">";
+        assert_eq!(preview(html).description.as_deref(), Some("lots of space"));
+    }
+
+    #[test]
+    fn title_and_description_are_capped() {
+        let long_title = "t".repeat(400);
+        let long_description = "d".repeat(700);
+        let html = format!(
+            r#"<meta property="og:title" content="{long_title}"><meta property="og:description" content="{long_description}">"#
+        );
+        let p = preview(&html);
+        assert_eq!(p.title.unwrap().chars().count(), MAX_TITLE_CHARS);
+        assert_eq!(
+            p.description.unwrap().chars().count(),
+            MAX_DESCRIPTION_CHARS
+        );
+        // The cut lands on a char boundary, never mid-codepoint.
+        let wide = "\u{1f600}".repeat(400);
+        let wide_html = format!(r#"<meta property="og:title" content="{wide}">"#);
+        assert_eq!(
+            preview(&wide_html).title.unwrap().chars().count(),
+            MAX_TITLE_CHARS
+        );
+    }
+
+    #[test]
+    fn a_page_without_metadata_yields_all_none() {
+        assert_eq!(
+            preview("<html><body>Nothing here</body></html>"),
+            LinkPreview::default()
+        );
+        assert_eq!(preview(""), LinkPreview::default());
+        // A meta tag with no `content` contributes nothing.
+        assert_eq!(
+            preview(r#"<meta property="og:title">"#),
+            LinkPreview::default()
+        );
+        // An empty `content` normalizes away rather than becoming an empty string.
+        assert_eq!(
+            preview(r#"<meta property="og:title" content="  ">"#),
+            LinkPreview::default()
+        );
+    }
+
+    #[test]
+    fn an_over_long_image_url_is_dropped_not_truncated() {
+        let base = url("https://example.com/p");
+        let long = format!("/{}.png", "a".repeat(MAX_IMAGE_URL_CHARS));
+        let html = format!(r#"<meta property="og:image" content="{long}">"#);
+        assert_eq!(preview_from_html(&html, &base).image_url, None);
+        // One character under the ceiling still comes through whole.
+        let fits = "b".repeat(MAX_IMAGE_URL_CHARS - "https://example.com/".len());
+        let ok_html = format!(r#"<meta property="og:image" content="/{fits}">"#);
+        let got = preview_from_html(&ok_html, &base).image_url.unwrap();
+        assert_eq!(got.chars().count(), MAX_IMAGE_URL_CHARS);
+        assert!(got.ends_with(&fits), "the URL must not be cut");
+    }
+
+    fn headers_with(content_type: Option<&str>) -> header::HeaderMap {
+        let mut map = header::HeaderMap::new();
+        if let Some(value) = content_type {
+            map.insert(
+                header::CONTENT_TYPE,
+                header::HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn is_html_accepts_html_and_xhtml_and_nothing_else() {
+        for value in [
+            "text/html",
+            "TEXT/HTML; charset=utf-8",
+            "application/xhtml+xml",
+            "Application/XHTML+XML; charset=utf-8",
+        ] {
+            assert!(is_html(&headers_with(Some(value))), "{value} should parse");
+        }
+        for value in [
+            "application/pdf",
+            "image/png",
+            "text/plain",
+            "application/json",
+        ] {
+            assert!(
+                !is_html(&headers_with(Some(value))),
+                "{value} should not parse"
+            );
+        }
+        // An absent header is not an implicit HTML page.
+        assert!(!is_html(&headers_with(None)));
+    }
+
+    /// Drive the cap the way the async reader does, over an explicit chunk sequence.
+    fn collect_capped(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for chunk in chunks {
+            if !push_capped(&mut buf, chunk) {
+                break;
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn the_body_cap_stops_at_exactly_max_body_bytes() {
+        // Well under the cap: everything is kept.
+        let small = collect_capped(&[b"abc", b"def"]);
+        assert_eq!(small, b"abcdef");
+
+        // A chunk landing exactly on the cap fills it and stops the read, so a chunk
+        // after it is never appended.
+        let exact = vec![b'x'; MAX_BODY_BYTES];
+        let filled = collect_capped(&[&exact, b"never"]);
+        assert_eq!(filled.len(), MAX_BODY_BYTES);
+        assert!(!filled.ends_with(b"never"));
+
+        // An overflowing chunk is cut at the cap.
+        let over = vec![b'y'; MAX_BODY_BYTES + 4096];
+        assert_eq!(collect_capped(&[&over]).len(), MAX_BODY_BYTES);
+
+        // The cap counts across chunks, not per chunk.
+        let half = vec![b'z'; MAX_BODY_BYTES / 2];
+        assert_eq!(collect_capped(&[&half, &half, &half]).len(), MAX_BODY_BYTES);
+    }
+
+    #[test]
+    fn a_body_cut_mid_utf8_sequence_decodes_lossily() {
+        // Cap-1 ASCII bytes then a 2-byte char: the cut lands between its bytes.
+        let mut body = vec![b'a'; MAX_BODY_BYTES - 1];
+        body.extend_from_slice("é".as_bytes());
+        let truncated = collect_capped(&[&body]);
+        assert_eq!(truncated.len(), MAX_BODY_BYTES);
+        let text = String::from_utf8_lossy(&truncated);
+        assert!(text.ends_with('\u{fffd}'), "the split char became U+FFFD");
+        assert_eq!(text.chars().count(), MAX_BODY_BYTES);
+    }
+
+    #[test]
+    fn an_unterminated_tag_or_quote_does_not_lose_earlier_metadata() {
+        let cut_mid_tag = r#"<meta property="og:title" content="Good"><meta property="og:desc"#;
+        assert_eq!(preview(cut_mid_tag).title.as_deref(), Some("Good"));
+
+        let unclosed_quote = r#"<meta property="og:title" content="never closed"#;
+        assert_eq!(preview(unclosed_quote), LinkPreview::default());
+
+        // A bare `<meta` at the very end is not a tag and must not panic.
+        assert_eq!(preview("<meta"), LinkPreview::default());
+        assert_eq!(preview("<title"), LinkPreview::default());
+        // A `<title>` with no `</title>` has no determinate text, so it yields nothing
+        // rather than swallowing the rest of the document.
+        assert_eq!(preview("<title>unterminated element").title, None);
+    }
+
+    /// A 512 KiB body of open tags made every occurrence rescan to EOF — quadratic, and
+    /// minutes of a tokio worker at the body cap. The wall-clock bound is a hang
+    /// detector with three orders of magnitude of headroom, not a performance assertion:
+    /// the pre-fix code needs minutes here, the fixed code microseconds.
+    #[test]
+    fn a_pathological_body_of_open_tags_parses_promptly() {
+        let base = url("https://example.com/p");
+        let cases = [
+            "<meta ".repeat(MAX_BODY_BYTES / "<meta ".len()),
+            "<meta a=\"".repeat(MAX_BODY_BYTES / "<meta a=\"".len()),
+            // Terminated, but every occurrence would scan to that single closing `>`.
+            format!("{}>", "<meta ".repeat(MAX_BODY_BYTES / "<meta ".len())),
+            "<title".repeat(MAX_BODY_BYTES / "<title".len()),
+        ];
+        for body in cases {
+            assert!(body.len() >= MAX_BODY_BYTES - 16, "the case fills the cap");
+            let started = std::time::Instant::now();
+            let got = preview_from_html(&body, &base);
+            let elapsed = started.elapsed();
+            assert_eq!(got, LinkPreview::default());
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "harvest took {elapsed:?} — the scan is not linear"
+            );
+        }
+    }
+
+    /// The image URL crosses IPC and is loaded by the webview under a null CSP, outside
+    /// this module's client — so it clears the blocklist here or it is not returned.
+    /// IP literals need no DNS, which is what makes both arms testable offline.
+    #[tokio::test]
+    async fn a_private_network_image_url_is_dropped_not_returned() {
+        for candidate in [
+            "http://192.168.1.1/setup.cgi?reboot=1",
+            "http://127.0.0.1:8080/x.png",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]/x.png",
+            "http://[::ffff:10.0.0.1]/x.png",
+            "http://localhost/x.png",
+            "file:///etc/passwd",
+            "not a url",
+        ] {
+            assert_eq!(
+                vet_image_url(candidate).await,
+                None,
+                "{candidate} must not reach the webview"
+            );
+        }
+        // A public literal passes through byte-for-byte.
+        let public = "https://93.184.216.34/cover.png";
+        assert_eq!(vet_image_url(public).await, Some(public.to_string()));
+    }
+
+    /// The examined-tag bound is what makes the scan linear regardless of body shape;
+    /// a page under it is unaffected.
+    #[test]
+    fn metadata_before_the_examined_tag_bound_is_still_read() {
+        let filler = r#"<meta name="x" content="y">"#.repeat(MAX_META_TAGS - 1);
+        let html = format!(r#"{filler}<meta property="og:title" content="Found">"#);
+        assert_eq!(preview(&html).title.as_deref(), Some("Found"));
+    }
+}

--- a/src/components/ui/markdown-link-card.tsx
+++ b/src/components/ui/markdown-link-card.tsx
@@ -12,6 +12,12 @@ const HTTP_SCHEME = /^https?:/i;
 const MAILTO_SCHEME = /^mailto:/i;
 const WWW_PREFIX = /^www\./;
 
+/** The only shape the og image may take: bytes the backend already fetched and
+ *  inlined. Matched exactly (no case fold) against the pinned wire format, so a
+ *  drifting shape can never put a fetchable URL — or a non-image payload — in
+ *  an `src` the webview would resolve. */
+const DATA_IMAGE = /^data:image\//;
+
 /** Bidi controls, stripped from every string a page or its author supplies.
  *  U+202E and its siblings reorder rendered text, so a URL can read as one host
  *  while addressing another — in the one surface built for judging that. CSS
@@ -55,18 +61,20 @@ function mailAddress(href: string): string {
   }
 }
 
-/** The footprint the settled card occupies at its largest: the og image box and
- *  its two text lines. The card must never GROW once open — Base UI re-runs
- *  collision avoidance as the popup resizes, and one opened near the viewport
- *  edge flips to the anchor's other side, out from under the pointer, which
- *  arms the close on the card the user is reading. Settling smaller only
- *  retracts the bottom edge, away from the anchor. */
+/** The card's settled maximum, reserved up front: the og image box over four
+ *  text lines — a `line-clamp-2` title above a `line-clamp-2` description — at
+ *  the popup's own `text-xs/relaxed` line box. The card may SHRINK on settle
+ *  (the bottom edge retracts, away from the anchor) but must never grow: Base
+ *  UI re-runs collision avoidance as the popup resizes, and one that flips to
+ *  the anchor's other side lands out from under the pointer and closes. */
 function LinkCardSkeleton() {
   return (
     <div className="flex flex-col gap-1.5">
       <Skeleton className="aspect-[1.91/1] w-full" />
-      <Skeleton className="h-3.5 w-full" />
-      <Skeleton className="h-3.5 w-4/5" />
+      <Skeleton className="h-[1.625em] w-full" />
+      <Skeleton className="h-[1.625em] w-4/5" />
+      <Skeleton className="h-[1.625em] w-full" />
+      <Skeleton className="h-[1.625em] w-3/5" />
     </div>
   );
 }
@@ -91,11 +99,11 @@ export function MarkdownLinkCard({ href }: { href: string }) {
   });
   // The setting gates the RENDER too, not just the fetch: a preview cached
   // before it was turned off outlives it (staleTime Infinity), and painting one
-  // would both show third-party content and re-request its image from the host
-  // the user just said not to contact.
+  // would show content pulled from a site the user has since said not to
+  // contact.
   const preview = previewsOn ? data : undefined;
-  // Which image URL failed, rather than a bare flag: the card carries no state
-  // to reset when a re-render swaps it to another link.
+  // Which image payload failed, rather than a bare flag: the card carries no
+  // state to reset when a re-render swaps it to another link.
   const [failedImage, setFailedImage] = useState<string | null>(null);
 
   if (!isHttp) {
@@ -107,13 +115,12 @@ export function MarkdownLinkCard({ href }: { href: string }) {
   }
 
   const host = displayHost(href);
-  const image = preview?.imageUrl;
-  // Belt and braces over the backend's own scheme check: the card must never
-  // resolve a `javascript:`/`data:` URL a drifting wire shape handed it.
+  const image = preview?.imageData;
+  // Belt and braces over the backend's own content-type gate — see DATA_IMAGE.
   const showImage =
     image !== null &&
     image !== undefined &&
-    HTTP_SCHEME.test(image) &&
+    DATA_IMAGE.test(image) &&
     image !== failedImage;
 
   return (
@@ -129,10 +136,9 @@ export function MarkdownLinkCard({ href }: { href: string }) {
         <img
           src={image}
           alt=""
-          // The app's own origin is nobody's business on a link the user has
-          // only hovered.
-          referrerPolicy="no-referrer"
           className="aspect-[1.91/1] w-full object-cover"
+          // A corrupt payload still fails to decode; hiding the block keeps a
+          // broken-image glyph out of a card the user only hovered.
           onError={() => setFailedImage(image)}
         />
       ) : null}

--- a/src/components/ui/markdown-link-card.tsx
+++ b/src/components/ui/markdown-link-card.tsx
@@ -1,0 +1,149 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { linkPreviewOptions } from "@/lib/link-preview";
+import { useFetchLinkPreviews } from "@/lib/settings/queries";
+
+/** The two schemes the card can be opened for arrive already filtered by the
+ *  body's dispatch; these tell them apart and gate the fetch. Case-insensitive
+ *  to match that dispatch — a `HTTPS://` href reaches the DOM verbatim.
+ *  Hoisted out of render: the patterns are constant. */
+const HTTP_SCHEME = /^https?:/i;
+const MAILTO_SCHEME = /^mailto:/i;
+const WWW_PREFIX = /^www\./;
+
+/** Bidi controls, stripped from every string a page or its author supplies.
+ *  U+202E and its siblings reorder rendered text, so a URL can read as one host
+ *  while addressing another — in the one surface built for judging that. CSS
+ *  `unicode-bidi` can't stand in: it sets the paragraph's own direction, while
+ *  these characters keep reordering the text INSIDE it. */
+const BIDI_CONTROLS = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g;
+
+function stripBidi(text: string): string {
+  return text.replace(BIDI_CONTROLS, "");
+}
+
+/** The site a URL belongs to, or null when it isn't parseable as one. The URL
+ *  parser hands back an IDN host already punycoded, so what lands here is
+ *  ASCII. */
+function displayHost(href: string): string | null {
+  let host: string;
+  try {
+    host = new URL(href).hostname;
+  } catch {
+    return null;
+  }
+  if (!host) return null;
+  // `www.` is dropped for reading only, and only when a host still remains —
+  // stripping it from `www.com` would name a different site.
+  const bare = host.replace(WWW_PREFIX, "");
+  return bare.includes(".") ? bare : host;
+}
+
+/** The address a `mailto:` link writes to, without the scheme or a
+ *  `?subject=`-style tail — those are the message, not the recipient. Decoding
+ *  comes before the bidi strip, since a percent-escape can encode one. A link
+ *  addressing nobody (`mailto:?subject=hi`) falls back to what was written,
+ *  rather than showing an empty card. */
+function mailAddress(href: string): string {
+  const raw = href.replace(MAILTO_SCHEME, "").split("?")[0];
+  if (!raw) return stripBidi(href);
+  try {
+    return stripBidi(decodeURIComponent(raw));
+  } catch {
+    return stripBidi(raw);
+  }
+}
+
+/** The footprint the settled card occupies at its largest: the og image box and
+ *  its two text lines. The card must never GROW once open — Base UI re-runs
+ *  collision avoidance as the popup resizes, and one opened near the viewport
+ *  edge flips to the anchor's other side, out from under the pointer, which
+ *  arms the close on the card the user is reading. Settling smaller only
+ *  retracts the bottom edge, away from the anchor. */
+function LinkCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Skeleton className="aspect-[1.91/1] w-full" />
+      <Skeleton className="h-3.5 w-full" />
+      <Skeleton className="h-3.5 w-4/5" />
+    </div>
+  );
+}
+
+/**
+ * What an external link opens, shown on hover or keyboard focus: the browser
+ * status bar's answer (site and full URL) with no network at all, plus the
+ * page's own Open Graph card once the backend fetches it.
+ *
+ * The URL-only form is the SETTLED state, not a loading one — a page with no og
+ * data, a refused fetch, and the setting turned off all rest there, so nothing
+ * below the URL ever reads as an error.
+ */
+export function MarkdownLinkCard({ href }: { href: string }) {
+  const isHttp = HTTP_SCHEME.test(href);
+  const previewsOn = useFetchLinkPreviews();
+  const { data, isFetching } = useQuery({
+    ...linkPreviewOptions(href),
+    // A `mailto:` addresses no page, and the setting is the user's standing
+    // answer about contacting the linked site — either way nothing is fetched.
+    enabled: previewsOn && isHttp,
+  });
+  // The setting gates the RENDER too, not just the fetch: a preview cached
+  // before it was turned off outlives it (staleTime Infinity), and painting one
+  // would both show third-party content and re-request its image from the host
+  // the user just said not to contact.
+  const preview = previewsOn ? data : undefined;
+  // Which image URL failed, rather than a bare flag: the card carries no state
+  // to reset when a re-render swaps it to another link.
+  const [failedImage, setFailedImage] = useState<string | null>(null);
+
+  if (!isHttp) {
+    return (
+      <div className="ph-no-capture">
+        <p className="break-all">{mailAddress(href)}</p>
+      </div>
+    );
+  }
+
+  const host = displayHost(href);
+  const image = preview?.imageUrl;
+  // Belt and braces over the backend's own scheme check: the card must never
+  // resolve a `javascript:`/`data:` URL a drifting wire shape handed it.
+  const showImage =
+    image !== null &&
+    image !== undefined &&
+    HTTP_SCHEME.test(image) &&
+    image !== failedImage;
+
+  return (
+    // ph-no-capture: third-party page titles, descriptions, and imagery — keep
+    // them out of session replay.
+    <div className="ph-no-capture flex flex-col gap-1.5">
+      {host ? <p className="truncate font-medium">{host}</p> : null}
+      <p className="line-clamp-3 break-all text-muted-foreground">
+        {stripBidi(href)}
+      </p>
+      {isFetching && preview === undefined ? <LinkCardSkeleton /> : null}
+      {showImage ? (
+        <img
+          src={image}
+          alt=""
+          // The app's own origin is nobody's business on a link the user has
+          // only hovered.
+          referrerPolicy="no-referrer"
+          className="aspect-[1.91/1] w-full object-cover"
+          onError={() => setFailedImage(image)}
+        />
+      ) : null}
+      {preview?.title ? (
+        <p className="line-clamp-2 font-medium">{stripBidi(preview.title)}</p>
+      ) : null}
+      {preview?.description ? (
+        <p className="line-clamp-2 text-muted-foreground">
+          {stripBidi(preview.description)}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ui/markdown-ref-card.tsx
+++ b/src/components/ui/markdown-ref-card.tsx
@@ -26,13 +26,24 @@ import type { IssueDetails, PrDetails, RemoteLens } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
+import { MarkdownLinkCard } from "./markdown-link-card";
 import type { MarkdownRefKind, MarkdownRefs } from "./markdown-refs";
 
-/** A reference that fully validated against the emitting renderer's grammar —
- *  what both the click dispatch and this card route on. */
+/** What an anchor in a rendered body opens a card for: a forge reference that
+ *  fully validated against the emitting renderer's grammar (what the click
+ *  dispatch routes on), or any link leaving the app — `mailto:` included, which
+ *  the card tells apart by scheme. */
 export type MarkdownRefTarget =
   | { kind: "user"; user: string }
-  | { kind: Exclude<MarkdownRefKind, "user">; number: number };
+  | { kind: Exclude<MarkdownRefKind, "user">; number: number }
+  | { kind: "external"; href: string };
+
+/** The forge-reference half of that union: what the click dispatch navigates
+ *  in-app and what the card's resolve runs for. An external link is neither. */
+export type MarkdownForgeTarget = Exclude<
+  MarkdownRefTarget,
+  { kind: "external" }
+>;
 
 /** What a reference IS, independent of the object carrying it — the dispatch
  *  mints a fresh target per pointer event, so resolved content is matched on
@@ -43,7 +54,7 @@ export type MarkdownRefTarget =
 function refKey(
   repoPath: string,
   lens: RemoteLens,
-  target: MarkdownRefTarget,
+  target: MarkdownForgeTarget,
 ): string {
   const ref =
     target.kind === "user"
@@ -247,18 +258,24 @@ function RefUserCard({
 }
 
 function RefCardBody({
-  repoPath,
-  lens,
+  refs,
   target,
   item,
 }: {
-  repoPath: string;
-  lens: RemoteLens;
+  /** Absent on bodies rendered with no forge context (the help screen, AI
+   *  output) — only external targets can arise there. */
+  refs: MarkdownRefs | undefined;
   target: MarkdownRefTarget | null;
   /** `undefined` while the reference is still resolving, `null` once it failed. */
   item: RefItem | null | undefined;
 }) {
   if (!target) return null;
+  if (target.kind === "external")
+    return <MarkdownLinkCard href={target.href} />;
+  // A forge reference only exists because the context that linkified it does,
+  // so this is unreachable rather than a state to render.
+  if (!refs) return null;
+  const { repoPath, lens } = refs;
   if (target.kind === "user") {
     return <RefUserCard repoPath={repoPath} lens={lens} login={target.user} />;
   }
@@ -317,7 +334,9 @@ export function MarkdownRefCard({
   /** The popup's element id, so the open card's anchor can point an
    *  `aria-describedby` at it. */
   id: string;
-  refs: MarkdownRefs;
+  /** Forge context for the reference kinds. Omitted on bodies that have none —
+   *  an external link needs no repo to describe itself. */
+  refs?: MarkdownRefs;
   /** The reference to show, or null to close. */
   target: MarkdownRefTarget | null;
   /** Viewport geometry of the active anchor, measured when the card opened. */
@@ -328,7 +347,10 @@ export function MarkdownRefCard({
   onPointerLeave: () => void;
 }) {
   const queryClient = useQueryClient();
-  const { repoPath, lens } = refs;
+  // Read as primitives rather than through `refs`, so a caller rebuilding that
+  // object each render can't re-run the resolve below.
+  const repoPath = refs?.repoPath;
+  const lens = refs?.lens;
   // The positioner's `anchor` prop never yields a measurable reference here —
   // probed live: the popup positioned against a 0×0 rect (element and virtual
   // forms alike) while a store-registered trigger in the same build measured
@@ -348,13 +370,18 @@ export function MarkdownRefCard({
   // The live target gates `open`; the retained one drives the content, so the
   // close animation doesn't play over an emptied card.
   const shown = useRetained(target);
+  // Null for anything the resolve never runs for — an external link, or a
+  // reference on a body with no forge context.
+  const shownKey =
+    shown && shown.kind !== "external" && repoPath && lens
+      ? refKey(repoPath, lens, shown)
+      : null;
   const item =
-    shown && resolved?.key === refKey(repoPath, lens, shown)
-      ? resolved.item
-      : undefined;
+    shownKey !== null && resolved?.key === shownKey ? resolved.item : undefined;
 
   useEffect(() => {
-    if (!target || target.kind === "user") return;
+    if (!repoPath || !lens) return;
+    if (!target || target.kind === "user" || target.kind === "external") return;
     const key = refKey(repoPath, lens, target);
     let cancelled = false;
     resolveRefItem(queryClient, repoPath, lens, target)
@@ -420,18 +447,20 @@ export function MarkdownRefCard({
         // is the skeleton's twin for the same reader, and holds the announcement
         // until the swap is done.
         role="status"
+        // External links are never busy: the site and URL are on screen the
+        // frame the card opens, and only the og section below them is still
+        // arriving. Holding the announcement for that would silence the part
+        // that always lands.
         aria-busy={
-          shown !== null && shown.kind !== "user" && item === undefined
+          shown !== null &&
+          shown.kind !== "user" &&
+          shown.kind !== "external" &&
+          item === undefined
         }
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}
       >
-        <RefCardBody
-          repoPath={repoPath}
-          lens={lens}
-          target={shown}
-          item={item}
-        />
+        <RefCardBody refs={refs} target={shown} item={item} />
       </HoverCardContent>
     </HoverCard>
   );

--- a/src/components/ui/markdown-ref-card.tsx
+++ b/src/components/ui/markdown-ref-card.tsx
@@ -211,15 +211,19 @@ const NEUTRAL_PILL: StatePill = {
   className: "text-muted-foreground",
 };
 
-/** Bars sized like the rows they stand in for, so the card doesn't resize under
- *  the pointer when the content lands. */
+/** The card's settled maximum, reserved up front: a state row, a `line-clamp-2`
+ *  title, and an author row — four lines at the popup's own `text-xs/relaxed`
+ *  line box. The card may SHRINK when the reference resolves (the bottom edge
+ *  retracts, away from the anchor) but must never grow: Base UI re-runs
+ *  collision avoidance as the popup resizes, and one that flips to the anchor's
+ *  other side lands out from under the pointer and closes itself. */
 function RefCardSkeleton() {
   return (
     <div className="flex flex-col gap-1.5">
-      <Skeleton className="h-3.5 w-20" />
-      <Skeleton className="h-3.5 w-full" />
-      <Skeleton className="h-3.5 w-4/5" />
-      <Skeleton className="h-3.5 w-24" />
+      <Skeleton className="h-[1.625em] w-20" />
+      <Skeleton className="h-[1.625em] w-full" />
+      <Skeleton className="h-[1.625em] w-4/5" />
+      <Skeleton className="h-[1.625em] w-24" />
     </div>
   );
 }

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -24,6 +24,7 @@ import { diffLang } from "@/features/diff/diff-lang";
 import { forgeRepoUrl } from "@/lib/git/api";
 import { issueDetailsOptions } from "@/lib/git/queries";
 import type { RemoteLens } from "@/lib/git/types";
+import { createCardLatch } from "@/lib/hover-card-latch";
 import {
   CARD_CLOSE_DELAY,
   CARD_OPEN_DELAY,
@@ -132,19 +133,6 @@ interface CardOwner {
   setTarget: (target: MarkdownRefTarget | null) => void;
 }
 
-/** Which body's card is open, across every rendered Markdown. Each body owns its
- *  own card state, so nothing else stops a conversation from floating two at
- *  once: a keyboard card in the description closes only on blur or dismissal,
- *  and hovering a link in a comment below fires none of its close routes.
- *  Written and read imperatively only — nothing renders from it. */
-let activeCard: CardOwner | null = null;
-
-/** Drops a body's claim, ignoring a body that no longer holds it — an unmounted
- *  body must never clear the card that replaced it. */
-function releaseCard(owner: CardOwner) {
-  if (activeCard === owner) activeCard = null;
-}
-
 /** Everything that can open or hold one body's card, torn down together. The
  *  pointer claim goes with it: a card closed from outside its own routes fires
  *  no `pointerout`, and a claim left set would block that body's next keyboard
@@ -157,11 +145,10 @@ function resetCard(owner: CardOwner) {
   releaseCard(owner);
 }
 
-/** Hands the single open card to `owner`, tearing down whoever held it. */
-function claimCard(owner: CardOwner) {
-  if (activeCard !== null && activeCard !== owner) resetCard(activeCard);
-  activeCard = owner;
-}
+/** This family is every rendered Markdown body, so the two cards it keeps apart
+ *  are typically a conversation's description and one of its comments. */
+const { claim: claimCard, release: releaseCard } =
+  createCardLatch<CardOwner>(resetCard);
 
 /** The external link this anchor addresses, or null when it isn't one. Read off
  *  the RAW href attribute, exactly as the click dispatch does, rather than the

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -24,6 +24,12 @@ import { diffLang } from "@/features/diff/diff-lang";
 import { forgeRepoUrl } from "@/lib/git/api";
 import { issueDetailsOptions } from "@/lib/git/queries";
 import type { RemoteLens } from "@/lib/git/types";
+import {
+  CARD_CLOSE_DELAY,
+  CARD_OPEN_DELAY,
+  cancelFrame,
+  cancelTimer,
+} from "@/lib/hover-card-timing";
 import { lensKey } from "@/lib/repo-lens/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
@@ -100,12 +106,6 @@ md.use({
 // active context names a provider (see markdown-refs.ts).
 md.use({ extensions: [forgeRefExtension] });
 
-// The preview card renders without a `PreviewCard.Trigger` — one card serves a
-// whole body, positioned at whichever anchor is active — so none of Base UI's
-// hover machinery applies and the delays are hand-rolled from its own constants.
-const CARD_OPEN_DELAY = 600;
-const CARD_CLOSE_DELAY = 300;
-
 /** The card's own subtree, for telling "the pointer left the anchor" apart from
  *  "the pointer moved into the card" — which the DOM reports identically, the
  *  popup being portaled out of the body. Both slots: `hover-card.tsx` stamps the
@@ -123,28 +123,52 @@ const CARD_POPUP_SELECTOR =
  *  deceptive-looking links this most needs to expose. */
 const EXTERNAL_HREF = /^(https?:|mailto:)/i;
 
+/** A body's handle on its own card — every field stable for the body's life, so
+ *  the object doubles as that body's identity in the latch below. */
+interface CardOwner {
+  timer: React.RefObject<ReturnType<typeof setTimeout> | null>;
+  frame: React.RefObject<number | null>;
+  pointerAnchor: React.RefObject<HTMLAnchorElement | null>;
+  setTarget: (target: MarkdownRefTarget | null) => void;
+}
+
+/** Which body's card is open, across every rendered Markdown. Each body owns its
+ *  own card state, so nothing else stops a conversation from floating two at
+ *  once: a keyboard card in the description closes only on blur or dismissal,
+ *  and hovering a link in a comment below fires none of its close routes.
+ *  Written and read imperatively only — nothing renders from it. */
+let activeCard: CardOwner | null = null;
+
+/** Drops a body's claim, ignoring a body that no longer holds it — an unmounted
+ *  body must never clear the card that replaced it. */
+function releaseCard(owner: CardOwner) {
+  if (activeCard === owner) activeCard = null;
+}
+
+/** Everything that can open or hold one body's card, torn down together. The
+ *  pointer claim goes with it: a card closed from outside its own routes fires
+ *  no `pointerout`, and a claim left set would block that body's next keyboard
+ *  card from closing on blur. */
+function resetCard(owner: CardOwner) {
+  cancelTimer(owner.timer);
+  cancelFrame(owner.frame);
+  owner.pointerAnchor.current = null;
+  owner.setTarget(null);
+  releaseCard(owner);
+}
+
+/** Hands the single open card to `owner`, tearing down whoever held it. */
+function claimCard(owner: CardOwner) {
+  if (activeCard !== null && activeCard !== owner) resetCard(activeCard);
+  activeCard = owner;
+}
+
 /** The external link this anchor addresses, or null when it isn't one. Read off
  *  the RAW href attribute, exactly as the click dispatch does, rather than the
  *  resolved `anchor.href` — so the card names the URL the click will open. */
 function linkTarget(anchor: HTMLAnchorElement): MarkdownRefTarget | null {
   const href = anchor.getAttribute("href");
   return href && EXTERNAL_HREF.test(href) ? { kind: "external", href } : null;
-}
-
-function cancelTimer(
-  ref: React.RefObject<ReturnType<typeof setTimeout> | null>,
-) {
-  if (ref.current !== null) {
-    clearTimeout(ref.current);
-    ref.current = null;
-  }
-}
-
-function cancelFrame(ref: React.RefObject<number | null>) {
-  if (ref.current !== null) {
-    cancelAnimationFrame(ref.current);
-    ref.current = null;
-  }
 }
 
 /** Natural-size floor, both axes, for an image the viewer will open: it clears
@@ -287,6 +311,14 @@ export function Markdown({
   // blur path must not close a card the mouse owns, and only the anchor's
   // identity can tell that apart from a claim on some unrelated reference.
   const cardPointerAnchor = useRef<HTMLAnchorElement | null>(null);
+  // Built once: the latch compares bodies by this object's identity, so it has
+  // to outlive every render.
+  const [card] = useState<CardOwner>(() => ({
+    timer: cardTimer,
+    frame: cardFrame,
+    pointerAnchor: cardPointerAnchor,
+    setTarget: setCardTarget,
+  }));
   const cardId = useId();
   const bodyRef = useRef<HTMLDivElement>(null);
   // Null is closed. The viewer copies src strings rather than nodes, so this
@@ -307,14 +339,14 @@ export function Markdown({
   // `html` is the trigger, not a value this reads — same shape as the parse memo.
   // biome-ignore lint/correctness/useExhaustiveDependencies: html is the intentional reset trigger
   useEffect(() => {
-    cancelTimer(cardTimer);
-    cancelFrame(cardFrame);
-    cardPointerAnchor.current = null;
-    setCardTarget(null);
+    closeCardNow();
     setLightbox(null);
+    // Unmount (or another re-parse) must drop the claim too: a body that still
+    // held it would tear down whichever card claims it next.
     return () => {
       cancelTimer(cardTimer);
       cancelFrame(cardFrame);
+      releaseCard(card);
     };
   }, [html]);
 
@@ -335,6 +367,10 @@ export function Markdown({
       // block the blur path from closing the NEXT card (pointerover re-arms it).
       cardPointerAnchor.current = null;
       setCardTarget(null);
+      // Released explicitly rather than through `resetCard`, which would also
+      // cancel a pending focus-open — one measuring AFTER this scroll, so it
+      // opens at a rect that is still good.
+      releaseCard(card);
     };
     const raf = requestAnimationFrame(() => {
       subscribed = true;
@@ -347,7 +383,7 @@ export function Markdown({
       window.removeEventListener("scroll", close, true);
       window.removeEventListener("resize", close);
     };
-  }, [cardTarget]);
+  }, [cardTarget, card]);
 
   // The open card describes its anchor. Set on the node rather than rendered:
   // the anchor is injected HTML, same as the image affordances below. The
@@ -396,25 +432,24 @@ export function Markdown({
     const imgs = lightboxImagesIn(root);
     const index = imgs.indexOf(img);
     if (index < 0) return;
-    cancelTimer(cardTimer);
-    cancelFrame(cardFrame);
-    cardPointerAnchor.current = null;
-    setCardTarget(null);
+    closeCardNow();
     setLightbox({ images: imgs.map(toLightboxImage), index });
   }
 
   /** Drop the card and every intent behind it — the open one, a pending hover
-   *  timer, and a pending focus frame. Both anchor branches of the click
-   *  dispatch end here: whether the target opens in-app or in the system
-   *  browser, the card describes something the user has just left. */
+   *  timer, and a pending focus frame. Every path that takes the user somewhere
+   *  else ends here: both anchor branches of the click dispatch, and the
+   *  lightbox, which would otherwise position a card against a hidden body. */
   function closeCardNow() {
-    cancelTimer(cardTimer);
-    cancelFrame(cardFrame);
-    cardPointerAnchor.current = null;
-    setCardTarget(null);
+    resetCard(card);
   }
 
+  /** The one open route — both the hover timer and the focus frame land here, so
+   *  claiming the latch here is what makes the card exclusive across bodies.
+   *  Re-opening this body's own card is not a takeover: `claimCard` tears down
+   *  the previous holder only when it is a different one. */
   function showCard(anchor: HTMLAnchorElement, target: MarkdownRefTarget) {
+    claimCard(card);
     cancelTimer(cardTimer);
     setCardAnchor(anchor);
     setCardRect(anchor.getBoundingClientRect());
@@ -429,6 +464,7 @@ export function Markdown({
       cardTimer.current = null;
       cardPointerAnchor.current = null;
       setCardTarget(null);
+      releaseCard(card);
     }, CARD_CLOSE_DELAY);
   }
 
@@ -511,6 +547,10 @@ export function Markdown({
     if (claim !== null && claim === cardAnchor) return;
     cancelTimer(cardTimer);
     setCardTarget(null);
+    // Released explicitly, not via `resetCard`: a pointer claim on some OTHER
+    // reference has to survive this close (that is what lets a keyboard card on
+    // B close while the mouse rests on A).
+    releaseCard(card);
   }
 
   /**
@@ -754,6 +794,9 @@ export function Markdown({
             cancelTimer(cardTimer);
             cardPointerAnchor.current = null;
             setCardTarget(null);
+            // Explicit release rather than `resetCard`, which would also cancel
+            // a pending focus-open the dismissal never addressed.
+            releaseCard(card);
           }}
           onPointerEnter={() => {
             // Inside the popup the pointer claims the card, so it claims the

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -33,6 +33,7 @@ import { hljsUpgradeStore, upgradeToFullHljs } from "./markdown-hljs";
 import {
   cachedRefKind,
   isPullRefUrl,
+  type MarkdownForgeTarget,
   MarkdownRefCard,
   type MarkdownRefTarget,
 } from "./markdown-ref-card";
@@ -111,6 +112,24 @@ const CARD_CLOSE_DELAY = 300;
  *  popup, and the portal wrapper covers the positioner between them. */
 const CARD_POPUP_SELECTOR =
   '[data-slot="hover-card-content"],[data-slot="hover-card-portal"]';
+
+/** The schemes a rendered link leaves the app for. One constant, because the
+ *  click dispatch and the preview card have to admit exactly the same set — a
+ *  link the card describes but the click doesn't open (or the reverse) is a
+ *  disagreement the user sees.
+ *  Case-insensitive because schemes are: marked emits `HTTPS://…` verbatim and
+ *  DOMPurify's own allowlist keeps it, so a case-sensitive test would hand the
+ *  click back to the webview — navigating the app away, with no card on the
+ *  deceptive-looking links this most needs to expose. */
+const EXTERNAL_HREF = /^(https?:|mailto:)/i;
+
+/** The external link this anchor addresses, or null when it isn't one. Read off
+ *  the RAW href attribute, exactly as the click dispatch does, rather than the
+ *  resolved `anchor.href` — so the card names the URL the click will open. */
+function linkTarget(anchor: HTMLAnchorElement): MarkdownRefTarget | null {
+  const href = anchor.getAttribute("href");
+  return href && EXTERNAL_HREF.test(href) ? { kind: "external", href } : null;
+}
 
 function cancelTimer(
   ref: React.RefObject<ReturnType<typeof setTimeout> | null>,
@@ -384,6 +403,17 @@ export function Markdown({
     setLightbox({ images: imgs.map(toLightboxImage), index });
   }
 
+  /** Drop the card and every intent behind it — the open one, a pending hover
+   *  timer, and a pending focus frame. Both anchor branches of the click
+   *  dispatch end here: whether the target opens in-app or in the system
+   *  browser, the card describes something the user has just left. */
+  function closeCardNow() {
+    cancelTimer(cardTimer);
+    cancelFrame(cardFrame);
+    cardPointerAnchor.current = null;
+    setCardTarget(null);
+  }
+
   function showCard(anchor: HTMLAnchorElement, target: MarkdownRefTarget) {
     cancelTimer(cardTimer);
     setCardAnchor(anchor);
@@ -404,7 +434,7 @@ export function Markdown({
 
   function onPointerOver(e: React.PointerEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
-    const target = anchor && refTarget(anchor);
+    const target = anchor && anyTarget(anchor);
     if (!anchor || !target) return;
     cardPointerAnchor.current = anchor;
     // Cancels the close armed on the way out — of the anchor itself, or of the
@@ -425,7 +455,7 @@ export function Markdown({
 
   function onPointerOut(e: React.PointerEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
-    if (!anchor || !refTarget(anchor)) return;
+    if (!anchor || !anyTarget(anchor)) return;
     // Crossing into the card is not leaving it. The popup portals outside this
     // wrapper, so the browser reports the move as a plain pointerout on the
     // anchor; treating that as a close would arm a timer the popup's own enter
@@ -446,7 +476,7 @@ export function Markdown({
 
   function onFocusCapture(e: React.FocusEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
-    const target = anchor && refTarget(anchor);
+    const target = anchor && anyTarget(anchor);
     if (!anchor || !target) return;
     // Keyboard arrival only. Landing on a reference by Tab is already the
     // deliberate ask the hover delay waits for, but a click focuses the anchor
@@ -466,7 +496,7 @@ export function Markdown({
 
   function onBlurCapture(e: React.FocusEvent) {
     const anchor = (e.target as HTMLElement).closest("a");
-    if (!anchor || !refTarget(anchor)) return;
+    if (!anchor || !anyTarget(anchor)) return;
     // A pending focus-open belongs to the anchor being blurred, so it dies here
     // whatever the pointer is doing — otherwise it would open a card for a
     // reference the keyboard has already left.
@@ -490,7 +520,7 @@ export function Markdown({
    * row and every value against the grammar the renderer emits. Synchronous
    * because the click handler decides whether to claim the event on its answer.
    */
-  function refTarget(anchor: HTMLAnchorElement): MarkdownRefTarget | null {
+  function refTarget(anchor: HTMLAnchorElement): MarkdownForgeTarget | null {
     if (!refs) return null;
     const kind = anchor.dataset.ref;
     if (!isEmittableRefKind(refs.provider, kind)) return null;
@@ -504,8 +534,16 @@ export function Markdown({
       : null;
   }
 
+  /** Whatever this anchor opens a preview card for. A forge reference wins over
+   *  the link it also is — a rendered `#12` carries an href too, and its card
+   *  describes the item, not the URL. Every hover and focus route reads this
+   *  one answer, so the card opens on the same set of anchors either way. */
+  function anyTarget(anchor: HTMLAnchorElement): MarkdownRefTarget | null {
+    return refTarget(anchor) ?? linkTarget(anchor);
+  }
+
   /** Navigate to whatever a validated reference target points at. */
-  async function openRef(target: MarkdownRefTarget) {
+  async function openRef(target: MarkdownForgeTarget) {
     if (!refs) return;
     const { repoPath, lens } = refs;
     const { kind } = target;
@@ -607,12 +645,19 @@ export function Markdown({
       const target = refTarget(anchor);
       if (target) {
         e.preventDefault();
+        // Same reason as the external branch below: `@user` and the cross-lens
+        // number path both hand off to the system browser, and the in-app ones
+        // switch the view out from under the card either way.
+        closeCardNow();
         void openRef(target);
         return;
       }
       const href = anchor.getAttribute("href");
-      if (href && /^(https?:|mailto:)/.test(href)) {
+      if (href && EXTERNAL_HREF.test(href)) {
         e.preventDefault();
+        // The system browser takes focus from here, so a card that is open (or
+        // one frame from opening) would hang over an app the user has left.
+        closeCardNow();
         openUrl(href);
       }
       return;
@@ -694,33 +739,35 @@ export function Markdown({
           (Tailwind compiles it to `> :not(:last-child)`) would otherwise hang a
           phantom margin off the body. Context crosses a portal, so the popup's
           own `usePanelPortalContainer()` still scopes it to the panel. */}
-      {refs
-        ? createPortal(
-            <MarkdownRefCard
-              id={cardId}
-              refs={refs}
-              target={cardTarget}
-              rect={cardRect}
-              onOpenChange={(open) => {
-                if (open) return;
-                cancelTimer(cardTimer);
-                cardPointerAnchor.current = null;
-                setCardTarget(null);
-              }}
-              onPointerEnter={() => {
-                // Inside the popup the pointer claims the card, so it claims the
-                // anchor the card belongs to — the blur path compares identities.
-                cardPointerAnchor.current = cardAnchor;
-                cancelTimer(cardTimer);
-              }}
-              onPointerLeave={() => {
-                cardPointerAnchor.current = null;
-                scheduleCardClose();
-              }}
-            />,
-            document.body,
-          )
-        : null}
+      {/* Unconditional: an external link previews on every surface, including
+          the ones with no forge context at all (the help screen, AI output).
+          The card takes `refs` only for the reference kinds, which can't arise
+          without it. */}
+      {createPortal(
+        <MarkdownRefCard
+          id={cardId}
+          refs={refs}
+          target={cardTarget}
+          rect={cardRect}
+          onOpenChange={(open) => {
+            if (open) return;
+            cancelTimer(cardTimer);
+            cardPointerAnchor.current = null;
+            setCardTarget(null);
+          }}
+          onPointerEnter={() => {
+            // Inside the popup the pointer claims the card, so it claims the
+            // anchor the card belongs to — the blur path compares identities.
+            cardPointerAnchor.current = cardAnchor;
+            cancelTimer(cardTimer);
+          }}
+          onPointerLeave={() => {
+            cardPointerAnchor.current = null;
+            scheduleCardClose();
+          }}
+        />,
+        document.body,
+      )}
       <ImageLightbox
         images={shownLightbox?.images ?? NO_IMAGES}
         index={shownLightbox?.index ?? 0}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -970,6 +970,15 @@ that person's avatar and handle. Esc dismisses the card. **Bitbucket** bodies le
 references plain, matching Bitbucket itself, and a reference inside backticks or a fenced
 code block stays plain text everywhere.
 
+Web and **mailto:** links get a card of their own. Pause the pointer on a link in any
+rendered body, or land on it with Tab, and the card names where it goes right away: the
+site's domain and the full URL. Esc dismisses it, the same as a reference card. For a
+web link GitDesktop then fills in the page's title, description, and image where the
+site publishes them, and a **mailto:** link shows the address it would write to. That
+lookup is **Fetch link previews** under **Settings → General**, on by default; turn it
+off and the cards show the destination alone. Pages on private or local network
+addresses are never fetched.
+
 Images in a rendered body open fullscreen too. Click a screenshot in a description,
 comment, or discussion (or Tab to it and press Enter) and it fills the window over a
 dimmed backdrop, with its name and pixel dimensions along the bottom, a **Fit** /
@@ -2497,7 +2506,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   puts your changes back once the switch lands), **create pull requests as drafts** by
   default (off by default — pre-checks the Create-PR dialog's draft box, still
   overridable per PR; pairs with *Review draft PRs when created* so a draft's automated
-  first review waits until it's marked ready), and privacy options.
+  first review waits until it's marked ready), **fetch link previews** (the title,
+  description, and image behind a link in a rendered body; off leaves the card showing
+  the destination alone), and privacy options.
 - **Appearance** — pick a theme: **System** (follows your OS's light/dark setting),
   **Light**, **Dark**, or **Slate** (a softer, blue-gray dark). Applies as you pick it,
   and *Cycle theme* in the command palette steps through them.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -970,14 +970,14 @@ that person's avatar and handle. Esc dismisses the card. **Bitbucket** bodies le
 references plain, matching Bitbucket itself, and a reference inside backticks or a fenced
 code block stays plain text everywhere.
 
-Web and **mailto:** links get a card of their own. Pause the pointer on a link in any
-rendered body, or land on it with Tab, and the card names where it goes right away: the
-site's domain and the full URL. Esc dismisses it, the same as a reference card. For a
-web link GitDesktop then fills in the page's title, description, and image where the
-site publishes them, and a **mailto:** link shows the address it would write to. That
-lookup is **Fetch link previews** under **Settings → General**, on by default; turn it
-off and the cards show the destination alone. Pages on private or local network
-addresses are never fetched.
+Web and **mailto:** links get a card of their own. Pause the pointer on a link in
+any rendered body, or land on it with Tab, and the card names where it goes right
+away: a web link's domain and full URL, or the address a **mailto:** link would
+write to. Esc dismisses it, the same as a reference card. For a web link GitDesktop
+then fills in the page's title, description, and image where the site publishes
+them. That lookup is **Fetch link previews** under **Settings → General**, on by
+default; turn it off and the cards show the destination alone. Pages on private or
+local network addresses are never fetched.
 
 Images in a rendered body open fullscreen too. Click a screenshot in a description,
 comment, or discussion (or Tab to it and press Enter) and it fills the window over a

--- a/src/features/repository/insights/DependenciesCard.tsx
+++ b/src/features/repository/insights/DependenciesCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
 import type { DependencyPackage, RepoDependencies } from "@/lib/git/types";
+import { createCardLatch } from "@/lib/hover-card-latch";
 import {
   CARD_CLOSE_DELAY,
   CARD_OPEN_DELAY,
@@ -72,18 +73,6 @@ interface CardOwner {
   setOpen: (open: boolean) => void;
 }
 
-/** Which row's card is open, across the whole list. The keyboard route can open
- *  a card on a row the pointer never visits, so no pointer path reaches it and
- *  hovering another row would float a second card beside it. Imperative only;
- *  nothing renders from this. */
-let activeCard: CardOwner | null = null;
-
-/** Drops a row's claim, ignoring a row that no longer holds it — an evicted row
- *  must never clear the card that replaced it. */
-function releaseCard(owner: CardOwner) {
-  if (activeCard === owner) activeCard = null;
-}
-
 /** Everything that can open or hold a card, torn down together. The pointer
  *  claim has to go with it: removing a hovered node fires no `pointerleave`, so
  *  a card closed under the pointer would leave the claim set forever, and the
@@ -96,11 +85,10 @@ function resetCard(owner: CardOwner) {
   releaseCard(owner);
 }
 
-/** Hands the single open card to `owner`, tearing down whoever held it. */
-function claimCard(owner: CardOwner) {
-  if (activeCard !== null && activeCard !== owner) resetCard(activeCard);
-  activeCard = owner;
-}
+/** This family is the dependency list's rows — the keyboard route can open a card
+ *  on a row the pointer never visits, where no pointer path could close it. */
+const { claim: claimCard, release: releaseCard } =
+  createCardLatch<CardOwner>(resetCard);
 
 /** One dependency row: clickable name (opens its registry/repo) + a hovercard
  *  that lazily fetches the package's description. */

--- a/src/features/repository/insights/DependenciesCard.tsx
+++ b/src/features/repository/insights/DependenciesCard.tsx
@@ -11,6 +11,12 @@ import {
 } from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
 import type { DependencyPackage, RepoDependencies } from "@/lib/git/types";
+import {
+  CARD_CLOSE_DELAY,
+  CARD_OPEN_DELAY,
+  cancelFrame,
+  cancelTimer,
+} from "@/lib/hover-card-timing";
 import { toastError } from "@/lib/toast";
 import { fmt } from "./primitives";
 import { canFetchPackageInfo, usePackageInfo } from "./usePackageInfo";
@@ -49,11 +55,6 @@ function packageUrl(ecosystem: string, name: string): string | null {
   }
 }
 
-// The card is positioned by hand off an inert trigger, so none of Base UI's own
-// hover machinery applies and both delays are hand-rolled from its constants.
-const CARD_OPEN_DELAY = 600;
-const CARD_CLOSE_DELAY = 300;
-
 /** Viewport geometry the card's inert trigger span is pinned to. */
 interface AnchorRect {
   left: number;
@@ -62,36 +63,43 @@ interface AnchorRect {
   height: number;
 }
 
-function cancelTimer(
-  ref: React.RefObject<ReturnType<typeof setTimeout> | null>,
-) {
-  if (ref.current !== null) {
-    clearTimeout(ref.current);
-    ref.current = null;
-  }
+/** A row's handle on its own card — every field stable for the row's life, so
+ *  the object doubles as the row's identity in the latch below. */
+interface CardOwner {
+  timer: React.RefObject<ReturnType<typeof setTimeout> | null>;
+  frame: React.RefObject<number | null>;
+  pointerHeld: React.RefObject<boolean>;
+  setOpen: (open: boolean) => void;
 }
 
-function cancelFrame(ref: React.RefObject<number | null>) {
-  if (ref.current !== null) {
-    cancelAnimationFrame(ref.current);
-    ref.current = null;
-  }
+/** Which row's card is open, across the whole list. The keyboard route can open
+ *  a card on a row the pointer never visits, so no pointer path reaches it and
+ *  hovering another row would float a second card beside it. Imperative only;
+ *  nothing renders from this. */
+let activeCard: CardOwner | null = null;
+
+/** Drops a row's claim, ignoring a row that no longer holds it — an evicted row
+ *  must never clear the card that replaced it. */
+function releaseCard(owner: CardOwner) {
+  if (activeCard === owner) activeCard = null;
 }
 
 /** Everything that can open or hold a card, torn down together. The pointer
  *  claim has to go with it: removing a hovered node fires no `pointerleave`, so
  *  a card closed under the pointer would leave the claim set forever, and the
  *  row's next keyboard card would refuse to close on blur. */
-function resetCard(
-  timer: React.RefObject<ReturnType<typeof setTimeout> | null>,
-  frame: React.RefObject<number | null>,
-  pointerHeld: React.RefObject<boolean>,
-  setOpen: (open: boolean) => void,
-) {
-  cancelTimer(timer);
-  cancelFrame(frame);
-  pointerHeld.current = false;
-  setOpen(false);
+function resetCard(owner: CardOwner) {
+  cancelTimer(owner.timer);
+  cancelFrame(owner.frame);
+  owner.pointerHeld.current = false;
+  owner.setOpen(false);
+  releaseCard(owner);
+}
+
+/** Hands the single open card to `owner`, tearing down whoever held it. */
+function claimCard(owner: CardOwner) {
+  if (activeCard !== null && activeCard !== owner) resetCard(activeCard);
+  activeCard = owner;
 }
 
 /** One dependency row: clickable name (opens its registry/repo) + a hovercard
@@ -112,6 +120,14 @@ function DependencyRow({ p }: { p: DependencyPackage }) {
   // Whether the pointer rests on the row or inside the popup. Blur must not close
   // a card the mouse still holds — clicking the name blurs it on the way out.
   const pointerHeld = useRef(false);
+  // Built once: the latch compares rows by this object's identity, so it has to
+  // outlive every render.
+  const [card] = useState<CardOwner>(() => ({
+    timer,
+    frame,
+    pointerHeld,
+    setOpen,
+  }));
   const cardId = useId();
   const url = packageUrl(p.ecosystem, p.name);
   const info = usePackageInfo(p.ecosystem, p.name, open);
@@ -124,7 +140,7 @@ function DependencyRow({ p }: { p: DependencyPackage }) {
   useEffect(() => {
     if (!open) return;
     let subscribed = false;
-    const close = () => resetCard(timer, frame, pointerHeld, setOpen);
+    const close = () => resetCard(card);
     const raf = requestAnimationFrame(() => {
       subscribed = true;
       window.addEventListener("scroll", close, true);
@@ -136,24 +152,27 @@ function DependencyRow({ p }: { p: DependencyPackage }) {
       window.removeEventListener("scroll", close, true);
       window.removeEventListener("resize", close);
     };
-  }, [open]);
+  }, [open, card]);
 
-  // The virtualizer evicts rows mid-dwell.
+  // The virtualizer evicts rows mid-dwell, and an evicted row that still held
+  // the latch would tear down whichever card claims it next.
   useEffect(
     () => () => {
-      cancelTimer(timer);
-      cancelFrame(frame);
+      cancelTimer(card.timer);
+      cancelFrame(card.frame);
+      releaseCard(card);
     },
-    [],
+    [card],
   );
 
   function showAt(anchor: AnchorRect) {
+    claimCard(card);
     setRect(anchor);
     setOpen(true);
   }
 
   function dismiss() {
-    resetCard(timer, frame, pointerHeld, setOpen);
+    resetCard(card);
   }
 
   /** A 1px anchor at the pointer's x spanning the row's height, so the popup
@@ -231,8 +250,7 @@ function DependencyRow({ p }: { p: DependencyPackage }) {
     // A pointer claim outlives focus: resting on the row keeps the card, and the
     // pointer route owns closing that one.
     if (pointerHeld.current) return;
-    cancelTimer(timer);
-    setOpen(false);
+    dismiss();
   }
 
   /** Opening the registry page hands focus to another application, where no
@@ -295,8 +313,12 @@ function DependencyRow({ p }: { p: DependencyPackage }) {
               eventDetails.cancel();
               return;
             }
-            if (next) setOpen(true);
-            else dismiss();
+            if (!next) {
+              dismiss();
+              return;
+            }
+            claimCard(card);
+            setOpen(true);
           }}
         >
           {/* Kept mounted through the close fade — an unmounting trigger

--- a/src/features/repository/insights/DependenciesCard.tsx
+++ b/src/features/repository/insights/DependenciesCard.tsx
@@ -1,6 +1,8 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { isUserDismissal } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import {
   HoverCard,
@@ -47,86 +49,338 @@ function packageUrl(ecosystem: string, name: string): string | null {
   }
 }
 
+// The card is positioned by hand off an inert trigger, so none of Base UI's own
+// hover machinery applies and both delays are hand-rolled from its constants.
+const CARD_OPEN_DELAY = 600;
+const CARD_CLOSE_DELAY = 300;
+
+/** Viewport geometry the card's inert trigger span is pinned to. */
+interface AnchorRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+function cancelTimer(
+  ref: React.RefObject<ReturnType<typeof setTimeout> | null>,
+) {
+  if (ref.current !== null) {
+    clearTimeout(ref.current);
+    ref.current = null;
+  }
+}
+
+function cancelFrame(ref: React.RefObject<number | null>) {
+  if (ref.current !== null) {
+    cancelAnimationFrame(ref.current);
+    ref.current = null;
+  }
+}
+
+/** Everything that can open or hold a card, torn down together. The pointer
+ *  claim has to go with it: removing a hovered node fires no `pointerleave`, so
+ *  a card closed under the pointer would leave the claim set forever, and the
+ *  row's next keyboard card would refuse to close on blur. */
+function resetCard(
+  timer: React.RefObject<ReturnType<typeof setTimeout> | null>,
+  frame: React.RefObject<number | null>,
+  pointerHeld: React.RefObject<boolean>,
+  setOpen: (open: boolean) => void,
+) {
+  cancelTimer(timer);
+  cancelFrame(frame);
+  pointerHeld.current = false;
+  setOpen(false);
+}
+
 /** One dependency row: clickable name (opens its registry/repo) + a hovercard
  *  that lazily fetches the package's description. */
 function DependencyRow({ p }: { p: DependencyPackage }) {
   const [open, setOpen] = useState(false);
+  // Kept through the close fade so the exit animation plays where the card was.
+  const [rect, setRect] = useState<AnchorRect | null>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
+  // One timer for both delays — the row is either dwelling toward an open or
+  // waiting out a close, never both.
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const frame = useRef<number | null>(null);
+  // Transient: read once, at open. A state write per pointer move would re-render
+  // the row on every pixel.
+  const cursorX = useRef(0);
+  const cursorY = useRef(0);
+  // Whether the pointer rests on the row or inside the popup. Blur must not close
+  // a card the mouse still holds — clicking the name blurs it on the way out.
+  const pointerHeld = useRef(false);
+  const cardId = useId();
   const url = packageUrl(p.ecosystem, p.name);
   const info = usePackageInfo(p.ecosystem, p.name, open);
   const fetchable = canFetchPackageInfo(p.ecosystem);
 
+  // The card is pinned to the rect measured at open while the virtualized rows
+  // translate under it, so any scroll or resize strands it. Capture-phase: the
+  // list's own scroll doesn't bubble. A frame late, because Tab's
+  // scroll-into-view can land in the same frame the focus route measured after.
+  useEffect(() => {
+    if (!open) return;
+    let subscribed = false;
+    const close = () => resetCard(timer, frame, pointerHeld, setOpen);
+    const raf = requestAnimationFrame(() => {
+      subscribed = true;
+      window.addEventListener("scroll", close, true);
+      window.addEventListener("resize", close);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      if (!subscribed) return;
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open]);
+
+  // The virtualizer evicts rows mid-dwell.
+  useEffect(
+    () => () => {
+      cancelTimer(timer);
+      cancelFrame(frame);
+    },
+    [],
+  );
+
+  function showAt(anchor: AnchorRect) {
+    setRect(anchor);
+    setOpen(true);
+  }
+
+  function dismiss() {
+    resetCard(timer, frame, pointerHeld, setOpen);
+  }
+
+  /** A 1px anchor at the pointer's x spanning the row's height, so the popup
+   *  lands under the cursor rather than centered on the full-width row. The row
+   *  can scroll out from under a pending dwell, so the pointer has to still be
+   *  on it; x is then clamped to it. */
+  function openAtCursor() {
+    const row = rowRef.current;
+    if (!row) return;
+    const r = row.getBoundingClientRect();
+    if (cursorY.current < r.top || cursorY.current > r.bottom) return;
+    const left = Math.min(Math.max(cursorX.current, r.left), r.right - 1);
+    showAt({ left, top: r.top, width: 1, height: r.height });
+  }
+
+  function armOpen(e: React.PointerEvent) {
+    cursorX.current = e.clientX;
+    cursorY.current = e.clientY;
+    if (timer.current !== null) return;
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      openAtCursor();
+    }, CARD_OPEN_DELAY);
+  }
+
+  /** The grace before an open card goes: re-entering the row or the popup
+   *  cancels it. */
+  function scheduleClose() {
+    cancelTimer(timer);
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      dismiss();
+    }, CARD_CLOSE_DELAY);
+  }
+
+  function onRowPointerEnter(e: React.PointerEvent) {
+    pointerHeld.current = true;
+    // Cancels the close armed on the way out — of the row, or of the popup the
+    // pointer is coming back from.
+    cancelTimer(timer);
+    if (open) return;
+    armOpen(e);
+  }
+
+  function onRowPointerMove(e: React.PointerEvent) {
+    // An open card stays where it opened; only a closed one tracks the cursor.
+    if (open) return;
+    armOpen(e);
+  }
+
+  function onRowPointerLeave() {
+    pointerHeld.current = false;
+    cancelTimer(timer);
+    if (open) scheduleClose();
+  }
+
+  function onNameFocus(e: React.FocusEvent<HTMLButtonElement>) {
+    const el = e.currentTarget;
+    // Keyboard arrival only — a click focuses the button too, and popping a card
+    // under the pointer that just clicked reads as a misfire.
+    if (!el.matches(":focus-visible")) return;
+    cancelTimer(timer);
+    cancelFrame(frame);
+    // A frame late: Tab fires focus before scrolling its target into view, so
+    // the rect measured now would be the pre-scroll one.
+    frame.current = requestAnimationFrame(() => {
+      frame.current = null;
+      const r = el.getBoundingClientRect();
+      showAt({ left: r.left, top: r.top, width: r.width, height: r.height });
+    });
+  }
+
+  function onNameBlur() {
+    cancelFrame(frame);
+    // A pointer claim outlives focus: resting on the row keeps the card, and the
+    // pointer route owns closing that one.
+    if (pointerHeld.current) return;
+    cancelTimer(timer);
+    setOpen(false);
+  }
+
+  /** Opening the registry page hands focus to another application, where no
+   *  pointer or blur event can reach a card left open or a dwell left armed. */
+  function openPackageUrl(target: string) {
+    dismiss();
+    openUrl(target).catch(toastError);
+  }
+
   return (
-    <HoverCard onOpenChange={setOpen}>
-      <HoverCardTrigger
-        render={
-          <div className="flex w-full items-baseline gap-2 border-b px-2 py-1 text-xs">
-            {url ? (
-              <button
-                type="button"
-                className="min-w-0 flex-1 cursor-pointer truncate text-left font-mono hover:underline focus-visible:underline focus-visible:outline-none"
-                onClick={() => openUrl(url).catch(toastError)}
-              >
-                {p.name}
-              </button>
-            ) : (
-              <span className="min-w-0 flex-1 truncate font-mono">
-                {p.name}
-              </span>
-            )}
-            {p.direct && (
-              <span className="shrink-0 rounded-none bg-accent px-1 text-[10px] text-accent-foreground">
-                direct
-              </span>
-            )}
-            <span className="shrink-0 rounded-none bg-muted px-1 text-[10px] text-muted-foreground">
-              {p.ecosystem}
-            </span>
-            {p.version && (
-              <span className="shrink-0 tabular-nums text-muted-foreground">
-                {p.version}
-              </span>
-            )}
-          </div>
-        }
-      />
-      <HoverCardContent className="w-72 space-y-1.5">
-        <div className="flex items-baseline gap-2">
-          <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium">
+    <>
+      <div
+        ref={rowRef}
+        onPointerEnter={onRowPointerEnter}
+        onPointerMove={onRowPointerMove}
+        onPointerLeave={onRowPointerLeave}
+        className="flex w-full items-baseline gap-2 border-b px-2 py-1 text-xs"
+      >
+        {url ? (
+          <button
+            type="button"
+            className="min-w-0 flex-1 cursor-pointer truncate text-left font-mono hover:underline focus-visible:underline focus-visible:outline-none"
+            aria-describedby={open ? cardId : undefined}
+            onFocus={onNameFocus}
+            onBlur={onNameBlur}
+            onClick={() => openPackageUrl(url)}
+          >
             {p.name}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 truncate font-mono">{p.name}</span>
+        )}
+        {p.direct && (
+          <span className="shrink-0 rounded-none bg-accent px-1 text-[10px] text-accent-foreground">
+            direct
           </span>
-          <span className="shrink-0 text-[10px] text-muted-foreground">
-            {p.direct ? "direct" : "transitive"}
+        )}
+        <span className="shrink-0 rounded-none bg-muted px-1 text-[10px] text-muted-foreground">
+          {p.ecosystem}
+        </span>
+        {p.version && (
+          <span className="shrink-0 tabular-nums text-muted-foreground">
+            {p.version}
           </span>
-        </div>
-        {fetchable &&
-          (info.isFetching ? (
-            <p className="text-[11px] text-muted-foreground italic">Loading…</p>
-          ) : info.data?.description ? (
-            <p className="text-[11px] text-muted-foreground">
-              {info.data.description}
-            </p>
-          ) : (
-            <p className="text-[11px] text-muted-foreground italic">
-              No description available.
-            </p>
-          ))}
-        <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-          <span className="truncate">
-            {p.ecosystem}
-            {p.version ? ` · ${p.version}` : ""}
-          </span>
-          {url && (
-            <button
-              type="button"
-              className="shrink-0 cursor-pointer hover:text-foreground hover:underline"
-              onClick={() => openUrl(url).catch(toastError)}
-            >
-              Open ↗
-            </button>
-          )}
-        </div>
-      </HoverCardContent>
-    </HoverCard>
+        )}
+      </div>
+      {/* Portalled to the body because the virtualizer gives every row wrapper a
+          `transform`, which makes it the containing block for `position: fixed`
+          descendants — the trigger span's viewport coordinates would resolve
+          against the row instead. Context crosses a portal, so the popup's own
+          `usePanelPortalContainer()` still scopes it to the panel. */}
+      {createPortal(
+        <HoverCard
+          open={open}
+          // The inert trigger's own hover machinery can never see the pointer
+          // over it (pointer-events: none), so it schedules a hover close after
+          // every open — metronomic flicker. Only a real dismissal may close it.
+          onOpenChange={(next, eventDetails) => {
+            if (!next && !isUserDismissal(eventDetails.reason)) {
+              eventDetails.cancel();
+              return;
+            }
+            if (next) setOpen(true);
+            else dismiss();
+          }}
+        >
+          {/* Kept mounted through the close fade — an unmounting trigger
+              force-closes the card mid-animation. A store-registered trigger is
+              what Base UI measures correctly; the positioner's `anchor` prop
+              yields a 0×0 rect. */}
+          <HoverCardTrigger
+            render={
+              <span
+                aria-hidden
+                className="pointer-events-none fixed"
+                style={
+                  rect
+                    ? {
+                        left: rect.left,
+                        top: rect.top,
+                        width: rect.width,
+                        height: rect.height,
+                      }
+                    : { display: "none" }
+                }
+              />
+            }
+          />
+          <HoverCardContent
+            id={cardId}
+            className="w-72 space-y-1.5"
+            // The card opens empty and fills in, but `aria-describedby` resolves
+            // once, at focus — so the popup is a polite live region and the
+            // description announces itself when it lands. `aria-busy` holds that
+            // announcement until the swap is done.
+            role="status"
+            aria-busy={fetchable && info.isFetching}
+            onPointerEnter={() => {
+              pointerHeld.current = true;
+              cancelTimer(timer);
+            }}
+            onPointerLeave={() => {
+              pointerHeld.current = false;
+              scheduleClose();
+            }}
+          >
+            <div className="flex items-baseline gap-2">
+              <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium">
+                {p.name}
+              </span>
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                {p.direct ? "direct" : "transitive"}
+              </span>
+            </div>
+            {fetchable &&
+              (info.isFetching ? (
+                <p className="text-[11px] text-muted-foreground italic">
+                  Loading…
+                </p>
+              ) : info.data?.description ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {info.data.description}
+                </p>
+              ) : (
+                <p className="text-[11px] text-muted-foreground italic">
+                  No description available.
+                </p>
+              ))}
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+              <span className="truncate">
+                {p.ecosystem}
+                {p.version ? ` · ${p.version}` : ""}
+              </span>
+              {url && (
+                <button
+                  type="button"
+                  className="shrink-0 cursor-pointer hover:text-foreground hover:underline"
+                  onClick={() => openPackageUrl(url)}
+                >
+                  Open ↗
+                </button>
+              )}
+            </div>
+          </HoverCardContent>
+        </HoverCard>,
+        document.body,
+      )}
+    </>
   );
 }
 

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -151,6 +151,22 @@ export const GeneralSection = withForm({
           </p>
         </div>
         <div className="space-y-1.5">
+          <form.AppField name="fetchLinkPreviews">
+            {(field) => (
+              <field.CheckboxField
+                label="Fetch link previews"
+                className="flex cursor-pointer items-center gap-2 text-xs"
+              />
+            )}
+          </form.AppField>
+          <p className="text-xs text-muted-foreground">
+            Shows a page's title, description, and image when you hover or focus
+            a link in a rendered description, comment, or release note. The
+            link's destination always shows; turning this off skips contacting
+            the linked site.
+          </p>
+        </div>
+        <div className="space-y-1.5">
           <form.AppField name="analyticsEnabled">
             {(field) => (
               <field.CheckboxField

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -161,7 +161,7 @@ export const GeneralSection = withForm({
           </form.AppField>
           <p className="text-xs text-muted-foreground">
             Shows a page's title, description, and image when you hover or focus
-            a link in a rendered description, comment, or release note. The
+            a web link in a rendered description, comment, or release note. The
             link's destination always shows; turning this off skips contacting
             the linked site.
           </p>

--- a/src/lib/hover-card-latch.ts
+++ b/src/lib/hover-card-latch.ts
@@ -1,0 +1,34 @@
+/**
+ * One-card-at-a-time exclusivity for a family of hovercards whose members each
+ * own their card state. That state can't enforce it alone: a keyboard-opened
+ * card closes only on blur or dismissal, so opening one elsewhere in the family
+ * fires none of the first one's close routes and both float.
+ *
+ * Each surface builds its OWN latch. One shared instance would make unrelated
+ * families — a rendered markdown body and the Insights dependency list —
+ * mutually exclusive, which is a behavior change rather than deduplication.
+ *
+ * `Owner` is whatever a member uses as its stable identity; the latch only ever
+ * compares it by reference and never reads it. `reset` is the surface's own
+ * teardown for an evicted member, and MUST end by releasing that member — the
+ * surface calls it directly on its own close paths too, not only through
+ * `claim`.
+ *
+ * Written and read imperatively only — nothing renders from a latch.
+ */
+export function createCardLatch<Owner>(reset: (owner: Owner) => void) {
+  let active: Owner | null = null;
+  return {
+    /** Hands the single open card to `owner`, tearing down whoever held it.
+     *  Re-claiming from the owner that already holds it is not a takeover. */
+    claim(owner: Owner) {
+      if (active !== null && active !== owner) reset(active);
+      active = owner;
+    },
+    /** Drops `owner`'s claim, ignoring one that no longer holds it — an evicted
+     *  or unmounted member must never clear the card that replaced it. */
+    release(owner: Owner) {
+      if (active === owner) active = null;
+    },
+  };
+}

--- a/src/lib/hover-card-timing.ts
+++ b/src/lib/hover-card-timing.ts
@@ -1,0 +1,22 @@
+import type { RefObject } from "react";
+
+// A card positioned by hand off an inert trigger gets none of Base UI's own
+// hover machinery, so its delays are hand-rolled from that library's constants.
+export const CARD_OPEN_DELAY = 600;
+export const CARD_CLOSE_DELAY = 300;
+
+export function cancelTimer(
+  ref: RefObject<ReturnType<typeof setTimeout> | null>,
+) {
+  if (ref.current !== null) {
+    clearTimeout(ref.current);
+    ref.current = null;
+  }
+}
+
+export function cancelFrame(ref: RefObject<number | null>) {
+  if (ref.current !== null) {
+    cancelAnimationFrame(ref.current);
+    ref.current = null;
+  }
+}

--- a/src/lib/link-preview.ts
+++ b/src/lib/link-preview.ts
@@ -9,7 +9,12 @@ import { invoke } from "@/lib/tauri/invoke";
 export type LinkPreview = {
   title: string | null;
   description: string | null;
-  imageUrl: string | null;
+  /** The og image as a complete `data:image/<subtype>;base64,…` URI — bytes the
+   *  backend already fetched through its own per-hop-validated client, never a
+   *  URL for the webview to resolve. An `<img src>` follows redirects with no
+   *  host re-validation, so a public image host could 302 into the user's LAN
+   *  and reduce the backend's URL vetting to decoration. */
+  imageData: string | null;
 };
 
 /** Reads a page's Open Graph card. Rejects on a refused or unreachable URL —
@@ -21,7 +26,9 @@ export function fetchLinkPreview(url: string): Promise<LinkPreview> {
 
 /**
  * A page's preview, cached for the session: a SETTLED one is never re-read, and
- * the half-hour `gcTime` keeps a body's links warm across view switches.
+ * the half-hour `gcTime` keeps a body's links warm across view switches. That
+ * cache now holds image BYTES rather than a URL, so `gcTime` bounds real memory
+ * — an entry is a page's card, not a pointer to one.
  *
  * A FAILED one needs the two mount options as much as `retry`: the card
  * remounts on every hover, and `staleTime` doesn't cover an error, so without

--- a/src/lib/link-preview.ts
+++ b/src/lib/link-preview.ts
@@ -1,0 +1,40 @@
+import { queryOptions } from "@tanstack/react-query";
+import { invoke } from "@/lib/tauri/invoke";
+
+/**
+ * The Open Graph fields the backend read off a linked page. Each is
+ * independently absent: all three null is a SETTLED answer (the page carries no
+ * og data), not a failure, and the card renders its URL-only form for it.
+ */
+export type LinkPreview = {
+  title: string | null;
+  description: string | null;
+  imageUrl: string | null;
+};
+
+/** Reads a page's Open Graph card. Rejects on a refused or unreachable URL —
+ *  the backend validates the scheme and refuses private hosts, so a rejection
+ *  is a verdict about this URL rather than a transient miss. */
+export function fetchLinkPreview(url: string): Promise<LinkPreview> {
+  return invoke<LinkPreview>("fetch_link_preview", { url });
+}
+
+/**
+ * A page's preview, cached for the session: a SETTLED one is never re-read, and
+ * the half-hour `gcTime` keeps a body's links warm across view switches.
+ *
+ * A FAILED one needs the two mount options as much as `retry`: the card
+ * remounts on every hover, and `staleTime` doesn't cover an error, so without
+ * them each re-hover re-invokes the command and can pay the full timeout again
+ * for an answer the backend already gave (a private host it refuses by design).
+ */
+export const linkPreviewOptions = (url: string) =>
+  queryOptions({
+    queryKey: ["link-preview", url] as const,
+    queryFn: () => fetchLinkPreview(url),
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 30 * 60_000,
+    retry: false,
+    retryOnMount: false,
+    refetchOnWindowFocus: false,
+  });

--- a/src/lib/link-preview.ts
+++ b/src/lib/link-preview.ts
@@ -25,22 +25,26 @@ export function fetchLinkPreview(url: string): Promise<LinkPreview> {
 }
 
 /**
- * A page's preview, cached for the session: a SETTLED one is never re-read, and
- * the half-hour `gcTime` keeps a body's links warm across view switches. That
- * cache now holds image BYTES rather than a URL, so `gcTime` bounds real memory
- * — an entry is a page's card, not a pointer to one.
+ * An entry carries the og image's BYTES, not a URL, so `gcTime` is this cache's
+ * memory bound rather than a convenience knob, and is deliberately short: five
+ * minutes covers re-hovering a link while reading around it, and caps retention
+ * at minutes of hovering rather than half an hour of it. `staleTime` stays
+ * infinite — while an entry is cached it is settled, and a re-hover repaints
+ * with no request at all.
  *
  * A FAILED one needs the two mount options as much as `retry`: the card
  * remounts on every hover, and `staleTime` doesn't cover an error, so without
  * them each re-hover re-invokes the command and can pay the full timeout again
  * for an answer the backend already gave (a private host it refuses by design).
+ * That memory expires with the entry: a refusal is re-earned once per `gcTime`,
+ * which is the price of bounding what the cache holds.
  */
 export const linkPreviewOptions = (url: string) =>
   queryOptions({
     queryKey: ["link-preview", url] as const,
     queryFn: () => fetchLinkPreview(url),
     staleTime: Number.POSITIVE_INFINITY,
-    gcTime: 30 * 60_000,
+    gcTime: 5 * 60_000,
     retry: false,
     retryOnMount: false,
     refetchOnWindowFocus: false,

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -257,6 +257,10 @@ export interface AppSettings {
   /** Default new pull requests to draft: the Create-PR dialog's "Create as draft" checkbox
    *  starts ticked. Off by default; still overridable per dialog. */
   createPrsAsDraft: boolean;
+  /** Let a link preview in rendered markdown contact the linked site for its
+   *  Open Graph title, description, and image. Off, the card still names the
+   *  link's destination — nothing leaves the machine. */
+  fetchLinkPreviews: boolean;
   /** First-run nudge toward the user guide; set once the user opens or dismisses it. */
   seenGuideNudge: boolean;
   /** Send anonymous usage events to PostHog. Default on (opt-out). */
@@ -350,6 +354,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   autoFetchInterval: "10",
   reviewDraftPrs: false,
   createPrsAsDraft: false,
+  fetchLinkPreviews: true,
   seenGuideNudge: false,
   analyticsEnabled: true,
   recordReplay: false,

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -66,6 +66,16 @@ export function useAiEnabled(): boolean {
   return !settings.data?.hideAi;
 }
 
+/** Whether a link preview may contact the linked site. Reads false until the
+ *  store answers — the opposite of {@link useAiEnabled}'s optimism, because
+ *  guessing wrong here would reach a third-party host the user opted out of;
+ *  the query resolves once per session and the card re-renders with the real
+ *  value. */
+export function useFetchLinkPreviews(): boolean {
+  const settings = useSettings();
+  return settings.data?.fetchLinkPreviews ?? false;
+}
+
 /**
  * Whether the commit/PR generation provider is actually usable: a saved API
  * key for key-based providers (Anthropic/OpenAI/OpenRouter), always true for


### PR DESCRIPTION
Rendered bodies (descriptions, comments, release notes) linkify URLs that the user did not write, and until now the only way to learn where one goes was to click it. This adds a hover/focus preview card for external links — the destination first, with the page's own Open Graph metadata filled in behind it — backed by a hardened fetcher that never touches private network addresses, plus a **Fetch link previews** setting for people who want the destination alone. The dependency hovercards on Insights are reworked with the same hand-positioned card machinery so they open at the cursor and are reachable by Tab.

### Backend link fetching

- Adds `src-tauri/src/link_preview.rs` with the `fetch_link_preview` command: a dedicated `reqwest` client that sends no credentials and installs no cookie store, with `redirect::Policy::none()` so every hop is re-validated by hand (`guard_hop` / `next_hop`, `MAX_REDIRECTS` of 3).
- Blocks non-public destinations via a hand-rolled address blocklist (`ip_is_blocked`, `ipv4_is_blocked`, `ipv6_is_blocked`, `embedded_ipv4`), covering loopback, private, link-local, CGNAT, multicast, and IPv4 addresses embedded in IPv6 forms. The returned `og:image` clears the same blocklist before crossing IPC, since the webview loads it outside this module's client.
- Bounds every budget a hostile page could stretch: `CONNECT_TIMEOUT`, `REQUEST_TIMEOUT`, `DNS_TIMEOUT`, an overall `PREVIEW_DEADLINE`, a 512 KiB body cap, and a bounded `<meta>` scan (`MAX_TAG_BYTES`, `MAX_META_TAGS`) instead of a full HTML parser. Title, description, and image URL are length-capped; an over-long image URL is dropped rather than truncated.
- Registers the module and command in `src-tauri/src/lib.rs`, and enables tokio's `net` feature in `src-tauri/Cargo.toml` for the DNS resolution path.

### Frontend card

- Adds `src/components/ui/markdown-link-card.tsx`: shows the host and full URL with no network at all, then the fetched title/description/image. Strips bidi control characters from every page- or author-supplied string (`BIDI_CONTROLS`, `stripBidi`) so a URL can't read as one host while addressing another, renders a fixed-footprint `LinkCardSkeleton` so the popup never grows and re-triggers Base UI collision flips, marks the card `ph-no-capture`, and sets `referrerPolicy="no-referrer"` on the image.
- Extends `MarkdownRefTarget` in `src/components/ui/markdown-ref-card.tsx` with an `{ kind: "external"; href }` arm and factors out `MarkdownForgeTarget` for the forge-only half. `refs` becomes optional so bodies with no forge context (help screen, AI output) can still show link cards, and `aria-busy` excludes external targets since their content is on screen the frame the card opens.
- Wires the new target into `src/components/ui/markdown.tsx`: one `EXTERNAL_HREF` scheme regex shared by the click dispatch and the card, `linkTarget` reading the raw `href` attribute so the card names the URL the click will open, `anyTarget` preferring a forge reference over the link it also is, and `closeCardNow` tearing down the card on both anchor click branches.
- Adds `src/lib/link-preview.ts` with `fetchLinkPreview` and `linkPreviewOptions` — infinite `staleTime`, 30-minute `gcTime`, and `retry: false` / `retryOnMount: false` so a refused URL isn't re-invoked (and re-timed-out) on every re-hover.

### Setting

- Adds `fetchLinkPreviews` to `AppSettings` and `DEFAULT_SETTINGS` (on by default) in `src/lib/settings/api.ts`, plus a `useFetchLinkPreviews` hook in `src/lib/settings/queries.ts` that reads `false` until the store answers, so an unresolved query never reaches a third-party host.
- Adds the **Fetch link previews** checkbox and its explanatory copy to `src/features/settings/GeneralSection.tsx`. The setting gates the render as well as the fetch, so a preview cached before it was turned off isn't painted.

### Insights dependency hovercards

- Reworks `DependencyRow` in `src/features/repository/insights/DependenciesCard.tsx` to position its card by hand off a portaled, inert 1px trigger at the pointer's x (`openAtCursor`, `AnchorRect`), with hand-rolled open/close delays (`CARD_OPEN_DELAY`, `CARD_CLOSE_DELAY`) matching the markdown cards.
- Adds keyboard access (focus/blur routes with a `useId` card id) and a `pointerHeld` claim so blurring the name doesn't close a card the mouse still holds; `resetCard` clears that claim because removing a hovered node fires no `pointerleave`.
- Closes the card on capture-phase `scroll` and `resize` — the card is pinned to a rect measured at open while the virtualized rows translate under it — and cancels pending timers/frames on unmount, since the virtualizer evicts rows mid-dwell.

### Documentation

- `README.md`: new **Link previews** bullet covering the card, the metadata fill-in, the setting, and the private-address refusal.
- `src/features/help/content.ts`: a link-preview paragraph in the rendered-bodies section, and **fetch link previews** added to the Settings → General list.
- `site/src/data/capabilities.ts`: a "Link previews" capability under *Keyboard & Markdown*.
- Changelog fragments `changelog.d/added-link-previews.md` and `changelog.d/changed-insights-hovercard-cursor.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added link preview cards for web and `mailto:` links when hovered or keyboard-focused in rendered content.
  - Web previews show the domain, full URL, title, description, and available image; private and local-network pages are excluded.
  - Added a **Fetch link previews** option under **Settings → General**.
- **Bug Fixes**
  - Improved hovercard positioning, keyboard navigation, and behavior so only one related card opens at a time.
- **Documentation**
  - Added guidance for link previews and the related setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->