### PR TITLE
fix(git,pull,branches): narrow lock holds so local work stays available

### DIFF
--- a/changelog.d/changed-repo-lock-identity.md
+++ b/changelog.d/changed-repo-lock-identity.md
@@ -1,3 +1,3 @@
-- Operations that reach one repository through a different path spelling now
-  share its operation locks, and transfers and worktree maintenance from a
-  linked worktree take their turn with the main checkout's instead of racing.
+- Git operations on one repository now recognize it across path spellings and
+  subfolders, and a linked worktree's transfers and worktree maintenance take
+  their turn with the main checkout's instead of racing.

--- a/changelog.d/changed-repo-lock-identity.md
+++ b/changelog.d/changed-repo-lock-identity.md
@@ -1,0 +1,3 @@
+- Operations that reach one repository through a different path spelling or
+  from a linked worktree now share that repository's operation locks, so
+  transfers and worktree maintenance take turns instead of racing.

--- a/changelog.d/changed-repo-lock-identity.md
+++ b/changelog.d/changed-repo-lock-identity.md
@@ -1,3 +1,3 @@
-- Operations that reach one repository through a different path spelling or
-  from a linked worktree now share that repository's operation locks, so
-  transfers and worktree maintenance take turns instead of racing.
+- Operations that reach one repository through a different path spelling now
+  share its operation locks, and transfers and worktree maintenance from a
+  linked worktree take their turn with the main checkout's instead of racing.

--- a/changelog.d/fixed-branch-update-worktree-lock.md
+++ b/changelog.d/fixed-branch-update-worktree-lock.md
@@ -1,3 +1,3 @@
 - Staging keeps working while a branch update prepares its temporary worktree,
-  and the update asks you to try again if its branch moved mid-run or its base
-  was rewritten, instead of acting on a stale snapshot.
+  and an update that can no longer proceed says exactly why (the branch moved,
+  the base was rewritten or deleted) instead of acting on a stale snapshot.

--- a/changelog.d/fixed-branch-update-worktree-lock.md
+++ b/changelog.d/fixed-branch-update-worktree-lock.md
@@ -1,0 +1,3 @@
+- Staging keeps working while a branch update prepares its temporary worktree,
+  and an update whose branch or base moved mid-run asks you to try again
+  instead of acting on a stale snapshot.

--- a/changelog.d/fixed-branch-update-worktree-lock.md
+++ b/changelog.d/fixed-branch-update-worktree-lock.md
@@ -1,3 +1,3 @@
 - Staging keeps working while a branch update prepares its temporary worktree,
-  and an update that can no longer proceed says exactly why (the branch moved,
-  the base was rewritten or deleted) instead of acting on a stale snapshot.
+  and an update that can no longer proceed says exactly why: the branch moved,
+  the base was rewritten or deleted.

--- a/changelog.d/fixed-branch-update-worktree-lock.md
+++ b/changelog.d/fixed-branch-update-worktree-lock.md
@@ -1,3 +1,3 @@
 - Staging keeps working while a branch update prepares its temporary worktree,
-  and an update whose branch or base moved mid-run asks you to try again
-  instead of acting on a stale snapshot.
+  and the update asks you to try again if its branch moved mid-run or its base
+  was rewritten, instead of acting on a stale snapshot.

--- a/changelog.d/fixed-pull-transfer-working-tree-lock.md
+++ b/changelog.d/fixed-pull-transfer-working-tree-lock.md
@@ -1,0 +1,3 @@
+- Staging, committing, and other local Git work stay available while a pull is
+  transferring: the network phase runs on the repository's network lock alone,
+  and the merge or rebase then applies exactly the commits that fetch delivered.

--- a/changelog.d/fixed-pull-transfer-working-tree-lock.md
+++ b/changelog.d/fixed-pull-transfer-working-tree-lock.md
@@ -1,3 +1,4 @@
 - Staging, committing, and other local Git work stay available while a pull is
-  transferring: the network phase runs on the repository's network lock alone,
-  and the merge or rebase then applies exactly the commits that fetch delivered.
+  transferring on the everyday setup (a branch tracking its remote, stock pull
+  configuration); the merge or rebase then applies exactly the commits that
+  fetch delivered.

--- a/changelog.d/fixed-terminal-resize-stall.md
+++ b/changelog.d/fixed-terminal-resize-stall.md
@@ -1,2 +1,2 @@
 - The integrated terminal stays responsive while its pane is being resized:
-  typed input and closing the pane no longer wait out a resize storm.
+  typed input and closing the pane remain available through a resize storm.

--- a/changelog.d/fixed-terminal-resize-stall.md
+++ b/changelog.d/fixed-terminal-resize-stall.md
@@ -1,0 +1,2 @@
+- The integrated terminal stays responsive while its pane is being resized:
+  typed input and closing the pane no longer wait out a resize storm.

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -58,6 +58,12 @@ const REFSPEC_ALLOWLIST = [
   },
   {
     file: "git/branches.rs",
+    fn: "branch_tip_sha",
+    rationale:
+      "read-only rev-parse tip probe (never a refspec); validates with validate_branch_name at fn entry",
+  },
+  {
+    file: "git/branches.rs",
     fn: "git_default_branch",
     rationale: "interpolates only the fixed literals main/master",
   },

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -4,9 +4,11 @@
 //! lock-free runners while holding it — `run_git_mutating` re-acquires the same
 //! non-reentrant mutex and deadlocks (precedent: `git_stash_paths_core`). The inner
 //! steps therefore lose `run_git_mutating`'s one-shot index.lock retry, the same
-//! trade-off that compound accepts. The pull compound's transfer additionally takes
-//! the NETWORK lock around its one network call, so it still serializes against the
-//! background auto-fetch; that nesting direction is the only one allowed (see
+//! trade-off that compound accepts. The pull compound runs its transfer FIRST, under
+//! the network domain alone (`git::pull_guard`), and takes the working tree only for
+//! the local half — so staging stays available across a transfer. Its bare
+//! fall-through keeps the older shape, taking the NETWORK lock inside the
+//! working-tree hold; that nesting direction is the only one allowed (see
 //! `run_git_mutating`).
 
 use tauri::State;
@@ -191,13 +193,18 @@ pub(crate) async fn git_pull_autostash_core(
     // mode it RAN. A refused `--ff-only` leaves nothing unmerged, so its label
     // never surfaces.
     let paused = if mode == "rebase" { "rebase" } else { "merge" };
-    // Rebase mode runs the two-phase guard first — bare `git pull --rebase` can
-    // silently drop a pushed commit a force-push rewrote away (git::pull_guard).
-    // `None` means the guard stood down and this pull proceeds unchanged.
+    // Every mode splits into a network phase and a local one (git::pull_guard), so the
+    // transfer runs before anything is stashed and holds the network domain alone.
+    // Rebase mode additionally runs the fork-point guard there — bare
+    // `git pull --rebase` can silently drop a pushed commit a force-push rewrote away.
     if mode == "rebase" {
         if let Some(outcome) = crate::git::pull_guard::guarded_pull_autostash(state, &repo_path).await? {
             return Ok(outcome);
         }
+    } else if let Some(plain) =
+        crate::git::pull_guard::pin_plain_pull(state, &repo_path, mode != "merge").await?
+    {
+        return crate::git::pull_guard::merge_pinned_autostash(state, &repo_path, &plain).await;
     }
     // A read that shells out to git itself — resolve it BEFORE taking the lock.
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
@@ -206,10 +213,11 @@ pub(crate) async fn git_pull_autostash_core(
     let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
 
-    // The transfer serializes with the network domain (the auto-fetch runs there),
-    // and the hold is taken BEFORE the stash so it spans stash → pull → settle: a
-    // refusal to wait must precede the first tree mutation, or the user's work is
-    // stashed and popped back purely to report that something else was running.
+    // The fall-through's transfer serializes with the network domain (the auto-fetch
+    // runs there), and the hold is taken BEFORE the stash so it spans
+    // stash → pull → settle: a refusal to wait must precede the first tree mutation,
+    // or the user's work is stashed and popped back purely to report that something
+    // else was running.
     let network = state.network_lock(&repo_path).await;
     let _net_guard = acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await?;
 
@@ -1697,19 +1705,17 @@ mod tests {
         }
     }
 
-    /// Pull's version of the same parity, on the split that hides the loss: the
-    /// fetch summary fills stderr while the merge verdict rides stdout, so an
-    /// error carrying stderr alone looks populated and still says nothing about
+    /// Pull's version of the same parity, on the split that hides the loss: a
+    /// conflicted merge reports on STDOUT and leaves stderr empty, so an error
+    /// shaped from stderr alone looks like a bare exit code and says nothing about
     /// the conflict. Both sides must carry the whole report, identically, and both
     /// must name the operation they paused.
     #[tokio::test]
     async fn a_conflicted_pull_with_nothing_stashed_carries_the_stdout_report() {
         let (dir, work, clone) = setup_clone("pull-parity-conflict").await;
-        // TWO clones, one per side: the fetch half of a pull reports
-        // `<old>..<new> main -> origin/main` on stderr and only when a ref
-        // actually moves, so running both pulls in ONE clone would compare a
-        // fetching pull against an already-up-to-date one. Cloned before the
-        // upstream push so each is behind by the same commit.
+        // TWO clones, one per side: the first pull leaves the tree mid-merge, so a
+        // second one in the SAME clone could only be measured against a refusal.
+        // Cloned before the upstream push so each is behind by the same commit.
         let url = format!(
             "file://{}",
             dir.path()

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -2801,8 +2801,8 @@ mod tests {
     /// The case an exit-code verdict gets wrong: a `pre-merge-commit` hook that
     /// declines exits 1 — the conflict's code — with the auto-merge clean and nothing
     /// unmerged. Hooks resolve from the COMMON dir, so the main repo's hook runs inside
-    /// the throwaway worktree. A hook that failed to fire would let the merge succeed
-    /// and fail this test, which is the safe direction.
+    /// the throwaway worktree. A hook that failed to fire trips the sentinel assertion
+    /// below rather than passing as a clean merge.
     #[tokio::test]
     async fn a_declined_merge_hook_is_not_reported_as_a_conflict() {
         let (_guard, repo, repo_s, main) = diverged_repo("update-declined-hook").await;

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1192,6 +1192,7 @@ struct UpdatePins {
 /// The FULL ref path is the point: under a bare `rev-parse <branch>` a tag sharing
 /// the name would shadow it, and the pin would then guard the wrong object.
 async fn branch_tip_sha(repo_path: &str, branch: &str) -> AppResult<Option<String>> {
+    validate_branch_name(branch)?;
     let out = run_git_raw(
         Some(repo_path),
         &[
@@ -1266,8 +1267,9 @@ async fn remove_tmp_worktree(repo_path: &str, tmp: &str) {
     let _ = run_git_raw(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
 }
 
-/// Under a fresh working-tree hold: confirm both pinned refs still stand, then merge
-/// `base` by NAME inside the throwaway worktree at `tmp`. The merge writes the shared
+/// Under a fresh working-tree hold: confirm the branch still stands where it was
+/// pinned and the base still descends from its pin, then merge `base` by NAME inside
+/// the throwaway worktree at `tmp`. The merge writes the shared
 /// `refs/heads/<branch>`, which is why it belongs in this domain, and the name is what
 /// gives the merge commit its `Merge branch '<base>'` subject; the pins are what keep
 /// a ref that moved while the worktree materialized from silently changing the
@@ -1291,11 +1293,15 @@ async fn verify_pin_and_merge(
         )));
     }
 
-    // The base check runs in the TMP worktree's cwd — the $GIT_DIR the merge itself
-    // will resolve in. gitrevisions resolves $GIT_DIR-local names (HEAD, MERGE_HEAD, …)
-    // ahead of `refs/heads/`, and `validate_branch_name` admits a literal "HEAD", so a
-    // check in the main checkout could pass over a different object than the merge
-    // takes. Same cwd makes "whatever the merge resolves" provably the pinned commit.
+    // The base check runs in the TMP worktree's cwd — the $GIT_DIR the merge resolves
+    // in. gitrevisions takes $GIT_DIR-local names (HEAD, MERGE_HEAD, …) ahead of
+    // `refs/heads/`, and `validate_branch_name` admits a literal "HEAD", so a check in
+    // the main checkout could pass over a different object than the merge takes.
+    //
+    // Descent, not equality, is the property: the app's own auto-fetch advances a
+    // remote-tracking base mid-window, and a base that only fast-forwarded is what a
+    // fresh update would merge anyway — only a rewound or rewritten one, an
+    // unresolvable name, or a failed probe invalidates the plan.
     let base_now = run_git_raw(
         Some(tmp),
         &[
@@ -1307,10 +1313,21 @@ async fn verify_pin_and_merge(
         DEFAULT_TIMEOUT,
     )
     .await?;
-    if base_now.code != 0 || base_now.stdout_lossy().trim() != pins.base_sha {
-        return Err(AppError::Command(format!(
-            "{base} moved while this update was running — try again to see where it stands."
-        )));
+    let base_now_sha = base_now.stdout_lossy().trim().to_string();
+    if base_now.code != 0 || base_now_sha != pins.base_sha {
+        let fast_forwarded = base_now.code == 0
+            && run_git_raw(
+                Some(tmp),
+                &["merge-base", "--is-ancestor", &pins.base_sha, &base_now_sha],
+                DEFAULT_TIMEOUT,
+            )
+            .await
+            .is_ok_and(|out| out.code == 0);
+        if !fast_forwarded {
+            return Err(AppError::Command(format!(
+                "{base} moved while this update was running — try again to see where it stands."
+            )));
+        }
     }
 
     // The merge keeps the default budget: it rewrites only the differing files, not
@@ -2669,13 +2686,13 @@ mod tests {
         );
     }
 
-    /// The base's half of the pin. Merging by NAME is what keeps git's own merge
-    /// subject, so the sha the name resolves to has to be checked — a base that gained
-    /// a commit while the worktree materialized is a different operation than the one
-    /// the user asked for, and is refused rather than quietly merged.
+    /// The base's half of the pin, on its refusing side. Merging by NAME is what keeps
+    /// git's own merge subject, so the sha the name resolves to has to be checked — a
+    /// base whose pinned commit is no longer an ancestor is a different operation than
+    /// the one the user asked for, and is refused rather than quietly merged.
     #[tokio::test]
-    async fn a_diverged_update_refuses_a_base_that_moved_under_it() {
-        let (_guard, repo, repo_s, main) = diverged_repo("update-moved-base").await;
+    async fn a_diverged_update_refuses_a_base_rewritten_under_it() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-rewritten-base").await;
         let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
             .await
             .trim()
@@ -2685,15 +2702,14 @@ mod tests {
             .trim()
             .to_string();
 
-        // The base moves after the pin — exactly the window the admin prologue opens.
-        std::fs::write(repo.join("later.txt"), "later\n").unwrap();
-        run(&repo_s, &["add", "-A"]).await;
-        run(&repo_s, &["commit", "-qm", "base work later"]).await;
+        // `--amend` REPLACES the base tip rather than advancing it, so the pinned
+        // commit stops being an ancestor — the only move that invalidates the plan.
+        run(&repo_s, &["commit", "-q", "--amend", "-m", "base work, reworded"]).await;
         let moved_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
             .await
             .trim()
             .to_string();
-        assert_ne!(pinned_base, moved_base, "the fixture must move the base");
+        assert_ne!(pinned_base, moved_base, "the fixture must rewrite the base");
 
         let tmp = repo
             .parent()
@@ -2730,6 +2746,74 @@ mod tests {
             "the throwaway worktree is unregistered: {list}"
         );
         assert!(!tmp.exists(), "and its directory is gone");
+    }
+
+    /// The base's tolerant side. The app's own auto-fetch advances a remote-tracking
+    /// base while the throwaway worktree materializes, and a base that only
+    /// fast-forwarded is what a fresh update would merge — refusing it would make
+    /// "Update from origin/…" intermittently unusable on an active repo.
+    #[tokio::test]
+    async fn a_diverged_update_tolerates_a_base_that_fast_forwarded() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-ff-base").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        // The base gains a commit after the pin — a fast-forward, the shape a fetch
+        // of a moving remote-tracking branch leaves behind.
+        std::fs::write(repo.join("later.txt"), "later\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "base work later"]).await;
+        let moved_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+        assert_ne!(pinned_base, moved_base, "the fixture must move the base");
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("ff-base-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let outcome = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip,
+                base_sha: pinned_base,
+            },
+        )
+        .await
+        .expect("a fast-forwarded base still merges");
+        assert_eq!(outcome, "merge");
+
+        // Point-of-execution semantics: the NEWER base commit is what landed.
+        let merged_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let reachable = run_git_raw(
+            Some(&repo_s),
+            &["merge-base", "--is-ancestor", &moved_base, &merged_tip],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            reachable.code, 0,
+            "the commit the base gained after the pin is in the merge: {}",
+            reachable.stderr
+        );
+        assert!(!tmp.exists(), "the throwaway worktree is torn down");
     }
 
     /// The happy path: both pins hold, so the merge runs by NAME and the branch gets

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -2790,7 +2790,12 @@ mod tests {
             feature_tip,
             "the abort leaves the branch exactly where it was"
         );
-        assert!(!tmp.exists(), "the throwaway worktree is torn down");
+        let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
+        assert!(
+            !list.contains("conflict-wt"),
+            "the throwaway worktree is unregistered: {list}"
+        );
+        assert!(!tmp.exists(), "and its directory is gone");
     }
 
     /// The case an exit-code verdict gets wrong: a `pre-merge-commit` hook that
@@ -2810,8 +2815,21 @@ mod tests {
             .trim()
             .to_string();
 
+        let base_dir = repo.parent().expect("the repo lives under the temp base");
+        // The hook stamps a sentinel before declining, so a host `core.hooksPath` that
+        // suppressed it fails this test by its real cause rather than as a merge that
+        // unexpectedly succeeded. Forward slashes: the script runs under `sh`, where a
+        // Windows backslash is an escape character.
+        let sentinel = base_dir.join("hook-fired");
         let hook = repo.join(".git").join("hooks").join("pre-merge-commit");
-        std::fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+        std::fs::write(
+            &hook,
+            format!(
+                "#!/bin/sh\necho fired > \"{}\"\nexit 1\n",
+                sentinel.to_string_lossy().replace('\\', "/")
+            ),
+        )
+        .unwrap();
         // git IGNORES a hook without the executable bit on POSIX, which would let the
         // merge succeed and leave this test asserting nothing.
         #[cfg(unix)]
@@ -2820,13 +2838,10 @@ mod tests {
             std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        let tmp = repo
-            .parent()
-            .expect("the repo lives under the temp base")
-            .join("declined-hook-wt");
+        let tmp = base_dir.join("declined-hook-wt");
         let tmp_s = tmp.to_string_lossy().into_owned();
         let state = AppState::default();
-        let err = merge_diverged_in_worktree(
+        let result = merge_diverged_in_worktree(
             &state,
             &repo_s,
             &tmp_s,
@@ -2837,8 +2852,12 @@ mod tests {
                 base_sha: pinned_base,
             },
         )
-        .await
-        .expect_err("the declined hook stops the merge");
+        .await;
+        assert!(
+            sentinel.exists(),
+            "the pre-merge-commit hook never fired — check core.hooksPath"
+        );
+        let err = result.expect_err("the declined hook stops the merge");
         let AppError::Command(message) = &err else {
             panic!("a clean auto-merge must never be reported as a conflict: {err:?}");
         };
@@ -2855,7 +2874,12 @@ mod tests {
             feature_tip,
             "the abort leaves the branch exactly where it was"
         );
-        assert!(!tmp.exists(), "the throwaway worktree is torn down");
+        let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
+        assert!(
+            !list.contains("declined-hook-wt"),
+            "the throwaway worktree is unregistered: {list}"
+        );
+        assert!(!tmp.exists(), "and its directory is gone");
     }
 
     /// A merge that fails for a reason other than a conflict must not claim one: the

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1298,10 +1298,13 @@ async fn verify_pin_and_merge(
     // `refs/heads/`, and `validate_branch_name` admits a literal "HEAD", so a check in
     // the main checkout could pass over a different object than the merge takes.
     //
-    // Descent, not equality, is the property: the app's own auto-fetch advances a
-    // remote-tracking base mid-window, and a base that only fast-forwarded is what a
-    // fresh update would merge anyway — only a rewound or rewritten one, an
-    // unresolvable name, or a failed probe invalidates the plan.
+    // Three arms, so the refusal describes what happened. A base that only
+    // fast-forwarded is what a fresh update would merge — the app's own auto-fetch
+    // advances a remote-tracking base mid-window — so it proceeds. Exit 1 means the
+    // name did not resolve, and phase 1 already resolved it, so that base was deleted:
+    // its own wording, since a retry cannot find it either. A rewound or rewritten
+    // base, and any OTHER non-zero exit (128 — a vanished or corrupt tmp gitdir,
+    // measured git 2.51.1), take the retry wording, which suits a transient state.
     let base_now = run_git_raw(
         Some(tmp),
         &[
@@ -1313,8 +1316,15 @@ async fn verify_pin_and_merge(
         DEFAULT_TIMEOUT,
     )
     .await?;
+    if base_now.code == 1 {
+        return Err(AppError::Command(format!(
+            "{base} was deleted while this update was running — there is nothing to update from."
+        )));
+    }
     let base_now_sha = base_now.stdout_lossy().trim().to_string();
     if base_now.code != 0 || base_now_sha != pins.base_sha {
+        // The ancestor probe needs a resolved sha, so a failed re-resolve skips it
+        // and refuses.
         let fast_forwarded = base_now.code == 0
             && run_git_raw(
                 Some(tmp),
@@ -2743,6 +2753,64 @@ mod tests {
         let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
         assert!(
             !list.contains("moved-base-wt"),
+            "the throwaway worktree is unregistered: {list}"
+        );
+        assert!(!tmp.exists(), "and its directory is gone");
+    }
+
+    /// A base that stops resolving was deleted, not moved: phase 1 resolved the name,
+    /// so "try again to see where it stands" would point the user at a retry that
+    /// cannot succeed. Paired with the rewritten-base test, which keeps the "moved"
+    /// wording, so the two messages discriminate. Driven at the predicate, because a
+    /// base deleted mid-window is not a schedulable event.
+    #[tokio::test]
+    async fn a_diverged_update_reports_a_base_deleted_under_it() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-deleted-base").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        // HEAD has to leave the base branch before git will delete it.
+        run(&repo_s, &["switch", "-qc", "spare"]).await;
+        run(&repo_s, &["branch", "-D", &main]).await;
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("deleted-base-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip.clone(),
+                base_sha: pinned_base,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Command(m)
+                if m.starts_with(&format!("{main} was deleted while this update was running"))),
+            "{err:?}"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "a refused update leaves the branch exactly where it was"
+        );
+        let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
+        assert!(
+            !list.contains("deleted-base-wt"),
             "the throwaway worktree is unregistered: {list}"
         );
         assert!(!tmp.exists(), "and its directory is gone");

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1239,7 +1239,9 @@ async fn merge_diverged_in_worktree(
     // Try-then-detach is the only teardown shape with no bad arm: a bounded acquire
     // that gave up on `Busy` would leak the throwaway worktree, and a synchronous
     // unbounded one holds a finished update's command hostage for the minutes a
-    // node_modules-scale removal can hold the shared admin domain.
+    // node_modules-scale removal can hold the shared admin domain. A quit or crash
+    // while the detached task waits leaks the `gd-update-*` DIRECTORY — the registry
+    // entry self-heals through `worktree::prune_worktrees_if_free`, the directory does not.
     let domain = state.worktree_admin_lock(repo_path).await;
     match try_acquire_repo_lock(&domain, "a worktree operation") {
         Some(_admin) => remove_tmp_worktree(repo_path, tmp).await,
@@ -1342,17 +1344,29 @@ async fn verify_pin_and_merge(
 
     // The merge keeps the default budget: it rewrites only the differing files, not
     // the whole tree. Lock-free runner — the hold is ours.
-    let merged = run_git(Some(tmp), &["merge", "--no-edit", base], DEFAULT_TIMEOUT).await;
-    match merged {
-        Ok(_) => Ok("merge".to_string()),
-        Err(_) => {
-            // Undo the half-done merge so the branch ref is left as it was.
-            let _ = run_git_raw(Some(tmp), &["merge", "--abort"], DEFAULT_TIMEOUT).await;
-            Err(AppError::InvalidArgument(format!(
-                "{branch} has changes that conflict with {base}. Switch to {branch} to merge and resolve them."
-            )))
-        }
+    let merged = run_git_raw(Some(tmp), &["merge", "--no-edit", base], DEFAULT_TIMEOUT).await;
+    if merged.as_ref().is_ok_and(|out| out.code == 0) {
+        return Ok("merge".to_string());
     }
+
+    // The abort runs before the verdict, on every failure including a runner Err: a
+    // timeout that returned early would leave tmp mid-merge with the branch ref moved.
+    let _ = run_git_raw(Some(tmp), &["merge", "--abort"], DEFAULT_TIMEOUT).await;
+    // Exit 1 is the conflict (measured, git 2.51.1); a hook, a vanished tmp gitdir or
+    // unrelated histories exit 128, and the runner's Err is a timeout or spawn failure.
+    // Only the first has a remedy to name, so the rest carry git's own report instead.
+    Err(match merged {
+        Ok(out) if out.code == 1 => AppError::InvalidArgument(format!(
+            "{branch} has changes that conflict with {base}. Switch to {branch} to merge and resolve them."
+        )),
+        Ok(out) => AppError::Command(format!(
+            "merging {base} into {branch} failed — try again to see where it stands.\n{}",
+            out.full_failure_text()
+        )),
+        Err(e) => AppError::Command(format!(
+            "merging {base} into {branch} failed — try again to see where it stands.\n{e}"
+        )),
+    })
 }
 
 /// Whether a commit is reachable from any remote-tracking ref (`refs/remotes/*`) —
@@ -2694,6 +2708,68 @@ mod tests {
                 .expect("an in-place merge needs no worktree"),
             "merge"
         );
+    }
+
+    /// A merge that fails for a reason other than a conflict must not claim one: the
+    /// conflict wording names a remedy — switch and resolve — that a hook, a timeout
+    /// or unrelated histories give the user no way to act on. Unrelated histories are
+    /// the deterministic non-conflict shape (exit 128, measured git 2.51.1).
+    #[tokio::test]
+    async fn a_failed_merge_that_is_not_a_conflict_carries_gits_own_report() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-merge-failure").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+
+        // An orphan branch shares no history with `feature`, so git refuses the merge
+        // outright rather than conflicting.
+        run(&repo_s, &["switch", "-q", "--orphan", "alien"]).await;
+        std::fs::write(repo.join("alien.txt"), "alien\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "alien root"]).await;
+        let alien_tip = run(&repo_s, &["rev-parse", "refs/heads/alien"])
+            .await
+            .trim()
+            .to_string();
+        run(&repo_s, &["switch", "-q", &main]).await;
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("merge-failure-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            "alien",
+            &UpdatePins {
+                branch_tip: feature_tip.clone(),
+                base_sha: alien_tip,
+            },
+        )
+        .await
+        .unwrap_err();
+        let AppError::Command(message) = &err else {
+            panic!("a non-conflict failure must not be the conflict refusal: {err:?}");
+        };
+        assert!(
+            message.starts_with("merging alien into feature failed"),
+            "{message}"
+        );
+        assert!(
+            message.contains("refusing to merge unrelated histories"),
+            "git's own report rides along: {message}"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "a failed merge leaves the branch exactly where it was"
+        );
+        assert!(!tmp.exists(), "the throwaway worktree is torn down");
     }
 
     /// The base's half of the pin, on its refusing side. Merging by NAME is what keeps

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1349,16 +1349,23 @@ async fn verify_pin_and_merge(
         return Ok("merge".to_string());
     }
 
-    // The abort runs before the verdict, on every failure including a runner Err: a
-    // timeout that returned early would leave tmp mid-merge with the branch ref moved.
+    // The conflict verdict comes from the INDEX, read before the abort clears it — the
+    // exit code cannot carry it: a `pre-merge-commit` hook that declines also exits 1
+    // with the auto-merge clean and nothing unmerged, and hooks resolve from the COMMON
+    // dir, so the main repo's hooks run in this worktree (measured, git 2.51.1).
+    let conflicted = !crate::git::ops::unmerged_paths(tmp).await.is_empty();
+    // Undo the half-done merge so the branch ref is left as it was. Every failure path
+    // reaches this, the runner's Err included — a timeout that returned early would
+    // leave tmp mid-merge.
     let _ = run_git_raw(Some(tmp), &["merge", "--abort"], DEFAULT_TIMEOUT).await;
-    // Exit 1 is the conflict (measured, git 2.51.1); a hook, a vanished tmp gitdir or
-    // unrelated histories exit 128, and the runner's Err is a timeout or spawn failure.
-    // Only the first has a remedy to name, so the rest carry git's own report instead.
-    Err(match merged {
-        Ok(out) if out.code == 1 => AppError::InvalidArgument(format!(
+
+    // Only a real conflict has a remedy to name; everything else carries git's report.
+    if conflicted {
+        return Err(AppError::InvalidArgument(format!(
             "{branch} has changes that conflict with {base}. Switch to {branch} to merge and resolve them."
-        )),
+        )));
+    }
+    Err(match merged {
         Ok(out) => AppError::Command(format!(
             "merging {base} into {branch} failed — try again to see where it stands.\n{}",
             out.full_failure_text()
@@ -2710,10 +2717,152 @@ mod tests {
         );
     }
 
+    /// [`diverged_repo`]'s conflicting twin: both branches rewrite the SAME line of the
+    /// seed file, so their merge stops with unmerged entries instead of succeeding.
+    async fn conflicting_repo(tag: &str) -> (tempfile::TempDir, std::path::PathBuf, String, String) {
+        let (guard, base_dir) = temp_base(tag);
+        let repo = base_dir.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "seed.txt").await;
+        let main = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo_s, &["switch", "-qc", "feature"]).await;
+        std::fs::write(repo.join("seed.txt"), "feature side\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "feature edit"]).await;
+
+        run(&repo_s, &["switch", "-q", &main]).await;
+        std::fs::write(repo.join("seed.txt"), "main side\n").unwrap();
+        run(&repo_s, &["commit", "-qam", "main edit"]).await;
+
+        (guard, repo, repo_s, main)
+    }
+
+    /// The diverged path's conflict arm. The merge happens in the throwaway worktree,
+    /// so the user's checkout never sees it and the branch ref stays put — the refusal
+    /// is the whole outcome, and it has to name the remedy that does apply.
+    #[tokio::test]
+    async fn a_diverged_update_refuses_a_conflicting_merge_and_leaves_the_branch() {
+        let (_guard, repo, repo_s, main) = conflicting_repo("update-conflict").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("conflict-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip.clone(),
+                base_sha: pinned_base,
+            },
+        )
+        .await
+        .unwrap_err();
+        let AppError::InvalidArgument(message) = &err else {
+            panic!("a conflicting merge must take the conflict refusal: {err:?}");
+        };
+        assert_eq!(
+            message,
+            &format!(
+                "feature has changes that conflict with {main}. \
+                 Switch to feature to merge and resolve them."
+            )
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "the abort leaves the branch exactly where it was"
+        );
+        assert!(!tmp.exists(), "the throwaway worktree is torn down");
+    }
+
+    /// The case an exit-code verdict gets wrong: a `pre-merge-commit` hook that
+    /// declines exits 1 — the conflict's code — with the auto-merge clean and nothing
+    /// unmerged. Hooks resolve from the COMMON dir, so the main repo's hook runs inside
+    /// the throwaway worktree. A hook that failed to fire would let the merge succeed
+    /// and fail this test, which is the safe direction.
+    #[tokio::test]
+    async fn a_declined_merge_hook_is_not_reported_as_a_conflict() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-declined-hook").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        let hook = repo.join(".git").join("hooks").join("pre-merge-commit");
+        std::fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+        // git IGNORES a hook without the executable bit on POSIX, which would let the
+        // merge succeed and leave this test asserting nothing.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("declined-hook-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip.clone(),
+                base_sha: pinned_base,
+            },
+        )
+        .await
+        .expect_err("the declined hook stops the merge");
+        let AppError::Command(message) = &err else {
+            panic!("a clean auto-merge must never be reported as a conflict: {err:?}");
+        };
+        assert!(
+            message.starts_with(&format!("merging {main} into feature failed")),
+            "{message}"
+        );
+        assert!(
+            message.contains("Not committing merge"),
+            "git's own report rides along: {message}"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "the abort leaves the branch exactly where it was"
+        );
+        assert!(!tmp.exists(), "the throwaway worktree is torn down");
+    }
+
     /// A merge that fails for a reason other than a conflict must not claim one: the
     /// conflict wording names a remedy — switch and resolve — that a hook, a timeout
     /// or unrelated histories give the user no way to act on. Unrelated histories are
-    /// the deterministic non-conflict shape (exit 128, measured git 2.51.1).
+    /// the deterministic shape: git refuses before merging anything, so the index has
+    /// no unmerged entries and the verdict falls to the report-carrying refusal.
     #[tokio::test]
     async fn a_failed_merge_that_is_not_a_conflict_carries_gits_own_report() {
         let (_guard, repo, repo_s, main) = diverged_repo("update-merge-failure").await;

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -2,7 +2,8 @@ use tauri::State;
 
 use crate::error::{AppError, AppResult};
 use crate::git::runner::{
-    acquire_repo_lock, run_git, run_git_mutating, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    acquire_repo_lock, acquire_repo_lock_unbounded, run_git, run_git_mutating, run_git_raw,
+    run_git_worktree_admin, try_acquire_repo_lock, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
     NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{Branch, BranchDivergence, RemoteBranch};
@@ -1048,7 +1049,8 @@ pub(crate) async fn branch_reset_to_upstream(
 /// - already contains `base` → no-op, `"up-to-date"`.
 /// - strictly behind → fast-forward the ref, `"fast-forward"`.
 /// - diverged → merge `base` in a throwaway worktree so the main checkout is
-///   untouched, `"merge"`; a conflicting merge is aborted and the branch left as-is.
+///   untouched, `"merge"`; a conflicting merge is aborted and the branch left as-is,
+///   and a `branch` that moved while that worktree was materializing is refused.
 ///
 /// When `branch` IS the current branch there's nothing to avoid switching to, so it
 /// merges in place (conflicts surface in the changes list as usual — no abort).
@@ -1080,7 +1082,7 @@ pub(crate) async fn update_branch_from(
 
     // Mutating refs — serialize against other writes to this repo's working tree.
     let domain = state.working_tree_lock(repo_path).await;
-    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a branch update").await?;
+    let guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a branch update").await?;
 
     let current = run_git(
         Some(repo_path),
@@ -1148,46 +1150,182 @@ pub(crate) async fn update_branch_from(
     }
 
     // Diverged → merge in a throwaway worktree so the user's checkout is untouched.
+    // Both ends are pinned under THIS hold, because the worktree steps below run in
+    // the worktree-admin domain, which nests with no other: the working-tree lock is
+    // released across them, so either ref can move meanwhile.
+    let Some(branch_tip) = branch_tip_sha(repo_path, branch).await? else {
+        return Err(AppError::InvalidArgument(format!("unknown branch: {branch}")));
+    };
+    let base_out = run_git_raw(
+        Some(repo_path),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{base}^{{commit}}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if base_out.code != 0 {
+        return Err(AppError::InvalidArgument(format!("unknown branch: {base}")));
+    }
+    let pins = UpdatePins {
+        branch_tip,
+        base_sha: base_out.stdout_lossy().trim().to_string(),
+    };
+    drop(guard);
+
     let tmp = std::env::temp_dir().join(format!("gd-update-{}", unique_suffix()));
     let tmp_str = tmp.to_string_lossy().to_string();
+    merge_diverged_in_worktree(state, repo_path, &tmp_str, branch, base, &pins).await
+}
 
-    run_git(
+/// The two refs an update is planned against, resolved under the first working-tree
+/// hold so nothing that moves afterwards can change what lands on the branch.
+struct UpdatePins {
+    branch_tip: String,
+    base_sha: String,
+}
+
+/// The sha `refs/heads/<branch>` points at, or `None` when there is no such branch.
+/// The FULL ref path is the point: under a bare `rev-parse <branch>` a tag sharing
+/// the name would shadow it, and the pin would then guard the wrong object.
+async fn branch_tip_sha(repo_path: &str, branch: &str) -> AppResult<Option<String>> {
+    let out = run_git_raw(
         Some(repo_path),
-        &["worktree", "add", "--quiet", &tmp_str, branch],
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Ok(None);
+    }
+    Ok(Some(out.stdout_lossy().trim().to_string()))
+}
+
+/// The diverged arm, run with the working-tree lock RELEASED: `worktree
+/// add/remove/prune` belong to the worktree-admin domain, which nests with no other,
+/// and materializing a whole checkout takes minutes that staging must not queue
+/// behind.
+///
+/// The add is bounded, so a concurrent removal's prune yields an explained `Busy`
+/// instead of an interleaved write to `.git/worktrees/`. Every path out of the merge
+/// — refusal, conflict, success — reaches the teardown below.
+async fn merge_diverged_in_worktree(
+    state: &AppState,
+    repo_path: &str,
+    tmp: &str,
+    branch: &str,
+    base: &str,
+    pins: &UpdatePins,
+) -> AppResult<String> {
+    run_git_worktree_admin(
+        state,
+        repo_path,
+        &["worktree", "add", "--quiet", tmp, branch],
         WORKTREE_OP_TIMEOUT,
     )
     .await?;
 
-    // The merge keeps the default budget: it rewrites only the differing files, not
-    // the whole tree, and both arms below tear the temp worktree down regardless.
-    let merged = run_git(
-        Some(&tmp_str),
-        &["merge", "--no-edit", base],
-        DEFAULT_TIMEOUT,
-    )
-    .await;
+    let result = verify_pin_and_merge(state, repo_path, tmp, branch, base, pins).await;
 
-    let result = match merged {
-        Ok(_) => Ok("merge".to_string()),
-        Err(_) => {
-            // Undo the half-done merge so the branch ref is left as it was.
-            let _ = run_git_raw(Some(&tmp_str), &["merge", "--abort"], DEFAULT_TIMEOUT).await;
-            Err(AppError::InvalidArgument(format!(
-                "{branch} has changes that conflict with {base}. Switch to {branch} to merge and resolve them."
-            )))
+    // Try-then-detach is the only teardown shape with no bad arm: a bounded acquire
+    // that gave up on `Busy` would leak the throwaway worktree, and a synchronous
+    // unbounded one holds a finished update's command hostage for the minutes a
+    // node_modules-scale removal can hold the shared admin domain.
+    let domain = state.worktree_admin_lock(repo_path).await;
+    match try_acquire_repo_lock(&domain, "a worktree operation") {
+        Some(_admin) => remove_tmp_worktree(repo_path, tmp).await,
+        None => {
+            let (repo, tmp) = (repo_path.to_string(), tmp.to_string());
+            tauri::async_runtime::spawn(async move {
+                let _admin = acquire_repo_lock_unbounded(&domain, "a worktree operation").await;
+                remove_tmp_worktree(&repo, &tmp).await;
+            });
         }
-    };
+    }
 
-    // Always tear the throwaway worktree down, success or failure.
+    result
+}
+
+/// `worktree remove --force` then `prune`, both best-effort and both lock-free: every
+/// caller already holds the worktree-admin domain.
+async fn remove_tmp_worktree(repo_path: &str, tmp: &str) {
     let _ = run_git_raw(
         Some(repo_path),
-        &["worktree", "remove", "--force", &tmp_str],
+        &["worktree", "remove", "--force", tmp],
         WORKTREE_OP_TIMEOUT,
     )
     .await;
     let _ = run_git_raw(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+}
 
-    result
+/// Under a fresh working-tree hold: confirm both pinned refs still stand, then merge
+/// `base` by NAME inside the throwaway worktree at `tmp`. The merge writes the shared
+/// `refs/heads/<branch>`, which is why it belongs in this domain, and the name is what
+/// gives the merge commit its `Merge branch '<base>'` subject; the pins are what keep
+/// a ref that moved while the worktree materialized from silently changing the
+/// operation. The hold covers writers on THIS checkout only — another worktree of the
+/// same repo takes its own working-tree lock, and a session-worktree removal deletes
+/// refs under the admin hold, so a cross-checkout mover is outside what it promises.
+async fn verify_pin_and_merge(
+    state: &AppState,
+    repo_path: &str,
+    tmp: &str,
+    branch: &str,
+    base: &str,
+    pins: &UpdatePins,
+) -> AppResult<String> {
+    let domain = state.working_tree_lock(repo_path).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a branch update").await?;
+
+    if branch_tip_sha(repo_path, branch).await?.as_deref() != Some(pins.branch_tip.as_str()) {
+        return Err(AppError::Command(format!(
+            "{branch} moved while this update was running — try again to see where it stands."
+        )));
+    }
+
+    // The base check runs in the TMP worktree's cwd — the $GIT_DIR the merge itself
+    // will resolve in. gitrevisions resolves $GIT_DIR-local names (HEAD, MERGE_HEAD, …)
+    // ahead of `refs/heads/`, and `validate_branch_name` admits a literal "HEAD", so a
+    // check in the main checkout could pass over a different object than the merge
+    // takes. Same cwd makes "whatever the merge resolves" provably the pinned commit.
+    let base_now = run_git_raw(
+        Some(tmp),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{base}^{{commit}}"),
+        ],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if base_now.code != 0 || base_now.stdout_lossy().trim() != pins.base_sha {
+        return Err(AppError::Command(format!(
+            "{base} moved while this update was running — try again to see where it stands."
+        )));
+    }
+
+    // The merge keeps the default budget: it rewrites only the differing files, not
+    // the whole tree. Lock-free runner — the hold is ours.
+    let merged = run_git(Some(tmp), &["merge", "--no-edit", base], DEFAULT_TIMEOUT).await;
+    match merged {
+        Ok(_) => Ok("merge".to_string()),
+        Err(_) => {
+            // Undo the half-done merge so the branch ref is left as it was.
+            let _ = run_git_raw(Some(tmp), &["merge", "--abort"], DEFAULT_TIMEOUT).await;
+            Err(AppError::InvalidArgument(format!(
+                "{branch} has changes that conflict with {base}. Switch to {branch} to merge and resolve them."
+            )))
+        }
+    }
 }
 
 /// Whether a commit is reachable from any remote-tracking ref (`refs/remotes/*`) —
@@ -1252,13 +1390,14 @@ mod tests {
     use super::{
         branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args,
         divergence_out_of_range, git_branch_merge_states, git_branches, git_create_branch_core,
-        git_default_branch, git_rename_branch_core, parse_cherry_counts, parse_upstream_track,
-        update_branch_from, validate_branch_name, validate_ref_name, BranchRewriteStatus,
-        MergePair,
+        git_default_branch, git_rename_branch_core, merge_diverged_in_worktree,
+        parse_cherry_counts, parse_upstream_track, update_branch_from, validate_branch_name,
+        validate_ref_name, BranchRewriteStatus, MergePair, UpdatePins,
     };
     use crate::error::AppError;
-    use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+    use crate::git::runner::{acquire_repo_lock, run_git, run_git_raw, DEFAULT_TIMEOUT};
     use crate::state::AppState;
+    use std::time::Duration;
 
     // Full decision table for the create-branch argv: checkout × start_point ×
     // no_track (8 cases). The no_track=false rows are a regression guard — their argv
@@ -2408,5 +2547,256 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A repo whose `feature` branch has diverged from the default branch — each side
+    /// adds a file the other doesn't have, so the merge itself succeeds. Returns the
+    /// temp guard, the repo directory, its path as a string, and the default branch.
+    async fn diverged_repo(tag: &str) -> (tempfile::TempDir, std::path::PathBuf, String, String) {
+        let (guard, base_dir) = temp_base(tag);
+        let repo = base_dir.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "seed.txt").await;
+        let main = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo_s, &["switch", "-qc", "feature"]).await;
+        std::fs::write(repo.join("feature.txt"), "feature\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "feature work"]).await;
+
+        run(&repo_s, &["switch", "-q", &main]).await;
+        std::fs::write(repo.join("base.txt"), "base\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "base work"]).await;
+
+        (guard, repo, repo_s, main)
+    }
+
+    /// The window the admin prologue opens: while the throwaway worktree materializes,
+    /// nothing holds the working-tree lock, so `branch` can move under the update. The
+    /// tip pinned before that window is what catches it — a mismatch refuses, leaves
+    /// the ref where it stands, and still tears the worktree down.
+    #[tokio::test]
+    async fn update_branch_from_refuses_a_branch_that_moved_under_it() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-stale-pin").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let base_sha = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("stale-pin-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        // A real commit that simply isn't feature's tip — the shape a branch someone
+        // moved mid-update leaves behind.
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: base_sha.clone(),
+                base_sha,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Command(m) if m.contains("moved while this update was running")),
+            "{err:?}"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "a refused update leaves the branch exactly where it was"
+        );
+        let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
+        assert!(
+            !list.contains("stale-pin-wt"),
+            "the throwaway worktree is unregistered: {list}"
+        );
+        assert!(!tmp.exists(), "and its directory is gone");
+    }
+
+    /// The three cheap arms touch no worktree admin, so a removal holding that domain
+    /// must not delay them. A zero budget takes the FREE admin lock deterministically
+    /// and refuses a held one.
+    #[tokio::test]
+    async fn cheap_update_arms_run_while_the_worktree_admin_domain_is_held() {
+        let (_guard, _repo, repo_s, main) = diverged_repo("update-admin-free").await;
+        run(&repo_s, &["branch", "level", &main]).await;
+        run(&repo_s, &["branch", "behind", &format!("{main}~1")]).await;
+
+        let state = AppState::default();
+        let _admin = acquire_repo_lock(
+            &state.worktree_admin_lock(&repo_s).await,
+            Duration::ZERO,
+            "a worktree removal",
+        )
+        .await
+        .expect("the admin domain is free");
+
+        assert_eq!(
+            update_branch_from(&state, &repo_s, "level", &main)
+                .await
+                .expect("up-to-date needs no worktree"),
+            "up-to-date"
+        );
+        assert_eq!(
+            update_branch_from(&state, &repo_s, "behind", &main)
+                .await
+                .expect("a fast-forward needs no worktree"),
+            "fast-forward"
+        );
+        // Last, since it moves the default branch: `branch == current` merges in place.
+        assert_eq!(
+            update_branch_from(&state, &repo_s, &main, "feature")
+                .await
+                .expect("an in-place merge needs no worktree"),
+            "merge"
+        );
+    }
+
+    /// The base's half of the pin. Merging by NAME is what keeps git's own merge
+    /// subject, so the sha the name resolves to has to be checked — a base that gained
+    /// a commit while the worktree materialized is a different operation than the one
+    /// the user asked for, and is refused rather than quietly merged.
+    #[tokio::test]
+    async fn a_diverged_update_refuses_a_base_that_moved_under_it() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-moved-base").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        // The base moves after the pin — exactly the window the admin prologue opens.
+        std::fs::write(repo.join("later.txt"), "later\n").unwrap();
+        run(&repo_s, &["add", "-A"]).await;
+        run(&repo_s, &["commit", "-qm", "base work later"]).await;
+        let moved_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+        assert_ne!(pinned_base, moved_base, "the fixture must move the base");
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("moved-base-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let err = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip.clone(),
+                base_sha: pinned_base,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Command(m)
+                if m.starts_with(&format!("{main} moved while this update was running"))),
+            "{err:?}"
+        );
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "refs/heads/feature"]).await.trim(),
+            feature_tip,
+            "a refused update leaves the branch exactly where it was"
+        );
+        let list = run(&repo_s, &["worktree", "list", "--porcelain"]).await;
+        assert!(
+            !list.contains("moved-base-wt"),
+            "the throwaway worktree is unregistered: {list}"
+        );
+        assert!(!tmp.exists(), "and its directory is gone");
+    }
+
+    /// The happy path: both pins hold, so the merge runs by NAME and the branch gets
+    /// git's own `Merge branch '<base>'` subject over the pinned commit.
+    #[tokio::test]
+    async fn a_diverged_update_merges_the_pinned_base_by_name() {
+        let (_guard, repo, repo_s, main) = diverged_repo("update-pinned-base").await;
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let pinned_base = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+
+        let tmp = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("pinned-base-wt");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let state = AppState::default();
+        let outcome = merge_diverged_in_worktree(
+            &state,
+            &repo_s,
+            &tmp_s,
+            "feature",
+            &main,
+            &UpdatePins {
+                branch_tip: feature_tip,
+                base_sha: pinned_base.clone(),
+            },
+        )
+        .await
+        .expect("an unmoved base merges cleanly");
+        assert_eq!(outcome, "merge");
+
+        let merged_tip = run(&repo_s, &["rev-parse", "refs/heads/feature"])
+            .await
+            .trim()
+            .to_string();
+        let parents = run(&repo_s, &["rev-list", "--parents", "-n", "1", &merged_tip]).await;
+        assert!(
+            parents.contains(pinned_base.as_str()),
+            "the pinned base is a parent of the merge: {parents}"
+        );
+        // Exit 0 specifically: `is_ancestor` answers 1 for "no", and 128 for a bad
+        // argument, so anything but 0 has to fail this.
+        let reachable = run_git_raw(
+            Some(&repo_s),
+            &["merge-base", "--is-ancestor", &pinned_base, &merged_tip],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            reachable.code, 0,
+            "the pinned base is reachable from the merge: {}",
+            reachable.stderr
+        );
+        // Merging by name is the whole reason for the base pin: a sha argument would
+        // have written `Merge commit '<sha>'` here instead.
+        let subject = run(&repo_s, &["log", "-1", "--format=%s", &merged_tip]).await;
+        assert!(
+            subject.trim().starts_with(&format!("Merge branch '{main}'")),
+            "git's own merge subject survives: {subject}"
+        );
+        assert!(!tmp.exists(), "the throwaway worktree is torn down");
     }
 }

--- a/src-tauri/src/git/commit.rs
+++ b/src-tauri/src/git/commit.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 
 use crate::error::{AppError, AppResult};
+use crate::git::history::{parse_commit_log, LOG_FORMAT};
 use crate::git::runner::{
     run_git, run_git_mutating, run_git_mutating_raw, run_git_raw, DEFAULT_TIMEOUT,
 };
@@ -301,30 +302,75 @@ pub async fn git_recent_commits(repo_path: String, limit: u32) -> AppResult<Vec<
     let limit_arg = limit.to_string();
     let out = run_git(
         Some(&repo_path),
-        &[
-            "log",
-            "-n",
-            &limit_arg,
-            "--format=%H%x00%s%x00%an%x00%ae%x00%cI",
-        ],
+        &["log", "-n", &limit_arg, LOG_FORMAT],
         DEFAULT_TIMEOUT,
     )
     .await?;
-    let text = out.stdout_lossy();
-    let commits = text
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.split('\0');
-            Some(CommitSummary {
-                hash: parts.next()?.to_string(),
-                subject: parts.next()?.to_string(),
-                author: parts.next()?.to_string(),
-                author_email: parts.next()?.to_string(),
-                date: parts.next()?.to_string(),
-                tags: Vec::new(),
-                is_merge: false,
-            })
-        })
-        .collect();
-    Ok(commits)
+    Ok(parse_commit_log(&out.stdout_lossy()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn run(repo: &str, args: &[&str]) -> String {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// The recent-commits list shares History's log format + parser, so its rows
+    /// carry the `%D` tag decorations and the `%P` merge flag.
+    #[tokio::test]
+    async fn recent_commits_carry_tags_and_merge_flags() {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-recent-commits-")
+            .tempdir()
+            .expect("create temp dir");
+        let root = dir.path();
+        let repo = root.to_string_lossy().into_owned();
+        run(&repo, &["init", "-q"]).await;
+        run(&repo, &["config", "user.email", "t@t.local"]).await;
+        run(&repo, &["config", "user.name", "T"]).await;
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        // `git init` picks the default branch name from the host's config.
+        let base_branch = run(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo, &["checkout", "-qb", "feature"]).await;
+        std::fs::write(root.join("feature.txt"), "feature\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "feature work"]).await;
+
+        run(&repo, &["checkout", "-q", &base_branch]).await;
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "base work"]).await;
+        run(&repo, &["tag", "v1.0"]).await;
+        // `--no-ff` so the fixture has a real two-parent commit to report on.
+        run(&repo, &["merge", "-q", "--no-ff", "--no-edit", "feature"]).await;
+
+        let commits = git_recent_commits(repo.clone(), 10)
+            .await
+            .expect("the log reads");
+
+        assert!(
+            commits[0].is_merge,
+            "the newest commit is the merge: {:?}",
+            commits[0]
+        );
+        assert!(commits[0].tags.is_empty(), "the merge carries no tag");
+        let tagged = commits
+            .iter()
+            .find(|c| c.subject == "base work")
+            .expect("the tagged commit is in range");
+        assert_eq!(tagged.tags, vec!["v1.0".to_string()]);
+        assert!(!tagged.is_merge, "an ordinary commit has one parent");
+    }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -87,49 +87,57 @@ async fn absolute_git_dir(repo: &str) -> Option<std::path::PathBuf> {
     (!dir.is_empty()).then(|| std::path::PathBuf::from(dir))
 }
 
-/// The dir holding `repo`'s op markers, resolved without spawning git — for the
-/// paths that pay this on EVERY commit or while holding a lock and must not grow a
-/// `rev-parse` child for it. `None` for anything unreadable, which callers must read
-/// as "no markers", never as an error.
+/// The target of a linked worktree's or submodule's `.git` pointer file
+/// (`gitdir: <path>`). The recorded path may be relative to the tree holding that
+/// file, so callers resolve it. Line-scanned rather than whole-content-trimmed, which
+/// keeps a pointer carrying stray leading lines readable.
+pub(crate) fn parse_gitdir_pointer(content: &str) -> Option<&str> {
+    content
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("gitdir:"))
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+}
+
+/// The admin dir behind a tree's `.git`, resolved without spawning git — for the
+/// paths that pay this on EVERY commit, or while holding a lock, and must not grow a
+/// `rev-parse` child for it. `None` for anything unreadable, which callers read as an
+/// absence ("no markers", "no activity"), never as an error.
 ///
 /// A linked worktree or submodule replaces `.git` with a one-line `gitdir:` pointer
-/// to the dir holding ITS markers, and that path may be relative to the tree holding
+/// to the dir holding ITS state, and that path may be relative to the tree holding
 /// the `.git` file — always for a submodule (`gitdir: ../.git/modules/<name>`), and
 /// for a worktree under `worktree.useRelativePaths` / `--relative-paths`
 /// (`gitdir: ../<main>/.git/worktrees/<name>`); measured, git 2.51.1. Joining on the
-/// repo path resolves those and leaves an absolute pointer untouched.
-///
-/// `git::worktree::worktree_last_activity_ms` duplicates this resolution rule, so a
-/// change here has to land there too until both are hoisted into one shared helper.
-fn marker_dir(repo: &str) -> Option<std::path::PathBuf> {
-    let repo_root = Path::new(repo);
-    let dot_git = repo_root.join(".git");
+/// tree root resolves those and leaves an absolute pointer untouched.
+pub(crate) fn resolve_git_admin_dir(tree_root: &Path) -> Option<std::path::PathBuf> {
+    let dot_git = tree_root.join(".git");
     match std::fs::metadata(&dot_git) {
         Ok(meta) if meta.is_dir() => Some(dot_git),
-        Ok(_) => std::fs::read_to_string(&dot_git)
-            .ok()?
-            .trim()
-            .strip_prefix("gitdir:")
-            .map(|dir| repo_root.join(dir.trim())),
+        Ok(_) => {
+            let pointer = std::fs::read_to_string(&dot_git).ok()?;
+            Some(tree_root.join(parse_gitdir_pointer(&pointer)?))
+        }
         Err(_) => None,
     }
 }
 
 /// Whether `CHERRY_PICK_HEAD` is present, resolved without spawning git (see
-/// [`marker_dir`]).
+/// [`resolve_git_admin_dir`]).
 ///
 /// Narrower than [`op_state`] on purpose: it answers only "is a single-commit pick
 /// stopped here", the state `cherry-pick <hash>` leaves and `git commit` clears. The
 /// sequencer-only pick (`cherry-pick -n`, no marker) is deliberately outside it.
 pub(crate) fn cherry_pick_marker_present(repo: &str) -> bool {
-    marker_dir(repo).is_some_and(|dir| dir.join("CHERRY_PICK_HEAD").exists())
+    resolve_git_admin_dir(Path::new(repo))
+        .is_some_and(|dir| dir.join("CHERRY_PICK_HEAD").exists())
 }
 
 /// Whether a rebase is stopped here, resolved without spawning git (see
-/// [`marker_dir`]) — the same `rebase-merge`/`rebase-apply` pair [`op_state`] reads,
-/// for the callers that need the verdict while holding a lock.
+/// [`resolve_git_admin_dir`]) — the same `rebase-merge`/`rebase-apply` pair
+/// [`op_state`] reads, for the callers that need the verdict while holding a lock.
 pub(crate) fn rebase_marker_present(repo: &str) -> bool {
-    marker_dir(repo).is_some_and(|dir| {
+    resolve_git_admin_dir(Path::new(repo)).is_some_and(|dir| {
         dir.join("rebase-merge").exists() || dir.join("rebase-apply").exists()
     })
 }
@@ -6235,6 +6243,43 @@ mod tests {
         assert!(
             cherry_pick_marker_present(&repo),
             "a relative pointer resolves against the tree holding the .git file"
+        );
+    }
+
+    /// The tolerance both spawn-free `.git` resolutions share: the line-scanning form,
+    /// which reads a pointer past stray leading lines. Its failure direction is the
+    /// safe one for both callers — an unresolvable pointer means "no markers" / "no
+    /// activity", never an error.
+    #[test]
+    fn a_junk_prefixed_gitdir_pointer_resolves_for_both_entry_points() {
+        let tmp = tempfile::Builder::new()
+            .prefix("gd-junk-gitdir-")
+            .tempdir()
+            .expect("create temp dir");
+        let tree = tmp.path().join("tree");
+        let admin = tmp.path().join("real/.git/worktrees/wt");
+        std::fs::create_dir_all(&tree).unwrap();
+        std::fs::create_dir_all(&admin).unwrap();
+        std::fs::write(
+            tree.join(".git"),
+            "# stray leading line\ngitdir: ../real/.git/worktrees/wt\n",
+        )
+        .unwrap();
+        let tree_s = tree.to_string_lossy().into_owned();
+
+        assert!(
+            resolve_git_admin_dir(&tree).is_some(),
+            "the pointer is found past the junk line"
+        );
+        std::fs::write(admin.join("CHERRY_PICK_HEAD"), "deadbeef\n").unwrap();
+        assert!(
+            cherry_pick_marker_present(&tree_s),
+            "the op-marker probe reads through it"
+        );
+        std::fs::write(admin.join("index"), b"idx").unwrap();
+        assert!(
+            crate::git::worktree::worktree_last_activity_ms(&tree_s).is_some(),
+            "and so does the worktree activity probe"
         );
     }
 

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -77,9 +77,9 @@ pub(crate) struct PullTarget {
 }
 
 /// What one pull's network phase produced, pinned under the hold that produced it.
-/// The local half is spelled in these values alone: the refs they were read from
-/// move under the background auto-fetch, and `FETCH_HEAD` is shared by every
-/// worktree of the repo, so re-reading either at merge time would act on a
+/// The local half is spelled in these values alone: the background auto-fetch moves
+/// the tracking refs they were read from and rewrites this checkout's own
+/// `FETCH_HEAD` on its way past, so re-reading either at merge time would act on a
 /// different snapshot than the one the plan was made from.
 pub(crate) struct PinnedFetch {
     /// The upstream tip this fetch produced.
@@ -519,8 +519,9 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 
 /// Phase A: fetch, then compute the fork-point verdict. Touches nothing the user
 /// owns — no stash, no ref of theirs — so a would-drop refusal leaves the tree
-/// exactly as it found it. `None` re-stands-down (the branch changed under the
-/// lock, or the upstream ref doesn't resolve post-fetch).
+/// exactly as it found it. `None` stands the guard down: the branch was switched
+/// since `resolve` saw it, HEAD or the upstream ref fails to rev-parse, or there is
+/// no merge base or no fork point to decide anything from.
 ///
 /// The fetch PRUNES, which the stand-down below depends on: without it, an
 /// upstream branch deleted on the forge leaves its tracking ref behind, every
@@ -544,6 +545,13 @@ pub(crate) async fn probe(
     target: &PullTarget,
     cred: &[String],
 ) -> AppResult<Option<PullPlan>> {
+    // Best-effort currency, checked before anything is planned: a switch since
+    // `resolve` would compute `base..HEAD` for the wrong branch, and the would-drop
+    // refusal is raised before any working-tree check could catch it. The WT phase's
+    // `ensure_pin_current` stays the authority.
+    if current_branch(repo).await.as_deref() != Some(target.branch.as_str()) {
+        return Ok(None);
+    }
     // ONE network hold spanning the fetch AND every read below it: the verdict is
     // only sound on the refs this fetch produced, and the background auto-fetch runs
     // in this same domain — released in between, it can move
@@ -657,6 +665,10 @@ async fn plain_pull_config_stands_down(repo: &str, remote: &str, merge_mode: boo
     // Pull-only keys `git merge` never reads, so honoring them is impossible here.
     // `--ff-only` mode passes its own flag on both sides, which overrides `pull.ff`
     // either way; `merge.ff` needs no arm, since bare pull reads it identically.
+    // `pull.rebase` needs none either: measured on git 2.51.1, bare `git pull
+    // --ff-only` under `pull.rebase=true` refuses a diverged branch (exit 128) and
+    // fast-forwards a behind one — what `merge --ff-only` does — and merge mode's
+    // bare side passes `--no-rebase`, which overrides the key outright.
     if merge_mode {
         for key in ["pull.ff", "pull.twohead"] {
             if config_is_set(repo, key).await {
@@ -773,10 +785,12 @@ async fn fetch_and_pin(
 /// branch with several `branch.<b>.merge` entries gets an OCTOPUS merge from bare
 /// pull, which one pinned record cannot reproduce.
 ///
-/// Read here rather than at merge time because `FETCH_HEAD` is shared by every
-/// worktree of the repo and the next fetch anywhere rewrites it. `--git-path` answers
-/// relative to the child's cwd, so the path is resolved against `repo` rather than
-/// this process's own working directory.
+/// Read here rather than at merge time because `FETCH_HEAD` holds only the LAST
+/// fetch: it is per-worktree (measured, git 2.51.1 — a linked worktree's own
+/// `--git-path FETCH_HEAD` sits under `worktrees/<id>/`), and this checkout's
+/// background auto-fetch rewrites its copy. `--git-path` answers relative to the
+/// child's cwd, so the path is resolved against `repo` rather than this process's own
+/// working directory.
 async fn fetch_head_record(repo: &str, new_tip: &str) -> Option<String> {
     let out = run_git_raw(
         Some(repo),
@@ -2504,6 +2518,37 @@ mod tests {
             git(&clone, &["status", "--porcelain"]).await.trim(),
             "?? dirty.txt",
             "and the dirty tree is exactly as the user left it"
+        );
+    }
+
+    /// A branch switched between `resolve` and `probe` — credential resolution shells
+    /// out to the forge CLI, so the gap is real. Standing down there is what keeps a
+    /// would-drop dialog from naming the WRONG branch's commits: that refusal is
+    /// raised before any working-tree check runs.
+    #[tokio::test]
+    async fn probe_stands_down_when_the_branch_switched_since_resolve() {
+        let (_dir, clone, _work, _tip) = behind_fixture("probe-switched").await;
+        let state = AppState::default();
+        let target = resolve(&clone)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+
+        assert!(
+            probe(&state, &clone, &target, &[])
+                .await
+                .unwrap()
+                .is_some(),
+            "the branch resolve saw is still checked out"
+        );
+
+        git(&clone, &["switch", "-q", "-c", "elsewhere"]).await;
+        assert!(
+            probe(&state, &clone, &target, &[])
+                .await
+                .unwrap()
+                .is_none(),
+            "a plan for a branch that is no longer HEAD must never be built"
         );
     }
 

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -521,7 +521,8 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// owns — no stash, no ref of theirs — so a would-drop refusal leaves the tree
 /// exactly as it found it. `None` stands the guard down: the branch was switched
 /// since `resolve` saw it, HEAD or the upstream ref fails to rev-parse, or there is
-/// no merge base or no fork point to decide anything from.
+/// no merge base or no fork point to decide anything from. A switch DURING the fetch
+/// is the one currency failure that errors instead — see the two-read paragraph below.
 ///
 /// The fetch PRUNES, which the stand-down below depends on: without it, an
 /// upstream branch deleted on the forge leaves its tracking ref behind, every
@@ -539,6 +540,14 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// and would otherwise be free to move them between the fetch and the revs read off
 /// it. `branch_tip` is what the caller's [`ensure_pin_current`] re-checks before any
 /// of these SHAs are acted on.
+///
+/// The branch is read for currency TWICE, because the working tree is deliberately
+/// not held across a transfer that may run for `NETWORK_TIMEOUT`. The read BEFORE the
+/// fetch stands down: nothing has happened yet, so bare `git pull` on the
+/// newly-current branch is the right answer. The read AFTER every rev the plan rests
+/// on REFUSES instead — a fall-through there would run bare `git pull --rebase` on a
+/// branch this guard never examined (the vaporize it exists to prevent), and the
+/// autostash core would have stashed the user's tree to do it.
 pub(crate) async fn probe(
     state: &AppState,
     repo: &str,
@@ -607,6 +616,11 @@ pub(crate) async fn probe(
     } else {
         dropped_commits(repo, &merge_base, &fork_point).await?
     };
+    // Currency again, after EVERY rev above: the transfer and these reads all ran with
+    // no working-tree hold, and a switch anywhere in that window leaves the SHAs
+    // describing one branch while the plan names another — the would-drop refusal is
+    // raised before any working-tree check, so it would name the wrong commits.
+    ensure_branch_current(repo, &target.branch).await?;
 
     Ok(Some(PullPlan {
         branch: target.branch.clone(),
@@ -656,39 +670,46 @@ pub(crate) async fn pin_plain_pull(
 /// Whether config makes the split phases behave differently from bare `git pull`, in
 /// which case the caller hands the pull back to bare `git pull` rather than quietly
 /// changing what it does. `merge_mode` gates the keys only a merge can trip.
+///
+/// Every read is independent and each is a `git` spawn, which is not cheap on
+/// Windows, so they go out together and one combined verdict decides — the whole
+/// check sits in front of the transfer on every plain pull.
 async fn plain_pull_config_stands_down(repo: &str, remote: &str, merge_mode: bool) -> bool {
-    // `submodule.recurse`: bare pull updates submodule worktrees for these modes, and
-    // the guard's measured parity step covers rebase only.
-    if submodule_recurse(repo).await {
-        return true;
+    let remote_prune_key = format!("remote.{remote}.pruneTags");
+    let (recurse, pull_only, fetch_prune_tags, remote_prune_tags, into_heads) = tokio::join!(
+        // `submodule.recurse`: bare pull updates submodule worktrees for these modes,
+        // and the guard's measured parity step covers rebase only.
+        submodule_recurse(repo),
+        pull_only_keys_set(repo, merge_mode),
+        // The `pruneTags` pair only bites because our fetch PRUNES: pruning is what
+        // lets them delete local tags, and bare pull (with `fetch.prune` unset) never
+        // pruned at all.
+        config_is_true(repo, "fetch.pruneTags"),
+        config_is_true(repo, &remote_prune_key),
+        // A refspec writing into `refs/heads/*` needs the `--update-head-ok` bare pull
+        // passes its own fetch; ours would hard-refuse ("Refusing to fetch into branch").
+        fetch_maps_into_heads(repo, remote),
+    );
+    recurse || pull_only || fetch_prune_tags || remote_prune_tags || into_heads
+}
+
+/// Whether either pull-only key `git merge` never reads is set, which makes honoring
+/// it impossible on the split path. `--ff-only` mode passes its own flag on both
+/// sides, which overrides `pull.ff` either way, so it probes nothing; `merge.ff` needs
+/// no arm, since bare pull reads it identically. `pull.rebase` needs none either:
+/// measured on git 2.51.1, bare `git pull --ff-only` under `pull.rebase=true` refuses
+/// a diverged branch (exit 128) and fast-forwards a behind one — what
+/// `merge --ff-only` does — and merge mode's bare side passes `--no-rebase`, which
+/// overrides the key outright.
+async fn pull_only_keys_set(repo: &str, merge_mode: bool) -> bool {
+    if !merge_mode {
+        return false;
     }
-    // Pull-only keys `git merge` never reads, so honoring them is impossible here.
-    // `--ff-only` mode passes its own flag on both sides, which overrides `pull.ff`
-    // either way; `merge.ff` needs no arm, since bare pull reads it identically.
-    // `pull.rebase` needs none either: measured on git 2.51.1, bare `git pull
-    // --ff-only` under `pull.rebase=true` refuses a diverged branch (exit 128) and
-    // fast-forwards a behind one — what `merge --ff-only` does — and merge mode's
-    // bare side passes `--no-rebase`, which overrides the key outright.
-    if merge_mode {
-        for key in ["pull.ff", "pull.twohead"] {
-            if config_is_set(repo, key).await {
-                return true;
-            }
-        }
-    }
-    // These only bite because our fetch PRUNES: pruning is what lets them delete local
-    // tags, and bare pull (with `fetch.prune` unset) never pruned at all.
-    for key in [
-        "fetch.pruneTags".to_string(),
-        format!("remote.{remote}.pruneTags"),
-    ] {
-        if config_is_true(repo, &key).await {
-            return true;
-        }
-    }
-    // A refspec writing into `refs/heads/*` needs the `--update-head-ok` bare pull
-    // passes its own fetch; ours would hard-refuse ("Refusing to fetch into branch").
-    fetch_maps_into_heads(repo, remote).await
+    let (ff, twohead) = tokio::join!(
+        config_is_set(repo, "pull.ff"),
+        config_is_set(repo, "pull.twohead"),
+    );
+    ff || twohead
 }
 
 /// Whether `key` is set at ALL, in any scope — the test for the tri-state and
@@ -825,6 +846,10 @@ async fn fetch_head_record(repo: &str, new_tip: &str) -> Option<String> {
 /// the plain local half does depends on it (there is no fork-point verdict), merging
 /// the pinned tip onto a HEAD the user just advanced is what a fresh pull would do,
 /// and refusing that would defeat the concurrency this split exists to allow.
+///
+/// [`probe`] closes with this too, for the same reason and with the tip likewise left
+/// to the working-tree phase's [`ensure_pin_current`]: a commit landing mid-fetch is
+/// ordinary, a branch SWITCH invalidates everything the plan names.
 ///
 /// Deliberately NOT [`PULL_DECISION_STALE`]: that marker keys the frontend's
 /// stale-decision flow, which has an answer to re-ask.
@@ -2549,6 +2574,72 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "a plan for a branch that is no longer HEAD must never be built"
+        );
+    }
+
+    /// The same switch landing DURING the fetch, which is the long window — the
+    /// transfer runs without the working tree held, for up to `NETWORK_TIMEOUT`. This
+    /// arm REFUSES where the pre-fetch one stands down: a stand-down here falls through
+    /// to bare `git pull --rebase` on a branch the guard never examined, and the
+    /// autostash core would stash the user's tree to run it.
+    ///
+    /// A `reference-transaction` hook does the switching: it fires inside the fetch, on
+    /// the tracking-ref update, so the flip lands after the pre-fetch read and before
+    /// the plan's own reads with no timing bet anywhere.
+    #[tokio::test]
+    async fn probe_refuses_when_the_branch_switched_during_the_fetch() {
+        let (dir, clone, work, _tip) = behind_fixture("probe-switched-mid-fetch").await;
+        let clone_dir = dir.path().join("clone");
+        git(&clone, &["branch", "elsewhere"]).await;
+        let hook = clone_dir
+            .join(".git")
+            .join("hooks")
+            .join("reference-transaction");
+        std::fs::write(
+            &hook,
+            "#!/bin/sh\nif [ \"$1\" = \"committed\" ]; then\n  \
+             printf 'ref: refs/heads/elsewhere\\n' > \"${GIT_DIR:-.git}/HEAD\"\nfi\n",
+        )
+        .unwrap();
+        // git IGNORES a hook without the executable bit on POSIX, which would leave the
+        // branch unswitched and this test asserting nothing.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let state = AppState::default();
+        let target = resolve(&clone)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+        // Upstream moves again, so this probe's fetch really updates a ref — the hook
+        // only fires on a committed transaction.
+        std::fs::write(dir.path().join("work").join("c.txt"), "c\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "upstream moves again"]).await;
+        git(&work, &["push", "-q"]).await;
+
+        // Mapped to a bool so the panic can name which Ok arm was taken: `true` built a
+        // plan for the wrong branch, `false` stood down where it had to refuse.
+        let err = probe(&state, &clone, &target, &[])
+            .await
+            .map(|plan| plan.is_some())
+            .expect_err("a plan whose revs outlived their branch must refuse, not stand down");
+        assert!(
+            matches!(&err, AppError::Command(m) if m.contains("The checked-out branch changed")),
+            "{err:?}"
+        );
+        assert_eq!(
+            current_branch(&clone).await.as_deref(),
+            Some("elsewhere"),
+            "the hook really did switch the branch mid-fetch"
+        );
+        assert_eq!(
+            rev(&clone, "refs/remotes/origin/main").await,
+            rev(&work, "HEAD").await,
+            "and the fetch really ran, so this is the POST-fetch arm"
         );
     }
 

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -8,6 +8,14 @@
 //! verdict into that argv: it has no `--no-fork-point` and never consults
 //! `rebase.forkPoint` (measured, git 2.51.1), so deciding at all means running the
 //! phases ourselves — probe here, then rebase onto pinned SHAs on the user's answer.
+//!
+//! Splitting the phases is also what keeps the TRANSFER off the working tree: EVERY
+//! mode routes its fetch through here (the plain modes via [`pin_plain_pull`]), under
+//! the NETWORK domain alone, and only then takes the working tree for the local half.
+//! So staging and committing stay available across a transfer, and the local half
+//! runs on the SHAs that one fetch pinned. (The rebase arms' submodule parity step is
+//! the exception: it runs a network-scale `submodule update` inside the working-tree
+//! hold, so `submodule.recurse` users still see a long hold after their rebase.)
 
 use tauri::State;
 
@@ -16,8 +24,8 @@ use crate::git::autostash::{autostash_push, settle, AutostashOutcome};
 use crate::git::history::validate_hash;
 use crate::git::remote::run_git_with_creds_once;
 use crate::git::runner::{
-    acquire_repo_lock, run_git, run_git_raw, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
-    NETWORK_LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT,
+    acquire_repo_lock, run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT, LOCK_WAIT_TIMEOUT,
+    NETWORK_LOCK_WAIT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
 };
 use crate::state::AppState;
 
@@ -66,6 +74,31 @@ pub(crate) struct PullTarget {
     upstream: String,
     /// The upstream's remote, or `"."` for a local-branch upstream (nothing to fetch).
     remote: String,
+}
+
+/// What one pull's network phase produced, pinned under the hold that produced it.
+/// The local half is spelled in these values alone: the refs they were read from
+/// move under the background auto-fetch, and `FETCH_HEAD` is shared by every
+/// worktree of the repo, so re-reading either at merge time would act on a
+/// different snapshot than the one the plan was made from.
+pub(crate) struct PinnedFetch {
+    /// The upstream tip this fetch produced.
+    new_tip: String,
+    /// The `FETCH_HEAD` record naming `new_tip`, kept verbatim so `git fmt-merge-msg`
+    /// can spell the merge subject exactly as bare pull's does.
+    merge_source: String,
+}
+
+/// A plain (non-rebase) pull past its network phase: the target it runs against, the
+/// SHAs one fetch pinned, and the mode both halves were decided under. `None` from
+/// [`pin_plain_pull`] means the caller must fall through to bare `git pull` instead.
+pub(crate) struct PlainPull {
+    target: PullTarget,
+    pinned: PinnedFetch,
+    /// Fast-forward-only, the app's default mode; `false` is merge mode. Carried here
+    /// rather than re-passed so the stand-down verdict and the argv can't disagree
+    /// about which mode was checked.
+    ff_only: bool,
 }
 
 /// The fork-point verdict for one pull, with every SHA it rests on pinned. The
@@ -128,14 +161,15 @@ fn rebase_argv<'a>(autostash: Option<&'a str>, new_tip: &'a str, base: &'a str) 
     argv
 }
 
-/// The autostash flag a PLAIN (non-compound) rebase pull carries, mirroring what
-/// bare `git pull --rebase` would have done — all four arms measured on git
-/// 2.51.1:
+/// The autostash flag a PLAIN (non-compound) pull carries, mirroring what bare
+/// `git pull` would have done — all four arms measured on git 2.51.1:
 ///
-/// - `pull.autoStash=true` ⇒ `--autostash`; a bare rebase would IGNORE that key.
+/// - `pull.autoStash=true` ⇒ `--autostash`; a bare rebase or merge IGNORES that key.
 /// - `pull.autoStash=false` ⇒ `--no-autostash`, refusing as pull would.
-/// - unset ⇒ NO flag, which is what lets `rebase.autoStash` govern (pull's own
-///   fallback; ignoring it there was a bug git fixed in 2.36).
+/// - unset ⇒ NO flag, which is what lets the command's OWN key govern —
+///   `rebase.autoStash` for the rebase arms, `merge.autoStash` for the merge ones,
+///   each read natively (pull's own fallback; ignoring it there was a bug git fixed
+///   in 2.36).
 ///
 /// An unreadable or non-boolean value reads as unset: the flagless form leaves
 /// git's own resolution in charge rather than forcing a verdict.
@@ -494,23 +528,22 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// pull that bare git refuses outright ("no such ref was fetched"). Pruned, the
 /// upstream ref stops resolving and that refusal is what the user sees.
 ///
-/// The caller must already hold the repo's working-tree lock, so every step here
-/// uses the lock-free runners — `run_git_mutating*` would re-acquire it and
-/// deadlock. The NETWORK lock is taken around the fetch and held through the plan's
-/// reads (that nesting direction only), so the whole verdict rests on ONE snapshot
-/// of the tracking refs: the background auto-fetch shares that domain and would
-/// otherwise be free to move them between the fetch and the revs read off it.
+/// This phase holds the NETWORK domain and nothing else, so a transfer running for
+/// its whole budget never stalls staging or a commit; the caller takes the working
+/// tree afterwards, for the local half alone. Every step uses the lock-free runners,
+/// since `run_git_mutating*` would re-acquire a domain held here and deadlock.
+///
+/// The network hold spans the fetch AND the plan's reads, so the whole verdict rests
+/// on ONE snapshot of the tracking refs: the background auto-fetch shares that domain
+/// and would otherwise be free to move them between the fetch and the revs read off
+/// it. `branch_tip` is what the caller's [`ensure_pin_current`] re-checks before any
+/// of these SHAs are acted on.
 pub(crate) async fn probe(
     state: &AppState,
     repo: &str,
     target: &PullTarget,
     cred: &[String],
 ) -> AppResult<Option<PullPlan>> {
-    // Taking the lock is what makes `target` current; a switch between `resolve`
-    // and here would rebase `base..HEAD` for the wrong branch.
-    if current_branch(repo).await.as_deref() != Some(target.branch.as_str()) {
-        return Ok(None);
-    }
     // ONE network hold spanning the fetch AND every read below it: the verdict is
     // only sound on the refs this fetch produced, and the background auto-fetch runs
     // in this same domain — released in between, it can move
@@ -520,8 +553,7 @@ pub(crate) async fn probe(
         "." => None,
         remote => {
             let network = state.network_lock(repo).await;
-            let guard =
-                acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a fetch").await?;
+            let guard = acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await?;
             let out = run_git_with_creds_once(
                 repo,
                 cred,
@@ -541,8 +573,8 @@ pub(crate) async fn probe(
 
     // The local side of every rev below is HEAD, not the branch NAME: rev-parse
     // resolves `refs/tags/<n>` ahead of `refs/heads/<n>`, so a tag sharing the
-    // branch's name would silently answer for it. The check above is what makes
-    // HEAD exactly this branch.
+    // branch's name would silently answer for it. `ensure_pin_current` is what makes
+    // HEAD provably this branch, at this tip, before any of these SHAs is acted on.
     let (Some(branch_tip), Some(new_tip)) = (
         rev_parse(repo, "HEAD").await,
         rev_parse(repo, &target.upstream_ref).await,
@@ -579,6 +611,332 @@ pub(crate) async fn probe(
     }))
 }
 
+/// The network phase of a PLAIN (merge / fast-forward) pull: one fetch under the
+/// network domain alone, with everything the local half needs pinned off it.
+///
+/// `None` stands the split phases down and the caller runs bare `git pull` — for a
+/// target `resolve` won't answer for (detached HEAD, no upstream, a tree mid-op,
+/// whose own git wording is what the user knows), for a local-branch upstream
+/// (nothing to transfer), for config the local half cannot honor
+/// ([`plain_pull_config_stands_down`]), and when the fetch leaves no usable snapshot.
+pub(crate) async fn pin_plain_pull(
+    state: &AppState,
+    repo: &str,
+    ff_only: bool,
+) -> AppResult<Option<PlainPull>> {
+    let Some(target) = resolve(repo).await? else {
+        return Ok(None);
+    };
+    if target.remote == "."
+        || plain_pull_config_stands_down(repo, &target.remote, !ff_only).await
+    {
+        return Ok(None);
+    }
+    // Shells out to git and the forge CLI — resolved before any lock, as the
+    // autostash compounds do.
+    let cred = credentials(repo, &target).await?;
+    let Some(pinned) = fetch_and_pin(state, repo, &target, &cred).await? else {
+        return Ok(None);
+    };
+    Ok(Some(PlainPull {
+        target,
+        pinned,
+        ff_only,
+    }))
+}
+
+/// Whether config makes the split phases behave differently from bare `git pull`, in
+/// which case the caller hands the pull back to bare `git pull` rather than quietly
+/// changing what it does. `merge_mode` gates the keys only a merge can trip.
+async fn plain_pull_config_stands_down(repo: &str, remote: &str, merge_mode: bool) -> bool {
+    // `submodule.recurse`: bare pull updates submodule worktrees for these modes, and
+    // the guard's measured parity step covers rebase only.
+    if submodule_recurse(repo).await {
+        return true;
+    }
+    // Pull-only keys `git merge` never reads, so honoring them is impossible here.
+    // `--ff-only` mode passes its own flag on both sides, which overrides `pull.ff`
+    // either way; `merge.ff` needs no arm, since bare pull reads it identically.
+    if merge_mode {
+        for key in ["pull.ff", "pull.twohead"] {
+            if config_is_set(repo, key).await {
+                return true;
+            }
+        }
+    }
+    // These only bite because our fetch PRUNES: pruning is what lets them delete local
+    // tags, and bare pull (with `fetch.prune` unset) never pruned at all.
+    for key in [
+        "fetch.pruneTags".to_string(),
+        format!("remote.{remote}.pruneTags"),
+    ] {
+        if config_is_true(repo, &key).await {
+            return true;
+        }
+    }
+    // A refspec writing into `refs/heads/*` needs the `--update-head-ok` bare pull
+    // passes its own fetch; ours would hard-refuse ("Refusing to fetch into branch").
+    fetch_maps_into_heads(repo, remote).await
+}
+
+/// Whether `key` is set at ALL, in any scope — the test for the tri-state and
+/// free-form keys where the value is irrelevant and a `--bool` read would collapse
+/// `only` into false. `--get` exits 1 when the key is unset. An unrunnable probe
+/// reads as set, so doubt stands the split phases down rather than acting.
+async fn config_is_set(repo: &str, key: &str) -> bool {
+    run_git_raw(Some(repo), &["config", "--get", key], DEFAULT_TIMEOUT)
+        .await
+        .is_ok_and(|out| out.code == 0)
+}
+
+/// Whether `key` reads true through git's own boolean resolution, so every spelling
+/// of true stays git's verdict. An unrunnable probe reads as true, standing the
+/// split phases down rather than acting on an unknown.
+async fn config_is_true(repo: &str, key: &str) -> bool {
+    let Ok(out) = run_git_raw(
+        Some(repo),
+        &["config", "--bool", "--get", key],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    else {
+        return true;
+    };
+    out.code == 0 && out.stdout_lossy().trim() == "true"
+}
+
+/// Whether any of the remote's fetch refspecs writes into `refs/heads/*` — the
+/// mirror-style clone whose fetch would collide with the checked-out branch. A
+/// leading `+` is the force marker, and the destination is the half after `:`; a
+/// refspec with no `:` (an exclusion, a fetch-only ref) writes nowhere local.
+async fn fetch_maps_into_heads(repo: &str, remote: &str) -> bool {
+    let Ok(out) = run_git_raw(
+        Some(repo),
+        &["config", "--get-all", &format!("remote.{remote}.fetch")],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    else {
+        return true;
+    };
+    out.stdout_lossy().lines().any(|spec| {
+        spec.trim()
+            .trim_start_matches('+')
+            .split_once(':')
+            .is_some_and(|(_, dst)| dst.starts_with("refs/heads/"))
+    })
+}
+
+/// The guard's own fetch, with the local half's inputs read under the SAME network
+/// hold — the one-snapshot invariant [`probe`] documents, for the modes that need no
+/// fork-point verdict. `None` when that snapshot is incomplete: an upstream branch
+/// deleted on the forge stops resolving once the fetch prunes it, and the caller's
+/// bare `git pull` then answers in git's own words ("no such ref was fetched").
+async fn fetch_and_pin(
+    state: &AppState,
+    repo: &str,
+    target: &PullTarget,
+    cred: &[String],
+) -> AppResult<Option<PinnedFetch>> {
+    let network = state.network_lock(repo).await;
+    let _net_guard = acquire_repo_lock(&network, NETWORK_LOCK_WAIT_TIMEOUT, "a pull").await?;
+    let out = run_git_with_creds_once(
+        repo,
+        cred,
+        &["fetch", "--prune", target.remote.as_str()],
+        NETWORK_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
+    let Some(new_tip) = rev_parse(repo, &target.upstream_ref).await else {
+        return Ok(None);
+    };
+    let Some(merge_source) = fetch_head_record(repo, &new_tip).await else {
+        return Ok(None);
+    };
+    Ok(Some(PinnedFetch {
+        new_tip,
+        merge_source,
+    }))
+}
+
+/// The `FETCH_HEAD` record this fetch wrote for `new_tip` — the for-merge line (an
+/// EMPTY second field; every other ref the refspec brought carries `not-for-merge`),
+/// which is what `git fmt-merge-msg` turns into pull's own merge subject.
+///
+/// `None` unless there is EXACTLY ONE for-merge record and it names `new_tip`: a
+/// branch with several `branch.<b>.merge` entries gets an OCTOPUS merge from bare
+/// pull, which one pinned record cannot reproduce.
+///
+/// Read here rather than at merge time because `FETCH_HEAD` is shared by every
+/// worktree of the repo and the next fetch anywhere rewrites it. `--git-path` answers
+/// relative to the child's cwd, so the path is resolved against `repo` rather than
+/// this process's own working directory.
+async fn fetch_head_record(repo: &str, new_tip: &str) -> Option<String> {
+    let out = run_git_raw(
+        Some(repo),
+        &["rev-parse", "--git-path", "FETCH_HEAD"],
+        DEFAULT_TIMEOUT,
+    )
+    .await
+    .ok()?;
+    if out.code != 0 {
+        return None;
+    }
+    let stdout = out.stdout_lossy();
+    let rel = std::path::Path::new(stdout.trim_end_matches(['\r', '\n']));
+    let path = if rel.is_absolute() {
+        rel.to_path_buf()
+    } else {
+        std::path::Path::new(repo).join(rel)
+    };
+    let text = std::fs::read_to_string(path).ok()?;
+    let for_merge: Vec<&str> = text
+        .lines()
+        .filter(|line| line.split('\t').nth(1) == Some(""))
+        .collect();
+    match for_merge.as_slice() {
+        [record] if record.split('\t').next() == Some(new_tip) => Some((*record).to_string()),
+        _ => None,
+    }
+}
+
+/// Refuse unless HEAD is still the branch the network phase ran against — the branch
+/// every pinned SHA was read for. The TIP is deliberately not checked here: nothing
+/// the plain local half does depends on it (there is no fork-point verdict), merging
+/// the pinned tip onto a HEAD the user just advanced is what a fresh pull would do,
+/// and refusing that would defeat the concurrency this split exists to allow.
+///
+/// Deliberately NOT [`PULL_DECISION_STALE`]: that marker keys the frontend's
+/// stale-decision flow, which has an answer to re-ask.
+async fn ensure_branch_current(repo: &str, branch: &str) -> AppResult<()> {
+    if current_branch(repo).await.as_deref() != Some(branch) {
+        return Err(AppError::Command(
+            "The checked-out branch changed while this pull was fetching — pull again to see where it stands."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// [`ensure_branch_current`] plus the tip, for the rebase arms: their fork-point
+/// verdict and the base it replays from are only sound on the HEAD the probe measured
+/// them against. A refusal rather than a fall-through to bare `git pull --rebase`,
+/// which would hand the fork-point verdict back to git and reopen the vaporize this
+/// module exists to prevent.
+async fn ensure_pin_current(repo: &str, branch: &str, branch_tip: &str) -> AppResult<()> {
+    let head_branch = current_branch(repo).await;
+    let head = rev_parse(repo, "HEAD").await.unwrap_or_default();
+    if head_branch.as_deref() != Some(branch) || !head.eq_ignore_ascii_case(branch_tip) {
+        return Err(AppError::Command(
+            "The branch or its tip moved while this pull was fetching — pull again to see where it stands."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// `git merge` argv for the local half of a plain pull, on the pinned tip and never
+/// a ref name. Fast-forward-only mode carries no message, since it can only advance
+/// HEAD. Merge mode has to spell bare pull's own subject, and letting
+/// `git fmt-merge-msg` shape the record the fetch wrote is what makes it
+/// byte-identical — re-deriving git's URL rendering (trailing `.git` stripped,
+/// credentials anonymized) and its `into <branch>` rule here would drift.
+///
+/// `autostash` is the flag to carry, or `None` for none at all — the same translation
+/// [`rebase_argv`] takes, since `git merge` reads `pull.autoStash` no more than
+/// `git rebase` does.
+async fn plain_merge_argv(
+    repo: &str,
+    plain: &PlainPull,
+    autostash: Option<&str>,
+) -> AppResult<Vec<String>> {
+    let mut argv = vec!["merge".to_string()];
+    argv.extend(autostash.map(str::to_string));
+    if plain.ff_only {
+        argv.push("--ff-only".to_string());
+        argv.push(plain.pinned.new_tip.clone());
+        return Ok(argv);
+    }
+    let out = run_git_raw_input(
+        Some(repo),
+        &["fmt-merge-msg"],
+        Some(&format!("{}\n", plain.pinned.merge_source)),
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Err(AppError::Git {
+            code: out.code,
+            stderr: out.full_failure_text(),
+        });
+    }
+    argv.extend(["--no-edit".to_string(), "-m".to_string()]);
+    argv.push(out.stdout_lossy().trim_end().to_string());
+    argv.push(plain.pinned.new_tip.clone());
+    Ok(argv)
+}
+
+/// Run the pinned merge under the hold the caller already owns.
+///
+/// `WORKTREE_OP_TIMEOUT`, not the default: the incoming delta after a long-offline
+/// pull is checkout-scale work, and a kill mid-checkout leaves a torn tree and a
+/// stranded `index.lock` rather than a slow pull.
+async fn run_pinned_merge(repo: &str, argv: &[String]) -> AppResult<crate::git::runner::GitOutput> {
+    run_git_raw(
+        Some(repo),
+        &argv.iter().map(String::as_str).collect::<Vec<_>>(),
+        WORKTREE_OP_TIMEOUT,
+    )
+    .await
+}
+
+/// The local half of a plain pull for the non-autostash core: the first point at
+/// which a pull touches the working tree at all.
+pub(crate) async fn merge_pinned(state: &AppState, repo: &str, plain: &PlainPull) -> AppResult<()> {
+    let domain = state.working_tree_lock(repo).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
+    ensure_branch_current(repo, &plain.target.branch).await?;
+    let argv = plain_merge_argv(repo, plain, plain_autostash_flag(repo).await).await?;
+    let already_unmerged = crate::git::ops::unmerged_paths(repo).await;
+    let out = run_pinned_merge(repo, &argv).await?;
+    if out.code != 0 {
+        return Err(crate::git::ops::classify_failure(
+            repo,
+            "merge",
+            &already_unmerged,
+            out.code,
+            out.full_failure_text(),
+        )
+        .await);
+    }
+    Ok(())
+}
+
+/// [`merge_pinned`] with the uncommitted changes stashed across the merge. The
+/// currency check runs BEFORE the stash, so a refused pull leaves the dirty tree
+/// exactly as it found it and there is nothing to settle.
+pub(crate) async fn merge_pinned_autostash(
+    state: &AppState,
+    repo: &str,
+    plain: &PlainPull,
+) -> AppResult<AutostashOutcome> {
+    let domain = state.working_tree_lock(repo).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
+    crate::git::ops::refuse_mid_op(repo).await?;
+    ensure_branch_current(repo, &plain.target.branch).await?;
+    let argv = plain_merge_argv(repo, plain, COMPOUND_AUTOSTASH).await?;
+
+    let stashed = autostash_push(repo).await?;
+    let op = run_pinned_merge(repo, &argv).await;
+    settle(repo, "merge", stashed, true, op).await
+}
+
 /// The guarded rebase-mode pull for the plain (non-autostash) core. `false` means
 /// the guard stood down and the caller must run bare `git pull --rebase` exactly
 /// as before.
@@ -586,9 +944,18 @@ pub(crate) async fn guarded_pull(state: &AppState, repo: &str) -> AppResult<bool
     let Some(target) = resolve(repo).await? else {
         return Ok(false);
     };
-    // Shells out to git and the forge CLI — resolved before the lock, as the
+    // Shells out to git and the forge CLI — resolved before any lock, as the
     // autostash compounds do.
     let cred = credentials(repo, &target).await?;
+    // Phase A holds the network domain alone, and its refusal touches nothing the
+    // user owns — so both the transfer and the would-drop answer come before the
+    // working tree is taken at all.
+    let Some(plan) = probe(state, repo, &target, &cred).await? else {
+        return Ok(false);
+    };
+    if !plan.dropped().is_empty() {
+        return Err(plan.into_error());
+    }
 
     let domain = state.working_tree_lock(repo).await;
     let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
@@ -597,12 +964,7 @@ pub(crate) async fn guarded_pull(state: &AppState, repo: &str) -> AppResult<bool
     if mid_op(repo).await {
         return Ok(false);
     }
-    let Some(plan) = probe(state, repo, &target, &cred).await? else {
-        return Ok(false);
-    };
-    if !plan.dropped().is_empty() {
-        return Err(plan.into_error());
-    }
+    ensure_pin_current(repo, &target.branch, &plan.branch_tip).await?;
     let autostash = plain_autostash_flag(repo).await;
     let already_unmerged = crate::git::ops::unmerged_paths(repo).await;
     let out = run_git_raw(
@@ -638,16 +1000,19 @@ pub(crate) async fn guarded_pull_autostash(
         return Ok(None);
     };
     let cred = credentials(repo, &target).await?;
-
-    let domain = state.working_tree_lock(repo).await;
-    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
-    crate::git::ops::refuse_mid_op(repo).await?;
     let Some(plan) = probe(state, repo, &target, &cred).await? else {
         return Ok(None);
     };
     if !plan.dropped().is_empty() {
         return Err(plan.into_error());
     }
+
+    let domain = state.working_tree_lock(repo).await;
+    let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a pull").await?;
+    crate::git::ops::refuse_mid_op(repo).await?;
+    // Both gates run BEFORE the stash, so a refused pull leaves the dirty tree
+    // exactly as it found it.
+    ensure_pin_current(repo, &target.branch, &plan.branch_tip).await?;
     let stashed = autostash_push(repo).await?;
     let op = run_git_raw(
         Some(repo),
@@ -1925,6 +2290,447 @@ mod tests {
             "dirty\n"
         );
         assert!(git(&clone, &["stash", "list"]).await.trim().is_empty());
+    }
+
+    // ---- plain pull: network phase, then the local half ----------------------
+
+    /// A bare origin, a teammate's `work` clone, and the clone under test — strictly
+    /// BEHIND origin by one commit, which is what a plain pull fast-forwards onto.
+    /// Returns the fixture guard, the clone, the work clone, and origin's tip.
+    ///
+    /// `b.txt` is three lines and the upstream commit rewrites only its FIRST: a local
+    /// edit to the third line then blocks a plain fast-forward while still popping
+    /// cleanly, which is what makes the autostash arms measurable.
+    async fn behind_fixture(marker: &str) -> (tempfile::TempDir, String, String, String) {
+        let dir = temp(marker);
+        let root = dir.path().to_string_lossy().into_owned();
+        git(&root, &["init", "-q", "--bare", "-b", "main", "origin.git"]).await;
+        let url = format!(
+            "file://{}",
+            dir.path()
+                .join("origin.git")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+
+        git(&root, &["init", "-q", "-b", "main", "work"]).await;
+        let work_dir = dir.path().join("work");
+        let work = work_dir.to_string_lossy().into_owned();
+        configure(&work).await;
+        std::fs::write(work_dir.join("a.txt"), "base\n").unwrap();
+        std::fs::write(work_dir.join("b.txt"), "one\ntwo\nthree\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "base"]).await;
+        git(&work, &["remote", "add", "origin", &url]).await;
+        git(&work, &["push", "-q", "-u", "origin", "main"]).await;
+
+        git(
+            &root,
+            &["-c", "core.autocrlf=false", "clone", "-q", &url, "clone"],
+        )
+        .await;
+        let clone = dir.path().join("clone").to_string_lossy().into_owned();
+        configure(&clone).await;
+
+        // Upstream moves on, and the clone has not seen it yet.
+        std::fs::write(work_dir.join("a.txt"), "upstream\n").unwrap();
+        std::fs::write(work_dir.join("b.txt"), "ONE\ntwo\nthree\n").unwrap();
+        git(&work, &["commit", "-qam", "upstream moves on"]).await;
+        git(&work, &["push", "-q"]).await;
+        let tip = rev(&work, "HEAD").await;
+        (dir, clone, work, tip)
+    }
+
+    /// The transfer holds the NETWORK domain alone, so the user can stage or commit
+    /// straight through it. A working-tree hold that OUTLIVES the phase is the proof:
+    /// a phase that took the working tree would have reported `Busy` instead.
+    #[tokio::test]
+    async fn the_network_phase_runs_with_the_working_tree_held() {
+        let (_dir, clone, _work, tip) = behind_fixture("net-only").await;
+
+        let state = AppState::default();
+        let wt = state.working_tree_lock(&clone).await;
+        let _held = acquire_repo_lock(&wt, std::time::Duration::ZERO, "a commit")
+            .await
+            .expect("the working tree is free for the test to take");
+
+        let plain = pin_plain_pull(&state, &clone, true)
+            .await
+            .expect("the network phase completes with the working tree held")
+            .expect("the fixture tracks a real remote branch");
+        assert_eq!(plain.pinned.new_tip, tip, "and it pinned the fetched tip");
+    }
+
+    /// The local half acts on the SHA the fetch pinned, never on a ref re-read at
+    /// merge time: a later fetch moves both the tracking ref and FETCH_HEAD, and
+    /// neither is allowed to change what lands.
+    #[tokio::test]
+    async fn the_local_half_merges_the_pinned_tip_not_a_later_one() {
+        let (dir, clone, work, pinned_tip) = behind_fixture("pinned-tip").await;
+
+        let state = AppState::default();
+        let plain = pin_plain_pull(&state, &clone, true)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+        assert_eq!(plain.pinned.new_tip, pinned_tip);
+
+        std::fs::write(dir.path().join("work").join("b.txt"), "later\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "upstream moves again"]).await;
+        git(&work, &["push", "-q"]).await;
+        git(&clone, &["fetch", "-q", "--prune", "origin"]).await;
+        let later = rev(&clone, "refs/remotes/origin/main").await;
+        assert_ne!(later, pinned_tip, "the second fetch must move the ref");
+        assert_eq!(rev(&clone, "FETCH_HEAD").await, later, "and FETCH_HEAD too");
+
+        merge_pinned(&state, &clone, &plain)
+            .await
+            .expect("the pinned tip is a fast-forward");
+        assert_eq!(
+            rev(&clone, "HEAD").await,
+            pinned_tip,
+            "the pull landed the tip its own fetch produced"
+        );
+    }
+
+    /// The merge SUBJECT is pinned by the same snapshot as the tip. A second fetch
+    /// rewrites `FETCH_HEAD` with a record for a different branch, and the merge must
+    /// still name the one this pull actually fetched — a subject read at merge time
+    /// would name the other branch and read as a merge that never happened.
+    #[tokio::test]
+    async fn the_merge_subject_names_this_pulls_own_fetch_not_a_later_one() {
+        let (dir, clone, work, pinned_tip) = behind_fixture("pinned-subject").await;
+        let clone_dir = dir.path().join("clone");
+        // A local commit on another file, so merge mode really merges: a fast-forward
+        // writes no subject to compare.
+        std::fs::write(clone_dir.join("mine.txt"), "mine\n").unwrap();
+        git(&clone, &["add", "-A"]).await;
+        git(&clone, &["commit", "-qm", "my local work"]).await;
+
+        let state = AppState::default();
+        let plain = pin_plain_pull(&state, &clone, false)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+
+        // A second branch published and fetched by name — an explicitly requested ref
+        // is FOR-MERGE, so it takes over the whole FETCH_HEAD verdict.
+        git(&work, &["switch", "-q", "-c", "other"]).await;
+        std::fs::write(dir.path().join("work").join("o.txt"), "o\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "other branch"]).await;
+        git(&work, &["push", "-q", "-u", "origin", "other"]).await;
+        git(&clone, &["fetch", "-q", "origin", "other"]).await;
+
+        merge_pinned(&state, &clone, &plain)
+            .await
+            .expect("a non-overlapping divergence merges cleanly");
+        let subject = log_subjects(&clone).await.first().cloned().unwrap();
+        assert!(
+            subject.starts_with("Merge branch 'main' of "),
+            "the subject must name the branch this pull fetched: {subject}"
+        );
+        assert!(
+            !subject.contains("'other'"),
+            "and never the record a later fetch left behind: {subject}"
+        );
+        assert_eq!(
+            rev(&clone, "HEAD^2").await,
+            pinned_tip,
+            "the merged parent is the pinned tip"
+        );
+    }
+
+    /// The plain half verifies branch IDENTITY only. A commit the user landed while
+    /// the transfer ran is exactly the concurrency this split exists to allow, so the
+    /// pull merges its pinned tip onto that new commit rather than refusing.
+    #[tokio::test]
+    async fn the_local_half_merges_onto_a_commit_made_during_the_fetch() {
+        let (dir, clone, _work, pinned_tip) = behind_fixture("commit-during-fetch").await;
+        let clone_dir = dir.path().join("clone");
+
+        let state = AppState::default();
+        let plain = pin_plain_pull(&state, &clone, false)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+
+        std::fs::write(clone_dir.join("late.txt"), "late\n").unwrap();
+        git(&clone, &["add", "-A"]).await;
+        git(&clone, &["commit", "-qm", "late local commit"]).await;
+        let mine = rev(&clone, "HEAD").await;
+
+        merge_pinned(&state, &clone, &plain)
+            .await
+            .expect("a commit made during the transfer must not refuse the pull");
+        assert_eq!(rev(&clone, "HEAD^1").await, mine, "the user's commit is kept");
+        assert_eq!(rev(&clone, "HEAD^2").await, pinned_tip, "and the pinned tip merged");
+    }
+
+    /// Branch identity is the one thing the plain half cannot proceed without: the
+    /// pinned tip was fetched for a branch that is no longer checked out. The autostash
+    /// arm is where the refusal has a stash to get wrong, so it is the arm tested.
+    #[tokio::test]
+    async fn the_autostash_local_half_refuses_a_switched_branch_without_stashing() {
+        let (dir, clone, _work, _tip) = behind_fixture("switched-branch").await;
+        let clone_dir = dir.path().join("clone");
+
+        let state = AppState::default();
+        let plain = pin_plain_pull(&state, &clone, false)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+
+        git(&clone, &["switch", "-q", "-c", "elsewhere"]).await;
+        std::fs::write(clone_dir.join("dirty.txt"), "dirty\n").unwrap();
+
+        let err = merge_pinned_autostash(&state, &clone, &plain)
+            .await
+            .expect_err("the pin was made for a branch that is no longer checked out");
+        assert!(
+            matches!(&err, AppError::Command(m) if m.contains("The checked-out branch changed")),
+            "{err:?}"
+        );
+        assert!(
+            !err.to_string().contains(PULL_DECISION_STALE),
+            "that marker keys a different frontend flow: {err}"
+        );
+        assert!(
+            git(&clone, &["stash", "list"]).await.trim().is_empty(),
+            "the refusal comes before the stash"
+        );
+        assert_eq!(
+            git(&clone, &["status", "--porcelain"]).await.trim(),
+            "?? dirty.txt",
+            "and the dirty tree is exactly as the user left it"
+        );
+    }
+
+    /// The REBASE arms keep the tip in their check: their fork-point verdict and the
+    /// base they replay from are only sound on the HEAD the probe measured. Driven at
+    /// the predicate, because a tip that moves mid-probe is not a schedulable event.
+    #[tokio::test]
+    async fn the_rebase_arms_refuse_a_branch_or_tip_that_moved_during_the_fetch() {
+        let (dir, clone, _work, _tip) = behind_fixture("rebase-pin").await;
+        let clone_dir = dir.path().join("clone");
+        let pinned_tip = rev(&clone, "HEAD").await;
+
+        ensure_pin_current(&clone, "main", &pinned_tip)
+            .await
+            .expect("an unmoved branch passes");
+
+        // The tip moves under the pin.
+        std::fs::write(clone_dir.join("late.txt"), "late\n").unwrap();
+        git(&clone, &["add", "-A"]).await;
+        git(&clone, &["commit", "-qm", "late local commit"]).await;
+        let err = ensure_pin_current(&clone, "main", &pinned_tip)
+            .await
+            .expect_err("a moved tip must be refused");
+        assert!(
+            matches!(&err, AppError::Command(m) if m.contains("The branch or its tip moved")),
+            "{err:?}"
+        );
+        assert!(!err.to_string().contains(PULL_DECISION_STALE), "{err}");
+
+        // And the tip alone is not identity: another branch at the SAME commit is a
+        // ref the pull was never resolved against.
+        let moved = rev(&clone, "HEAD").await;
+        git(&clone, &["switch", "-q", "-c", "elsewhere"]).await;
+        assert!(ensure_pin_current(&clone, "main", &moved).await.is_err());
+        assert!(ensure_branch_current(&clone, "main").await.is_err());
+        assert!(ensure_branch_current(&clone, "elsewhere").await.is_ok());
+    }
+
+    /// Config the plain half's `git merge` cannot honor has to hand the pull back to
+    /// bare `git pull`, or the pull silently stops doing what the user configured.
+    /// Every key is set locally, so the machine's own git config cannot decide this.
+    #[tokio::test]
+    async fn the_plain_arms_stand_down_on_config_git_merge_cannot_honor() {
+        let (_dir, clone, _work, _tip) = behind_fixture("stand-down").await;
+        // The boolean keys pinned false up front: an unset key would otherwise read
+        // through to a global one and decide the baseline.
+        for key in ["submodule.recurse", "fetch.pruneTags", "remote.origin.pruneTags"] {
+            git(&clone, &["config", key, "false"]).await;
+        }
+        assert!(
+            !plain_pull_config_stands_down(&clone, "origin", true).await,
+            "an ordinary clone runs the split phases"
+        );
+
+        for (key, value) in [
+            ("pull.ff", "only"),
+            ("pull.ff", "false"),
+            ("pull.twohead", "ours"),
+            ("fetch.pruneTags", "true"),
+            ("remote.origin.pruneTags", "yes"),
+            ("submodule.recurse", "true"),
+        ] {
+            git(&clone, &["config", key, value]).await;
+            assert!(
+                plain_pull_config_stands_down(&clone, "origin", true).await,
+                "{key}={value} must stand the split phases down"
+            );
+            git(&clone, &["config", "--unset", key]).await;
+        }
+
+        // `--ff-only` mode passes its own flag on both sides, so the pull-only merge
+        // keys are overridden there and cost nothing.
+        for key in ["pull.ff", "pull.twohead"] {
+            git(&clone, &["config", key, "only"]).await;
+            assert!(
+                !plain_pull_config_stands_down(&clone, "origin", false).await,
+                "{key} is overridden by an explicit --ff-only on both sides"
+            );
+            git(&clone, &["config", "--unset", key]).await;
+        }
+
+        // A mirror-style refspec needs the `--update-head-ok` bare pull's fetch carries.
+        git(
+            &clone,
+            &[
+                "config",
+                "--add",
+                "remote.origin.fetch",
+                "+refs/heads/*:refs/heads/upstream/*",
+            ],
+        )
+        .await;
+        assert!(
+            plain_pull_config_stands_down(&clone, "origin", true).await,
+            "a refspec writing into refs/heads/* would hard-refuse"
+        );
+    }
+
+    /// A branch with several `branch.<b>.merge` entries gets an OCTOPUS merge from
+    /// bare pull, and one pinned FETCH_HEAD record cannot reproduce it — so the phase
+    /// stands down rather than merging whichever record it happened to pick.
+    #[tokio::test]
+    async fn a_multi_upstream_branch_stands_the_network_phase_down() {
+        let (dir, clone, work, _tip) = behind_fixture("octopus").await;
+
+        let state = AppState::default();
+        assert!(
+            pin_plain_pull(&state, &clone, true).await.unwrap().is_some(),
+            "one upstream is the ordinary case"
+        );
+
+        git(&work, &["switch", "-q", "-c", "topic"]).await;
+        std::fs::write(dir.path().join("work").join("t.txt"), "t\n").unwrap();
+        git(&work, &["add", "-A"]).await;
+        git(&work, &["commit", "-qm", "topic"]).await;
+        git(&work, &["push", "-q", "-u", "origin", "topic"]).await;
+        git(
+            &clone,
+            &["config", "--add", "branch.main.merge", "refs/heads/topic"],
+        )
+        .await;
+
+        assert!(
+            pin_plain_pull(&state, &clone, true).await.unwrap().is_none(),
+            "two upstreams is an octopus merge the pinned record cannot spell"
+        );
+    }
+
+    /// Bare `git pull` honors `pull.autoStash` where a bare `git merge` ignores it, so
+    /// the plain arms have to translate it — and to pass NOTHING when it is unset,
+    /// which is what leaves `merge.autoStash` (read natively by `git merge`) in charge.
+    /// Both keys drive the same fixture, and the unset control is what gives them
+    /// teeth: without a flag the fast-forward is refused outright.
+    #[tokio::test]
+    async fn a_plain_pull_honors_the_autostash_config() {
+        for key in ["pull.autoStash", "merge.autoStash", "none"] {
+            let (dir, clone, _work, tip) = behind_fixture(&format!("plain-autostash-{key}")).await;
+            let clone_dir = dir.path().join("clone");
+            if key != "none" {
+                git(&clone, &["config", key, "true"]).await;
+            }
+            // The upstream commit rewrote b.txt's first line; this edits its third, so
+            // a plain fast-forward refuses to overwrite it and only an autostash gets
+            // the pull through — then pops cleanly.
+            std::fs::write(clone_dir.join("b.txt"), "one\ntwo\nTHREE\n").unwrap();
+
+            let state = AppState::default();
+            let plain = pin_plain_pull(&state, &clone, true)
+                .await
+                .unwrap()
+                .expect("the fixture tracks a real remote branch");
+            let result = merge_pinned(&state, &clone, &plain).await;
+
+            if key == "none" {
+                let err = result.expect_err("with neither key set git must refuse");
+                assert!(
+                    err.to_string().to_lowercase().contains("would be overwritten"),
+                    "git's own refusal must reach the user: {err}"
+                );
+                assert_ne!(rev(&clone, "HEAD").await, tip, "and nothing moved");
+                continue;
+            }
+            result.unwrap_or_else(|e| panic!("{key}=true must let the pull through: {e}"));
+            assert_eq!(rev(&clone, "HEAD").await, tip, "{key}: the pull landed");
+            assert_eq!(
+                std::fs::read_to_string(clone_dir.join("b.txt")).unwrap(),
+                "ONE\ntwo\nTHREE\n",
+                "{key}: the upstream's line and the user's both survive"
+            );
+            assert!(
+                git(&clone, &["stash", "list"]).await.trim().is_empty(),
+                "{key}: the autostash entry is not left behind"
+            );
+        }
+    }
+
+    /// The flag's position in the argv, and the compound arms' opposite answer: they
+    /// stash for themselves, so git must not.
+    #[tokio::test]
+    async fn plain_merge_argv_carries_only_the_autostash_flag_it_is_given() {
+        let (_dir, clone, _work, tip) = behind_fixture("plain-argv").await;
+        let state = AppState::default();
+        let plain = pin_plain_pull(&state, &clone, true)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+
+        assert_eq!(
+            plain_merge_argv(&clone, &plain, None).await.unwrap(),
+            vec!["merge".to_string(), "--ff-only".into(), tip.clone()]
+        );
+        assert_eq!(
+            plain_merge_argv(&clone, &plain, Some("--autostash"))
+                .await
+                .unwrap(),
+            vec![
+                "merge".to_string(),
+                "--autostash".into(),
+                "--ff-only".into(),
+                tip.clone()
+            ]
+        );
+        assert_eq!(
+            plain_merge_argv(&clone, &plain, COMPOUND_AUTOSTASH)
+                .await
+                .unwrap(),
+            vec![
+                "merge".to_string(),
+                "--no-autostash".into(),
+                "--ff-only".into(),
+                tip.clone()
+            ]
+        );
+
+        // Merge mode: the flag still leads, with the subject between it and the tip.
+        let merge_mode = PlainPull {
+            target: plain.target,
+            pinned: plain.pinned,
+            ff_only: false,
+        };
+        let argv = plain_merge_argv(&clone, &merge_mode, COMPOUND_AUTOSTASH)
+            .await
+            .unwrap();
+        assert_eq!(argv[..3], ["merge", "--no-autostash", "--no-edit"]);
+        assert_eq!(argv[3], "-m");
+        assert!(argv[4].starts_with("Merge branch 'main' of "), "{argv:?}");
+        assert_eq!(argv[5], tip);
     }
 
     // ---- submodule parity ---------------------------------------------------

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -719,7 +719,7 @@ async fn pull_only_keys_set(repo: &str, merge_mode: bool) -> bool {
 async fn config_is_set(repo: &str, key: &str) -> bool {
     run_git_raw(Some(repo), &["config", "--get", key], DEFAULT_TIMEOUT)
         .await
-        .is_ok_and(|out| out.code == 0)
+        .map_or(true, |out| out.code == 0)
 }
 
 /// Whether `key` reads true through git's own boolean resolution, so every spelling

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -61,9 +61,10 @@ fn is_auth_class_failure(stderr: &str) -> bool {
 }
 
 /// Run a git network op with one-shot credential `-c` entries prefixed, taking NO
-/// lock — so it is callable from inside a held working-tree lock (the autostash
-/// compounds, which take the network lock around it themselves). Returns the raw
-/// output: a non-zero exit is not an error here.
+/// lock — so it is callable from inside a held domain: a pull's network phase
+/// (`git::pull_guard`) holds the network lock around it, and the autostash pull's
+/// bare fall-through holds the working tree and takes the network lock around it.
+/// Returns the raw output: a non-zero exit is not an error here.
 ///
 /// When `cred` is non-empty and the injected run fails with an auth-class git error
 /// ([`is_auth_class_failure`]), retries EXACTLY ONCE with NO injected config (the
@@ -107,10 +108,11 @@ pub(crate) async fn run_git_with_creds_once(
 /// (fetch/pull/push) is written against.
 ///
 /// The network domain rather than the working tree: a transfer runs for up to
-/// `NETWORK_TIMEOUT` and must not stall staging or a commit for that long. A caller
-/// whose command also touches the working tree (`git_pull_core`) takes the
-/// working-tree lock around this call — that direction only (see
-/// `run_git_mutating`).
+/// `NETWORK_TIMEOUT` and must not stall staging or a commit for that long. The pull
+/// cores' bare fall-through is the one caller whose command also touches the working
+/// tree: it holds the working-tree lock across this call, which is the only sanctioned
+/// nesting direction (see `run_git_mutating`). Every other caller here — fetch, push,
+/// set-head — holds nothing but the network domain this takes.
 pub(crate) async fn run_git_mutating_with_creds(
     state: &AppState,
     repo_path: &str,
@@ -485,19 +487,26 @@ pub(crate) async fn git_pull_core(
     // would each pay for an unmerged probe that can only come back empty.
     // A refused `--ff-only` leaves nothing unmerged, so its label never surfaces.
     let op = if mode == "rebase" { "rebase" } else { "merge" };
-    // Rebase mode runs the two-phase guard first — bare `git pull --rebase`
-    // computes its own fork point and can silently drop a pushed commit a
-    // force-push rewrote away (git::pull_guard). `false` means the guard stood
-    // down (detached HEAD, no upstream, unrelated histories, a tree mid-op) and
-    // this pull runs byte-identically to before.
-    if mode == "rebase" && crate::git::pull_guard::guarded_pull(state, &repo_path).await? {
-        return Ok(());
+    // Every mode splits into a network phase and a local one (git::pull_guard), so the
+    // transfer holds the network domain alone and staging stays available across it.
+    // Rebase mode additionally runs the fork-point guard there — bare
+    // `git pull --rebase` computes its own fork point and can silently drop a pushed
+    // commit a force-push rewrote away.
+    if mode == "rebase" {
+        if crate::git::pull_guard::guarded_pull(state, &repo_path).await? {
+            return Ok(());
+        }
+    } else if let Some(plain) =
+        crate::git::pull_guard::pin_plain_pull(state, &repo_path, mode != "merge").await?
+    {
+        return crate::git::pull_guard::merge_pinned(state, &repo_path, &plain).await;
     }
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    // Bare `git pull` is a transfer AND a merge in one command, so it needs both
-    // domains: the working tree here, the network inside `run_git_mutating_with_creds`
-    // — that order only (see `run_git_mutating`). The guarded rebase path above takes
-    // the working-tree lock itself and must stay outside this hold.
+    // The fall-through, for every state the split phases stand down on (each listed at
+    // `pin_plain_pull` / `guarded_pull`): bare `git pull` is a transfer AND a merge in
+    // one command, so it needs both domains — the working tree here, the network inside
+    // `run_git_mutating_with_creds` — that order only (see `run_git_mutating`). The
+    // split phases above take their own locks and must stay outside this hold.
     let wt = state.working_tree_lock(&repo_path).await;
     let _wt_guard = acquire_repo_lock(&wt, LOCK_WAIT_TIMEOUT, "a pull").await?;
     let already_unmerged = crate::git::ops::unmerged_paths(&repo_path).await;
@@ -1764,6 +1773,52 @@ mod tests {
                 "{key}: the autostash entry is not left behind"
             );
         }
+    }
+
+    /// A merge-mode pull runs its own `git merge` rather than `git pull`, so it has
+    /// to spell pull's own merge subject — the line the user reads in their history,
+    /// and the one place git's URL rendering (a stripped trailing `.git`, anonymized
+    /// credentials) and its `into <branch>` rule show through. Compared against a
+    /// real bare pull in a twin clone, so no wording is asserted from memory.
+    #[tokio::test]
+    async fn a_merge_mode_pull_writes_bare_pulls_merge_subject() {
+        let (_guard, base, _origin_s, url) = seeded_origin("merge-subject").await;
+        let base_s = base.to_string_lossy().into_owned();
+        let work = base.join("work");
+        let work_s = work.to_string_lossy().into_owned();
+
+        let mut clones = Vec::new();
+        for name in ["guarded", "bare"] {
+            run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, name]).await;
+            let c = base.join(name).to_string_lossy().into_owned();
+            run(&c, &["config", "core.autocrlf", "false"]).await;
+            run(&c, &["config", "user.email", "t@t.local"]).await;
+            run(&c, &["config", "user.name", "T"]).await;
+            // A local commit on a file upstream never touches: the branch has to have
+            // DIVERGED, since a fast-forward writes no merge commit to compare.
+            std::fs::write(base.join(name).join("mine.txt"), "mine\n").unwrap();
+            run(&c, &["add", "-A"]).await;
+            run(&c, &["commit", "-qm", "my local work"]).await;
+            clones.push(c);
+        }
+
+        std::fs::write(work.join("a.txt"), "upstream\n").unwrap();
+        run(&work_s, &["commit", "-qam", "upstream moves on"]).await;
+        run(&work_s, &["push", "-q"]).await;
+
+        let state = AppState::default();
+        git_pull_core(&state, clones[0].clone(), "merge".into())
+            .await
+            .expect("a non-overlapping divergence merges cleanly");
+        run(&clones[1], &["pull", "--no-rebase", "-q"]).await;
+
+        let ours = subjects(&clones[0]).await.first().cloned().unwrap();
+        let theirs = subjects(&clones[1]).await.first().cloned().unwrap();
+        assert_eq!(ours, theirs, "the merge subject must be pull's own");
+        assert!(
+            ours.starts_with("Merge branch 'main' of "),
+            "and it names the upstream branch it merged: {ours}"
+        );
     }
 
     // --- Pure arg-building for a named-branch push. ---

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -793,16 +793,6 @@ fn is_session_worktree(
     false
 }
 
-/// The target of a linked worktree's `.git` pointer file (`gitdir: <path>`).
-/// The recorded path may be relative to the worktree, so callers resolve it.
-fn parse_gitdir_pointer(content: &str) -> Option<&str> {
-    content
-        .lines()
-        .find_map(|l| l.trim().strip_prefix("gitdir:"))
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-}
-
 /// A file's mtime as epoch ms, or `None` when it is unreadable.
 fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
@@ -820,23 +810,8 @@ fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
 /// 8 real worktrees, 2026-08-30). HEAD's mtime is the fallback. `None` on
 /// anything unreadable — one worktree with odd admin files must never fail the
 /// whole list.
-fn worktree_last_activity_ms(worktree_path: &str) -> Option<i64> {
-    let root = std::path::Path::new(worktree_path);
-    let dotgit = root.join(".git");
-    // `git::ops::marker_dir` resolves the same `.git`-dir-or-pointer question for
-    // op markers, so a change to either resolution rule has to land in both until
-    // they are hoisted into one shared helper.
-    let admin = match std::fs::metadata(&dotgit) {
-        Ok(meta) if meta.is_dir() => dotgit,
-        // A linked worktree's `.git` is a pointer to `<repo>/.git/worktrees/<id>`,
-        // recorded relative under `worktree.useRelativePaths` — joining on the
-        // tree resolves that and leaves an absolute pointer untouched.
-        Ok(_) => {
-            let pointer = std::fs::read_to_string(&dotgit).ok()?;
-            root.join(parse_gitdir_pointer(&pointer)?)
-        }
-        Err(_) => return None,
-    };
+pub(crate) fn worktree_last_activity_ms(worktree_path: &str) -> Option<i64> {
+    let admin = crate::git::ops::resolve_git_admin_dir(std::path::Path::new(worktree_path))?;
     file_mtime_ms(&admin.join("index")).or_else(|| file_mtime_ms(&admin.join("HEAD")))
 }
 
@@ -878,6 +853,7 @@ mod tests {
     use super::*;
     // The module itself no longer calls the working-tree runner — the interleave
     // tests below drive it as an ordinary caller would.
+    use crate::git::ops::parse_gitdir_pointer;
     use crate::git::runner::run_git_mutating;
 
     #[test]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -42,7 +42,11 @@ pub struct PtyState {
 /// Control side of one PTY: the master (resize), an input queue, and the child
 /// (kill). The reader is owned by the streaming thread, not here.
 struct PtyHandle {
-    master: Box<dyn MasterPty + Send>,
+    /// Behind its own `Arc<Mutex<…>>` so `pty_resize` can clone it out of the map,
+    /// release the map lock, and only then make the blocking OS call; the mutex is
+    /// what makes that clone shareable at all, since `Arc<T>: Send` needs `T: Send +
+    /// Sync` and the bare `Box<dyn MasterPty + Send>` is not `Sync`.
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     /// Queues input for the PTY's writer thread. The writer itself lives there, so
     /// a child that stops reading can never block a caller holding the PTY map
     /// lock; dropping this handle closes the channel, which ends that thread.
@@ -582,7 +586,7 @@ pub async fn pty_open(
     let prev = state.ptys.lock().unwrap().insert(
         id.clone(),
         PtyHandle {
-            master: pair.master,
+            master: Arc::new(Mutex::new(pair.master)),
             input,
             queued,
             child,
@@ -685,12 +689,22 @@ pub fn pty_write(state: State<'_, PtyState>, id: String, data: String) -> AppRes
     Ok(())
 }
 
-/// Resizes the PTY when the terminal element resizes.
+/// Resizes the PTY when the terminal element resizes. Sync command (main thread),
+/// so the master is cloned OUT of the map and the guard dropped before the resize:
+/// that is an OS call, and holding the map lock across it stalls `pty_write`,
+/// `pty_close` and every reader/writer thread on a resize storm.
+///
+/// A resize racing `pty_close` keeps the master alive through this clone for the
+/// length of the call — harmless: the result is discarded either way, and teardown
+/// owns the handle's child and temp-script halves regardless.
 #[tauri::command]
 pub fn pty_resize(state: State<'_, PtyState>, id: String, cols: u16, rows: u16) -> AppResult<()> {
-    let map = state.ptys.lock().unwrap();
-    if let Some(h) = map.get(&id) {
-        let _ = h.master.resize(PtySize {
+    let master = {
+        let map = state.ptys.lock().unwrap();
+        map.get(&id).map(|h| Arc::clone(&h.master))
+    };
+    if let Some(master) = master {
+        let _ = master.lock().unwrap().resize(PtySize {
             rows: rows.max(1),
             cols: cols.max(1),
             pixel_width: 0,
@@ -907,6 +921,27 @@ mod tests {
     /// concurrency tests key on the two fields `pty_write` touches.
     type TestPtys = Arc<Mutex<HashMap<String, (Sender<Vec<u8>>, Arc<AtomicUsize>)>>>;
 
+    /// The resize side of the PTY map: a real master needs a live child, so this
+    /// mirrors the one field `pty_resize` touches, wrapping included.
+    type TestResizePtys = Arc<Mutex<HashMap<String, Arc<Mutex<WedgedResizer>>>>>;
+
+    /// Blocks inside `resize` until released — the OS resize call that has not
+    /// returned yet.
+    struct WedgedResizer {
+        entered: Sender<()>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+    impl WedgedResizer {
+        fn resize(&self) {
+            let _ = self.entered.send(());
+            let (lock, cv) = &*self.release;
+            let mut go = lock.lock().unwrap();
+            while !*go {
+                go = cv.wait(go).unwrap();
+            }
+        }
+    }
+
     /// Appends every write to a shared buffer, so a test can assert ordering.
     struct RecordingWriter(Arc<Mutex<Vec<u8>>>);
     impl Write for RecordingWriter {
@@ -1059,6 +1094,42 @@ mod tests {
         release(&wedge.gate);
         ptys.lock().unwrap().remove("t");
         pump.join().unwrap();
+    }
+
+    #[test]
+    fn a_blocked_resize_leaves_the_pty_map_lock_free() {
+        // `resize` is an OS call on the main thread, so `pty_resize` clones the master
+        // out and DROPS the map guard before making it — `pty_write` and `pty_close`
+        // take that same lock and must stay reachable through a resize storm.
+        let ptys: TestResizePtys = Arc::default();
+        let (entered_tx, entered) = channel();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        ptys.lock().unwrap().insert(
+            "t".to_string(),
+            Arc::new(Mutex::new(WedgedResizer {
+                entered: entered_tx,
+                release: gate.clone(),
+            })),
+        );
+
+        let resizing = ptys.clone();
+        let resize = std::thread::spawn(move || {
+            let master = {
+                let map = resizing.lock().unwrap();
+                map.get("t").map(Arc::clone)
+            };
+            master.expect("the handle is registered").lock().unwrap().resize();
+        });
+        entered
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the resizing thread should have reached the blocking resize");
+        assert!(
+            ptys.try_lock().is_ok(),
+            "a blocked resize is holding the PTY map lock — pty_close would be stuck"
+        );
+
+        release(&gate);
+        resize.join().unwrap();
     }
 
     #[test]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1102,6 +1102,8 @@ mod tests {
         // `resize` is an OS call on the main thread, so `pty_resize` clones the master
         // out and DROPS the map guard before making it — `pty_write` and `pty_close`
         // take that same lock and must stay reachable through a resize storm.
+        // Shape mirror over a test map, like the write test above (see
+        // `TestResizePtys`) — it pins the clone-then-drop shape, not `pty_resize`'s body.
         let ptys: TestResizePtys = Arc::default();
         let (entered_tx, entered) = channel();
         let gate = Arc::new((Mutex::new(false), Condvar::new()));
@@ -1135,8 +1137,9 @@ mod tests {
 
     #[test]
     fn writing_under_the_map_lock_blocks_close_control() {
-        // Negative control for the test above: the pre-fix shape (write_all under the
-        // map lock) DOES block a `pty_close`-style acquire, so that assertion can fail.
+        // Negative control for `a_wedged_write_leaves_the_pty_map_lock_free`: the
+        // pre-fix shape (write_all under the map lock) DOES block a `pty_close`-style
+        // acquire, so that assertion can fail.
         let writers: Arc<Mutex<HashMap<String, WedgedWriter>>> = Arc::default();
         let (writer, wedge) = wedged_writer();
         writers.lock().unwrap().insert("t".to_string(), writer);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -692,10 +692,11 @@ pub fn pty_write(state: State<'_, PtyState>, id: String, data: String) -> AppRes
 /// Resizes the PTY when the terminal element resizes. Sync command (main thread),
 /// so the master is cloned OUT of the map and the guard dropped before the resize:
 /// that is an OS call, and holding the map lock across it stalls `pty_write`,
-/// `pty_close` and every reader/writer thread on a resize storm.
+/// `pty_close` and the reader threads on a resize storm (the writer thread owns
+/// its channel and never touches the map).
 ///
-/// A resize racing `pty_close` keeps the master alive through this clone for the
-/// length of the call — harmless: the result is discarded either way, and teardown
+/// A resize racing `pty_close` keeps the MASTER alive past the map entry's removal
+/// for the length of one OS call; the result is discarded either way, and teardown
 /// owns the handle's child and temp-script halves regardless.
 #[tauri::command]
 pub fn pty_resize(state: State<'_, PtyState>, id: String, cols: u16, rows: u16) -> AppResult<()> {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,12 +1,12 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as SyncMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify, OnceCell};
 
 use crate::git::types::GitInfo;
+use crate::git::worktree::normalize_wt_path;
 
 /// The agent cancel registry: run id → the `Notify` the cancel command fires.
 type AgentCancels = SyncMutex<HashMap<String, CancelEntry>>;
@@ -74,17 +74,40 @@ impl LockDomain {
     }
 }
 
-/// The three independent lock domains of one repo path. They are separate mutexes
+/// The lock domains every checkout of one repository SHARES, keyed by the common
+/// git dir. Separate mutexes from the working-tree domain (and from each other)
 /// precisely so a multi-minute worktree removal can't stall staging or a commit.
 #[derive(Clone, Default)]
-struct RepoDomains {
-    working_tree: LockDomain,
+struct SharedDomains {
     worktree_admin: LockDomain,
     network: LockDomain,
 }
 
+/// What one input spelling resolves to: the CHECKOUT it names, and the repository
+/// that checkout belongs to. Two keys because the domains split that way — see
+/// [`AppState::working_tree_lock`].
+///
+/// Both are folded through [`normalize_wt_path`], the same transform git::worktree
+/// uses for cross-source path comparison: git prints forward slashes while the GUI
+/// passes native separators (`validate_repo` normalizes to backslashes), and Windows
+/// paths are case-insensitive, so one checkout is reachable under several spellings
+/// that must land on one mutex. Its lower-casing can only MERGE two case-distinct
+/// Unix paths onto one lock, which over-serializes — the safe direction.
+#[derive(Clone)]
+struct LockKeys {
+    checkout: String,
+    shared: String,
+}
+
 pub struct AppState {
-    repo_domains: Mutex<HashMap<PathBuf, RepoDomains>>,
+    /// Input spelling → its resolved [`LockKeys`], so the two git probes run once per
+    /// spelling instead of once per acquisition. Bounded by the paths a session
+    /// touches, like the domain maps themselves.
+    lock_keys: Mutex<HashMap<String, LockKeys>>,
+    /// Working-tree domains keyed by checkout identity.
+    checkout_domains: Mutex<HashMap<String, LockDomain>>,
+    /// Worktree-admin and network domains keyed by shared repository identity.
+    shared_domains: Mutex<HashMap<String, SharedDomains>>,
     pub git_info: OnceCell<GitInfo>,
     /// In-flight agent-CLI reviews and sessions keyed by a frontend-supplied id, so a
     /// separate cancel command can signal the streaming run to stop. A blocking mutex:
@@ -101,7 +124,9 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            repo_domains: Mutex::new(HashMap::new()),
+            lock_keys: Mutex::new(HashMap::new()),
+            checkout_domains: Mutex::new(HashMap::new()),
+            shared_domains: Mutex::new(HashMap::new()),
             git_info: OnceCell::new(),
             agent_cancels: Arc::new(SyncMutex::new(HashMap::new())),
             close_to_tray: AtomicBool::new(true),
@@ -110,39 +135,100 @@ impl Default for AppState {
 }
 
 impl AppState {
-    /// The three domains for `repo_path`, created on first use.
-    async fn domains(&self, repo_path: &str) -> RepoDomains {
-        let mut map = self.repo_domains.lock().await;
-        map.entry(PathBuf::from(repo_path)).or_default().clone()
+    /// The lock keys for `repo_path`, resolved through git once per spelling.
+    ///
+    /// Both probes run WITHOUT the cache lock held, so one repo's first touch never
+    /// queues every other repo's behind a git spawn. Two callers racing a first touch
+    /// both resolve and the first insert wins — the same value either way.
+    ///
+    /// Each resolver degrades to the raw spelling when git can't answer, and an
+    /// UNRESOLVED pair is deliberately never cached: a transient failure (a timeout,
+    /// an antivirus hold) would otherwise pin that spelling to raw-path keys for the
+    /// process lifetime, permanently outside the domains of the repo it names.
+    async fn resolve_lock_keys(&self, repo_path: &str) -> LockKeys {
+        if let Some(keys) = self.lock_keys.lock().await.get(repo_path) {
+            return keys.clone();
+        }
+        let toplevel = crate::git::runner::worktree_toplevel(repo_path).await;
+        let identity = crate::git::repo::repo_identity(repo_path).await;
+        // `repo_identity` answers with its input on failure, so equality with the
+        // input is the fallback-detection seam. It reads a caller that passed the
+        // common git dir ITSELF as unresolved, which costs a re-probe per call and
+        // never a wrong key.
+        let resolved = toplevel.is_ok() && identity != repo_path;
+        let keys = LockKeys {
+            checkout: normalize_wt_path(toplevel.as_deref().unwrap_or(repo_path)),
+            shared: normalize_wt_path(&identity),
+        };
+        if !resolved {
+            return keys;
+        }
+        self.lock_keys
+            .lock()
+            .await
+            .entry(repo_path.to_string())
+            .or_insert(keys)
+            .clone()
+    }
+
+    /// The two shared-identity domains for `repo_path`, created on first use.
+    async fn shared(&self, repo_path: &str) -> SharedDomains {
+        let key = self.resolve_lock_keys(repo_path).await.shared;
+        self.shared_domains
+            .lock()
+            .await
+            .entry(key)
+            .or_default()
+            .clone()
     }
 
     /// The **working-tree** domain: index, HEAD and ref mutations of the checkout
     /// at `repo_path` — the lock that keeps concurrent git invocations from
     /// fighting over `.git/index.lock`.
     ///
+    /// Keyed by the CHECKOUT (`rev-parse --show-toplevel`), so any subdirectory or
+    /// alternate spelling of one checkout shares its lock while each linked worktree
+    /// keeps its own: the index and HEAD are per-checkout, and keying this domain by
+    /// the common git dir would queue the user's staging behind an agent session's
+    /// unbounded commit holds in a session worktree.
+    ///
     /// Lock ordering across domains, which keeps the wait graph acyclic: a task may
     /// take NETWORK while holding WORKING-TREE (a pull is a transfer plus a merge)
     /// and never the reverse; the ADMIN domain nests with neither, and no task takes
     /// two locks of one domain.
     pub(crate) async fn working_tree_lock(&self, repo_path: &str) -> LockDomain {
-        self.domains(repo_path).await.working_tree
+        let key = self.resolve_lock_keys(repo_path).await.checkout;
+        self.checkout_domains
+            .lock()
+            .await
+            .entry(key)
+            .or_default()
+            .clone()
     }
 
     /// The **worktree-admin** domain: every `git worktree
-    /// add/remove/prune/move/lock/unlock/repair` on the main repo path. Separate
-    /// from the working tree because a removal holds it for minutes while staging
-    /// and committing must keep working. Never nested with another domain (see
+    /// add/remove/prune/move/lock/unlock/repair` on the repo. Separate from the
+    /// working tree because a removal holds it for minutes while staging and
+    /// committing must keep working. Never nested with another domain (see
     /// [`working_tree_lock`](Self::working_tree_lock) for the ordering rule).
+    ///
+    /// Keyed by the SHARED identity (the common git dir): the `.git/worktrees`
+    /// registry is one file tree for every checkout, so a command run from inside a
+    /// linked worktree serializes with one run from the main checkout.
     pub(crate) async fn worktree_admin_lock(&self, repo_path: &str) -> LockDomain {
-        self.domains(repo_path).await.worktree_admin
+        self.shared(repo_path).await.worktree_admin
     }
 
     /// The **network** domain: fetch, push, set-head and pull transfers, serialized
     /// so a user pull's fetch can't race the background auto-fetch at the ref level.
     /// May be taken while holding the working-tree lock, never the reverse (see
     /// [`working_tree_lock`](Self::working_tree_lock)).
+    ///
+    /// Keyed by the SHARED identity: `refs/remotes/*` and FETCH_HEAD live in the
+    /// common git dir, so a worktree session's fetch and the main window's auto-fetch
+    /// are the very race this domain exists to prevent.
     pub(crate) async fn network_lock(&self, repo_path: &str) -> LockDomain {
-        self.domains(repo_path).await.network
+        self.shared(repo_path).await.network
     }
 
     /// Register (or adopt) the cancellation handle for a run id and return it. The
@@ -247,6 +333,204 @@ fn sweep_unadopted_tombstone(registry: &AgentCancels, id: &str) {
         .is_some_and(|e| e.tombstoned_at.is_some() && Arc::strong_count(&e.notify) == 1)
     {
         map.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod lock_key_tests {
+    use super::*;
+    use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
+
+    async fn git(repo: &str, args: &[&str]) {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("git {args:?} in {repo} failed: {e:?}"));
+    }
+
+    fn temp_dir(marker: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(&format!("gd-lockkey-{marker}-"))
+            .tempdir()
+            .expect("create temp dir")
+    }
+
+    /// The spelling a fixture hands to git. Canonicalized off Windows because macOS
+    /// puts temp dirs under `/var/folders/…`, a symlink to `/private/var/…`: the
+    /// shared-key assertions would otherwise rest on git's two probes agreeing about
+    /// that symlink. Windows keeps the plain path — canonicalizing there yields a
+    /// `\\?\` verbatim spelling, which is not what the app passes.
+    fn fixture_path(dir: &std::path::Path) -> String {
+        #[cfg(not(windows))]
+        let dir = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+        dir.to_string_lossy().into_owned()
+    }
+
+    /// Turns an existing directory into a repo with one commit.
+    async fn init_repo(repo: &str) {
+        git(repo, &["init"]).await;
+        git(repo, &["config", "user.email", "t@t"]).await;
+        git(repo, &["config", "user.name", "t"]).await;
+        std::fs::write(std::path::Path::new(repo).join("a.txt"), "v0\n").unwrap();
+        git(repo, &["add", "."]).await;
+        git(repo, &["commit", "-m", "base"]).await;
+    }
+
+    /// A real repo with one commit, under its own temp dir (which must outlive the
+    /// test — dropping it removes the repo).
+    async fn setup_repo(marker: &str) -> (tempfile::TempDir, String) {
+        let dir = temp_dir(marker);
+        let repo = fixture_path(dir.path());
+        init_repo(&repo).await;
+        (dir, repo)
+    }
+
+    /// Domain identity is the mutex itself: two lookups share a domain exactly when
+    /// they handed back the same `Arc`.
+    fn same(a: &LockDomain, b: &LockDomain) -> bool {
+        Arc::ptr_eq(&a.lock, &b.lock)
+    }
+
+    /// All three domains of one spelling, in (working-tree, admin, network) order.
+    async fn domains_of(state: &AppState, path: &str) -> (LockDomain, LockDomain, LockDomain) {
+        (
+            state.working_tree_lock(path).await,
+            state.worktree_admin_lock(path).await,
+            state.network_lock(path).await,
+        )
+    }
+
+    /// A path inside the checkout names the same checkout and the same repo, so all
+    /// three domains must be the root spelling's. The MCP server takes `--repo`
+    /// verbatim, so a subdirectory reaches these accessors.
+    #[tokio::test]
+    async fn a_subdirectory_spelling_shares_every_domain_with_the_root() {
+        let (_dir, repo) = setup_repo("subdir").await;
+        let sub = std::path::Path::new(&repo).join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let sub = sub.to_string_lossy().into_owned();
+
+        let state = AppState::default();
+        let root = domains_of(&state, &repo).await;
+        let inner = domains_of(&state, &sub).await;
+        assert!(
+            same(&root.0, &inner.0),
+            "a subdirectory is the same checkout"
+        );
+        assert!(same(&root.1, &inner.1), "and the same worktree registry");
+        assert!(same(&root.2, &inner.2), "and the same remote refs");
+    }
+
+    /// The differentiated keying, in one test: a linked worktree has its OWN index
+    /// and HEAD (so its own working-tree lock, which is what keeps a session's
+    /// unbounded holds off the user's staging) but shares the `.git/worktrees`
+    /// registry, `refs/remotes/*` and FETCH_HEAD with the main checkout.
+    #[tokio::test]
+    async fn a_linked_worktree_keeps_its_own_working_tree_domain_but_shares_the_repo() {
+        let (_dir, repo) = setup_repo("worktree").await;
+        let holder = temp_dir("linked");
+        // `git worktree add` requires the path NOT to exist yet, so the HOLDER is what
+        // gets canonicalized.
+        let linked = std::path::Path::new(&fixture_path(holder.path())).join("wt");
+        let linked = linked.to_string_lossy().into_owned();
+        git(&repo, &["worktree", "add", "-b", "gd-lockkey-wt", &linked]).await;
+
+        let state = AppState::default();
+        let main = domains_of(&state, &repo).await;
+        let wt = domains_of(&state, &linked).await;
+        assert!(
+            !same(&main.0, &wt.0),
+            "each checkout owns its index/HEAD lock"
+        );
+        assert!(
+            same(&main.1, &wt.1),
+            "the .git/worktrees registry is shared, so admin ops serialize"
+        );
+        assert!(
+            same(&main.2, &wt.2),
+            "refs/remotes and FETCH_HEAD are shared, so fetches serialize"
+        );
+    }
+
+    /// The control: unrelated repos must serialize nothing against each other.
+    #[tokio::test]
+    async fn two_repos_share_no_domain() {
+        let (_a_dir, a) = setup_repo("distinct-a").await;
+        let (_b_dir, b) = setup_repo("distinct-b").await;
+
+        let state = AppState::default();
+        let da = domains_of(&state, &a).await;
+        let db = domains_of(&state, &b).await;
+        assert!(!same(&da.0, &db.0));
+        assert!(!same(&da.1, &db.1));
+        assert!(!same(&da.2, &db.2));
+    }
+
+    /// A path git can't resolve falls back to its own spelling, which is what keeps
+    /// the fake-path callers (the runner's lock tests) meaningful: one path is still
+    /// one mutex, and two are still two.
+    #[tokio::test]
+    async fn a_non_repo_path_falls_back_to_its_own_spelling() {
+        let state = AppState::default();
+        let fake = domains_of(&state, "C:/repos/gd-lockkey-absent").await;
+        let again = domains_of(&state, "C:/repos/gd-lockkey-absent").await;
+        let other = domains_of(&state, "C:/repos/gd-lockkey-absent-other").await;
+
+        assert!(
+            same(&fake.0, &again.0) && same(&fake.1, &again.1) && same(&fake.2, &again.2),
+            "the same unresolvable path must find the same mutexes"
+        );
+        assert!(
+            !same(&fake.0, &other.0) && !same(&fake.1, &other.1) && !same(&fake.2, &other.2),
+            "two unresolvable paths must stay independent"
+        );
+    }
+
+    /// A resolution that failed must not be remembered: the same spelling has to
+    /// rejoin the real domains once git can answer for it, or one transient probe
+    /// failure exiles it for the process lifetime. A path that does not exist yet is
+    /// the deterministic failure — git can't even be spawned there.
+    #[tokio::test]
+    async fn a_failed_resolution_is_never_cached() {
+        let holder = temp_dir("late");
+        let repo_dir = std::path::Path::new(&fixture_path(holder.path())).join("repo");
+        let repo = repo_dir.to_string_lossy().into_owned();
+
+        let state = AppState::default();
+        let absent = domains_of(&state, &repo).await;
+
+        std::fs::create_dir(&repo_dir).unwrap();
+        init_repo(&repo).await;
+        let present = domains_of(&state, &repo).await;
+        let sub = repo_dir.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let via_sub = domains_of(&state, &sub.to_string_lossy()).await;
+
+        assert!(
+            !same(&absent.1, &present.1),
+            "the failed probe must not have been cached — the shared key is the repo's \
+             common git dir, never its work-tree path"
+        );
+        assert!(same(&present.0, &via_sub.0), "working tree");
+        assert!(same(&present.1, &via_sub.1), "worktree admin");
+        assert!(same(&present.2, &via_sub.2), "network");
+    }
+
+    /// Windows reaches one checkout under several spellings — git's forward slashes,
+    /// the GUI's backslashes, and any casing — and the filesystem treats them as one
+    /// path, so the locks must too.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn case_and_slash_variants_share_every_domain() {
+        let (_dir, repo) = setup_repo("spelling").await;
+        let state = AppState::default();
+        let base = domains_of(&state, &repo).await;
+
+        for variant in [repo.replace('\\', "/"), repo.to_uppercase()] {
+            let got = domains_of(&state, &variant).await;
+            assert!(same(&base.0, &got.0), "working tree: {variant}");
+            assert!(same(&base.1, &got.1), "worktree admin: {variant}");
+            assert!(same(&base.2, &got.2), "network: {variant}");
+        }
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -152,9 +152,9 @@ impl AppState {
         let toplevel = crate::git::runner::worktree_toplevel(repo_path).await;
         let identity = crate::git::repo::repo_identity(repo_path).await;
         // `repo_identity` answers with its input on failure, so equality with the
-        // input is the fallback-detection seam. It reads a caller that passed the
-        // common git dir ITSELF as unresolved, which costs a re-probe per call and
-        // never a wrong key.
+        // input is the fallback-detection seam. A caller passing the common git dir
+        // ITSELF can read as unresolved (when the spellings match exactly) — a
+        // re-probe per call at worst, never a wrong key.
         let resolved = toplevel.is_ok() && identity != repo_path;
         let keys = LockKeys {
             checkout: normalize_wt_path(toplevel.as_deref().unwrap_or(repo_path)),
@@ -224,9 +224,10 @@ impl AppState {
     /// May be taken while holding the working-tree lock, never the reverse (see
     /// [`working_tree_lock`](Self::working_tree_lock)).
     ///
-    /// Keyed by the SHARED identity: `refs/remotes/*` and FETCH_HEAD live in the
-    /// common git dir, so a worktree session's fetch and the main window's auto-fetch
-    /// are the very race this domain exists to prevent.
+    /// Keyed by the SHARED identity: `refs/remotes/*` lives in the common git dir
+    /// (FETCH_HEAD does not — it is per-worktree, measured via `--git-path`), so a
+    /// worktree session's fetch and the main window's auto-fetch race on the same
+    /// tracking refs — the very race this domain exists to prevent.
     pub(crate) async fn network_lock(&self, repo_path: &str) -> LockDomain {
         self.shared(repo_path).await.network
     }
@@ -423,7 +424,7 @@ mod lock_key_tests {
     /// The differentiated keying, in one test: a linked worktree has its OWN index
     /// and HEAD (so its own working-tree lock, which is what keeps a session's
     /// unbounded holds off the user's staging) but shares the `.git/worktrees`
-    /// registry, `refs/remotes/*` and FETCH_HEAD with the main checkout.
+    /// registry and `refs/remotes/*` with the main checkout.
     #[tokio::test]
     async fn a_linked_worktree_keeps_its_own_working_tree_domain_but_shares_the_repo() {
         let (_dir, repo) = setup_repo("worktree").await;
@@ -447,7 +448,7 @@ mod lock_key_tests {
         );
         assert!(
             same(&main.2, &wt.2),
-            "refs/remotes and FETCH_HEAD are shared, so fetches serialize"
+            "refs/remotes is shared, so fetches serialize"
         );
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -385,6 +385,17 @@ mod lock_key_tests {
         (dir, repo)
     }
 
+    /// An ABSOLUTE path guaranteed not to exist: a temp dir's child, minted and then
+    /// dropped along with the whole tree. A literal like `C:/repos/x` is a RELATIVE
+    /// path off Windows, which would leave resolvability up to the test cwd.
+    fn absent_path(marker: &str) -> String {
+        let dir = temp_dir(marker);
+        // Canonicalize while the dir still exists (see `fixture_path`).
+        let path = std::path::Path::new(&fixture_path(dir.path())).join("absent");
+        drop(dir);
+        path.to_string_lossy().into_owned()
+    }
+
     /// Domain identity is the mutex itself: two lookups share a domain exactly when
     /// they handed back the same `Arc`.
     fn same(a: &LockDomain, b: &LockDomain) -> bool {
@@ -471,10 +482,13 @@ mod lock_key_tests {
     /// one mutex, and two are still two.
     #[tokio::test]
     async fn a_non_repo_path_falls_back_to_its_own_spelling() {
+        let one = absent_path("absent");
+        let two = absent_path("absent-other");
+
         let state = AppState::default();
-        let fake = domains_of(&state, "C:/repos/gd-lockkey-absent").await;
-        let again = domains_of(&state, "C:/repos/gd-lockkey-absent").await;
-        let other = domains_of(&state, "C:/repos/gd-lockkey-absent-other").await;
+        let fake = domains_of(&state, &one).await;
+        let again = domains_of(&state, &one).await;
+        let other = domains_of(&state, &two).await;
 
         assert!(
             same(&fake.0, &again.0) && same(&fake.1, &again.1) && same(&fake.2, &again.2),


### PR DESCRIPTION
Long-running Git operations were holding the working-tree lock across phases that don't touch the working tree at all — a pull's network transfer, a branch update's temporary worktree materialization — so staging and committing queued behind them for the full duration. This splits those operations into phases that each hold only the domain they need, and keys the shared domains by repository identity so different path spellings of the same repo actually serialize.

### Pull: split the transfer off the working tree

- `src-tauri/src/git/pull_guard.rs` grows the plain (non-rebase) half of the phase split: `PinnedFetch` and `PlainPull` carry the tip SHA and the verbatim `FETCH_HEAD` record produced by one fetch, and `pin_plain_pull` / `merge_pinned` / `merge_pinned_autostash` run the network phase under the network domain alone before taking the working tree for the local merge. Pinning matters because the background auto-fetch moves the tracking refs and rewrites the checkout's own `FETCH_HEAD` (per-worktree, measured on git 2.51.1).
- `src-tauri/src/git/remote.rs::git_pull_core` and `src-tauri/src/git/autostash.rs::git_pull_autostash_core` route every mode through the split — rebase mode keeps the existing fork-point guard (including its entry stand-down when the branch was switched since `resolve`), the plain modes go through `pin_plain_pull` — and keep the old both-domains shape only as the fall-through for the states the split stands down on.
- The autostash flag helper in `pull_guard.rs` is reused by the merge arms; an unset `pull.autoStash` leaves `git merge` reading `merge.autoStash` natively, a parity its doc now records against measured git 2.51.1 behavior.
- New test in `remote.rs` (`a_merge_mode_pull_writes_bare_pulls_merge_subject`) diffs the merge subject our own `git merge` writes against a real bare `git pull` in a twin clone, so pull's URL rendering and `into <branch>` wording aren't asserted from memory. The conflict-parity test in `autostash.rs` keeps its two-clone fixture, with an updated rationale comment for the split shape.
- Comment updates in `remote.rs::run_git_with_creds_once` / `run_git_mutating_with_creds` re-state which callers still nest the network lock inside a working-tree hold.

### Branch update: release the working tree around the temp worktree

- `src-tauri/src/git/branches.rs::update_branch_from` now resolves both ends of the planned merge under the first working-tree hold (`UpdatePins`, with `branch_tip_sha` reading the full `refs/heads/<branch>` path so a same-named tag can't shadow the pin), drops that guard, and runs the diverged arm in `merge_diverged_in_worktree` under the worktree-admin domain.
- A branch that moved, or a base rewritten rather than fast-forwarded, while the temporary checkout was materializing is refused rather than merged from a stale snapshot; a base the background auto-fetch merely advanced merges normally. Teardown is try-then-detach (inline when the worktree-admin domain is free, detached behind a running removal); the narrow strand windows that remain — a kill mid-add, an app quit mid-teardown — are recorded with a staged fix in the backlog.
- Pulls in `acquire_repo_lock_unbounded`, `try_acquire_repo_lock` and `run_git_worktree_admin` from `git::runner` for those bounded/unbounded acquisitions.

### Lock identity: one repository, one set of domains

- `src-tauri/src/state.rs` replaces the single `repo_domains` map keyed by raw `PathBuf` with `lock_keys` (spelling → resolved keys), `checkout_domains` (working tree, keyed by checkout) and `shared_domains` (worktree-admin + network, keyed by common git dir). Linked worktrees and alternate path spellings of one repo now share the network and worktree-admin locks.
- `resolve_lock_keys` runs its two git probes without the cache lock held, folds both keys through `normalize_wt_path` for the Windows case/separator mismatch, and deliberately never caches an unresolved pair so a transient git failure can't pin a spelling to raw-path keys for the process lifetime.

### Shared `.git` resolution

- `src-tauri/src/git/ops.rs` hoists the duplicated `.git`-dir-or-pointer resolution into `resolve_git_admin_dir` and `parse_gitdir_pointer` (both `pub(crate)`), used by `cherry_pick_marker_present`, `rebase_marker_present` and now `git::worktree::worktree_last_activity_ms` — `src-tauri/src/git/worktree.rs` drops its copy. New test `a_junk_prefixed_gitdir_pointer_resolves_for_both_entry_points` covers the line-scanning tolerance from both entry points.

### PTY resize

- `src-tauri/src/pty.rs` wraps `PtyHandle::master` in `Arc<Mutex<…>>` so `pty_resize` clones the handle out of the map and drops the map guard before the blocking OS resize; previously a resize storm stalled `pty_write`, `pty_close` and the reader threads. Covered by `a_blocked_resize_leaves_the_pty_map_lock_free`.

### Recent commits

- `src-tauri/src/git/commit.rs::git_recent_commits` now uses History's `LOG_FORMAT` and `parse_commit_log` instead of its own format string and inline parser, so those rows carry tag decorations and the merge flag. New test `recent_commits_carry_tags_and_merge_flags` builds a repo with a tag and a `--no-ff` merge to check both.

### Changelog

- Four fragments in `changelog.d/`: `fixed-pull-transfer-working-tree-lock.md`, `fixed-branch-update-worktree-lock.md`, `fixed-terminal-resize-stall.md`, and `changed-repo-lock-identity.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git operations now coordinate correctly across repository path spellings, subfolders, and linked worktrees.
  - Staging and committing remain available while pulls or branch updates prepare temporary worktrees.
  - Pulls and branch updates detect changed or rewritten references, apply fetched commits accurately, and explain why updates cannot proceed.
  - Merge failures now distinguish actual conflicts from hook or command errors.
  - Integrated terminal panes remain responsive during resizing, including typing and closing.
  - Recent commits now show tag decorations and merge indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->