### PR TITLE
feat(hotkeys,settings): allow single-key shortcuts and name control groups

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -102,6 +102,14 @@ separators.
 **Mod-key display.** Shortcut hints render via `isMac` / `formatBinding` from
 `@/lib/hotkeys/binding` — never a literal ⌘ or "Ctrl+"; only labels branch.
 
+**Key-dispatch guards are shared, never re-derived:** `hasModifier`,
+`isTypeaheadTarget`, and `isEditableTarget` / `firesInEditable` all live in
+`src/lib/hotkeys/binding.ts`. Any path that compares `eventToBinding(e)` against
+a user binding and then `preventDefault`s applies the same editable + typeahead
+guard pair the global listener does — bindings are rebindable down to a single
+key, so an unguarded second dispatcher steals keystrokes from every text field.
+The `unguarded-binding-dispatcher` guard in `pnpm run checks` is the ratchet.
+
 **Patterns the user has ruled on:**
 - No hover-revealed per-row buttons — contextual actions are always-visible,
   or live in keyboard/context-menu/toolbar.
@@ -166,11 +174,12 @@ separators.
   highlights, no spinner where skeletons exist.
 - A caption over a GROUP of controls rides `LabeledGroup`
   (`src/components/form/labeled-group.tsx`), which ties the group to it via
-  `role="group"` + `aria-labelledby` — a bare `<Label>` with no `htmlFor` names
-  nothing for assistive tech; the `bare-group-label` guard in `pnpm run checks`
-  fails on a new attribute-less one. Existing idioms that already do their own
-  aria wiring stay as they are: the CreatePrDialog / CreateIssueDialog field-group
-  wrappers and McpServersSection's `role="group"` scope groups.
+  `role="group"` + `aria-labelledby` — a `<Label>` that associates with nothing
+  names nothing for assistive tech, however it is styled; the `bare-group-label`
+  guard in `pnpm run checks` fails on any `<Label>` carrying neither `htmlFor`
+  nor `id`. Existing idioms that already do their own aria wiring stay as they
+  are: the CreatePrDialog / CreateIssueDialog field-group wrappers and
+  McpServersSection's `role="group"` scope groups.
 - A lazy panel's `Suspense` fallback is `LazyPanelFallback`
   (`src/components/lazy-panel-fallback.tsx`) — never `fallback={null}`: a blank
   region has no aria-busy and announces nothing to assistive tech.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -164,6 +164,13 @@ separators.
   not a silent gap.
 - Never degrade a surface to dodge machinery: no plain `<pre>` where the app
   highlights, no spinner where skeletons exist.
+- A caption over a GROUP of controls rides `LabeledGroup`
+  (`src/components/form/labeled-group.tsx`), which ties the group to it via
+  `role="group"` + `aria-labelledby` — a bare `<Label>` with no `htmlFor` names
+  nothing for assistive tech; the `bare-group-label` guard in `pnpm run checks`
+  fails on a new attribute-less one. Existing idioms that already do their own
+  aria wiring stay as they are: the CreatePrDialog / CreateIssueDialog field-group
+  wrappers and McpServersSection's `role="group"` scope groups.
 - A lazy panel's `Suspense` fallback is `LazyPanelFallback`
   (`src/components/lazy-panel-fallback.tsx`) — never `fallback={null}`: a blank
   region has no aria-busy and announces nothing to assistive tech.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -103,12 +103,15 @@ separators.
 `@/lib/hotkeys/binding` — never a literal ⌘ or "Ctrl+"; only labels branch.
 
 **Key-dispatch guards are shared, never re-derived:** `hasModifier`,
-`isTypeaheadTarget`, and `isEditableTarget` / `firesInEditable` all live in
-`src/lib/hotkeys/binding.ts`. Any path that compares `eventToBinding(e)` against
-a user binding and then `preventDefault`s applies the same editable + typeahead
-guard pair the global listener does — bindings are rebindable down to a single
-key, so an unguarded second dispatcher steals keystrokes from every text field.
-The `unguarded-binding-dispatcher` guard in `pnpm run checks` is the ratchet.
+`isTypeaheadTarget`, `isTypeaheadKey`, and `isEditableTarget` / `firesInEditable`
+all live in `src/lib/hotkeys/binding.ts`. Any path that compares
+`eventToBinding(e)` against a user binding and then `preventDefault`s applies the
+same three-predicate clause the global listener does — `isEditableTarget`,
+`isTypeaheadTarget`, `isTypeaheadKey` — because bindings are rebindable down
+to a single key, a dispatcher missing any of them either steals keystrokes from
+a text field or typeahead list, or withholds a named key that should still fire.
+Inner-clause drift between two dispatchers is the regression this prevents; the
+`unguarded-binding-dispatcher` guard in `pnpm run checks` is the ratchet.
 
 **Patterns the user has ruled on:**
 - No hover-revealed per-row buttons — contextual actions are always-visible,

--- a/README.md
+++ b/README.md
@@ -904,10 +904,10 @@ review via its subscription login. The full list is under
   issues (local, on the forge, and Jira), discussions, and commits. Approve,
   Review, and Close stay on the strip, a saved draft shows its first line there,
   and the choice is remembered until you expand it again.
-- **Keyboard-first**: rebindable shortcuts with GitHub-Desktop-compatible
-  defaults, a generated cheat sheet (`Ctrl`/`⌘`+`/`), a command palette
-  (`Ctrl`/`⌘`+`K`), a filterable shortcut list in Settings (by name, category,
-  or key), and arrow-key navigation everywhere.
+- **Keyboard-first**: rebindable shortcuts (single keys included) with
+  GitHub-Desktop-compatible defaults, a generated cheat sheet (`Ctrl`/`⌘`+`/`),
+  a command palette (`Ctrl`/`⌘`+`K`), a filterable shortcut list in Settings
+  (by name, category, or key), and arrow-key navigation everywhere.
 - **Themes**: System, Light, Dark, and a softer **Slate** (a cool, lifted
   blue-gray) that eases eye strain; switch in **Settings → Appearance** or
   cycle from the command palette.

--- a/changelog.d/changed-single-key-shortcuts.md
+++ b/changelog.d/changed-single-key-shortcuts.md
@@ -1,2 +1,3 @@
 - Keyboard shortcuts can be a single key: record one in **Settings → Keyboard**
-  and it stays quiet while you're typing or in a menu, then fires anywhere else.
+  and it stays quiet while you're typing or in a menu or picker, then fires
+  anywhere else.

--- a/changelog.d/changed-single-key-shortcuts.md
+++ b/changelog.d/changed-single-key-shortcuts.md
@@ -1,3 +1,3 @@
-- Keyboard shortcuts can be a single key: record one in **Settings → Keyboard**
-  and it stays quiet while you're typing or in a menu or picker, then fires
-  anywhere else.
+- Keyboard shortcuts can be a single key: record one in **Settings → Keyboard** —
+  a bare character key stays quiet while you're typing or in a menu or picker,
+  then fires anywhere else.

--- a/changelog.d/changed-single-key-shortcuts.md
+++ b/changelog.d/changed-single-key-shortcuts.md
@@ -1,0 +1,2 @@
+- Keyboard shortcuts can be a single key: record one in **Settings → Keyboard**
+  and it stays quiet while you're typing or in a menu, then fires anywhere else.

--- a/changelog.d/fixed-push-failure-reasons.md
+++ b/changelog.d/fixed-push-failure-reasons.md
@@ -1,0 +1,3 @@
+- When a remote turns down a push, the reason now reads as one line: a read-only
+  mirror or archived repository, missing credentials, credentials the remote
+  rejected, or an account without permission on that repository.

--- a/changelog.d/fixed-push-failure-reasons.md
+++ b/changelog.d/fixed-push-failure-reasons.md
@@ -1,3 +1,4 @@
-- When a remote turns down a push, the reason now reads as one line: a read-only
-  mirror or archived repository, missing credentials, credentials the remote
-  rejected, or an account without permission on that repository.
+- When a remote turns down a push, fetch, or clone, the reason now reads as one
+  line: a read-only mirror or archived repository, missing credentials,
+  credentials the remote rejected, or an account without permission on that
+  repository.

--- a/changelog.d/fixed-settings-group-labels.md
+++ b/changelog.d/fixed-settings-group-labels.md
@@ -1,0 +1,3 @@
+- Screen readers now announce which group a settings control belongs to:
+  captions like Rules, Features, and Events name their group of toggles across
+  the repository-settings and app-settings surfaces.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -154,13 +154,15 @@ const onlyWhen = (gate, scan) => (v) => {
   return gate.test(v.text) ? scan(v) : [];
 };
 
-/** Scanner: `scan`'s hits, but only in files whose whole-file view does NOT
- *  match `absent` — the negative twin of `onlyWhen`, for a class whose remedy is
- *  the PRESENCE of a shared helper somewhere in the file rather than the absence
- *  of a bad shape. Same `lastIndex` reset, for the same reason. */
-const unlessPresent = (absent, scan) => (v) => {
-  absent.lastIndex = 0;
-  return absent.test(v.text) ? [] : scan(v);
+/** Scanner: `scan`'s hits, unless the whole-file view matches EVERY regex in
+ *  `required` — the negative twin of `onlyWhen`, for a class whose remedy is the
+ *  PRESENCE of shared helpers rather than the absence of a bad shape. All-or-
+ *  nothing on purpose: a file carrying one guard of a pair is exactly the
+ *  half-guarded shape worth reporting. Same `lastIndex` reset, for the same
+ *  reason. */
+const unlessAllPresent = (required, scan) => (v) => {
+  for (const re of required) re.lastIndex = 0;
+  return required.every((re) => re.test(v.text)) ? [] : scan(v);
 };
 
 /** Scanner: the union of several `nearPair`s — one check, one allowlist, every
@@ -332,24 +334,34 @@ const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 // `className` styles a label without naming anything. `\/?` is what also catches
 // the self-closing forms. A `<Label>` that WRAPS its control is associated at
 // RUNTIME, which no static pattern can see, so those ride the allowlist.
-// Three documented edges, all zero-instance today. Two fail OPEN: an open tag
-// broken across lines is unseen (this reads per line, not the joined view), and
-// an attribute merely ENDING in `id` (`data-id=`) satisfies the `\b` and reads
-// as associated. One fails CLOSED: both `[^>]*` spans stop at the first `>`, so
-// an attribute VALUE containing `>` ahead of the `htmlFor` (a template-literal
-// title reordered before it) hides the association and reports a correct label.
+// Runs over the JOINED view so an open tag the formatter split across lines is
+// still one match — the props of a wrapping label wrap routinely. That view
+// trims each line and rejoins with a single space, which the `\s` between
+// attributes absorbs; both `[^>]*` spans still stop at the tag's own `>`.
+// Two documented edges, both zero-instance today. One fails OPEN: an attribute
+// merely ENDING in `id` (`data-id=`) satisfies the `\b` and reads as associated.
+// One fails CLOSED: those `[^>]*` spans stop at the FIRST `>`, so an attribute
+// VALUE containing `>` ahead of the `htmlFor` (a template-literal title
+// reordered before it) hides the association and reports a correct label.
 const UNASSOCIATED_LABEL_RE =
-  /<Label(?![^>]*\b(?:htmlFor|id)\s*=)(?:\s[^>]*)?\/?>/;
+  /<Label(?![^>]*\b(?:htmlFor|id)\s*=)(?:\s[^>]*)?\/?>/g;
 
 // A key-dispatch path that compares a live event against a user binding and
-// swallows the key, in a file that never mentions the editable-target guard.
-// Deliberately COARSE — presence of a symbol anywhere in the file, not on the
+// swallows the key, in a file missing any predicate of the canonical clause.
+// ALL THREE are required because each covers a different escape: the two target
+// guards refuse different surfaces (a text field vs a typeahead-driven list),
+// and the key half keeps named keys reaching preventDefault on a surface the
+// target guards alone would hand back. A file carrying a subset is the
+// half-guarded shape — drift between two dispatchers is the regression this
+// exists for. Deliberately COARSE — presence anywhere in the file, not on the
 // right path — so it can report a file that guards one handler and not the one
 // added next to it. It is a ratchet, not a proof: its job is to make a NEW
 // dispatch path stop a reader at the allowlist rather than merge unnoticed.
 const EVENT_TO_BINDING_RE = /\beventToBinding\s*\(/;
 const PREVENT_DEFAULT_RE = /\.preventDefault\s*\(/;
 const EDITABLE_GUARD_RE = /\bisEditableTarget\s*\(/;
+const TYPEAHEAD_GUARD_RE = /\bisTypeaheadTarget\s*\(/;
+const TYPEAHEAD_KEY_RE = /\bisTypeaheadKey\s*\(/;
 
 // The two halves of an async settings rollback. The gate: an OPTIMISTIC patch of
 // the settings cache — the file flips the preference itself so the UI can commit
@@ -590,7 +602,7 @@ export const CHECKS = [
   {
     name: "bare-group-label",
     appliesTo: notVendoredUi,
-    scan: perLine(UNASSOCIATED_LABEL_RE),
+    scan: perFile(UNASSOCIATED_LABEL_RE),
     // Keyed per FILE, not per site, for both kinds of entry below: a coarser key
     // means an unrelated edit to one of these files can't turn the entry stale
     // mid-flight. The gate blocks NEW unassociated captions; the deferred group
@@ -613,6 +625,10 @@ export const CHECKS = [
       "src/features/repo-settings/GitLabVariablesSection.tsx",
       // "Secured" on the variable form and its repository-variable twin.
       "src/features/repo-settings/BitbucketVariablesSection.tsx",
+      // One wrapping label per trigger-event checkbox, mapped over the event
+      // list — the same shape, split across lines by the formatter.
+      "src/features/repo-settings/BitbucketWebhooksSection.tsx",
+      "src/features/repo-settings/GitLabWebhooksSection.tsx",
     ],
     message:
       'a `<Label>` with no htmlFor and no id names nothing for assistive tech, however it is styled — whatever sits under it reads as anonymous; caption a GROUP with LabeledGroup (src/components/form/labeled-group.tsx), which pairs the label\'s id with role="group" + aria-labelledby, or point a single-control label at its control with htmlFor; a label that WRAPS its control is associated at runtime and a genuinely decorative one names nothing on purpose — either needs an allowlist entry with rationale',
@@ -620,8 +636,8 @@ export const CHECKS = [
   {
     name: "unguarded-binding-dispatcher",
     appliesTo: notVendoredUi,
-    scan: unlessPresent(
-      EDITABLE_GUARD_RE,
+    scan: unlessAllPresent(
+      [EDITABLE_GUARD_RE, TYPEAHEAD_GUARD_RE, TYPEAHEAD_KEY_RE],
       onlyWhen(PREVENT_DEFAULT_RE, perLine(EVENT_TO_BINDING_RE)),
     ),
     // Neither entry dispatches a REBINDABLE binding, which is what the guards
@@ -636,7 +652,7 @@ export const CHECKS = [
       "src/components/mention-autocomplete.tsx",
     ],
     message:
-      "a path that matches eventToBinding(e) against a user binding and preventDefaults it must apply the same guards as the global listener — isEditableTarget to keep typing out of it, plus the typeahead guard (src/lib/hotkeys/binding.ts) — or a single-key binding steals keystrokes from every text field; a file that dispatches no rebindable binding needs an allowlist entry with rationale",
+      "a path that matches eventToBinding(e) against a user binding and preventDefaults it must apply the same clause the global listener does — isEditableTarget, isTypeaheadTarget, and isTypeaheadKey (src/lib/hotkeys/binding.ts) — or a single-key binding steals keystrokes from text fields or typeahead lists, and named keys stop reaching the surfaces that should still get them; any subset leaves the case the missing predicate covers, and a file that dispatches no rebindable binding needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -317,6 +317,16 @@ const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
 // converted site had.
 const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 
+// An ATTRIBUTE-LESS `<Label>` open tag. Every legitimately associated label in
+// this tree carries an attribute — `htmlFor` for a single control, `id` for a
+// group caption, `className` on a styled one — and a label that WRAPS its control
+// is spelled as a plain `<label>`, so the bare form is the class itself: it names
+// nothing for assistive tech. The optional whitespace covers the formatter's
+// never-produced-here `<Label >`; a tag broken across lines is not seen, since
+// this reads per line rather than the joined view (the formatter has no reason to
+// wrap a tag with no attributes to wrap).
+const BARE_LABEL_RE = /<Label\s*>/;
+
 // The two halves of an async settings rollback. The gate: an OPTIMISTIC patch of
 // the settings cache — the file flips the preference itself so the UI can commit
 // before the store write resolves. The hit: that file's mutation `onError`
@@ -552,6 +562,25 @@ export const CHECKS = [
     allowlist: [],
     message:
       "`fallback={null}` blanks the region while the boundary is active, with no aria-busy and nothing announced to assistive tech — lazy panels use LazyPanelFallback (src/components/lazy-panel-fallback.tsx); any other fallback-taking host, or a boundary whose absence is genuinely invisible, needs an allowlist entry with rationale",
+  },
+  {
+    name: "bare-group-label",
+    appliesTo: notVendoredUi,
+    scan: perLine(BARE_LABEL_RE),
+    // Keyed per FILE, not per site: these three carry captions of the same class
+    // whose conversion belongs to their own change, and a coarser key means an
+    // unrelated edit to one of them can't turn the entry stale mid-flight. The
+    // gate blocks NEW bare captions; it is not a to-do list for these.
+    allowlist: [
+      // Two "Linked issues" captions over the linked-issue chip rows.
+      "src/features/pulls/LinkedIssuesField.tsx",
+      // "Target" over the tag/commitish picker, "Release notes" over the editor.
+      "src/features/tags/CreateReleaseDialog.tsx",
+      // "Script" over the interpreter + path row.
+      "src/features/scripts/TaskDialog.tsx",
+    ],
+    message:
+      'a `<Label>` with no attributes names nothing for assistive tech — it has no htmlFor to point at a control and wraps none, so the controls under it read as anonymous; caption a group with LabeledGroup (src/components/form/labeled-group.tsx), which pairs the label\'s id with role="group" + aria-labelledby, or give the label an htmlFor when it belongs to one control; a genuinely decorative caption needs an allowlist entry with rationale',
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -154,6 +154,15 @@ const onlyWhen = (gate, scan) => (v) => {
   return gate.test(v.text) ? scan(v) : [];
 };
 
+/** Scanner: `scan`'s hits, but only in files whose whole-file view does NOT
+ *  match `absent` — the negative twin of `onlyWhen`, for a class whose remedy is
+ *  the PRESENCE of a shared helper somewhere in the file rather than the absence
+ *  of a bad shape. Same `lastIndex` reset, for the same reason. */
+const unlessPresent = (absent, scan) => (v) => {
+  absent.lastIndex = 0;
+  return absent.test(v.text) ? [] : scan(v);
+};
+
 /** Scanner: the union of several `nearPair`s — one check, one allowlist, every
  *  Tailwind spelling of the same idiom. */
 const anyPair = (pairs) => anyOf(pairs.map(([a, b]) => nearPair(a, b)));
@@ -317,15 +326,30 @@ const ACTIVITY_JSX_RE = /<Activity(?![\w$])/;
 // converted site had.
 const NULL_FALLBACK_RE = /\bfallback\s*=\s*\{\s*null\s*\}/g;
 
-// An ATTRIBUTE-LESS `<Label>` open tag. Every legitimately associated label in
-// this tree carries an attribute — `htmlFor` for a single control, `id` for a
-// group caption, `className` on a styled one — and a label that WRAPS its control
-// is spelled as a plain `<label>`, so the bare form is the class itself: it names
-// nothing for assistive tech. The optional whitespace covers the formatter's
-// never-produced-here `<Label >`; a tag broken across lines is not seen, since
-// this reads per line rather than the joined view (the formatter has no reason to
-// wrap a tag with no attributes to wrap).
-const BARE_LABEL_RE = /<Label\s*>/;
+// A `<Label>` open tag carrying no ASSOCIATION. Only two attributes associate a
+// label with what it names — `htmlFor` for a single control, `id` for a caption
+// an `aria-labelledby` points at — so the key is those, not attribute-vs-bare:
+// `className` styles a label without naming anything. `\/?` is what also catches
+// the self-closing forms. A `<Label>` that WRAPS its control is associated at
+// RUNTIME, which no static pattern can see, so those ride the allowlist.
+// Three documented edges, all zero-instance today. Two fail OPEN: an open tag
+// broken across lines is unseen (this reads per line, not the joined view), and
+// an attribute merely ENDING in `id` (`data-id=`) satisfies the `\b` and reads
+// as associated. One fails CLOSED: both `[^>]*` spans stop at the first `>`, so
+// an attribute VALUE containing `>` ahead of the `htmlFor` (a template-literal
+// title reordered before it) hides the association and reports a correct label.
+const UNASSOCIATED_LABEL_RE =
+  /<Label(?![^>]*\b(?:htmlFor|id)\s*=)(?:\s[^>]*)?\/?>/;
+
+// A key-dispatch path that compares a live event against a user binding and
+// swallows the key, in a file that never mentions the editable-target guard.
+// Deliberately COARSE — presence of a symbol anywhere in the file, not on the
+// right path — so it can report a file that guards one handler and not the one
+// added next to it. It is a ratchet, not a proof: its job is to make a NEW
+// dispatch path stop a reader at the allowlist rather than merge unnoticed.
+const EVENT_TO_BINDING_RE = /\beventToBinding\s*\(/;
+const PREVENT_DEFAULT_RE = /\.preventDefault\s*\(/;
+const EDITABLE_GUARD_RE = /\bisEditableTarget\s*\(/;
 
 // The two halves of an async settings rollback. The gate: an OPTIMISTIC patch of
 // the settings cache — the file flips the preference itself so the UI can commit
@@ -566,21 +590,53 @@ export const CHECKS = [
   {
     name: "bare-group-label",
     appliesTo: notVendoredUi,
-    scan: perLine(BARE_LABEL_RE),
-    // Keyed per FILE, not per site: these three carry captions of the same class
-    // whose conversion belongs to their own change, and a coarser key means an
-    // unrelated edit to one of them can't turn the entry stale mid-flight. The
-    // gate blocks NEW bare captions; it is not a to-do list for these.
+    scan: perLine(UNASSOCIATED_LABEL_RE),
+    // Keyed per FILE, not per site, for both kinds of entry below: a coarser key
+    // means an unrelated edit to one of these files can't turn the entry stale
+    // mid-flight. The gate blocks NEW unassociated captions; the deferred group
+    // is not a to-do list.
     allowlist: [
+      // Deferred captions — same class, converted in their own change.
       // Two "Linked issues" captions over the linked-issue chip rows.
       "src/features/pulls/LinkedIssuesField.tsx",
       // "Target" over the tag/commitish picker, "Release notes" over the editor.
       "src/features/tags/CreateReleaseDialog.tsx",
       // "Script" over the interpreter + path row.
       "src/features/scripts/TaskDialog.tsx",
+      // WRAPPING labels around a `<Checkbox>`, associated at RUNTIME: Base UI's
+      // Root renders a `<span role="checkbox">` and routes a caller `id` to its
+      // aria-hidden proxy input, so an `htmlFor` could not reach the interactive
+      // element — instead `useAriaLabelledBy` walks from that input to the
+      // wrapping `<label>` and points the span's `aria-labelledby` at it. Correct
+      // as written; a static pattern simply cannot see it.
+      // "Protected" / "Masked in job logs" on the variable form.
+      "src/features/repo-settings/GitLabVariablesSection.tsx",
+      // "Secured" on the variable form and its repository-variable twin.
+      "src/features/repo-settings/BitbucketVariablesSection.tsx",
     ],
     message:
-      'a `<Label>` with no attributes names nothing for assistive tech — it has no htmlFor to point at a control and wraps none, so the controls under it read as anonymous; caption a group with LabeledGroup (src/components/form/labeled-group.tsx), which pairs the label\'s id with role="group" + aria-labelledby, or give the label an htmlFor when it belongs to one control; a genuinely decorative caption needs an allowlist entry with rationale',
+      'a `<Label>` with no htmlFor and no id names nothing for assistive tech, however it is styled — whatever sits under it reads as anonymous; caption a GROUP with LabeledGroup (src/components/form/labeled-group.tsx), which pairs the label\'s id with role="group" + aria-labelledby, or point a single-control label at its control with htmlFor; a label that WRAPS its control is associated at runtime and a genuinely decorative one names nothing on purpose — either needs an allowlist entry with rationale',
+  },
+  {
+    name: "unguarded-binding-dispatcher",
+    appliesTo: notVendoredUi,
+    scan: unlessPresent(
+      EDITABLE_GUARD_RE,
+      onlyWhen(PREVENT_DEFAULT_RE, perLine(EVENT_TO_BINDING_RE)),
+    ),
+    // Neither entry dispatches a REBINDABLE binding, which is what the guards
+    // protect; both are keyed per file, like every other entry here.
+    allowlist: [
+      // The shortcut RECORDER: capturing and swallowing every key, guards
+      // included, is precisely its contract — a guard would make keys
+      // unbindable.
+      "src/features/settings/KeyboardSection.tsx",
+      // Its `eventToBinding` call tests a HARDCODED mod+enter submit chord, not
+      // a user binding, so there is no rebindable dispatch to guard.
+      "src/components/mention-autocomplete.tsx",
+    ],
+    message:
+      "a path that matches eventToBinding(e) against a user binding and preventDefaults it must apply the same guards as the global listener — isEditableTarget to keep typing out of it, plus the typeahead guard (src/lib/hotkeys/binding.ts) — or a single-key binding steals keystrokes from every text field; a file that dispatches no rebindable binding needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -157,7 +157,7 @@ const onlyWhen = (gate, scan) => (v) => {
 /** Scanner: `scan`'s hits, unless the whole-file view matches EVERY regex in
  *  `required` — the negative twin of `onlyWhen`, for a class whose remedy is the
  *  PRESENCE of shared helpers rather than the absence of a bad shape. All-or-
- *  nothing on purpose: a file carrying one guard of a pair is exactly the
+ *  nothing on purpose: a file carrying any subset of `required` is exactly the
  *  half-guarded shape worth reporting. Same `lastIndex` reset, for the same
  *  reason. */
 const unlessAllPresent = (required, scan) => (v) => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -879,12 +879,19 @@ test("unguarded-binding-dispatcher needs both tokens and clears on the full clau
   );
   assert.deepEqual(unguardedDispatcher("e.preventDefault();"), []);
   // The WHOLE clause named ANYWHERE in the file clears it — the coarseness is
-  // the documented trade: presence, not proof it guards this path.
+  // the documented trade: presence, not proof it guards this path. Mirrors the
+  // canonical clause in hotkeys.tsx, because fixtures get copied.
   const guarded = [
     "function onKeyDown(e) {",
-    "  if (isEditableTarget(e.target) && !isTypeaheadKey(binding)) return;",
-    "  if (isTypeaheadTarget(e.target)) return;",
     "  const binding = eventToBinding(e);",
+    "  if (!binding) return;",
+    "  if (isEditableTarget(e.target) && !firesInEditable(binding)) return;",
+    "  if (",
+    "    !hasModifier(binding) &&",
+    "    isTypeaheadKey(binding) &&",
+    "    isTypeaheadTarget(e.target)",
+    "  )",
+    "    return;",
     "  if (binding === effective) e.preventDefault();",
     "}",
   ].join("\n");

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -53,6 +53,7 @@ const loneActivity = scanner("lone-activity-boundary");
 const seedOnOpen = scanner("seed-effect-on-open");
 const diffStatPair = scanner("hand-rolled-diff-stat");
 const nullFallback = scanner("null-suspense-fallback");
+const bareGroupLabel = scanner("bare-group-label");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -700,9 +701,10 @@ test("hand-rolled-diff-stat exempts the component file and vendored ui only", ()
 });
 
 test("null-suspense-fallback flags the literal on one line or wrapped", () => {
-  assert.deepEqual(nullFallback("<Suspense fallback={null}>{kids}</Suspense>"), [
-    1,
-  ]);
+  assert.deepEqual(
+    nullFallback("<Suspense fallback={null}>{kids}</Suspense>"),
+    [1],
+  );
   // The formatter's shape: the prop on its own line, with inner spacing.
   const wrapped = [
     "<Suspense",
@@ -722,6 +724,72 @@ test("null-suspense-fallback leaves a real fallback and a forwarded prop alone",
     "<Suspense fallback={compact ? null : <Skeleton />}>{kids}</Suspense>",
   ])
     assert.deepEqual(nullFallback(source), [], `should ignore ${source}`);
+});
+
+test("bare-group-label flags an attribute-less Label caption", () => {
+  const caption = [
+    '<div className="space-y-2">',
+    "  <Label>Rules</Label>",
+    '  <RuleToggle label="Require a pull request" checked={d.requirePr} />',
+    "</div>",
+  ].join("\n");
+  assert.deepEqual(bareGroupLabel(caption), [2]);
+  assert.deepEqual(bareGroupLabel("<Label>{label}</Label>"), [1]);
+  // Two captions in one file are two findings, so a partial conversion can't
+  // read as clean once the first is fixed.
+  const two = ["<Label>Features</Label>", "<Label>Commits</Label>"].join("\n");
+  assert.deepEqual(bareGroupLabel(two), [1, 2]);
+});
+
+test("bare-group-label leaves every ASSOCIATED label alone", () => {
+  for (const source of [
+    // The single-control idiom.
+    '<Label htmlFor="pages-cname">Custom domain</Label>',
+    // The group idiom LabeledGroup emits — the id is what names the group.
+    "<Label id={id}>{label}</Label>",
+    // A styled caption still carries an attribute.
+    '<Label className="text-xs">Only these branches</Label>',
+    // A wrapping label is a plain lowercase `<label>`, never this component.
+    '<label className="flex items-center gap-2"><Checkbox />Issues</label>',
+    // The LabeledGroup call site itself.
+    '<LabeledGroup label="Rules">{children}</LabeledGroup>',
+  ])
+    assert.deepEqual(bareGroupLabel(source), [], `should ignore ${source}`);
+  // Comment stripping keeps the doc comment that NAMES the banned shape clean.
+  assert.deepEqual(
+    bareGroupLabel("// a bare `<Label>` names nothing for assistive tech"),
+    [],
+  );
+});
+
+test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
+  const check = CHECKS.find((c) => c.name === "bare-group-label");
+  assert.equal(check.appliesTo("src/components/ui/label.tsx"), false);
+  assert.equal(check.appliesTo("src/components/form/labeled-group.tsx"), true);
+  assert.equal(
+    check.appliesTo("src/features/repo-settings/PagesSection.tsx"),
+    true,
+  );
+  // The deferred siblings are keyed per file: both of one file's captions are
+  // suppressed by its single entry, while an unlisted file still reports.
+  const files = [
+    "src/features/pulls/LinkedIssuesField.tsx",
+    "src/features/repo-settings/PagesSection.tsx",
+  ];
+  const views = new Map([
+    [
+      "src/features/pulls/LinkedIssuesField.tsx",
+      view("<Label>Linked issues</Label>\n<Label>Linked issues</Label>"),
+    ],
+    [
+      "src/features/repo-settings/PagesSection.tsx",
+      view("<Label>Source</Label>"),
+    ],
+  ]);
+  const { violations } = runCheck(check, files, views);
+  assert.deepEqual(violations, [
+    "src/features/repo-settings/PagesSection.tsx:1",
+  ]);
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {
@@ -837,9 +905,11 @@ test("compare-endpoint check flags an interpolated basehead, either side", () =>
     "repos/{slug}/compare/main...{head}",
     "repos/{slug}/compare/{base}...{owner}:{branch}?per_page=1",
   ]) {
-    const src = ["fn build() -> String {", `    format!("${template}")`, "}"].join(
-      "\n",
-    );
+    const src = [
+      "fn build() -> String {",
+      `    format!("${template}")`,
+      "}",
+    ].join("\n");
     const hits = [];
     checkCompareEndpoints("fixture.rs", src, src.split("\n"), hits);
     assert.equal(hits.length, 1, `should flag ${template}`);
@@ -854,9 +924,11 @@ test("compare-endpoint check ignores a fully literal path and the slug alone", (
     "repos/{slug}/compare/main...dev",
     "repos/{slug}/pulls/{number}",
   ]) {
-    const src = ["fn build() -> String {", `    format!("${template}")`, "}"].join(
-      "\n",
-    );
+    const src = [
+      "fn build() -> String {",
+      `    format!("${template}")`,
+      "}",
+    ].join("\n");
     const hits = [];
     checkCompareEndpoints("fixture.rs", src, src.split("\n"), hits);
     assert.deepEqual(hits, [], `should ignore ${template}`);

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -54,6 +54,7 @@ const seedOnOpen = scanner("seed-effect-on-open");
 const diffStatPair = scanner("hand-rolled-diff-stat");
 const nullFallback = scanner("null-suspense-fallback");
 const bareGroupLabel = scanner("bare-group-label");
+const unguardedDispatcher = scanner("unguarded-binding-dispatcher");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -741,15 +742,29 @@ test("bare-group-label flags an attribute-less Label caption", () => {
   assert.deepEqual(bareGroupLabel(two), [1, 2]);
 });
 
+test("bare-group-label flags a styled caption — className is not association", () => {
+  // The most common spelling of the defect: a caption that looks deliberate
+  // because it carries styling, but still names nothing.
+  for (const source of [
+    '<Label className="text-xs">Rules</Label>',
+    '<Label className="text-xs text-muted-foreground">Pending invitations</Label>',
+    // Styled AND self-closing, in both spellings.
+    '<Label className="text-xs" />',
+    "<Label/>",
+    "<Label />",
+  ])
+    assert.deepEqual(bareGroupLabel(source), [1], `should flag ${source}`);
+});
+
 test("bare-group-label leaves every ASSOCIATED label alone", () => {
   for (const source of [
     // The single-control idiom.
     '<Label htmlFor="pages-cname">Custom domain</Label>',
     // The group idiom LabeledGroup emits — the id is what names the group.
     "<Label id={id}>{label}</Label>",
-    // A styled caption still carries an attribute.
-    '<Label className="text-xs">Only these branches</Label>',
-    // A wrapping label is a plain lowercase `<label>`, never this component.
+    // Association plus styling: the id still answers for the whole tag.
+    '<Label id={invitesLabelId} className="text-xs text-muted-foreground">',
+    // A lowercase `<label>` is the DOM element, not this component.
     '<label className="flex items-center gap-2"><Checkbox />Issues</label>',
     // The LabeledGroup call site itself.
     '<LabeledGroup label="Rules">{children}</LabeledGroup>',
@@ -770,16 +785,25 @@ test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
     check.appliesTo("src/features/repo-settings/PagesSection.tsx"),
     true,
   );
-  // The deferred siblings are keyed per file: both of one file's captions are
-  // suppressed by its single entry, while an unlisted file still reports.
+  // Both kinds of entry are keyed per file: a deferred file's two captions are
+  // suppressed by its single entry, a WRAPPING label (implicit association, which
+  // neither htmlFor nor id can express) is suppressed by its own, and an unlisted
+  // file still reports.
   const files = [
     "src/features/pulls/LinkedIssuesField.tsx",
+    "src/features/repo-settings/GitLabVariablesSection.tsx",
     "src/features/repo-settings/PagesSection.tsx",
   ];
   const views = new Map([
     [
       "src/features/pulls/LinkedIssuesField.tsx",
       view("<Label>Linked issues</Label>\n<Label>Linked issues</Label>"),
+    ],
+    [
+      "src/features/repo-settings/GitLabVariablesSection.tsx",
+      view(
+        '<Label className="flex items-center gap-1.5 text-xs">\n<Checkbox checked={isProtected} />\nProtected\n</Label>',
+      ),
     ],
     [
       "src/features/repo-settings/PagesSection.tsx",
@@ -789,6 +813,61 @@ test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
   const { violations } = runCheck(check, files, views);
   assert.deepEqual(violations, [
     "src/features/repo-settings/PagesSection.tsx:1",
+  ]);
+});
+
+test("unguarded-binding-dispatcher flags a swallowing dispatch with no guard", () => {
+  // The shape the class fix closed: a second listener matching the live event
+  // against a user binding and swallowing the key, with no editable guard.
+  const source = [
+    "function onKeyDown(e) {",
+    "  const binding = eventToBinding(e);",
+    "  if (binding && binding === effective) {",
+    "    e.preventDefault();",
+    "    run();",
+    "  }",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(source), [2]);
+});
+
+test("unguarded-binding-dispatcher needs BOTH halves and clears on the guard", () => {
+  // Each token alone is ordinary: a binding read that swallows nothing, and a
+  // preventDefault with no binding comparison at all.
+  assert.deepEqual(
+    unguardedDispatcher("const hint = eventToBinding(e) ?? null;"),
+    [],
+  );
+  assert.deepEqual(unguardedDispatcher("e.preventDefault();"), []);
+  // The guard named ANYWHERE in the file clears it — the coarseness is the
+  // documented trade: presence, not proof it guards this path.
+  const guarded = [
+    "function onKeyDown(e) {",
+    "  if (isEditableTarget(e.target)) return;",
+    "  const binding = eventToBinding(e);",
+    "  if (binding === effective) e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(guarded), []);
+});
+
+test("unguarded-binding-dispatcher allowlists the non-rebindable dispatchers", () => {
+  const check = CHECKS.find((c) => c.name === "unguarded-binding-dispatcher");
+  const files = [
+    "src/features/settings/KeyboardSection.tsx",
+    "src/features/pulls/SomeNewView.tsx",
+  ];
+  const dispatcher = [
+    "const binding = eventToBinding(e);",
+    "if (binding === effective) e.preventDefault();",
+  ].join("\n");
+  const views = new Map([
+    ["src/features/settings/KeyboardSection.tsx", view(dispatcher)],
+    ["src/features/pulls/SomeNewView.tsx", view(dispatcher)],
+  ]);
+  // The recorder is exempt by contract; a NEW file with the same shape is not.
+  assert.deepEqual(runCheck(check, files, views).violations, [
+    "src/features/pulls/SomeNewView.tsx:1",
   ]);
 });
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -756,6 +756,29 @@ test("bare-group-label flags a styled caption — className is not association",
     assert.deepEqual(bareGroupLabel(source), [1], `should flag ${source}`);
 });
 
+test("bare-group-label sees an open tag the formatter split across lines", () => {
+  // The joined view is what makes this work: it trims each line and rejoins
+  // with one space, which the `\s` between attributes absorbs.
+  const split = [
+    "<Label",
+    "  key={e.id}",
+    '  className="flex items-center gap-1.5 text-xs"',
+    ">",
+    "  Trigger events",
+    "</Label>",
+  ].join("\n");
+  assert.deepEqual(bareGroupLabel(split), [1]);
+  // A split open tag that DOES associate still passes — the lookahead reaches
+  // across the rejoined attributes.
+  const splitAssociated = [
+    "<Label",
+    "  htmlFor={`${idBase}-name`}",
+    '  className="text-xs"',
+    ">",
+  ].join("\n");
+  assert.deepEqual(bareGroupLabel(splitAssociated), []);
+});
+
 test("bare-group-label leaves every ASSOCIATED label alone", () => {
   for (const source of [
     // The single-control idiom.
@@ -792,6 +815,7 @@ test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
   const files = [
     "src/features/pulls/LinkedIssuesField.tsx",
     "src/features/repo-settings/GitLabVariablesSection.tsx",
+    "src/features/repo-settings/GitLabWebhooksSection.tsx",
     "src/features/repo-settings/PagesSection.tsx",
   ];
   const views = new Map([
@@ -803,6 +827,21 @@ test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
       "src/features/repo-settings/GitLabVariablesSection.tsx",
       view(
         '<Label className="flex items-center gap-1.5 text-xs">\n<Checkbox checked={isProtected} />\nProtected\n</Label>',
+      ),
+    ],
+    // A wrapping label whose open tag the formatter split — the webhook shape.
+    [
+      "src/features/repo-settings/GitLabWebhooksSection.tsx",
+      view(
+        [
+          "<Label",
+          "  key={e.id}",
+          '  className="flex items-center gap-1.5 text-xs font-normal"',
+          ">",
+          "  <Checkbox checked={events.includes(e.id)} />",
+          "  {e.label}",
+          "</Label>",
+        ].join("\n"),
       ),
     ],
     [
@@ -831,7 +870,7 @@ test("unguarded-binding-dispatcher flags a swallowing dispatch with no guard", (
   assert.deepEqual(unguardedDispatcher(source), [2]);
 });
 
-test("unguarded-binding-dispatcher needs BOTH halves and clears on the guard", () => {
+test("unguarded-binding-dispatcher needs both tokens and clears on the full clause", () => {
   // Each token alone is ordinary: a binding read that swallows nothing, and a
   // preventDefault with no binding comparison at all.
   assert.deepEqual(
@@ -839,16 +878,58 @@ test("unguarded-binding-dispatcher needs BOTH halves and clears on the guard", (
     [],
   );
   assert.deepEqual(unguardedDispatcher("e.preventDefault();"), []);
-  // The guard named ANYWHERE in the file clears it — the coarseness is the
-  // documented trade: presence, not proof it guards this path.
+  // The WHOLE clause named ANYWHERE in the file clears it — the coarseness is
+  // the documented trade: presence, not proof it guards this path.
   const guarded = [
+    "function onKeyDown(e) {",
+    "  if (isEditableTarget(e.target) && !isTypeaheadKey(binding)) return;",
+    "  if (isTypeaheadTarget(e.target)) return;",
+    "  const binding = eventToBinding(e);",
+    "  if (binding === effective) e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(guarded), []);
+});
+
+test("unguarded-binding-dispatcher flags a HALF-guarded dispatcher", () => {
+  // The two guards refuse different surfaces, so one without the other still
+  // steals keys from the surface it does not cover.
+  const editableOnly = [
     "function onKeyDown(e) {",
     "  if (isEditableTarget(e.target)) return;",
     "  const binding = eventToBinding(e);",
     "  if (binding === effective) e.preventDefault();",
     "}",
   ].join("\n");
-  assert.deepEqual(unguardedDispatcher(guarded), []);
+  assert.deepEqual(unguardedDispatcher(editableOnly), [3]);
+  const typeaheadOnly = [
+    "function onKeyDown(e) {",
+    "  if (isTypeaheadTarget(e.target)) return;",
+    "  const binding = eventToBinding(e);",
+    "  if (binding === effective) e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(typeaheadOnly), [3]);
+  // A key-narrowing helper is NOT a substitute for either target guard.
+  const narrowingOnly = [
+    "function onKeyDown(e) {",
+    "  if (!isTypeaheadKey(binding)) return;",
+    "  const binding = eventToBinding(e);",
+    "  if (binding === effective) e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(narrowingOnly), [3]);
+  // Two of three is still a subset: both target guards without the key half
+  // is the drift shape — one dispatcher narrowing by key, its twin not.
+  const targetsOnly = [
+    "function onKeyDown(e) {",
+    "  if (isEditableTarget(e.target)) return;",
+    "  if (isTypeaheadTarget(e.target)) return;",
+    "  const binding = eventToBinding(e);",
+    "  if (binding === effective) e.preventDefault();",
+    "}",
+  ].join("\n");
+  assert.deepEqual(unguardedDispatcher(targetsOnly), [4]);
 });
 
 test("unguarded-binding-dispatcher allowlists the non-rebindable dispatchers", () => {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -489,7 +489,8 @@ export const capabilities: Capability[] = [
   // — Keyboard & Markdown —
   {
     group: "Keyboard & Markdown",
-    label: "Command palette + rebindable, filterable keys",
+    label:
+      "Command palette + rebindable, filterable keys — down to a single key",
     highlight: true,
   },
   { group: "Keyboard & Markdown", label: "Arrow-key navigation on every list" },

--- a/src/components/form/labeled-group.tsx
+++ b/src/components/form/labeled-group.tsx
@@ -1,0 +1,41 @@
+import { type ReactNode, useId } from "react";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+/** A caption that NAMES the controls under it: a bare `<Label>` with no `htmlFor`
+ *  and no wrapped control names nothing for assistive tech, so the caption's id
+ *  ties the group to it — as McpServersSection's role="group" scope groups do. */
+export function LabeledGroup({
+  label,
+  children,
+  className,
+  actions,
+}: {
+  label: ReactNode;
+  children: ReactNode;
+  /** Merged over the default spacing, so a caller adding only borders or padding
+   *  keeps it and one passing its own `space-y-*` still wins (tailwind-merge). */
+  className?: string;
+  /** Rendered opposite the caption on its own row (e.g. an Add button). */
+  actions?: ReactNode;
+}) {
+  const id = useId();
+  const caption = <Label id={id}>{label}</Label>;
+  return (
+    <div
+      role="group"
+      aria-labelledby={id}
+      className={cn("space-y-2", className)}
+    >
+      {actions ? (
+        <div className="flex items-center justify-between">
+          {caption}
+          {actions}
+        </div>
+      ) : (
+        caption
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/features/accounts/expiry.ts
+++ b/src/features/accounts/expiry.ts
@@ -1,23 +1,33 @@
 /** Whole LOCAL calendar days from today until a `YYYY-MM-DD` date (negative when
  *  past). Pure date-to-date diff — no time-of-day/timezone math, so every surface
- *  shows the same count for the same stored date. Null when unparseable. */
+ *  shows the same count for the same stored date. Null when unparseable.
+ *  A pre-Temporal runtime falls back to the legacy Date arithmetic rather than to
+ *  null: this drives the Bitbucket token-expiry warning and macOS WKWebView ships
+ *  no Temporal, so degrading would silence that warning on a whole platform. */
 export function calendarDaysUntil(
   date: string | null | undefined,
 ): number | null {
   if (!date) return null;
+  // Prefilter, not a formality: Temporal.PlainDate.from accepts more than the
+  // stored contract allows (datetime strings among them).
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
   if (!m) return null;
-  const year = Number(m[1]);
-  const month = Number(m[2]);
-  const day = Number(m[3]);
-  // LOCAL midnight of the stored date and of today; the difference is a whole number
-  // of days once rounded (Math.round absorbs the ±1h DST wobble between the two).
-  const target = new Date(year, month - 1, day).getTime();
-  const now = new Date();
-  const today = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-  ).getTime();
-  return Math.round((target - today) / 86_400_000);
+  try {
+    return Temporal.Now.plainDateISO().until(Temporal.PlainDate.from(date))
+      .days;
+  } catch {
+    const year = Number(m[1]);
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    // LOCAL midnight of the stored date and of today; the difference is a whole number
+    // of days once rounded (Math.round absorbs the ±1h DST wobble between the two).
+    const target = new Date(year, month - 1, day).getTime();
+    const now = new Date();
+    const today = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    ).getTime();
+    return Math.round((target - today) / 86_400_000);
+  }
 }

--- a/src/features/accounts/expiry.ts
+++ b/src/features/accounts/expiry.ts
@@ -3,7 +3,10 @@
  *  shows the same count for the same stored date. Null when unparseable.
  *  A pre-Temporal runtime falls back to the legacy Date arithmetic rather than to
  *  null: this drives the Bitbucket token-expiry warning and macOS WKWebView ships
- *  no Temporal, so degrading would silence that warning on a whole platform. */
+ *  no Temporal, so degrading would silence that warning on a whole platform.
+ *  That same catch also takes `PlainDate.from` rejecting an impossible date
+ *  the prefilter admits (2026-02-30), which the legacy arm rolls over into the
+ *  next month instead of reporting as unparseable. */
 export function calendarDaysUntil(
   date: string | null | undefined,
 ): number | null {

--- a/src/features/conversations/EditTitleBodyDialog.tsx
+++ b/src/features/conversations/EditTitleBodyDialog.tsx
@@ -146,8 +146,9 @@ export const EditTitleBodyDialog = withForm({
           // leak to the global commit / generate-commit-message actions behind the
           // dialog. Capturing on the Popup covers the X and every field, so the
           // preventDefault here is what actually contains each chord: mod+enter
-          // unconditionally, and the generate chord on every match for as long as
-          // the consumer HAS a Generate. A consumer that passes no `onGenerate`
+          // unconditionally, and the generate chord whenever it may fire for as
+          // long as the consumer HAS a Generate (the hook mirrors the global
+          // listener's own guards). A consumer that passes no `onGenerate`
           // (the issue views) lets it fall through untouched, which is safe:
           // the only global handler is CommitBox's, and it runs nothing unless
           // it is both mounted (Changes tab only) and enabled (never under

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2484,11 +2484,13 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
 {{ai}}- **Agent:** {{kbd:agent-toggle-terminal}} toggle the session terminal.
 {{/ai}}
 Every shortcut is **rebindable** in **Settings → Keyboard**: click a binding, press a new
-combination, and if it clashes with another action the app moves it for you. The list
-there is filterable by action name, category, or key — {{kbd:focus-filter}} jumps to the
-filter while the section is open. Many actions (creating issues/releases, repository
-settings, stash views{{ai}}, most agent commands{{/ai}}) are palette-only until you bind
-a key. Defaults match GitHub Desktop where there's an equivalent.`,
+combination, and if it clashes with another action the app moves it for you. A shortcut can
+be a single key: bare keys stay quiet while you're typing or in a menu or picker, and
+fire everywhere else. The list there is filterable by action name, category, or key —
+{{kbd:focus-filter}} jumps to the filter while the section is open. Many actions
+(creating issues/releases, repository settings, stash views{{ai}}, most agent
+commands{{/ai}}) are palette-only until you bind a key. Defaults match GitHub Desktop
+where there's an equivalent.`,
   },
   {
     id: "settings",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2485,9 +2485,9 @@ bindings (formatted for your platform) — rebind any of them in **Settings → 
 {{/ai}}
 Every shortcut is **rebindable** in **Settings → Keyboard**: click a binding, press a new
 combination, and if it clashes with another action the app moves it for you. A shortcut can
-be a single key: bare keys stay quiet while you're typing or in a menu or picker, and
-fire everywhere else. The list there is filterable by action name, category, or key —
-{{kbd:focus-filter}} jumps to the filter while the section is open. Many actions
+be a single key: a bare character key stays quiet while you're typing or in a menu or
+picker, and fires everywhere else. The list there is filterable by action name, category,
+or key — {{kbd:focus-filter}} jumps to the filter while the section is open. Many actions
 (creating issues/releases, repository settings, stash views{{ai}}, most agent
 commands{{/ai}}) are palette-only until you bind a key. Defaults match GitHub Desktop
 where there's an equivalent.`,

--- a/src/features/history/RewriteDialogs.tsx
+++ b/src/features/history/RewriteDialogs.tsx
@@ -131,8 +131,9 @@ export function SquashDialog({
   const runHead = steps.find((s) => s.hashes.length > 1)?.hashes.at(-1);
   // The generate chord writes the squashed message while this dialog is open.
   // Mounted on DialogContent so it also covers the X close button (a form
-  // SIBLING inside the Popup); the swallow is unconditional so it can't reach
-  // the global generate-commit-message action behind the dialog, and while
+  // SIBLING inside the Popup). It is swallowed here whenever it may fire (the
+  // hook mirrors the global listener's own guards), so the global
+  // generate-commit-message action can't run behind the dialog; while
   // generating it swallows but DOESN'T cancel.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && !ai.generating && Boolean(runHead),

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -186,9 +186,10 @@ export function CreateIssueDialog({
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
   // inside the Popup, so a form-level handler would miss a chord pressed with
-  // focus on X. The swallow is unconditional so it can't reach the global
-  // generate-commit-message action behind the dialog; while generating it
-  // swallows but DOESN'T cancel.
+  // focus on X. It is swallowed here whenever it may fire (the hook mirrors the
+  // global listener's own guards), so the global generate-commit-message action
+  // can't run behind the dialog; while generating it swallows but DOESN'T
+  // cancel.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -144,9 +144,10 @@ export function CreateJiraIssueDialog({
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
   // inside the Popup, so a form-level handler would miss a chord pressed with
-  // focus on X. The swallow is unconditional so it can't reach the global
-  // generate-commit-message action behind the dialog; while generating it
-  // swallows but DOESN'T cancel.
+  // focus on X. It is swallowed here whenever it may fire (the hook mirrors the
+  // global listener's own guards), so the global generate-commit-message action
+  // can't run behind the dialog; while generating it swallows but DOESN'T
+  // cancel.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -84,9 +84,10 @@ export function CreateLocalIssueDialog({
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
   // inside the Popup, so a form-level handler would miss a chord pressed with
-  // focus on X. The swallow is unconditional so it can't reach the global
-  // generate-commit-message action behind the dialog; while generating it
-  // swallows but DOESN'T cancel.
+  // focus on X. It is swallowed here whenever it may fire (the hook mirrors the
+  // global listener's own guards), so the global generate-commit-message action
+  // can't run behind the dialog; while generating it swallows but DOESN'T
+  // cancel.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -285,9 +285,10 @@ export function CreateLocalPrDialog({
           // The generate chord runs this dialog's own Generate while it's open.
           // This dialog is hoisted over the Changes tab, where the global
           // generate-commit-message action has a live handler — so while that
-          // Generate exists the chord is swallowed on every match, enabled or
-          // not. With Hide-AI on there's no Generate here at all and the chord
-          // falls through instead, which is still safe: the same flag leaves
+          // Generate exists the chord is swallowed whenever it may fire,
+          // enabled or not (the hook mirrors the global listener's own guards).
+          // With Hide-AI on there's no Generate here at all and the chord falls
+          // through instead, which is still safe: the same flag leaves
           // CommitBox's handler DISABLED and the listener only ever runs an
           // enabled one, and off the Changes tab CommitBox registers nothing.
           generateChord.onKeyDown(e);

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -685,13 +685,14 @@ export function CreatePrDialog({
             return;
           }
           // The generate chord runs this dialog's own Generate while it's open.
-          // While that Generate exists it swallows the chord on every match,
-          // enabled or not, so it can't reach the global listener and generate a
-          // commit message behind the dialog. With Hide-AI on there's no
-          // Generate here at all and the chord falls through instead — harmless,
-          // because the same flag leaves CommitBox's global handler DISABLED
-          // (the listener only ever runs an enabled one), and off the Changes
-          // tab CommitBox is unmounted and registers nothing.
+          // While that Generate exists the chord is swallowed whenever it may
+          // fire, enabled or not (the hook mirrors the global listener's own
+          // guards), so no commit message is written behind the dialog. With
+          // Hide-AI on there's no Generate here at all and the chord falls
+          // through instead — harmless, because the same flag leaves
+          // CommitBox's global handler DISABLED (the listener only ever runs an
+          // enabled one), and off the Changes tab CommitBox is unmounted and
+          // registers nothing.
           generateChord.onKeyDown(e);
         }}
       >

--- a/src/features/repo-settings/CollaboratorsSection.tsx
+++ b/src/features/repo-settings/CollaboratorsSection.tsx
@@ -1,5 +1,5 @@
 import { UserPlusIcon, XIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { toast } from "sonner";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { useRelativeNow } from "@/components/relative-time";
@@ -81,6 +81,7 @@ export function CollaboratorsSection({
   const [confirming, setConfirming] = useState<string | null>(null);
   const [activeCollab, setActiveCollab] = useState(-1);
   const [activeInvite, setActiveInvite] = useState(-1);
+  const invitesLabelId = useId();
   // `meta` is a plain string prop, so the shared clock has to be threaded in by
   // hand — `<RelativeTime>` can't render there.
   const now = useRelativeNow();
@@ -244,12 +245,12 @@ export function CollaboratorsSection({
 
       {inviteRows.length > 0 && (
         <div className="space-y-2">
-          <Label className="text-xs text-muted-foreground">
+          <Label id={invitesLabelId} className="text-xs text-muted-foreground">
             Pending invitations
           </Label>
           <div
             role="listbox"
-            aria-label="Pending invitations"
+            aria-labelledby={invitesLabelId}
             tabIndex={0}
             className="space-y-2 rounded-md outline-none focus-visible:ring-1 focus-visible:ring-ring"
             onKeyDown={listKeyboardNav({

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon, SparkleIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -368,8 +369,7 @@ function GeneralForm({
         </div>
       </div>
 
-      <div className="space-y-2">
-        <Label>Features</Label>
+      <LabeledGroup label="Features">
         <div className="grid grid-cols-2 gap-2">
           <label className="flex cursor-pointer items-center gap-2 text-xs">
             <Checkbox
@@ -400,10 +400,9 @@ function GeneralForm({
             Discussions
           </label>
         </div>
-      </div>
+      </LabeledGroup>
 
-      <div className="space-y-2">
-        <Label>Pull request merges</Label>
+      <LabeledGroup label="Pull request merges">
         <div className="grid grid-cols-3 gap-2">
           <label className="flex cursor-pointer items-center gap-2 text-xs">
             <Checkbox
@@ -480,10 +479,9 @@ function GeneralForm({
           />
           Automatically delete head branches after merge
         </label>
-      </div>
+      </LabeledGroup>
 
-      <div className="space-y-2">
-        <Label>Commits</Label>
+      <LabeledGroup label="Commits">
         <label className="flex cursor-pointer items-center gap-2 text-xs">
           <Switch
             checked={form.webCommitSignoffRequired}
@@ -491,10 +489,9 @@ function GeneralForm({
           />
           Require contributors to sign off on web-based commits
         </label>
-      </div>
+      </LabeledGroup>
 
-      <div className="space-y-2">
-        <Label>Repository</Label>
+      <LabeledGroup label="Repository">
         <label className="flex cursor-pointer items-center gap-2 text-xs">
           <Switch
             checked={form.isTemplate}
@@ -512,11 +509,10 @@ function GeneralForm({
             Allow forking
           </label>
         )}
-      </div>
+      </LabeledGroup>
 
       {settings.htmlUrl && (
-        <div className="space-y-2">
-          <Label>Only on GitHub</Label>
+        <LabeledGroup label="Only on GitHub">
           <p className="text-xs text-muted-foreground">
             GitHub doesn't expose these to apps — manage them in your browser.
           </p>
@@ -534,7 +530,7 @@ function GeneralForm({
               </li>
             ))}
           </ul>
-        </div>
+        </LabeledGroup>
       )}
 
       <GhScopesNote />

--- a/src/features/repo-settings/PagesSection.tsx
+++ b/src/features/repo-settings/PagesSection.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -285,8 +286,7 @@ function PagesEnabled({
       </div>
 
       {!isWorkflow && (
-        <div className="space-y-1.5">
-          <Label>Source</Label>
+        <LabeledGroup label="Source" className="space-y-1.5">
           <div className="flex items-end gap-2">
             <Select value={branch} onValueChange={(v) => v && setBranch(v)}>
               <SelectTrigger className="w-44">
@@ -324,7 +324,7 @@ function PagesEnabled({
               Update
             </Button>
           </div>
-        </div>
+        </LabeledGroup>
       )}
 
       <div className="space-y-1.5">

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -352,11 +352,12 @@ export function RepoSettingsDialog({
   // affordance — only the General sections have one, and they publish it here,
   // keyed by the section they mounted under so the crossfade's outgoing section
   // can't answer the chord (see `useGenerateActionSink`).
-  // The swallow below is unconditional whatever the active section: this dialog
+  // The chord is swallowed below whenever it may fire, whatever the active
+  // section (the hook mirrors the global listener's own guards): this dialog
   // opens over any tab, including Changes where the global
-  // generate-commit-message action is live, so a chord that leaked would write
-  // a commit message behind the dialog. `enabled: true` is that swallow; the
-  // published action's own gate decides whether anything actually runs.
+  // generate-commit-message action is live, so a chord that leaked would
+  // write a commit message behind the dialog. `enabled: true` is that
+  // swallow; the published action's own gate decides whether anything runs.
   const generate = useGenerateActionSink(activeSection);
   const generateChord = useGenerateChord({
     enabled: true,

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { type ComponentType, useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { NavRail, type NavRailGroup } from "@/components/NavRail";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
@@ -932,8 +933,7 @@ function WebhookForm({
         </div>
       </div>
 
-      <div className="space-y-2">
-        <Label>Events</Label>
+      <LabeledGroup label="Events">
         <label className="flex cursor-pointer items-center gap-2 text-xs">
           <Switch checked={allEvents} onCheckedChange={setAllEvents} />
           Send me everything
@@ -954,7 +954,7 @@ function WebhookForm({
             ))}
           </div>
         )}
-      </div>
+      </LabeledGroup>
 
       <div className="flex items-center justify-between gap-4">
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/repo-settings/RulesetsSection.tsx
+++ b/src/features/repo-settings/RulesetsSection.tsx
@@ -2,6 +2,7 @@ import { CaretLeftIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -641,9 +642,7 @@ function RulesetForm({
         )}
       </div>
 
-      <div className="space-y-2">
-        <Label>Rules</Label>
-
+      <LabeledGroup label="Rules">
         <RuleToggle
           label="Require a pull request before merging"
           checked={d.requirePr}
@@ -727,7 +726,7 @@ function RulesetForm({
           checked={d.requireSignatures}
           onChange={(v) => set("requireSignatures", v)}
         />
-      </div>
+      </LabeledGroup>
 
       <div className="flex items-center justify-end gap-2 pt-1">
         <Button variant="outline" onClick={onDone} disabled={pending}>

--- a/src/features/repo-settings/SecuritySection.tsx
+++ b/src/features/repo-settings/SecuritySection.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -378,8 +379,7 @@ function MoreOnGitHub({ repoPath, open }: { repoPath: string; open: boolean }) {
   const url = settings.data?.htmlUrl;
   if (!url) return null;
   return (
-    <div className="space-y-2 border-t pt-3">
-      <Label>Only on GitHub</Label>
+    <LabeledGroup label="Only on GitHub" className="space-y-2 border-t pt-3">
       <p className="text-[11px] text-muted-foreground">
         GitHub exposes no API for these — manage them in your browser.
       </p>
@@ -397,7 +397,7 @@ function MoreOnGitHub({ repoPath, open }: { repoPath: string; open: boolean }) {
           </li>
         ))}
       </ul>
-    </div>
+    </LabeledGroup>
   );
 }
 

--- a/src/features/repository/CreateBranchDialog.tsx
+++ b/src/features/repository/CreateBranchDialog.tsx
@@ -166,8 +166,9 @@ export function CreateBranchDialog({
     onName: (name) => createForm.setFieldValue("name", name),
   });
   // This dialog opens from the header over any tab, including Changes where the
-  // global generate-commit-message action is live — so the chord is swallowed
-  // here whether or not it can generate, and never reaches the commit box.
+  // global generate-commit-message action is live. The chord is swallowed here
+  // whenever it may fire, generate-capable or not (the hook mirrors the global
+  // listener's own guards), so nothing writes into the commit box behind it.
   const generateChord = useGenerateChord({
     enabled: generateAction.enabled,
     run: generateAction.run,

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -308,8 +308,9 @@ export function PublishDialog({
     });
   }
   // This dialog opens from the header over any tab, including Changes where the
-  // global generate-commit-message action is live — so the chord is swallowed
-  // here whether or not it can generate. Mounted on DialogContent, not the
+  // global generate-commit-message action is live. The chord is swallowed here
+  // whenever it may fire, generate-capable or not (the hook mirrors the global
+  // listener's own guards). Mounted on DialogContent, not the
   // <form>: the X close button is a form SIBLING inside the Popup.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && !descGen.generating,

--- a/src/features/repository/RenameBranchDialog.tsx
+++ b/src/features/repository/RenameBranchDialog.tsx
@@ -154,8 +154,9 @@ export function RenameBranchDialog({
     onName: (name) => renameForm.setFieldValue("name", name),
   });
   // This dialog opens from any branch row over any tab, including Changes where
-  // the global generate-commit-message action is live — so the chord is
-  // swallowed here whether or not it can generate.
+  // the global generate-commit-message action is live. The chord is swallowed
+  // here whenever it may fire, generate-capable or not (the hook mirrors the
+  // global listener's own guards).
   const generateChord = useGenerateChord({
     enabled: generateAction.enabled,
     run: generateAction.run,

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -24,9 +24,11 @@ export function RepoSettingsDialogFallback({
 }: {
   onOpenChange: (open: boolean) => void;
 }) {
-  // The chord must not reach the Changes-tab generator behind this frame. A
-  // defined `run` is what arms the hook's swallow at all; `enabled: false` is
-  // what keeps it from generating before the real dialog owns the chord.
+  // The Changes-tab generator must not run behind this frame. A defined `run`
+  // is what arms the hook's swallow at all, and the chord is then swallowed
+  // whenever it may fire (the hook mirrors the global listener's own guards);
+  // `enabled: false` is what keeps it from generating before the real dialog
+  // owns the chord.
   const generateChord = useGenerateChord({
     enabled: false,
     run: () => undefined,

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -219,10 +219,11 @@ export function TaskDialog({
   }
   // The generate chord drives Generate — never Analyze, which documents an
   // existing script rather than writing one. Mounted on DialogContent so it also
-  // covers the X close button (a SIBLING of the fields inside the Popup); the
-  // swallow is unconditional, including the file-source case where there's no
-  // Generate at all, so it can't reach the global generate-commit-message action
-  // behind the dialog.
+  // covers the X close button (a SIBLING of the fields inside the Popup). It is
+  // swallowed here whenever it may fire (the hook mirrors the global listener's
+  // own guards), including the file-source case where there's no Generate at
+  // all, so the global generate-commit-message action can't run behind the
+  // dialog.
   const generateChord = useGenerateChord({
     enabled:
       sourceKind === "inline" &&

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { withForm } from "@/lib/form";
 import {
+  bindingKey,
   eventToBinding,
   formatBinding,
   hasModifier,
@@ -41,20 +42,13 @@ const NAV_KEYS = new Set([
   "pagedown",
 ]);
 
-/** The key a binding ends on — its final "+"-joined token, so the `shift+`
- *  forms land in the same bucket as the bare key. A lone "+" yields "", which
- *  is in neither refuse set and therefore binds. */
-function finalKey(binding: string): string {
-  return binding.split("+").pop() ?? "";
-}
-
 /** Without a modifier, only the activation and navigation keys above are
  *  refused: each already means something on every focused surface. Every other
  *  key binds, because the dispatcher holds modifier-less bindings back wherever
  *  the keystroke is already typing or driving a menu. */
 function isBindableCombo(binding: string): boolean {
   if (hasModifier(binding)) return true;
-  const key = finalKey(binding);
+  const key = bindingKey(binding);
   return !ACTIVATION_KEYS.has(key) && !NAV_KEYS.has(key);
 }
 
@@ -67,7 +61,7 @@ function consequenceNote(binding: string): string {
     ? "while you're typing or in a menu or picker"
     : "while you're typing";
   const quiet = `${formatBinding(binding)} stays quiet ${zones}, and fires anywhere else`;
-  return finalKey(binding) === "space"
+  return bindingKey(binding) === "space"
     ? `${quiet} — including on a focused button, where it replaces the button's own Space press.`
     : `${quiet}.`;
 }
@@ -75,7 +69,7 @@ function consequenceNote(binding: string): string {
 /** Why a refused key can't stand alone. The two sets collide with different
  *  things, so each names what the bare key would have taken over. */
 function refusalNote(binding: string): string {
-  return ACTIVATION_KEYS.has(finalKey(binding))
+  return ACTIVATION_KEYS.has(bindingKey(binding))
     ? `Enter activates the focused control, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`
     : `That key scrolls and navigates on its own, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`;
 }

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -8,6 +8,7 @@ import {
   eventToBinding,
   formatBinding,
   hasModifier,
+  isTypeaheadKey,
 } from "@/lib/hotkeys/binding";
 import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import {
@@ -57,11 +58,15 @@ function isBindableCombo(binding: string): boolean {
   return !ACTIVATION_KEYS.has(key) && !NAV_KEYS.has(key);
 }
 
-/** What accepting a modifier-less binding costs. Space earns the longer line:
- *  it is the one bindable key whose native job is activating the focused
- *  control, so a live action takes that keypress instead. */
+/** What accepting a modifier-less binding costs. The menu-and-picker clause is
+ *  true only of character keys, which is all typeahead consumes; Space earns a
+ *  longer line, being the one bindable key whose native job is activating the
+ *  focused control, so a live action takes that keypress instead. */
 function consequenceNote(binding: string): string {
-  const quiet = `${formatBinding(binding)} stays quiet while you're typing or in a menu or picker, and fires anywhere else`;
+  const zones = isTypeaheadKey(binding)
+    ? "while you're typing or in a menu or picker"
+    : "while you're typing";
+  const quiet = `${formatBinding(binding)} stays quiet ${zones}, and fires anywhere else`;
   return finalKey(binding) === "space"
     ? `${quiet} — including on a focused button, where it replaces the button's own Space press.`
     : `${quiet}.`;

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -4,7 +4,11 @@ import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { withForm } from "@/lib/form";
-import { eventToBinding, formatBinding } from "@/lib/hotkeys/binding";
+import {
+  eventToBinding,
+  formatBinding,
+  hasModifier,
+} from "@/lib/hotkeys/binding";
 import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import {
   ACTIONS,
@@ -15,8 +19,12 @@ import { matchesActionText, queryTokens } from "@/lib/hotkeys/search";
 import { cn } from "@/lib/utils";
 import { settingsFormOpts } from "./settings-form";
 
-/** Keys that activate whatever control has focus. */
-const ACTIVATION_KEYS = new Set(["enter", "space"]);
+/** Keys refused without a modifier because they activate whatever has focus,
+ *  on every surface. Space is deliberately NOT here — binding a single key to
+ *  stage or select is the primary ask — so it binds, and the note on assignment
+ *  carries its cost: a live bound action takes the keypress a focused button or
+ *  checkbox would have used, and page scroll with it. */
+const ACTIVATION_KEYS = new Set(["enter"]);
 
 /** Keys that scroll or move a selection on their own. A bare binding on one
  *  preventDefaults it on every surface where the action is live, so list
@@ -33,7 +41,8 @@ const NAV_KEYS = new Set([
 ]);
 
 /** The key a binding ends on — its final "+"-joined token, so the `shift+`
- *  forms land in the same bucket as the bare key. */
+ *  forms land in the same bucket as the bare key. A lone "+" yields "", which
+ *  is in neither refuse set and therefore binds. */
 function finalKey(binding: string): string {
   return binding.split("+").pop() ?? "";
 }
@@ -43,16 +52,26 @@ function finalKey(binding: string): string {
  *  key binds, because the dispatcher holds modifier-less bindings back wherever
  *  the keystroke is already typing or driving a menu. */
 function isBindableCombo(binding: string): boolean {
-  if (binding.includes("mod+") || binding.includes("alt+")) return true;
+  if (hasModifier(binding)) return true;
   const key = finalKey(binding);
   return !ACTIVATION_KEYS.has(key) && !NAV_KEYS.has(key);
+}
+
+/** What accepting a modifier-less binding costs. Space earns the longer line:
+ *  it is the one bindable key whose native job is activating the focused
+ *  control, so a live action takes that keypress instead. */
+function consequenceNote(binding: string): string {
+  const quiet = `${formatBinding(binding)} stays quiet while you're typing or in a menu or picker, and fires anywhere else`;
+  return finalKey(binding) === "space"
+    ? `${quiet} — including on a focused button, where it replaces the button's own Space press.`
+    : `${quiet}.`;
 }
 
 /** Why a refused key can't stand alone. The two sets collide with different
  *  things, so each names what the bare key would have taken over. */
 function refusalNote(binding: string): string {
   return ACTIVATION_KEYS.has(finalKey(binding))
-    ? `Enter and Space activate the focused control, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`
+    ? `Enter activates the focused control, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`
     : `That key scrolls and navigates on its own, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`;
 }
 
@@ -135,14 +154,8 @@ export const KeyboardSection = withForm({
       // The assignment always stands; a modifier-less binding only earns a note
       // about where it stays quiet, and never over the steal message. (Chords
       // are exempt: the quiet zones named by the note don't apply to them.)
-      if (
-        !setBinding(id, binding) &&
-        !binding.includes("mod+") &&
-        !binding.includes("alt+")
-      ) {
-        setNote(
-          `${formatBinding(binding)} stays quiet while you're typing or in a menu or picker, and fires anywhere else.`,
-        );
+      if (!setBinding(id, binding) && !hasModifier(binding)) {
+        setNote(consequenceNote(binding));
       }
       setRecordingId(null);
     });

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -15,11 +15,45 @@ import { matchesActionText, queryTokens } from "@/lib/hotkeys/search";
 import { cn } from "@/lib/utils";
 import { settingsFormOpts } from "./settings-form";
 
-/** Bindings must carry a real modifier or be a function key — anything a
- *  user could type into a text field is rejected during recording. */
+/** Keys that activate whatever control has focus. */
+const ACTIVATION_KEYS = new Set(["enter", "space"]);
+
+/** Keys that scroll or move a selection on their own. A bare binding on one
+ *  preventDefaults it on every surface where the action is live, so list
+ *  navigation and scrolling die app-wide. */
+const NAV_KEYS = new Set([
+  "up",
+  "down",
+  "left",
+  "right",
+  "home",
+  "end",
+  "pageup",
+  "pagedown",
+]);
+
+/** The key a binding ends on — its final "+"-joined token, so the `shift+`
+ *  forms land in the same bucket as the bare key. */
+function finalKey(binding: string): string {
+  return binding.split("+").pop() ?? "";
+}
+
+/** Without a modifier, only the activation and navigation keys above are
+ *  refused: each already means something on every focused surface. Every other
+ *  key binds, because the dispatcher holds modifier-less bindings back wherever
+ *  the keystroke is already typing or driving a menu. */
 function isBindableCombo(binding: string): boolean {
-  if (/^f\d{1,2}$/.test(binding)) return true;
-  return binding.includes("mod+") || binding.includes("alt+");
+  if (binding.includes("mod+") || binding.includes("alt+")) return true;
+  const key = finalKey(binding);
+  return !ACTIVATION_KEYS.has(key) && !NAV_KEYS.has(key);
+}
+
+/** Why a refused key can't stand alone. The two sets collide with different
+ *  things, so each names what the bare key would have taken over. */
+function refusalNote(binding: string): string {
+  return ACTIVATION_KEYS.has(finalKey(binding))
+    ? `Enter and Space activate the focused control, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`
+    : `That key scrolls and navigates on its own, so this shortcut needs ${formatBinding("mod")} or ${formatBinding("alt")} added.`;
 }
 
 export const KeyboardSection = withForm({
@@ -43,7 +77,9 @@ export const KeyboardSection = withForm({
       return ACTIONS.find((a) => a.id === id)?.defaultBinding ?? null;
     };
 
-    function setBinding(id: string, binding: string | null) {
+    /** Assigns or clears a binding, returning true when it posted the steal
+     *  message — that note outranks any softer one the caller would add. */
+    function setBinding(id: string, binding: string | null): boolean {
       const next = { ...overrides };
       let stolenFrom: string | null = null;
       if (binding) {
@@ -61,11 +97,12 @@ export const KeyboardSection = withForm({
       if (binding === def) delete next[id];
       else next[id] = binding;
       form.setFieldValue("hotkeys", next);
-      setNote(
+      const stealNote =
         stolenFrom && binding
           ? `${formatBinding(binding)} was taken from "${stolenFrom}", which is now unbound.`
-          : null,
-      );
+          : null;
+      setNote(stealNote);
+      return stealNote !== null;
     }
 
     // While recording, capture every keypress before the app's own hotkey
@@ -92,12 +129,21 @@ export const KeyboardSection = withForm({
       const binding = eventToBinding(e);
       if (!binding) return; // bare modifier — keep waiting
       if (!isBindableCombo(binding)) {
-        setNote(
-          `Shortcuts need a modifier (${formatBinding("mod")} or ${formatBinding("alt")}) or a function key, so they can't collide with typing.`,
-        );
+        setNote(refusalNote(binding));
         return;
       }
-      setBinding(id, binding);
+      // The assignment always stands; a modifier-less binding only earns a note
+      // about where it stays quiet, and never over the steal message. (Chords
+      // are exempt: the quiet zones named by the note don't apply to them.)
+      if (
+        !setBinding(id, binding) &&
+        !binding.includes("mod+") &&
+        !binding.includes("alt+")
+      ) {
+        setNote(
+          `${formatBinding(binding)} stays quiet while you're typing or in a menu or picker, and fires anywhere else.`,
+        );
+      }
       setRecordingId(null);
     });
 

--- a/src/features/settings/SyntaxSection.tsx
+++ b/src/features/settings/SyntaxSection.tsx
@@ -8,6 +8,7 @@ import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -266,8 +267,7 @@ function CustomLanguageDialog({
 
             {/* Right: comments, strings, options */}
             <div className="flex flex-col gap-5">
-              <div className="space-y-2">
-                <Label>Comments</Label>
+              <LabeledGroup label="Comments">
                 <div className="grid grid-cols-3 gap-2">
                   <div className="space-y-1.5">
                     <Label
@@ -315,7 +315,7 @@ function CustomLanguageDialog({
                     />
                   </div>
                 </div>
-              </div>
+              </LabeledGroup>
 
               <div className="space-y-2">
                 <Label htmlFor="cl-strings">String delimiters</Label>

--- a/src/features/settings/mcp/EntryEditor.tsx
+++ b/src/features/settings/mcp/EntryEditor.tsx
@@ -4,9 +4,9 @@ import {
   PlusIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import type { EntryRow } from "./shared";
 
 /** The env-var / header rows editor inside the dialog. Each row can hold a plain
@@ -29,13 +29,14 @@ export function EntryEditor({
   onRemove: (rowId: string) => void;
 }) {
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label>{label}</Label>
+    <LabeledGroup
+      label={label}
+      actions={
         <Button type="button" variant="ghost" size="sm" onClick={onAdd}>
           <PlusIcon data-icon="inline-start" /> Add
         </Button>
-      </div>
+      }
+    >
       {rows.length === 0 ? (
         <p className="text-xs text-muted-foreground">None.</p>
       ) : (
@@ -105,6 +106,6 @@ export function EntryEditor({
           ))}
         </div>
       )}
-    </div>
+    </LabeledGroup>
   );
 }

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -1,4 +1,5 @@
 import { useId, useState } from "react";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -215,8 +216,7 @@ export function McpServerDialog({
                 spellCheck={false}
               />
             </div>
-            <div className="space-y-2">
-              <Label>Transport</Label>
+            <LabeledGroup label="Transport">
               <div className="flex gap-1">
                 {(["stdio", "http"] as const).map((t) => (
                   <Button
@@ -232,7 +232,7 @@ export function McpServerDialog({
                   </Button>
                 ))}
               </div>
-            </div>
+            </LabeledGroup>
           </div>
 
           <div className="space-y-2">

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -256,9 +256,10 @@ export function CreateReleaseDialog({
 
   // The generate chord drives the AI item only — never the From-GitHub one, and
   // it never opens the dropdown. Mounted on DialogContent, not the <form>: the X
-  // close button is a form SIBLING inside the Popup. The swallow is
-  // unconditional so the chord can't reach the global generate-commit-message
-  // action behind the dialog; while generating it swallows but DOESN'T cancel.
+  // close button is a form SIBLING inside the Popup. It is swallowed here
+  // whenever it may fire (the hook mirrors the global listener's own guards),
+  // so the global generate-commit-message action can't run behind the dialog;
+  // while generating it swallows but DOESN'T cancel.
   const generateChord = useGenerateChord({
     enabled: aiEnabled && Boolean(tagTrimmed) && !busyGenerating,
     run: generateWithAi,

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -183,6 +183,39 @@ function pushRejectionSummary(text: string): string | null {
   return PUSH_REJECTION_SUMMARIES.find(([m]) => m.test(text))?.[1] ?? null;
 }
 
+/** Transport and sideband refusals — the remote answering the connection rather
+ *  than rejecting a ref, so they are deliberately separate from the per-ref
+ *  `! [rejected]` family above. Every pattern is line-anchored, since the same
+ *  blob echoes URLs, paths, and commit subjects. ORDER IS PRECEDENCE: a
+ *  repository-state refusal carries git's generic 403 line in the same blob, so
+ *  it must be read before that line's own entry. Shapes measured verbatim
+ *  against github.com on git 2.51.1.windows.1, 2026-09; the mirror line is a
+ *  Gitea server's, from a user report. */
+const REMOTE_ACCESS_SUMMARIES: readonly (readonly [RegExp, string])[] = [
+  [
+    /^[ \t]*remote: .*\b[Rr]ead-only\b/m,
+    "The remote reports this repository as read-only (usually a mirror or an archived repository), so different credentials won't change the answer. If it mirrors another repository, push there instead.",
+  ],
+  [
+    /^fatal: could not read Username for /m,
+    "No credentials are stored for this remote, and GitDesktop never lets Git prompt for them. Add them to your Git credential helper, then try again.",
+  ],
+  [
+    /^fatal: Authentication failed for /m,
+    "The remote rejected the credentials it was given. Update them in your Git credential helper, then try again.",
+  ],
+  [
+    /^fatal: unable to access '[^'\n]*': The requested URL returned error: 403/m,
+    "The remote recognizes the account but it lacks permission for this operation on this repository. Ask an owner for access, or check that the credentials in use belong to the account you expect.",
+  ],
+];
+
+/** The humanized line for a remote refusing access, or null when the text
+ *  carries none of the mapped shapes. */
+function remoteAccessSummary(text: string): string | null {
+  return REMOTE_ACCESS_SUMMARIES.find(([m]) => m.test(text))?.[1] ?? null;
+}
+
 /** Windows MAX_PATH refusals. git prints its reason as the TAIL of a diagnostic
  *  (`fatal: cannot create directory at '<path>': Filename too long`, measured on
  *  git 2.51.1.windows.1), so the marker is end-anchored like `: needs merge`
@@ -461,6 +494,7 @@ export function presentError(e: unknown): ErrorPresentation {
       (isConflict
         ? conflictSummary(combined)
         : (pushRejectionSummary(combined) ??
+          remoteAccessSummary(combined) ??
           (firstMeaningfulLine(message) || label)));
 
     const distinctStderr = stderr !== "" && !message.includes(stderr);

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -188,12 +188,14 @@ function pushRejectionSummary(text: string): string | null {
  *  `! [rejected]` family above. Every pattern is line-anchored, since the same
  *  blob echoes URLs, paths, and commit subjects. ORDER IS PRECEDENCE: a
  *  repository-state refusal carries git's generic 403 line in the same blob, so
- *  it must be read before that line's own entry. Shapes measured verbatim
- *  against github.com on git 2.51.1.windows.1, 2026-09; the mirror line is a
- *  Gitea server's, from a user report. */
+ *  it must be read before that line's own entry. The read-only line must also
+ *  name a repository: that token is what keeps the summary's claim scoped to
+ *  the whole repository. Shapes measured verbatim against github.com on git
+ *  2.51.1.windows.1, 2026-09; the mirror line is a Gitea server's, from a user
+ *  report. */
 const REMOTE_ACCESS_SUMMARIES: readonly (readonly [RegExp, string])[] = [
   [
-    /^[ \t]*remote: .*\b[Rr]ead-only\b/m,
+    /^[ \t]*remote: (?=.*\b[Rr]epositor(?:y|ies)\b).*\b[Rr]ead-only\b/m,
     "The remote reports this repository as read-only (usually a mirror or an archived repository), so different credentials won't change the answer. If it mirrors another repository, push there instead.",
   ],
   [

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -154,16 +154,24 @@ export function isEditableTarget(target: EventTarget | null): boolean {
 }
 
 /** Surfaces that consume plain keystrokes without being editable targets, where
- *  a bare-key binding would double-act. `combobox` is the measured case: a
+ *  a bare-key binding would double-act — the target half of the pair, with
+ *  {@link isTypeaheadKey} as the key half. `combobox` is the measured case: a
  *  CLOSED Base UI select trigger runs value-mutating typeahead with no
- *  preventDefault. The menu arms are our own invariant, since open Base UI
- *  popups stop character keys but not named ones. `listbox` is excluded: the
- *  app's lists navigate by arrows alone and are its primary keyboard surfaces. */
+ *  preventDefault. `listbox` is excluded: the app's lists navigate by arrows
+ *  alone and are its primary keyboard surfaces. */
 export function isTypeaheadTarget(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
   return (
     target.closest('[role="menu"],[role="menubar"],[role="combobox"]') !== null
   );
+}
+
+/** Whether a binding is the kind of keystroke a typeahead surface consumes — a
+ *  printable character. Named keys (f1, f5, …) are not typeahead input, so a
+ *  registered one still has to reach the listener's preventDefault. */
+export function isTypeaheadKey(binding: string): boolean {
+  const key = binding.split("+").pop() ?? "";
+  return key.length === 1 || key === "space";
 }
 
 /** Native text-editing combos a hotkey must never shadow while typing. */

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -153,6 +153,19 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 }
 
+/** Surfaces that consume plain keystrokes without being editable targets, where
+ *  a bare-key binding would double-act. `combobox` is the measured case: a
+ *  CLOSED Base UI select trigger runs value-mutating typeahead with no
+ *  preventDefault. The menu arms are our own invariant, since open Base UI
+ *  popups stop character keys but not named ones. `listbox` is excluded: the
+ *  app's lists navigate by arrows alone and are its primary keyboard surfaces. */
+export function isTypeaheadTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return (
+    target.closest('[role="menu"],[role="menubar"],[role="combobox"]') !== null
+  );
+}
+
 /** Native text-editing combos a hotkey must never shadow while typing. */
 const EDITING_COMBOS = new Set([
   "mod+a",

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -170,7 +170,7 @@ export function isTypeaheadTarget(target: EventTarget | null): boolean {
  *  printable character. Named keys (f1, f5, …) are not typeahead input, so a
  *  registered one still has to reach the listener's preventDefault. */
 export function isTypeaheadKey(binding: string): boolean {
-  const key = binding.split("+").pop() ?? "";
+  const key = bindingKey(binding);
   return key.length === 1 || key === "space";
 }
 
@@ -191,6 +191,12 @@ const EDITING_COMBOS = new Set([
  *  test, so the predicate can't drift between them. */
 export function hasModifier(binding: string): boolean {
   return binding.includes("mod+") || binding.includes("alt+");
+}
+
+/** The key token of a canonical binding — whatever follows the fixed
+ *  mod → alt → shift prefix, so the `+` key survives (`shift++` → `+`). */
+export function bindingKey(binding: string): string {
+  return binding.replace(/^(?:mod\+)?(?:alt\+)?(?:shift\+)?/, "");
 }
 
 /**

--- a/src/lib/hotkeys/binding.ts
+++ b/src/lib/hotkeys/binding.ts
@@ -178,12 +178,18 @@ const EDITING_COMBOS = new Set([
   "mod+shift+v",
 ]);
 
+/** Whether a binding carries a real modifier — plain keys and `shift+key` are
+ *  typing. Every dispatcher gates its editable and typeahead guards on this one
+ *  test, so the predicate can't drift between them. */
+export function hasModifier(binding: string): boolean {
+  return binding.includes("mod+") || binding.includes("alt+");
+}
+
 /**
- * Whether a binding is allowed to fire while focus sits in a text field:
- * it must carry a real modifier (plain keys and shift+key are typing) and
- * not collide with the native editing combos.
+ * Whether a binding is allowed to fire while focus sits in a text field: it
+ * must carry a real modifier and not collide with the native editing combos.
  */
 export function firesInEditable(binding: string): boolean {
-  if (!binding.includes("mod+") && !binding.includes("alt+")) return false;
+  if (!hasModifier(binding)) return false;
   return !EDITING_COMBOS.has(binding);
 }

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -10,6 +10,7 @@ import {
   firesInEditable,
   hasModifier,
   isEditableTarget,
+  isTypeaheadKey,
   isTypeaheadTarget,
 } from "./binding";
 import { ACTIONS, type ActionId } from "./registry";
@@ -145,7 +146,12 @@ export function useHotkeysListener() {
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
     // Typeahead surfaces only ever swallow modifier-less bindings: a mod/alt
     // chord is not something they can consume, so it keeps firing everywhere.
-    if (!hasModifier(binding) && isTypeaheadTarget(e.target)) return;
+    if (
+      !hasModifier(binding) &&
+      isTypeaheadKey(binding) &&
+      isTypeaheadTarget(e.target)
+    )
+      return;
     const id = byBinding.get(binding);
     // Registered-vs-unregistered rule. A chord OWNED by an on-screen surface —
     // an action with at least one live handler, even a disabled one — must

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -8,6 +8,7 @@ import { useSettings } from "@/lib/settings/queries";
 import {
   eventToBinding,
   firesInEditable,
+  hasModifier,
   isEditableTarget,
   isTypeaheadTarget,
 } from "./binding";
@@ -144,12 +145,7 @@ export function useHotkeysListener() {
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
     // Typeahead surfaces only ever swallow modifier-less bindings: a mod/alt
     // chord is not something they can consume, so it keeps firing everywhere.
-    if (
-      !binding.includes("mod+") &&
-      !binding.includes("alt+") &&
-      isTypeaheadTarget(e.target)
-    )
-      return;
+    if (!hasModifier(binding) && isTypeaheadTarget(e.target)) return;
     const id = byBinding.get(binding);
     // Registered-vs-unregistered rule. A chord OWNED by an on-screen surface —
     // an action with at least one live handler, even a disabled one — must

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -5,7 +5,12 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useSettings } from "@/lib/settings/queries";
-import { eventToBinding, firesInEditable, isEditableTarget } from "./binding";
+import {
+  eventToBinding,
+  firesInEditable,
+  isEditableTarget,
+  isTypeaheadTarget,
+} from "./binding";
 import { ACTIONS, type ActionId } from "./registry";
 
 interface HandlerEntry {
@@ -137,6 +142,14 @@ export function useHotkeysListener() {
     const binding = eventToBinding(e);
     if (!binding) return;
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
+    // Typeahead surfaces only ever swallow modifier-less bindings: a mod/alt
+    // chord is not something they can consume, so it keeps firing everywhere.
+    if (
+      !binding.includes("mod+") &&
+      !binding.includes("alt+") &&
+      isTypeaheadTarget(e.target)
+    )
+      return;
     const id = byBinding.get(binding);
     // Registered-vs-unregistered rule. A chord OWNED by an on-screen surface —
     // an action with at least one live handler, even a disabled one — must

--- a/src/lib/hotkeys/hotkeys.tsx
+++ b/src/lib/hotkeys/hotkeys.tsx
@@ -144,8 +144,9 @@ export function useHotkeysListener() {
     const binding = eventToBinding(e);
     if (!binding) return;
     if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
-    // Typeahead surfaces only ever swallow modifier-less bindings: a mod/alt
-    // chord is not something they can consume, so it keeps firing everywhere.
+    // Typeahead surfaces only ever swallow modifier-less bindings, and only
+    // character keys, which is all typeahead consumes: a mod/alt chord and a
+    // named key alike keep firing everywhere.
     if (
       !hasModifier(binding) &&
       isTypeaheadKey(binding) &&

--- a/src/lib/hotkeys/useGenerateChord.ts
+++ b/src/lib/hotkeys/useGenerateChord.ts
@@ -1,5 +1,12 @@
 import { createContext, useContext, useEffect, useMemo, useRef } from "react";
-import { eventToBinding, formatBinding } from "./binding";
+import {
+  eventToBinding,
+  firesInEditable,
+  formatBinding,
+  hasModifier,
+  isEditableTarget,
+  isTypeaheadTarget,
+} from "./binding";
 import { useEffectiveBindings } from "./hotkeys";
 
 /** What a surface does when the generate chord fires there. */
@@ -21,9 +28,19 @@ export interface GenerateAction {
  * cleared it, and the chord stays fully inert.
  *
  * Swallowing follows the generator, not its enabled state: while this surface
- * HAS a generator the chord is swallowed on every match, before `enabled` is
- * consulted, so a disabled Generate can't let the chord reach the global
- * listener. `run` undefined means the surface has no generator at all — Hide-AI
+ * HAS a generator the chord is swallowed before `enabled` is consulted, so a
+ * disabled Generate can't let the chord reach the global listener.
+ *
+ * Two rebinds are declined rather than swallowed, mirroring the guards the
+ * global listener applies to the same keystroke. In a text field: a binding
+ * carrying no real modifier (a bare or shift-only key), or one of the native
+ * editing combos `firesInEditable` excludes (mod+z, mod+c, …). In a menu,
+ * menubar, or select trigger: a binding carrying no real modifier. Nothing
+ * generates behind a dialog in either case, because the global listener
+ * declines exactly the same keystrokes — what this hook lets past is what that
+ * listener will not act on either.
+ *
+ * `run` undefined means the surface has no generator at all — Hide-AI
  * removed it, or a shared dialog's host passes none — and the chord falls
  * through untouched instead. Nothing generates behind a dialog in that arm
  * either, because the global handlers are the two commit surfaces' (the box and
@@ -51,6 +68,8 @@ export function useGenerateChord({
     onKeyDown: (e) => {
       if (binding === null || run === undefined || e.repeat) return;
       if (eventToBinding(e) !== binding) return;
+      if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
+      if (!hasModifier(binding) && isTypeaheadTarget(e.target)) return;
       e.preventDefault();
       if (enabled) run();
     },
@@ -94,8 +113,9 @@ export const GenerateActionContext = createContext<GenerateActionSink | null>(
  * Shell side of {@link GenerateActionContext}, for a container that owns the
  * chord but not the generator — a settings dialog whose sections come and go.
  * Provide `sink` on the context and call `runPublished` from the chord handler;
- * the swallow stays unconditional, so the chord can never leak out of the
- * shell, and a section without a generator makes it a no-op.
+ * the swallow follows {@link useGenerateChord}'s contract, so the chord can
+ * never leak out of the shell, and a section without a generator makes it a
+ * no-op.
  *
  * `activeKey` is what makes the published action safe to run. Under an
  * `AnimatePresence mode="wait"` crossfade the OUTGOING section stays mounted —

--- a/src/lib/hotkeys/useGenerateChord.ts
+++ b/src/lib/hotkeys/useGenerateChord.ts
@@ -5,6 +5,7 @@ import {
   formatBinding,
   hasModifier,
   isEditableTarget,
+  isTypeaheadKey,
   isTypeaheadTarget,
 } from "./binding";
 import { useEffectiveBindings } from "./hotkeys";
@@ -31,14 +32,15 @@ export interface GenerateAction {
  * HAS a generator the chord is swallowed before `enabled` is consulted, so a
  * disabled Generate can't let the chord reach the global listener.
  *
- * Two rebinds are declined rather than swallowed, mirroring the guards the
- * global listener applies to the same keystroke. In a text field: a binding
+ * Two kinds of rebind are declined rather than swallowed, mirroring the guards
+ * the global listener applies to the same keystroke. In a text field: a binding
  * carrying no real modifier (a bare or shift-only key), or one of the native
  * editing combos `firesInEditable` excludes (mod+z, mod+c, …). In a menu,
- * menubar, or select trigger: a binding carrying no real modifier. Nothing
- * generates behind a dialog in either case, because the global listener
- * declines exactly the same keystrokes — what this hook lets past is what that
- * listener will not act on either.
+ * menubar, or select trigger: a binding carrying no real modifier whose key is
+ * a character, which is all those surfaces consume. Nothing generates behind a
+ * dialog in either case, because the global listener declines exactly the same
+ * keystrokes — what this hook lets past is what that listener will not act on
+ * either.
  *
  * `run` undefined means the surface has no generator at all — Hide-AI
  * removed it, or a shared dialog's host passes none — and the chord falls
@@ -69,7 +71,12 @@ export function useGenerateChord({
       if (binding === null || run === undefined || e.repeat) return;
       if (eventToBinding(e) !== binding) return;
       if (isEditableTarget(e.target) && !firesInEditable(binding)) return;
-      if (!hasModifier(binding) && isTypeaheadTarget(e.target)) return;
+      if (
+        !hasModifier(binding) &&
+        isTypeaheadKey(binding) &&
+        isTypeaheadTarget(e.target)
+      )
+        return;
       e.preventDefault();
       if (enabled) run();
     },


### PR DESCRIPTION
Keyboard shortcuts no longer have to carry a modifier: a bare key can be recorded in Settings → Keyboard, and the dispatcher holds modifier-less bindings back on the surfaces that already consume plain keystrokes. Alongside that, group captions across the settings surfaces now actually name their controls for assistive tech, and a remote refusing a push explains itself in one line.

### Single-key shortcuts

- Relaxes `isBindableCombo` in `src/features/settings/KeyboardSection.tsx`: `mod+`/`alt+` chords always bind, and any other key binds unless its final token is an activation key (`enter`, `space`) or a navigation key (arrows, `home`/`end`, `pageup`/`pagedown`). `finalKey` splits on `+` so `shift+`-prefixed forms land in the same bucket as the bare key.
- Adds `refusalNote` in the same file so a refused key says which thing it would have taken over (activating the focused control vs. scrolling and navigating), and adds a note on accepted bare keys explaining that they stay quiet while typing or in a menu or picker.
- `setBinding` now returns whether it posted the "taken from another action" steal message, so the softer bare-key note never overwrites it.
- Adds `isTypeaheadTarget` to `src/lib/hotkeys/binding.ts` — a `closest()` match on `[role="menu"]`, `[role="menubar"]`, and `[role="combobox"]`. `listbox` is deliberately excluded, since the app's lists navigate by arrows alone.
- Wires that guard into `useHotkeysListener` in `src/lib/hotkeys/hotkeys.tsx`, bailing only for modifier-less bindings; chords still fire on those surfaces.

### Group captions and accessibility

- Adds `LabeledGroup` (`src/components/form/labeled-group.tsx`), which pairs a `<Label id>` caption with `role="group"` + `aria-labelledby`, merges a caller `className` over the default `space-y-2`, and takes an optional `actions` node rendered opposite the caption.
- Converts the bare `<Label>` group captions to it: `GeneralSettingsSection.tsx` (Features, Pull request merges, Commits, Repository, Only on GitHub), `RulesetsSection.tsx` (Rules), `RepoSettingsDialog.tsx` (webhook Events), `SecuritySection.tsx`, `PagesSection.tsx` (Source), `SyntaxSection.tsx` (Comments), `settings/mcp/McpServerDialog.tsx` (Transport), and `settings/mcp/EntryEditor.tsx`, whose Add button moves into the new `actions` slot.
- `CollaboratorsSection.tsx` gives the "Pending invitations" caption a `useId` and points the listbox at it with `aria-labelledby`, replacing the duplicated `aria-label`.
- Adds a `bare-group-label` guard to `scripts/check-banned-patterns.mjs` that flags an attribute-less `<Label>` open tag, with a per-file allowlist for `LinkedIssuesField.tsx`, `CreateReleaseDialog.tsx`, and `TaskDialog.tsx` whose conversions belong to their own change.
- Covers the guard in `scripts/checks.test.mjs`: flagged captions (including two in one file), every associated-label shape it must ignore, vendored-ui exemption, and whole-file allowlist behavior.

### Push failure messages

- Adds `REMOTE_ACCESS_SUMMARIES` and `remoteAccessSummary` to `src/lib/error-summary.ts`, mapping four line-anchored remote refusals to a single explanatory line: a read-only mirror or archived repository, no stored credentials (`could not read Username for`), rejected credentials (`Authentication failed for`), and a generic HTTP 403. Order is precedence, since a repository-state refusal echoes the 403 line in the same blob.
- Hooks it into `presentError` after `pushRejectionSummary`, so per-ref `! [rejected]` handling keeps priority.

### Docs and changelog

- Updates the keyboard-shortcuts section of `src/features/help/content.ts` to describe single-key bindings and where they stay quiet.
- Adds three fragments: `changelog.d/changed-single-key-shortcuts.md`, `changelog.d/fixed-settings-group-labels.md`, and `changelog.d/fixed-push-failure-reasons.md`.
- Records the group-caption rule and the new guard in `.claude/skills/gd-conventions/SKILL.md`, naming the existing idioms that keep their own aria wiring.

### Other

- `src/features/accounts/expiry.ts` computes `calendarDaysUntil` with `Temporal.Now.plainDateISO().until(...)`, keeping the existing local-midnight `Date` arithmetic as a `catch` fallback for runtimes without Temporal (macOS WKWebView), so the Bitbucket token-expiry warning can't go silent on a platform. The `YYYY-MM-DD` regex stays as a prefilter, since `Temporal.PlainDate.from` accepts more than the stored contract allows.
- Reformats a few unrelated assertions in `scripts/checks.test.mjs` to the formatter's shape.

Relates to #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Keyboard shortcuts can now be assigned to a single key, including Space, and remain inactive while typing or navigating menus and pickers.
- **Bug Fixes**
  - Push, fetch, and clone failures now display clearer, single-line explanations for read-only, archived, authentication, and permission-related errors.
- **Accessibility**
  - Improved screen-reader announcements and accessible labeling for settings controls, pending invitations, form sections, dialogs, and grouped controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->