### PR TITLE
fix(pull,branches,ai-ignore): keep local tags and hide update checkouts

### DIFF
--- a/changelog.d/fixed-branch-update-hidden-staging.md
+++ b/changelog.d/fixed-branch-update-hidden-staging.md
@@ -1,3 +1,3 @@
 - While **Update from** brings a branch up to date behind the scenes, the
-  Worktrees manager and the branch lists stay yours alone: every entry they show
-  is a worktree you created.
+  Worktrees manager and the branch lists show only your own work: the update's
+  temporary checkout stays out of both.

--- a/changelog.d/fixed-branch-update-hidden-staging.md
+++ b/changelog.d/fixed-branch-update-hidden-staging.md
@@ -1,0 +1,3 @@
+- While **Update from** brings a branch up to date behind the scenes, the
+  Worktrees manager and the branch lists stay yours alone: every entry they show
+  is a worktree you created.

--- a/changelog.d/fixed-pull-fetch-tag-prune.md
+++ b/changelog.d/fixed-pull-fetch-tag-prune.md
@@ -1,3 +1,4 @@
-- Pulls keep your local tags on repositories configured to prune tags, and
-  repositories whose remote fetches into local branches (mirror-style refspecs)
-  pull the way plain `git pull` does.
+- Pulls and fetches keep the local tags a `fetch.pruneTags` configuration would
+  prune, and repositories whose remote fetch writes outside the usual
+  remote-tracking refs (mirror-style refspecs) pull the way plain `git pull`
+  does.

--- a/changelog.d/fixed-pull-fetch-tag-prune.md
+++ b/changelog.d/fixed-pull-fetch-tag-prune.md
@@ -1,0 +1,3 @@
+- Pulls keep your local tags on repositories configured to prune tags, and
+  repositories whose remote fetches into local branches (mirror-style refspecs)
+  pull the way plain `git pull` does.

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -35,7 +35,7 @@ use tokio::sync::OnceCell;
 
 use crate::error::{AppError, AppResult};
 use crate::git::diff::{parse_numstat_z_rows, DiffStatRow};
-use crate::git::runner::{run_git, run_git_raw, run_git_raw_input, DEFAULT_TIMEOUT};
+use crate::git::runner::{run_git, run_git_raw, run_git_raw_input_bytes, DEFAULT_TIMEOUT};
 use crate::git::types::DiffStatEntry;
 
 /// The lines of an AI-ignore list the matcher acts on — trimmed, with blanks and
@@ -145,11 +145,16 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 }
 
 /// `check-ignore` over `paths` with `lines` as the only rules in play, returning
-/// its raw `-z` stdout and the excludes-file path exactly as `core.excludesFile`
-/// received it — git echoes that spelling back as a verbose record's `<source>`
-/// (measured, git 2.51.1), so the caller can verify a record came from OUR list.
-/// `verbose` selects the four-token `<source> <linenum> <pattern> <path>` records
-/// instead of bare paths.
+/// its raw `-z` stdout BYTES and the excludes-file path exactly as
+/// `core.excludesFile` received it — git echoes that spelling back as a verbose
+/// record's `<source>` (measured, git 2.51.1), so the caller can verify a record
+/// came from OUR list. `verbose` selects the four-token
+/// `<source> <linenum> <pattern> <path>` records instead of bare paths.
+///
+/// Names are bytes in both directions, because git's matcher is: a name that is
+/// not valid UTF-8 has no `&str` spelling, and decoding one loses the very bytes
+/// the user's patterns were written against. Pattern LINES stay text — they come
+/// from settings the user typed.
 ///
 /// The one spawn path of the AI-ignore engine: every property below is part of
 /// the privacy boundary, so no caller re-derives one.
@@ -175,10 +180,10 @@ async fn neutral_repo() -> AppResult<PathBuf> {
 /// as a backstop.
 async fn run_check_ignore(
     repo_path: &str,
-    paths: &[String],
+    paths: &[Vec<u8>],
     lines: &[&str],
     verbose: bool,
-) -> AppResult<(String, String)> {
+) -> AppResult<(Vec<u8>, String)> {
     let icase = repo_ignorecase(repo_path).await;
     let neutral = neutral_repo().await?.to_string_lossy().into_owned();
 
@@ -204,8 +209,11 @@ async fn run_check_ignore(
     let excludes_arg = excludes_file.to_string_lossy().replace('\\', "/");
     let result = async {
         let config = format!("core.excludesFile={excludes_arg}");
-        let mut stdin = paths.join("\0");
-        stdin.push('\0');
+        let mut stdin: Vec<u8> = Vec::new();
+        for path in paths {
+            stdin.extend_from_slice(path);
+            stdin.push(0);
+        }
         let case = format!("core.ignorecase={icase}");
         let mut args: Vec<&str> = vec![
             "-c",
@@ -220,7 +228,8 @@ async fn run_check_ignore(
         if verbose {
             args.push("--verbose");
         }
-        let out = run_git_raw_input(Some(&neutral), &args, Some(&stdin), DEFAULT_TIMEOUT).await?;
+        let out =
+            run_git_raw_input_bytes(Some(&neutral), &args, Some(&stdin), DEFAULT_TIMEOUT).await?;
         // 0 = at least one path matched a rule, 1 = none did (not an error).
         if out.code > 1 {
             return Err(AppError::Git {
@@ -228,7 +237,7 @@ async fn run_check_ignore(
                 stderr: out.stderr,
             });
         }
-        Ok(out.stdout_lossy())
+        Ok(out.stdout)
     }
     .await;
 
@@ -251,11 +260,42 @@ async fn run_check_ignore(
 /// to `[]` without spawning git; so does "nothing matched" (check-ignore's exit
 /// code 1, which is not an error). The spawn itself, and the security properties
 /// around it, live in [`run_check_ignore`].
+///
+/// A `String` can only spell a name that decoded cleanly, so callers holding a
+/// name's real bytes want [`filter_ignored_bytes`], which this delegates to.
 pub async fn filter_ignored(
     repo_path: &str,
     paths: &[String],
     exclude: &[String],
 ) -> AppResult<Vec<String>> {
+    let bytes: Vec<Vec<u8>> = paths.iter().map(|p| p.as_bytes().to_vec()).collect();
+    let ignored = filter_ignored_bytes(repo_path, &bytes, exclude).await?;
+    // Inputs are `String`s and git echoes the input bytes back, so this decode is
+    // exact for every name this signature can carry.
+    Ok(ignored
+        .iter()
+        .map(|p| String::from_utf8_lossy(p).into_owned())
+        .collect())
+}
+
+/// [`filter_ignored`] over names as the BYTES they really are.
+///
+/// gitignore matching is byte-domain, and a filename is not required to be valid
+/// UTF-8: decoding one to a `String` first replaces every unreadable byte with
+/// U+FFFD, so the engine is asked about a name the user never wrote and no
+/// pattern of theirs can match it. Callers that hold real bytes — anything
+/// reading names out of git with `-z` — should ask here, and only spell a name as
+/// text once its verdict is in.
+///
+/// Semantics, short-circuits and security properties are [`filter_ignored`]'s;
+/// the returned names are a subset of `paths`, byte-identical. A name must not
+/// carry an interior NUL — impossible in the `-z` streams callers read names
+/// from — since the NUL-framed wire would read it as two names.
+pub async fn filter_ignored_bytes(
+    repo_path: &str,
+    paths: &[Vec<u8>],
+    exclude: &[String],
+) -> AppResult<Vec<Vec<u8>>> {
     let (lines, has_positive) = actionable_lines(exclude);
     if paths.is_empty() || !has_positive {
         return Ok(Vec::new());
@@ -264,9 +304,9 @@ pub async fn filter_ignored(
     // `-z` output is NUL-TERMINATED, so the split yields a trailing empty
     // element; nothing else needs trimming (no CR, no quoting).
     Ok(stdout
-        .split('\0')
+        .split(|byte| *byte == 0)
         .filter(|p| !p.is_empty())
-        .map(String::from)
+        .map(<[u8]>::to_vec)
         .collect())
 }
 
@@ -322,7 +362,11 @@ pub async fn git_ai_ignore_verdicts(
         return Ok(Vec::new());
     }
     let kept: Vec<&str> = lines.iter().map(|(_, line)| *line).collect();
-    let (stdout, excludes) = run_check_ignore(&repo_path, &paths, &kept, true).await?;
+    // This surface is reached from JSON alone, so its paths ARE text; the decode
+    // below is the inverse of that, not a lossy step the engine imposes.
+    let names: Vec<Vec<u8>> = paths.into_iter().map(String::into_bytes).collect();
+    let (stdout, excludes) = run_check_ignore(&repo_path, &names, &kept, true).await?;
+    let stdout = String::from_utf8_lossy(&stdout);
 
     // Four NUL-separated tokens per record: source, line number, pattern, path.
     // The line number is 1-based into the excludes file just written — i.e. into
@@ -1041,6 +1085,71 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    /// A name that is not valid UTF-8 is matched on the bytes it really has and
+    /// comes back byte-identical. `check-ignore --no-index --stdin` matches names
+    /// that need not exist, so no filesystem is involved — the only way such a
+    /// name is expressible at all under Windows git.
+    #[tokio::test]
+    async fn byte_names_match_on_their_own_bytes() {
+        let (_dir, repo) = parity_repo().await;
+        // A lone 0xE9 is latin-1 `é` and invalid UTF-8, so this name has no
+        // `String` spelling: the byte API is the only one that can carry it.
+        let latin1 = b"caf\xE9.env".to_vec();
+
+        let hit = filter_ignored_bytes(&repo, std::slice::from_ref(&latin1), &["*.env".into()])
+            .await
+            .unwrap();
+        assert_eq!(hit, vec![latin1], "matched, and returned exactly as sent");
+
+        // A newline inside a name, and a name that is a PREFIX of another: what
+        // the NUL-joined stdin and NUL-split stdout have to keep apart.
+        let names = vec![
+            b"we\nird.env".to_vec(),
+            b"a.env".to_vec(),
+            b"a.envx".to_vec(),
+        ];
+        let hit = filter_ignored_bytes(&repo, &names, &["*.env".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(hit, vec![b"we\nird.env".to_vec(), b"a.env".to_vec()]);
+    }
+
+    /// The distinction the byte API exists for: latin-1 `café.env` and UTF-8
+    /// `café.env` are DIFFERENT names to git's matcher, so a literal pattern
+    /// naming one leaves the other visible.
+    ///
+    /// The String path cannot express it — the latin-1 name reaches it only as
+    /// `caf\u{FFFD}.env` — so the control below pins what that path really
+    /// decides: a verdict on the U+FFFD spelling, which is nobody's filename.
+    #[tokio::test]
+    async fn a_literal_pattern_tells_the_two_spellings_apart() {
+        let (_dir, repo) = parity_repo().await;
+        let latin1 = b"caf\xE9.env".to_vec();
+        let utf8 = "café.env".as_bytes().to_vec();
+        let both = vec![latin1.clone(), utf8.clone()];
+
+        let hit = filter_ignored_bytes(&repo, &both, &["café.env".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(hit, vec![utf8], "the UTF-8 spelling alone");
+
+        // The hole the byte arm closes: the String API answers about the lossy
+        // name it was given, a spelling that is nobody's filename.
+        let lossy = String::from_utf8_lossy(&latin1).into_owned();
+        assert_eq!(lossy, "caf\u{FFFD}.env");
+        let by_string = filter_ignored(&repo, std::slice::from_ref(&lossy), &["*.env".into()])
+            .await
+            .unwrap();
+        assert_eq!(by_string, vec![lossy.clone()]);
+        let by_bytes = filter_ignored_bytes(&repo, &[latin1], &[lossy])
+            .await
+            .unwrap();
+        assert!(
+            by_bytes.is_empty(),
+            "…and that spelling names no real file: {by_bytes:?}"
+        );
     }
 
     /// A fresh repo with an identity and pinned case sensitivity, for the

--- a/src-tauri/src/git/ai_ignore.rs
+++ b/src-tauri/src/git/ai_ignore.rs
@@ -288,9 +288,9 @@ pub async fn filter_ignored(
 /// text once its verdict is in.
 ///
 /// Semantics, short-circuits and security properties are [`filter_ignored`]'s;
-/// the returned names are a subset of `paths`, byte-identical. A name must not
-/// carry an interior NUL — impossible in the `-z` streams callers read names
-/// from — since the NUL-framed wire would read it as two names.
+/// the returned names are a subset of `paths`, byte-identical. Names must not
+/// carry an interior NUL: the NUL-framed wire (shared with the `String` path)
+/// would read one as two names.
 pub async fn filter_ignored_bytes(
     repo_path: &str,
     paths: &[Vec<u8>],

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1176,9 +1176,23 @@ pub(crate) async fn update_branch_from(
     };
     drop(guard);
 
-    let tmp = std::env::temp_dir().join(format!("gd-update-{}", unique_suffix()));
+    // Minted under the app-data worktrees root, never the OS temp dir: that
+    // placement is what hides the checkout from the user-facing worktree listing
+    // and the surfaces built on it (`is_session_worktree`'s app-data arm).
+    let tmp = update_worktree_path(repo_path)?;
+    if let Some(root) = tmp.parent() {
+        std::fs::create_dir_all(root).map_err(AppError::Io)?;
+    }
     let tmp_str = tmp.to_string_lossy().to_string();
     merge_diverged_in_worktree(state, repo_path, &tmp_str, branch, base, &pins).await
+}
+
+/// Where an update's throwaway checkout goes: `<app-data>/worktrees/<repo-hash>/
+/// gd-update-<unique>`. Resolution only — creating the root is the caller's job,
+/// which keeps this callable from a test without writing under the real app data.
+fn update_worktree_path(repo_path: &str) -> AppResult<std::path::PathBuf> {
+    Ok(crate::git::ops::worktree_root_dir(repo_path)?
+        .join(format!("gd-update-{}", unique_suffix())))
 }
 
 /// The two refs an update is planned against, resolved under the first working-tree
@@ -1439,8 +1453,8 @@ mod tests {
         branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args,
         divergence_out_of_range, git_branch_merge_states, git_branches, git_create_branch_core,
         git_default_branch, git_rename_branch_core, merge_diverged_in_worktree,
-        parse_cherry_counts, parse_upstream_track, update_branch_from, validate_branch_name,
-        validate_ref_name, BranchRewriteStatus, MergePair, UpdatePins,
+        parse_cherry_counts, parse_upstream_track, update_branch_from, update_worktree_path,
+        validate_branch_name, validate_ref_name, BranchRewriteStatus, MergePair, UpdatePins,
     };
     use crate::error::AppError;
     use crate::git::runner::{acquire_repo_lock, run_git, run_git_raw, DEFAULT_TIMEOUT};
@@ -2560,6 +2574,27 @@ mod tests {
                 "base {bad_base:?}"
             );
         }
+    }
+
+    /// The throwaway checkout is minted under the app-data worktrees root, which is
+    /// what keeps it out of the worktree manager, with a unique `gd-update-` name.
+    /// Shape only — resolving a path creates nothing under the real app data.
+    #[test]
+    fn update_worktree_path_sits_under_the_app_data_root() {
+        let repo = "C:\\repos\\app";
+        let root = crate::git::ops::worktree_root_dir(repo).expect("app-data root resolves");
+        let first = update_worktree_path(repo).expect("update path resolves");
+        assert_eq!(first.parent(), Some(root.as_path()));
+        let name = first
+            .file_name()
+            .and_then(|s| s.to_str())
+            .expect("the mint has a basename");
+        assert!(name.starts_with("gd-update-"), "{name}");
+        assert_ne!(
+            first,
+            update_worktree_path(repo).expect("update path resolves"),
+            "two mints in one process must not collide"
+        );
     }
 
     /// `update_branch_from` merges into `refs/heads/<branch>` and merges `<base>`,

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1255,7 +1255,8 @@ async fn merge_diverged_in_worktree(
     // unbounded one holds a finished update's command hostage for the minutes a
     // node_modules-scale removal can hold the shared admin domain. A quit or crash
     // while the detached task waits leaks the `gd-update-*` DIRECTORY — the registry
-    // entry self-heals through `worktree::prune_worktrees_if_free`, the directory does not.
+    // entry self-heals through `worktree::prune_worktrees_if_free` only once the
+    // directory is gone; a surviving directory keeps the entry and the branch hold.
     let domain = state.worktree_admin_lock(repo_path).await;
     match try_acquire_repo_lock(&domain, "a worktree operation") {
         Some(_admin) => remove_tmp_worktree(repo_path, tmp).await,

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2500,7 +2500,7 @@ pub(crate) fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf
     let data = dirs::data_dir()
         .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
     Ok(data
-        .join("com.thebguy.gitdesktop")
+        .join(crate::local_prs::APP_IDENTIFIER)
         .join("worktrees")
         .join(repo_hash(repo_path)))
 }
@@ -4704,7 +4704,7 @@ mod tests {
 
     /// Pins the runner's zero-budget contract, both halves: a timeout is reported,
     /// and git never runs (a `git init` under it leaves no repository behind). A
-    /// red here means the guard in `run_git_raw_input` is gone and every killed-git
+    /// red here means the guard in `run_git_raw_input_bytes` is gone and every killed-git
     /// test below is silently racing the child again.
     #[tokio::test]
     async fn a_zero_budget_times_out_without_running_git() {
@@ -7261,6 +7261,33 @@ detached
                 "C:/repos/app".to_string(),
                 "C:/data/worktrees/h/gd-resolve-abc".to_string(),
             ]
+        );
+    }
+
+    /// `worktree_root_dir` hardcodes the bundle identifier, but the filter that
+    /// hides our internal checkouts (`is_session_worktree`'s app-data arm) reads
+    /// Tauri's `app_data_dir()`, i.e. `dirs::data_dir()/<identifier>` from
+    /// `tauri.conf.json`. Renaming the identifier there alone would strand every
+    /// hidden family (`gd-resolve-*`, `gd-update-*`) outside that filter with no
+    /// other signal, so the two sides are pinned against each other here — the
+    /// non-circular half of the mint-path tests, which check a path against the
+    /// resolver that built it.
+    #[test]
+    fn worktree_root_dir_uses_the_shipped_bundle_identifier() {
+        let conf: serde_json::Value = serde_json::from_str(include_str!("../../tauri.conf.json"))
+            .expect("tauri.conf.json parses");
+        let identifier = conf["identifier"]
+            .as_str()
+            .expect("tauri.conf.json declares an identifier");
+        let data = dirs::data_dir().expect("the app-data directory resolves");
+        let root = worktree_root_dir("C:\\repos\\app").expect("the worktree root resolves");
+        let under = root
+            .strip_prefix(&data)
+            .expect("the worktree root sits under the app-data directory");
+        assert_eq!(
+            under.components().next().map(|c| c.as_os_str()),
+            Some(std::ffi::OsStr::new(identifier)),
+            "worktree_root_dir's identifier drifted from tauri.conf.json's"
         );
     }
 

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -4704,8 +4704,8 @@ mod tests {
 
     /// Pins the runner's zero-budget contract, both halves: a timeout is reported,
     /// and git never runs (a `git init` under it leaves no repository behind). A
-    /// red here means the guard in `run_git_raw_input_bytes` is gone and every killed-git
-    /// test below is silently racing the child again.
+    /// red here means the guard in `run_git_raw_input_bytes` is gone and every
+    /// killed-git test below is silently racing the child again.
     #[tokio::test]
     async fn a_zero_budget_times_out_without_running_git() {
         let (dir, repo) = setup_repo("zero-budget").await;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2495,7 +2495,7 @@ fn repo_hash(repo_path: &str) -> String {
 /// `dirs::data_dir()` (as `local_prs.rs` / `oplog.rs` do) since the local-PR
 /// merge commands carry no `AppHandle`. Tauri's `app_data_dir()` is exactly
 /// `dirs::data_dir()/<identifier>`, so this points at the same directory.
-fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf> {
+pub(crate) fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf> {
     let data = dirs::data_dir()
         .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
     Ok(data

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2480,9 +2480,10 @@ pub(crate) async fn classify_failure(
 
 /// A short, stable hash of the repo path, kept in sync BY HAND with
 /// `worktree.rs::repo_hash` (both hash the lower-cased path with `DefaultHasher`).
-/// Resolve worktrees must land under the same `<app_data>/worktrees/<repo-hash>`
-/// root, because that placement is what makes `git_worktree_list_user` hide them
-/// from the user-facing worktree manager (`is_session_worktree`'s app-data check).
+/// Resolve worktrees — and `branches.rs`'s `gd-update-*` checkouts — must land
+/// under the same `<app_data>/worktrees/<repo-hash>` root, because that placement
+/// is what makes `git_worktree_list_user` hide them from the user-facing worktree
+/// manager (`is_session_worktree`'s app-data check).
 fn repo_hash(repo_path: &str) -> String {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -531,9 +531,9 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// pull that bare git refuses outright ("no such ref was fetched"). Pruned, the
 /// upstream ref stops resolving and that refusal is what the user sees. It prunes
 /// BRANCHES alone: `--no-prune-tags` keeps a `fetch.pruneTags` user's local tags. That
-/// is parity while `fetch.prune` is unset, and a deliberate divergence once it is set —
-/// bare pull deletes those tags there (measured, git 2.51.1), and a transfer this guard
-/// introduced is not where a user should lose refs.
+/// is parity while no prune config is set (`fetch.prune` / `remote.<name>.prune`), and a
+/// deliberate divergence once one is — bare pull deletes those tags there (measured,
+/// git 2.51.1), and a transfer this guard introduced is not where a user should lose refs.
 ///
 /// This phase holds the NETWORK domain and nothing else, so a transfer running for
 /// its whole budget never stalls staging or a commit; the caller takes the working
@@ -2704,9 +2704,10 @@ mod tests {
         }
 
         // The `pruneTags` pair is answered by the fetch's own `--no-prune-tags`: the
-        // split phases keep those tags, matching bare pull while `fetch.prune` is unset
-        // and deliberately diverging from it — in the user's favor — once it is set.
-        // Either way there is no difference left for a stand-down to protect.
+        // split phases keep those tags, matching bare pull while no prune config is set
+        // (`fetch.prune` / `remote.<name>.prune`) and deliberately diverging from it, in
+        // the user's favor, once one is. Either way there is no difference left for a
+        // stand-down to protect.
         for (key, value) in [("fetch.pruneTags", "true"), ("remote.origin.pruneTags", "yes")] {
             git(&clone, &["config", key, value]).await;
             assert!(
@@ -2813,8 +2814,9 @@ mod tests {
     }
 
     /// The rebase arm's probe fetch carries the same flag, for the same reason.
-    /// `submodule.recurse` needs no pin here: `probe` reads no config stand-down key
-    /// (that check belongs to `pin_plain_pull` alone), so no global can divert it.
+    /// `submodule.recurse` needs no pin here: the boolean stand-down keys belong to
+    /// `pin_plain_pull` alone. `probe`'s one config read is the fetch-refspec
+    /// predicate, whose fixture value the clone itself wrote.
     #[tokio::test]
     async fn the_probe_fetch_keeps_local_tags() {
         let (_dir, clone, _work, _tip) = behind_fixture("probe-prune-tags").await;

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -520,7 +520,7 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// Phase A: fetch, then compute the fork-point verdict. Touches nothing the user
 /// owns — no stash, no ref of theirs — so a would-drop refusal leaves the tree
 /// exactly as it found it. `None` stands the guard down: the branch was switched
-/// since `resolve` saw it, the remote's fetch refspec writes into `refs/heads/*`,
+/// since `resolve` saw it, the remote's fetch refspec writes outside `refs/remotes/`,
 /// HEAD or the upstream ref fails to rev-parse, or there is no merge base or no
 /// fork point to decide anything from. A switch DURING the fetch is the one currency
 /// failure that errors instead — see the two-read paragraph below.
@@ -534,6 +534,9 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// is parity while no prune config is set (`fetch.prune` / `remote.<name>.prune`), and a
 /// deliberate divergence once one is — bare pull deletes those tags there (measured,
 /// git 2.51.1), and a transfer this guard introduced is not where a user should lose refs.
+/// The flag reaches only the IMPLICIT tag refspec, so a remote spelling `refs/tags/*` out
+/// in its own fetch config prunes tags regardless (measured on that git); those remotes
+/// never reach this fetch — the destination check above stands them down first.
 ///
 /// This phase holds the NETWORK domain and nothing else, so a transfer running for
 /// its whole budget never stalls staging or a commit; the caller takes the working
@@ -566,15 +569,20 @@ pub(crate) async fn probe(
     if current_branch(repo).await.as_deref() != Some(target.branch.as_str()) {
         return Ok(None);
     }
-    // Checked BEFORE the fetch, because the fetch is what fails: git refuses
-    // ("refusing to fetch into branch") when a destination covers a CHECKED-OUT branch,
-    // where bare pull gets through on the `--update-head-ok` its own fetch carries — a
-    // flag the probe must never adopt, since a fetch free to move checked-out refs
-    // mid-probe invalidates the tips the verdict is pinned to. So it stands down to
-    // bare pull, the behavior those refspecs get from git itself. The predicate
-    // over-approximates deliberately: standing down for refspecs whose fetch would have
-    // worked is the price of never hard-erroring, and it costs only the vaporize check.
-    if target.remote != "." && fetch_maps_into_heads(repo, target.remote.as_str()).await {
+    // Two reasons, one predicate, both of which make the guard's own fetch wrong for
+    // these remotes. A destination outside `refs/remotes/` puts real local refs in
+    // reach of this fetch's unconditional `--prune`, which bare pull leaves alone while
+    // no prune config is set. And a `refs/heads/` destination covering a CHECKED-OUT
+    // branch makes git refuse outright ("refusing to fetch into branch") where bare pull
+    // gets through on the `--update-head-ok` its own fetch carries — a flag the probe
+    // must never adopt, since a fetch free to move checked-out refs mid-probe
+    // invalidates the tips the verdict is pinned to. Hence BEFORE the fetch, the step
+    // that would do the damage. Standing down runs the pull bare, the behavior these
+    // refspecs get from git itself; it over-approximates (a `fetch.prune=true` user
+    // would have been pruned anyway) and costs only the vaporize check.
+    if target.remote != "."
+        && fetch_writes_outside_remote_tracking(repo, target.remote.as_str()).await
+    {
         return Ok(None);
     }
     // ONE network hold spanning the fetch AND every read below it: the verdict is
@@ -691,18 +699,18 @@ pub(crate) async fn pin_plain_pull(
 /// Windows, so they go out together and one combined verdict decides — the whole
 /// check sits in front of the transfer on every plain pull.
 async fn plain_pull_config_stands_down(repo: &str, remote: &str, merge_mode: bool) -> bool {
-    let (recurse, pull_only, into_heads) = tokio::join!(
+    let (recurse, pull_only, outside_remotes) = tokio::join!(
         // `submodule.recurse`: bare pull updates submodule worktrees for these modes,
         // and the guard's measured parity step covers rebase only.
         submodule_recurse(repo),
         pull_only_keys_set(repo, merge_mode),
-        // A refspec writing into `refs/heads/*` may need the `--update-head-ok` bare pull
-        // passes its own fetch: git refuses ("refusing to fetch into branch") when a
-        // destination covers the CHECKED-OUT branch. Over-approximated on purpose — see
-        // [`probe`], which stands down on the same predicate for the same reason.
-        fetch_maps_into_heads(repo, remote),
+        // A refspec writing outside `refs/remotes/` puts real local refs in reach of the
+        // fetch's `--prune`, and a `refs/heads/` destination can additionally make the
+        // fetch refuse ("refusing to fetch into branch"). Over-approximated on purpose —
+        // see [`probe`], which stands down on the same predicate for the same reasons.
+        fetch_writes_outside_remote_tracking(repo, remote),
     );
-    recurse || pull_only || into_heads
+    recurse || pull_only || outside_remotes
 }
 
 /// Whether either pull-only key `git merge` never reads is set, which makes honoring
@@ -734,11 +742,19 @@ async fn config_is_set(repo: &str, key: &str) -> bool {
         .map_or(true, |out| out.code == 0)
 }
 
-/// Whether any of the remote's fetch refspecs writes into `refs/heads/*` — the
-/// mirror-style clone whose fetch would collide with the checked-out branch. A
-/// leading `+` is the force marker, and the destination is the half after `:`; a
-/// refspec with no `:` (an exclusion, a fetch-only ref) writes nowhere local.
-async fn fetch_maps_into_heads(repo: &str, remote: &str) -> bool {
+/// Whether any of the remote's fetch refspecs writes OUTSIDE `refs/remotes/`, which
+/// is the line the guard's unconditional `--prune` is only safe inside: prune deletes
+/// whatever a destination covers that the remote no longer has, and outside
+/// remote-tracking that means real local refs. Measured on git 2.51.1 with
+/// `+refs/heads/*:refs/custom/*`, a pruning fetch deleted a hand-made
+/// `refs/custom/mine-only` the remote never had; bare pull keeps it while
+/// `fetch.prune` is unset. A `refs/heads/*` destination is the same class and can
+/// additionally make the fetch hard-refuse, so this one predicate covers both.
+///
+/// A leading `+` is the force marker, and the destination is the half after `:`; a
+/// refspec with no `:` (a negative refspec, a fetch-only ref) writes nowhere local —
+/// measured: git rejects a destination on a negative refspec, so they never carry one.
+async fn fetch_writes_outside_remote_tracking(repo: &str, remote: &str) -> bool {
     let Ok(out) = run_git_raw(
         Some(repo),
         &["config", "--get-all", &format!("remote.{remote}.fetch")],
@@ -752,7 +768,7 @@ async fn fetch_maps_into_heads(repo: &str, remote: &str) -> bool {
         spec.trim()
             .trim_start_matches('+')
             .split_once(':')
-            .is_some_and(|(_, dst)| dst.starts_with("refs/heads/"))
+            .is_some_and(|(_, dst)| !dst.starts_with("refs/remotes/"))
     })
 }
 
@@ -2728,21 +2744,34 @@ mod tests {
             git(&clone, &["config", "--unset", key]).await;
         }
 
-        // A mirror-style refspec needs the `--update-head-ok` bare pull's fetch carries.
-        git(
-            &clone,
-            &[
-                "config",
-                "--add",
-                "remote.origin.fetch",
-                "+refs/heads/*:refs/heads/upstream/*",
-            ],
-        )
-        .await;
-        assert!(
-            plain_pull_config_stands_down(&clone, "origin", true).await,
-            "a refspec writing into refs/heads/* would hard-refuse"
-        );
+        // Destinations outside `refs/remotes/` put real local refs in reach of the
+        // fetch's `--prune`, and a `refs/heads/` one can additionally make it refuse.
+        // The stock refspec restored between rows is what pins the verdict on the
+        // ADDED spec rather than on config left over from the row before.
+        for spec in [
+            "+refs/heads/*:refs/heads/upstream/*",
+            "+refs/tags/*:refs/tags/*",
+        ] {
+            git(&clone, &["config", "--add", "remote.origin.fetch", spec]).await;
+            assert!(
+                plain_pull_config_stands_down(&clone, "origin", true).await,
+                "{spec} writes outside refs/remotes/ and must stand the split phases down"
+            );
+            git(&clone, &["config", "--unset-all", "remote.origin.fetch"]).await;
+            git(
+                &clone,
+                &[
+                    "config",
+                    "remote.origin.fetch",
+                    "+refs/heads/*:refs/remotes/origin/*",
+                ],
+            )
+            .await;
+            assert!(
+                !plain_pull_config_stands_down(&clone, "origin", true).await,
+                "while the stock remote-tracking refspec alone does not"
+            );
+        }
     }
 
     /// A tag-pruning user keeps their local tags through the plain arms' own fetch,
@@ -2839,11 +2868,13 @@ mod tests {
         );
     }
 
-    /// A fetch refspec writing into `refs/heads/*` stands the PROBE down BEFORE its
-    /// fetch, since the fetch is what fails. `Ok(None)` hands the pull to bare
-    /// `git pull --rebase`, which handled this config all along.
+    /// A fetch refspec writing outside `refs/remotes/` stands the PROBE down BEFORE its
+    /// fetch, since the fetch is what does the damage — refusing outright on a
+    /// checked-out `refs/heads/` destination, or pruning real local refs on any other.
+    /// `Ok(None)` hands the pull to bare `git pull --rebase`, which handled these
+    /// configs all along. Each shape carries its own measured control.
     #[tokio::test]
-    async fn the_probe_stands_down_on_a_refspec_that_writes_into_refs_heads() {
+    async fn the_probe_stands_down_on_a_refspec_that_writes_outside_remote_tracking() {
         let (_dir, clone, _work, _tip) = behind_fixture("probe-mirror-refspec").await;
         let state = AppState::default();
         let target = resolve(&clone)
@@ -2895,6 +2926,42 @@ mod tests {
         assert!(
             probe(&state, &clone, &target, &[]).await.unwrap().is_none(),
             "so the probe must never reach that fetch"
+        );
+
+        // The tag shape, which no flag can save: `--no-prune-tags` governs only the
+        // IMPLICIT tag refspec, so an explicit one stays prune-subject. Here the fetch
+        // SUCCEEDS and takes the tag with it, which is why the destination — not the
+        // exit code — is what the predicate reads.
+        git(&clone, &["config", "--unset-all", "remote.origin.fetch"]).await;
+        for spec in [
+            "+refs/heads/*:refs/remotes/origin/*",
+            "+refs/tags/*:refs/tags/*",
+        ] {
+            git(&clone, &["config", "--add", "remote.origin.fetch", spec]).await;
+        }
+        git(&clone, &["tag", "local-only"]).await;
+        let pruned = run_git_raw(
+            Some(&clone),
+            &["fetch", "--prune", "--no-prune-tags", "origin"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .expect("git ran");
+        assert_eq!(pruned.code, 0, "this fetch succeeds — it just takes the tag");
+        assert!(
+            git(&clone, &["tag"]).await.trim().is_empty(),
+            "the control: an explicit tag refspec is pruned despite --no-prune-tags"
+        );
+
+        git(&clone, &["tag", "local-only"]).await;
+        assert!(
+            probe(&state, &clone, &target, &[]).await.unwrap().is_none(),
+            "so the probe stands down rather than running that fetch"
+        );
+        assert_eq!(
+            git(&clone, &["tag"]).await.trim(),
+            "local-only",
+            "and the tag the guarded path would have deleted is still there"
         );
     }
 

--- a/src-tauri/src/git/pull_guard.rs
+++ b/src-tauri/src/git/pull_guard.rs
@@ -520,15 +520,20 @@ fn parse_dropped(stdout: &str) -> Vec<DroppedCommit> {
 /// Phase A: fetch, then compute the fork-point verdict. Touches nothing the user
 /// owns — no stash, no ref of theirs — so a would-drop refusal leaves the tree
 /// exactly as it found it. `None` stands the guard down: the branch was switched
-/// since `resolve` saw it, HEAD or the upstream ref fails to rev-parse, or there is
-/// no merge base or no fork point to decide anything from. A switch DURING the fetch
-/// is the one currency failure that errors instead — see the two-read paragraph below.
+/// since `resolve` saw it, the remote's fetch refspec writes into `refs/heads/*`,
+/// HEAD or the upstream ref fails to rev-parse, or there is no merge base or no
+/// fork point to decide anything from. A switch DURING the fetch is the one currency
+/// failure that errors instead — see the two-read paragraph below.
 ///
 /// The fetch PRUNES, which the stand-down below depends on: without it, an
 /// upstream branch deleted on the forge leaves its tracking ref behind, every
 /// rev here resolves against that stale tip, and the rebase reports success for a
 /// pull that bare git refuses outright ("no such ref was fetched"). Pruned, the
-/// upstream ref stops resolving and that refusal is what the user sees.
+/// upstream ref stops resolving and that refusal is what the user sees. It prunes
+/// BRANCHES alone: `--no-prune-tags` keeps a `fetch.pruneTags` user's local tags. That
+/// is parity while `fetch.prune` is unset, and a deliberate divergence once it is set —
+/// bare pull deletes those tags there (measured, git 2.51.1), and a transfer this guard
+/// introduced is not where a user should lose refs.
 ///
 /// This phase holds the NETWORK domain and nothing else, so a transfer running for
 /// its whole budget never stalls staging or a commit; the caller takes the working
@@ -561,6 +566,17 @@ pub(crate) async fn probe(
     if current_branch(repo).await.as_deref() != Some(target.branch.as_str()) {
         return Ok(None);
     }
+    // Checked BEFORE the fetch, because the fetch is what fails: git refuses
+    // ("refusing to fetch into branch") when a destination covers a CHECKED-OUT branch,
+    // where bare pull gets through on the `--update-head-ok` its own fetch carries — a
+    // flag the probe must never adopt, since a fetch free to move checked-out refs
+    // mid-probe invalidates the tips the verdict is pinned to. So it stands down to
+    // bare pull, the behavior those refspecs get from git itself. The predicate
+    // over-approximates deliberately: standing down for refspecs whose fetch would have
+    // worked is the price of never hard-erroring, and it costs only the vaporize check.
+    if target.remote != "." && fetch_maps_into_heads(repo, target.remote.as_str()).await {
+        return Ok(None);
+    }
     // ONE network hold spanning the fetch AND every read below it: the verdict is
     // only sound on the refs this fetch produced, and the background auto-fetch runs
     // in this same domain — released in between, it can move
@@ -574,7 +590,7 @@ pub(crate) async fn probe(
             let out = run_git_with_creds_once(
                 repo,
                 cred,
-                &["fetch", "--prune", remote],
+                &["fetch", "--prune", "--no-prune-tags", remote],
                 NETWORK_TIMEOUT,
             )
             .await?;
@@ -675,22 +691,18 @@ pub(crate) async fn pin_plain_pull(
 /// Windows, so they go out together and one combined verdict decides — the whole
 /// check sits in front of the transfer on every plain pull.
 async fn plain_pull_config_stands_down(repo: &str, remote: &str, merge_mode: bool) -> bool {
-    let remote_prune_key = format!("remote.{remote}.pruneTags");
-    let (recurse, pull_only, fetch_prune_tags, remote_prune_tags, into_heads) = tokio::join!(
+    let (recurse, pull_only, into_heads) = tokio::join!(
         // `submodule.recurse`: bare pull updates submodule worktrees for these modes,
         // and the guard's measured parity step covers rebase only.
         submodule_recurse(repo),
         pull_only_keys_set(repo, merge_mode),
-        // The `pruneTags` pair only bites because our fetch PRUNES: pruning is what
-        // lets them delete local tags, and bare pull (with `fetch.prune` unset) never
-        // pruned at all.
-        config_is_true(repo, "fetch.pruneTags"),
-        config_is_true(repo, &remote_prune_key),
-        // A refspec writing into `refs/heads/*` needs the `--update-head-ok` bare pull
-        // passes its own fetch; ours would hard-refuse ("Refusing to fetch into branch").
+        // A refspec writing into `refs/heads/*` may need the `--update-head-ok` bare pull
+        // passes its own fetch: git refuses ("refusing to fetch into branch") when a
+        // destination covers the CHECKED-OUT branch. Over-approximated on purpose — see
+        // [`probe`], which stands down on the same predicate for the same reason.
         fetch_maps_into_heads(repo, remote),
     );
-    recurse || pull_only || fetch_prune_tags || remote_prune_tags || into_heads
+    recurse || pull_only || into_heads
 }
 
 /// Whether either pull-only key `git merge` never reads is set, which makes honoring
@@ -722,22 +734,6 @@ async fn config_is_set(repo: &str, key: &str) -> bool {
         .map_or(true, |out| out.code == 0)
 }
 
-/// Whether `key` reads true through git's own boolean resolution, so every spelling
-/// of true stays git's verdict. An unrunnable probe reads as true, standing the
-/// split phases down rather than acting on an unknown.
-async fn config_is_true(repo: &str, key: &str) -> bool {
-    let Ok(out) = run_git_raw(
-        Some(repo),
-        &["config", "--bool", "--get", key],
-        DEFAULT_TIMEOUT,
-    )
-    .await
-    else {
-        return true;
-    };
-    out.code == 0 && out.stdout_lossy().trim() == "true"
-}
-
 /// Whether any of the remote's fetch refspecs writes into `refs/heads/*` — the
 /// mirror-style clone whose fetch would collide with the checked-out branch. A
 /// leading `+` is the force marker, and the destination is the half after `:`; a
@@ -764,7 +760,8 @@ async fn fetch_maps_into_heads(repo: &str, remote: &str) -> bool {
 /// hold — the one-snapshot invariant [`probe`] documents, for the modes that need no
 /// fork-point verdict. `None` when that snapshot is incomplete: an upstream branch
 /// deleted on the forge stops resolving once the fetch prunes it, and the caller's
-/// bare `git pull` then answers in git's own words ("no such ref was fetched").
+/// bare `git pull` then answers in git's own words ("no such ref was fetched"). The
+/// flags are [`probe`]'s, for the same reasons: branches pruned, local tags kept.
 async fn fetch_and_pin(
     state: &AppState,
     repo: &str,
@@ -776,7 +773,7 @@ async fn fetch_and_pin(
     let out = run_git_with_creds_once(
         repo,
         cred,
-        &["fetch", "--prune", target.remote.as_str()],
+        &["fetch", "--prune", "--no-prune-tags", target.remote.as_str()],
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -2684,11 +2681,9 @@ mod tests {
     #[tokio::test]
     async fn the_plain_arms_stand_down_on_config_git_merge_cannot_honor() {
         let (_dir, clone, _work, _tip) = behind_fixture("stand-down").await;
-        // The boolean keys pinned false up front: an unset key would otherwise read
-        // through to a global one and decide the baseline.
-        for key in ["submodule.recurse", "fetch.pruneTags", "remote.origin.pruneTags"] {
-            git(&clone, &["config", key, "false"]).await;
-        }
+        // The one boolean key pinned false up front: unset, it would read through to a
+        // global one and decide the baseline.
+        git(&clone, &["config", "submodule.recurse", "false"]).await;
         assert!(
             !plain_pull_config_stands_down(&clone, "origin", true).await,
             "an ordinary clone runs the split phases"
@@ -2698,14 +2693,25 @@ mod tests {
             ("pull.ff", "only"),
             ("pull.ff", "false"),
             ("pull.twohead", "ours"),
-            ("fetch.pruneTags", "true"),
-            ("remote.origin.pruneTags", "yes"),
             ("submodule.recurse", "true"),
         ] {
             git(&clone, &["config", key, value]).await;
             assert!(
                 plain_pull_config_stands_down(&clone, "origin", true).await,
                 "{key}={value} must stand the split phases down"
+            );
+            git(&clone, &["config", "--unset", key]).await;
+        }
+
+        // The `pruneTags` pair is answered by the fetch's own `--no-prune-tags`: the
+        // split phases keep those tags, matching bare pull while `fetch.prune` is unset
+        // and deliberately diverging from it — in the user's favor — once it is set.
+        // Either way there is no difference left for a stand-down to protect.
+        for (key, value) in [("fetch.pruneTags", "true"), ("remote.origin.pruneTags", "yes")] {
+            git(&clone, &["config", key, value]).await;
+            assert!(
+                !plain_pull_config_stands_down(&clone, "origin", true).await,
+                "{key}={value} is handled by the fetch flag, not by standing down"
             );
             git(&clone, &["config", "--unset", key]).await;
         }
@@ -2735,6 +2741,158 @@ mod tests {
         assert!(
             plain_pull_config_stands_down(&clone, "origin", true).await,
             "a refspec writing into refs/heads/* would hard-refuse"
+        );
+    }
+
+    /// A tag-pruning user keeps their local tags through the plain arms' own fetch,
+    /// and the BRANCH half of the prune still runs — that half is what the
+    /// deleted-upstream stand-down rests on. Both spellings are driven, since only the
+    /// command line's precedence over them makes the flag enough. A sibling clone under
+    /// the same config is the negative control: there a pruning fetch deletes the tag.
+    #[tokio::test]
+    async fn the_plain_fetch_keeps_local_tags_and_still_prunes_branches() {
+        for key in ["fetch.pruneTags", "remote.origin.pruneTags"] {
+            let (dir, clone, work, tip) = behind_fixture(&format!("prune-tags-{key}")).await;
+            let root = dir.path().to_string_lossy().into_owned();
+            let url = format!(
+                "file://{}",
+                dir.path()
+                    .join("origin.git")
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            );
+            // Pinned false, as the neighbouring stand-down test does: a global
+            // `submodule.recurse=true` on the machine would stand `pin_plain_pull` down
+            // and this test would panic on its own setup rather than measure the fetch.
+            git(&clone, &["config", "submodule.recurse", "false"]).await;
+
+            // A branch the clone tracks, then deleted on the origin — the stale tracking
+            // ref a prune has to take. The control clone is taken while it still exists.
+            git(&work, &["switch", "-q", "-c", "doomed"]).await;
+            std::fs::write(dir.path().join("work").join("d.txt"), "d\n").unwrap();
+            git(&work, &["add", "-A"]).await;
+            git(&work, &["commit", "-qm", "doomed"]).await;
+            git(&work, &["push", "-q", "-u", "origin", "doomed"]).await;
+            git(&clone, &["fetch", "-q", "origin"]).await;
+            git(
+                &root,
+                &["-c", "core.autocrlf=false", "clone", "-q", &url, "control"],
+            )
+            .await;
+            let control = dir.path().join("control").to_string_lossy().into_owned();
+            git(&work, &["push", "-q", "origin", "--delete", "doomed"]).await;
+
+            for repo in [&clone, &control] {
+                git(repo, &["config", key, "true"]).await;
+                git(repo, &["tag", "keep-me"]).await;
+            }
+
+            // The config has to bite, or the assertions below prove nothing.
+            git(&control, &["fetch", "--prune", "origin"]).await;
+            assert!(
+                git(&control, &["tag"]).await.trim().is_empty(),
+                "{key} must delete the tag on the control's raw pruning fetch"
+            );
+
+            let state = AppState::default();
+            let plain = pin_plain_pull(&state, &clone, true)
+                .await
+                .unwrap()
+                .expect("the fixture tracks a real remote branch");
+            assert_eq!(plain.pinned.new_tip, tip, "the phase pinned the fetched tip");
+            assert_eq!(
+                git(&clone, &["tag"]).await.trim(),
+                "keep-me",
+                "and {key} never costs the user their tags"
+            );
+            assert!(
+                rev_parse(&clone, "refs/remotes/origin/doomed").await.is_none(),
+                "while the branch half of the prune still ran"
+            );
+        }
+    }
+
+    /// The rebase arm's probe fetch carries the same flag, for the same reason.
+    /// `submodule.recurse` needs no pin here: `probe` reads no config stand-down key
+    /// (that check belongs to `pin_plain_pull` alone), so no global can divert it.
+    #[tokio::test]
+    async fn the_probe_fetch_keeps_local_tags() {
+        let (_dir, clone, _work, _tip) = behind_fixture("probe-prune-tags").await;
+        git(&clone, &["config", "fetch.pruneTags", "true"]).await;
+        git(&clone, &["tag", "keep-me"]).await;
+
+        let state = AppState::default();
+        let target = resolve(&clone)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+        assert!(
+            probe(&state, &clone, &target, &[]).await.unwrap().is_some(),
+            "the probe still plans"
+        );
+        assert_eq!(
+            git(&clone, &["tag"]).await.trim(),
+            "keep-me",
+            "and the probe's own fetch left the tag alone"
+        );
+    }
+
+    /// A fetch refspec writing into `refs/heads/*` stands the PROBE down BEFORE its
+    /// fetch, since the fetch is what fails. `Ok(None)` hands the pull to bare
+    /// `git pull --rebase`, which handled this config all along.
+    #[tokio::test]
+    async fn the_probe_stands_down_on_a_refspec_that_writes_into_refs_heads() {
+        let (_dir, clone, _work, _tip) = behind_fixture("probe-mirror-refspec").await;
+        let state = AppState::default();
+        let target = resolve(&clone)
+            .await
+            .unwrap()
+            .expect("the fixture tracks a real remote branch");
+        assert!(
+            probe(&state, &clone, &target, &[]).await.unwrap().is_some(),
+            "an ordinary refspec probes a plan"
+        );
+
+        git(
+            &clone,
+            &[
+                "config",
+                "--add",
+                "remote.origin.fetch",
+                "+refs/heads/*:refs/heads/upstream/*",
+            ],
+        )
+        .await;
+        assert!(
+            probe(&state, &clone, &target, &[]).await.unwrap().is_none(),
+            "a refspec writing into refs/heads/* stands the probe down"
+        );
+
+        // The mirror shape whose destination IS the checked-out branch, where the
+        // refusal is what the guard's fetch would actually hit: run raw first, so the
+        // stand-down is measured against a fetch this repo can be seen to reject.
+        git(&clone, &["config", "--unset-all", "remote.origin.fetch"]).await;
+        git(
+            &clone,
+            &["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+        )
+        .await;
+        let refused = run_git_raw(
+            Some(&clone),
+            &["fetch", "--prune", "--no-prune-tags", "origin"],
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .expect("git ran");
+        assert_ne!(refused.code, 0, "the guard's own fetch is refused here");
+        assert!(
+            refused.stderr.contains("refusing to fetch into branch"),
+            "for the reason the stand-down exists: {}",
+            refused.stderr
+        );
+        assert!(
+            probe(&state, &clone, &target, &[]).await.unwrap().is_none(),
+            "so the probe must never reach that fetch"
         );
     }
 

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -2181,6 +2181,212 @@ hint: Updates were rejected because the tip of your current branch is behind
         );
     }
 
+    /// git asked for a username with prompting disabled and nothing in the
+    /// credential helper — measured against github.com on git 2.51.1.windows.1,
+    /// 2026-09.
+    const NO_CREDENTIALS_STDERR: &str = "\
+fatal: could not read Username for 'https://github.com': terminal prompts disabled
+";
+
+    /// Credentials github.com refused, same provenance. The sideband line names
+    /// the cause; the `fatal:` line is the one the frontend anchors on.
+    const REJECTED_CREDENTIALS_STDERR: &str = "\
+remote: Invalid username or token. Password authentication is not supported for Git operations.
+fatal: Authentication failed for 'https://github.com/octocat/Hello-World.git/'
+";
+
+    /// A push to a repository the authenticated account cannot write, same
+    /// provenance: the account is recognized, the permission is not there.
+    const FORBIDDEN_STDERR: &str = "\
+remote: Permission to octocat/Hello-World.git denied to theBGuy.
+fatal: unable to access 'https://github.com/octocat/Hello-World.git/': The requested URL returned error: 403
+";
+
+    /// A push dry-run against an archived GitHub repository, same provenance.
+    /// Only the `remote:` line is measured verbatim; the `fatal:` line under it is
+    /// git's standard curl-error shape, written out rather than captured — hence a
+    /// placeholder URL, so this blob makes no claim about a repository another
+    /// fixture presents differently.
+    const ARCHIVED_STDERR: &str = "\
+remote: This repository was archived so it is read-only.
+fatal: unable to access 'https://github.com/example/archived.git/': The requested URL returned error: 403
+";
+
+    /// A push to a Gitea pull-mirror over plain HTTP, from the user report the
+    /// read-only marker was written for (GitDesktop 0.10.0 on Linux, self-hosted
+    /// Gitea). The marker-bearing `remote:` line is verbatim; the report's paste
+    /// wraps the `fatal:` line after the colon, which git emits on one line, and
+    /// the `99xx` port is the reporter's own masking.
+    const GITEA_MIRROR_STDERR: &str = "\
+remote: mirror repository is read-only
+fatal: unable to access 'http://192.168.1.10:99xx/gituser1/GitDesktop/': The requested URL returned error: 403
+";
+
+    /// The chunks the frontend's `/m` regexes see as lines. JS `.` refuses every
+    /// LineTerminator and `^` re-anchors after each, while `str::lines` splits on
+    /// `\n` alone — and git's sideband re-emits `remote: ` after a BARE `\r` when
+    /// it overwrites a progress line, so `lines` would hand two sideband chunks to
+    /// one marker as a single matchable line.
+    fn js_lines(report: &str) -> impl Iterator<Item = &str> {
+        report.split(['\n', '\r', '\u{2028}', '\u{2029}'])
+    }
+
+    /// Whether `text` carries `word` at JS `\b` boundaries — `[A-Za-z0-9_]` on
+    /// either flank refuses the hit, which is what keeps `read-onlyish` and
+    /// `repositoryX` out. `-` is outside that set, so `read-only`'s own hyphen
+    /// never ends the word.
+    fn contains_word(text: &str, word: &str) -> bool {
+        fn is_word_char(c: char) -> bool {
+            c.is_ascii_alphanumeric() || c == '_'
+        }
+        text.match_indices(word).any(|(start, _)| {
+            text[..start].chars().next_back().is_none_or(|c| !is_word_char(c))
+                && text[start + word.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !is_word_char(c))
+        })
+    }
+
+    /// Entry one: a `remote:` line naming both a repository and a read-only state.
+    /// The JS lookahead makes the two order-independent within the line, and `.`
+    /// never crosses a line terminator, so both tokens must sit on the SAME line.
+    /// The case tolerance is `[Rr]` only, not a case-insensitive match.
+    fn marks_read_only_repository(report: &str) -> bool {
+        js_lines(report).any(|l| {
+            l.trim_start_matches([' ', '\t'])
+                .strip_prefix("remote: ")
+                .is_some_and(|rest| {
+                    ["repository", "Repository", "repositories", "Repositories"]
+                        .iter()
+                        .any(|w| contains_word(rest, w))
+                        && ["read-only", "Read-only"]
+                            .iter()
+                            .any(|w| contains_word(rest, w))
+                })
+        })
+    }
+
+    /// Entry two. Line-anchored with no indent tolerance, exactly like the regex.
+    fn marks_missing_credentials(report: &str) -> bool {
+        js_lines(report).any(|l| l.starts_with("fatal: could not read Username for "))
+    }
+
+    /// Entry three, anchored the same way.
+    fn marks_rejected_credentials(report: &str) -> bool {
+        js_lines(report).any(|l| l.starts_with("fatal: Authentication failed for "))
+    }
+
+    /// Entry four: git's curl-level 403. The regex's `[^'\n]*` cannot cross a
+    /// quote, so the URL runs to the FIRST `'` on the line and the tail has to
+    /// follow immediately. A bare `\r` inside the quotes ends the chunk here while
+    /// JS would keep reading — stricter than the frontend, the safe direction.
+    fn marks_forbidden_403(report: &str) -> bool {
+        js_lines(report).any(|l| {
+            l.strip_prefix("fatal: unable to access '")
+                .and_then(|r| r.split_once('\''))
+                .is_some_and(|(_url, tail)| {
+                    tail.starts_with(": The requested URL returned error: 403")
+                })
+        })
+    }
+
+    /// Rust mirrors of `REMOTE_ACCESS_SUMMARIES` (src/lib/error-summary.ts), in
+    /// the frontend's table order.
+    const REMOTE_ACCESS_MARKERS: [fn(&str) -> bool; 4] = [
+        marks_read_only_repository,
+        marks_missing_credentials,
+        marks_rejected_credentials,
+        marks_forbidden_403,
+    ];
+
+    /// Positions in [`REMOTE_ACCESS_MARKERS`], named for the verdict each entry
+    /// produces in the toast.
+    const READ_ONLY: usize = 0;
+    const NO_CREDENTIALS: usize = 1;
+    const REJECTED_CREDENTIALS: usize = 2;
+    const FORBIDDEN_403: usize = 3;
+
+    /// The entry `remoteAccessSummary` would pick: the FIRST match in table order,
+    /// mirroring its `.find()`. The index IS the verdict, so order is precedence.
+    fn first_remote_access_match(report: &str) -> Option<usize> {
+        REMOTE_ACCESS_MARKERS.iter().position(|m| m(report))
+    }
+
+    /// Canary for the frontend's remote-access markers: `remoteAccessSummary`
+    /// (src/lib/error-summary.ts) can only turn a transport or sideband refusal
+    /// into one human line while these measured stderr shapes still land on the
+    /// entry whose wording was written for them, so the blobs and Rust mirrors of
+    /// `REMOTE_ACCESS_SUMMARIES` are pinned together here. Keep the two lists in
+    /// step, ORDER INCLUDED — the table's order is precedence, not just layout.
+    /// GitLab and Bitbucket sideband wording is absent on purpose: the table grows
+    /// from captured stderr, never from guessed regexes.
+    #[test]
+    fn remote_access_stderr_still_matches_the_frontend_markers() {
+        for (stderr, entry, what) in [
+            (NO_CREDENTIALS_STDERR, NO_CREDENTIALS, "no stored credentials"),
+            (
+                REJECTED_CREDENTIALS_STDERR,
+                REJECTED_CREDENTIALS,
+                "rejected credentials",
+            ),
+            (FORBIDDEN_STDERR, FORBIDDEN_403, "a permission refusal"),
+            (ARCHIVED_STDERR, READ_ONLY, "an archived repository"),
+            (GITEA_MIRROR_STDERR, READ_ONLY, "a read-only mirror"),
+        ] {
+            assert_eq!(
+                first_remote_access_match(stderr),
+                Some(entry),
+                "{what} no longer reaches entry {entry} — the toast would explain \
+                 something else, or nothing. Actual stderr:\n{stderr}"
+            );
+        }
+
+        // Both read-only blobs also carry git's generic 403 line, so the read-only
+        // verdict above rests on the table's ORDER rather than on exclusivity.
+        for stderr in [ARCHIVED_STDERR, GITEA_MIRROR_STDERR] {
+            assert!(
+                REMOTE_ACCESS_MARKERS[FORBIDDEN_403](stderr),
+                "a read-only blob lost its 403 line — the fixture no longer exercises \
+                 the precedence entry one depends on. Actual stderr:\n{stderr}"
+            );
+        }
+
+        // The permission blob reaches entry four on its own merits: its `remote:`
+        // line reports no repository state, and no credential entry claims it.
+        for earlier in [READ_ONLY, NO_CREDENTIALS, REJECTED_CREDENTIALS] {
+            assert!(
+                !REMOTE_ACCESS_MARKERS[earlier](FORBIDDEN_STDERR),
+                "entry {earlier} claimed a plain permission refusal, which has its own \
+                 summary"
+            );
+        }
+
+        // Shapes the line anchor and word boundaries refuse. Looser matching here
+        // would let the canary pass stderr the frontend leaves raw, which is the one
+        // direction it must not be loose in.
+        for line in [
+            "Add read-only repository guard",          // a commit subject echoed back
+            "remote: repository is readonly",          // no hyphen
+            "remote: branch main is read-only",        // no repository token
+            "remote: this repository is read-onlyish", // past the word boundary
+            // Two sideband chunks a bare `\r` separates: neither carries both
+            // tokens, and JS `.` cannot span the `\r` to join them.
+            "remote: repository access\rremote: mirror is read-only\n",
+            // Entry two is anchored at the line start with no indent tolerance.
+            "  fatal: could not read Username for 'https://x'",
+            // Entry four's quoted run stops at the first `'`, so the tail has to
+            // follow that quote and not a later one.
+            "fatal: unable to access 'a': 'b': The requested URL returned error: 403",
+        ] {
+            assert_eq!(
+                first_remote_access_match(line),
+                None,
+                "`{line}` matched a remote-access marker the frontend would refuse"
+            );
+        }
+    }
+
     /// The wire values the TS `PushGuard` union (src/lib/git/api.ts) mirrors: the
     /// success toast keys on these exact strings, so a variant rename that skips
     /// the mirror would silently stop reporting a degraded force push.

--- a/src-tauri/src/git/remote.rs
+++ b/src-tauri/src/git/remote.rs
@@ -336,10 +336,23 @@ pub async fn git_fetch(state: State<'_, AppState>, repo_path: String) -> AppResu
     git_fetch_core(&state, repo_path).await
 }
 
+/// The shared fetch. It prunes BRANCHES — clearing tracking refs for branches the
+/// forge no longer has is the action's whole point — and keeps the local tags a
+/// `fetch.pruneTags` / `remote.<name>.pruneTags` config would prune: the background
+/// auto-fetch runs this on a timer, and a transfer the user never asked for must
+/// not delete their refs. The flag reaches only the IMPLICIT tag refspec — a remote
+/// spelling `refs/tags/*` out in its own fetch config still prunes them here (the
+/// pull side stands down for that shape; this always-prune action has no stand-down).
 pub(crate) async fn git_fetch_core(state: &AppState, repo_path: String) -> AppResult<()> {
     let cred = crate::forge::credential_config_for_remote(&repo_path, "origin").await?;
-    run_git_mutating_with_creds(state, &repo_path, &cred, &["fetch", "--prune"], NETWORK_TIMEOUT)
-        .await?;
+    run_git_mutating_with_creds(
+        state,
+        &repo_path,
+        &cred,
+        &["fetch", "--prune", "--no-prune-tags"],
+        NETWORK_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -360,11 +373,11 @@ async fn ensure_remote_exists(repo_path: &str, remote: &str) -> AppResult<()> {
     }
 }
 
-/// Fetch a single named remote (`git fetch --prune <remote>`), unlike
-/// [`git_fetch`] which fetches only the default remote. Powers "Update from
-/// upstream" for forks: `git fetch --prune` alone never touches an `upstream`
-/// remote, so a fork needs this to see upstream's new commits at all. The
-/// remote is validated to exist before use.
+/// Fetch a single named remote, unlike [`git_fetch`] which fetches only the
+/// default remote. Powers "Update from upstream" for forks: a default-remote fetch
+/// never touches an `upstream` remote, so a fork needs this to see upstream's new
+/// commits at all. The remote is validated to exist before use; the flags are
+/// [`git_fetch_core`]'s, for the same reasons.
 #[tauri::command]
 pub async fn git_fetch_remote(
     state: State<'_, AppState>,
@@ -377,7 +390,7 @@ pub async fn git_fetch_remote(
         &state,
         &repo_path,
         &cred,
-        &["fetch", "--prune", &remote],
+        &["fetch", "--prune", "--no-prune-tags", &remote],
         NETWORK_TIMEOUT,
     )
     .await?;
@@ -914,8 +927,8 @@ pub(crate) fn publish_refspec(branch: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_push_args, cache_get, cache_invalidate, cache_put, git_pull_core, git_push_core,
-        git_remote_remove_core, is_auth_class_failure, is_unknown_push_option,
+        build_push_args, cache_get, cache_invalidate, cache_put, git_fetch_core, git_pull_core,
+        git_push_core, git_remote_remove_core, is_auth_class_failure, is_unknown_push_option,
         parse_upstream_tracking, publish_refspec, resolve_push_target, run_git_mutating_with_creds,
         without_force_if_includes, IF_INCLUDES_REJECTION, PushGuard,
     };
@@ -2976,6 +2989,74 @@ fatal: unable to access 'http://192.168.1.10:99xx/gituser1/GitDesktop/': The req
         assert!(
             matches!(g, Some((_, _, true))),
             "goner upstream should read gone: {g:?}"
+        );
+    }
+
+    /// A tag-pruning user keeps their local tags through the Fetch action, and the
+    /// BRANCH half of the prune still runs — that half is what the action exists
+    /// for, and the auto-fetch timer is what makes the tag half matter. A sibling
+    /// clone under the same config is the negative control: there a raw pruning
+    /// fetch deletes the tag, so the config is proven to bite before the flag is
+    /// credited with anything.
+    #[tokio::test]
+    async fn fetch_keeps_local_tags_and_still_prunes_branches() {
+        let (_guard, base, _origin_s, url) = seeded_origin("prune-tags").await;
+        let base_s = base.to_string_lossy().into_owned();
+        let work = base.join("work");
+        let work_s = work.to_string_lossy().into_owned();
+
+        // A branch both clones track, deleted on the origin afterwards — the stale
+        // tracking ref the prune has to take.
+        run(&work_s, &["switch", "-q", "-c", "doomed"]).await;
+        std::fs::write(work.join("d.txt"), "d\n").unwrap();
+        run(&work_s, &["add", "-A"]).await;
+        run(&work_s, &["commit", "-qm", "doomed"]).await;
+        run(&work_s, &["push", "-q", "-u", "origin", "doomed"]).await;
+
+        for name in ["clone", "control"] {
+            run(&base_s, &["-c", "core.autocrlf=false", "clone", "-q", &url, name]).await;
+            let c = base.join(name).to_string_lossy().into_owned();
+            run(&c, &["config", "fetch.pruneTags", "true"]).await;
+            // A tag the origin does not carry, which is what makes it prunable.
+            run(&c, &["tag", "keep-me"]).await;
+        }
+        run(&work_s, &["push", "-q", "origin", "--delete", "doomed"]).await;
+
+        let clone_s = base.join("clone").to_string_lossy().into_owned();
+        let control_s = base.join("control").to_string_lossy().into_owned();
+
+        // Both preconditions, asserted before the fetch: without them the two
+        // assertions below would pass on an empty starting state.
+        assert_eq!(run(&clone_s, &["tag"]).await.trim(), "keep-me");
+        assert!(
+            !run(&clone_s, &["for-each-ref", "refs/remotes/origin/doomed"])
+                .await
+                .trim()
+                .is_empty(),
+            "the clone must start with the tracking ref the prune is meant to clear"
+        );
+
+        // The config has to bite, or retention below proves nothing.
+        run(&control_s, &["fetch", "--prune", "origin"]).await;
+        assert!(
+            run(&control_s, &["tag"]).await.trim().is_empty(),
+            "fetch.pruneTags must delete the tag on the control's raw pruning fetch"
+        );
+
+        git_fetch_core(&AppState::default(), clone_s.clone())
+            .await
+            .expect("the fetch action succeeds");
+        assert_eq!(
+            run(&clone_s, &["tag"]).await.trim(),
+            "keep-me",
+            "the Fetch action deleted a tag the user still holds"
+        );
+        assert!(
+            run(&clone_s, &["for-each-ref", "refs/remotes/origin/doomed"])
+                .await
+                .trim()
+                .is_empty(),
+            "the deleted upstream branch's tracking ref must still be pruned"
         );
     }
 }

--- a/src-tauri/src/git/runner.rs
+++ b/src-tauri/src/git/runner.rs
@@ -209,7 +209,7 @@ impl GitOutput {
 
 /// The resolved `git` binary, memoized for the process lifetime.
 ///
-/// `run_git_raw_input` is the base of the whole git call stack (status, diffs,
+/// `run_git_raw_input_bytes` is the base of the whole git call stack (status, diffs,
 /// history, staging — all firing continuously as the user works), and a packaged
 /// GUI app on macOS doesn't inherit the user's shell PATH. So we resolve `git`
 /// the way the About screen does (`crate::agent::resolve_named`: PATH + known
@@ -351,6 +351,18 @@ pub async fn run_git_raw_input(
     input: Option<&str>,
     timeout: Duration,
 ) -> AppResult<GitOutput> {
+    run_git_raw_input_bytes(repo_path, args, input.map(str::as_bytes), timeout).await
+}
+
+/// [`run_git_raw_input`] over a stdin that need not be text. Callers whose input
+/// carries PATH bytes want this: git's path handling is byte-domain, so a name
+/// that is not valid UTF-8 has no `&str` spelling that reaches git unchanged.
+pub async fn run_git_raw_input_bytes(
+    repo_path: Option<&str>,
+    args: &[&str],
+    input: Option<&[u8]>,
+    timeout: Duration,
+) -> AppResult<GitOutput> {
     // A zero budget refuses before spawning — no production caller passes one (they
     // all use a *_TIMEOUT constant), and it makes the tests' `Duration::ZERO` seam
     // deterministic: a nonzero expired budget loses the race to a fast child (Linux).
@@ -417,10 +429,10 @@ pub async fn run_git_raw_input(
         let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
         let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
         let write = async move {
-            let (Some(mut pipe), Some(text)) = (stdin_pipe, input) else {
+            let (Some(mut pipe), Some(bytes)) = (stdin_pipe, input) else {
                 return Ok(());
             };
-            let written = pipe.write_all(text.as_bytes()).await;
+            let written = pipe.write_all(bytes).await;
             // Close the pipe the moment the write ends (error path included) so
             // git sees EOF while the drains still poll — `--stdin` blocks forever
             // without it; the explicit drop pins that close point across refactors.

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -964,7 +964,16 @@ prunable gitdir file points to non-existent location
         };
         assert!(is_session_worktree(&by_path, &HashSet::new(), app_root));
 
-        // 4) an ordinary user worktree is NOT excluded
+        // 4) an update's throwaway `gd-update-*` checkout, hidden by that same root
+        // (the branch it holds is one of the user's own, so only the path can hide it)
+        let by_update = RawWorktree {
+            path: "C:/Users/me/AppData/Local/app/worktrees/h/gd-update-1234-99".into(),
+            branch: "feature".into(),
+            ..Default::default()
+        };
+        assert!(is_session_worktree(&by_update, &HashSet::new(), app_root));
+
+        // 5) an ordinary user worktree is NOT excluded
         let user = RawWorktree {
             path: "C:/repos/app-feature".into(),
             branch: "feature".into(),

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -766,7 +766,8 @@ impl GitDesktopMcp {
 
     #[tool(
         description = "Fetch the bound repository's default remote, pruning stale \
-                       remote-tracking branches and keeping local tags. \
+                       remote-tracking branches and retaining local tags unless the \
+                       remote explicitly fetches refs/tags/*. \
                        Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]

--- a/src-tauri/src/mcp_server/write_git.rs
+++ b/src-tauri/src/mcp_server/write_git.rs
@@ -765,7 +765,8 @@ impl GitDesktopMcp {
     }
 
     #[tool(
-        description = "Fetch from all remotes (with --prune) in the bound repository. \
+        description = "Fetch the bound repository's default remote, pruning stale \
+                       remote-tracking branches and keeping local tags. \
                        Requires --allow-git-write.",
         annotations(read_only_hint = false, destructive_hint = false)
     )]

--- a/src/lib/error-summary.ts
+++ b/src/lib/error-summary.ts
@@ -192,7 +192,10 @@ function pushRejectionSummary(text: string): string | null {
  *  name a repository: that token is what keeps the summary's claim scoped to
  *  the whole repository. Shapes measured verbatim against github.com on git
  *  2.51.1.windows.1, 2026-09; the mirror line is a Gitea server's, from a user
- *  report. */
+ *  report. Paired with the Rust canary
+ *  `remote_access_stderr_still_matches_the_frontend_markers` (git/remote.rs),
+ *  which pins measured stderr against Rust mirrors of these patterns — keep
+ *  the two lists in step, ORDER INCLUDED. */
 const REMOTE_ACCESS_SUMMARIES: readonly (readonly [RegExp, string])[] = [
   [
     /^[ \t]*remote: (?=.*\b[Rr]epositor(?:y|ies)\b).*\b[Rr]ead-only\b/m,

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -749,7 +749,7 @@ export const gitCommitFileDiff = (
 export const gitFetch = (repoPath: string) =>
   invoke<void>("git_fetch", { repoPath });
 
-/** Fetch a single named remote (`git fetch --prune <remote>`) — unlike
+/** Fetch a single named remote (`git fetch --prune --no-prune-tags <remote>`) — unlike
  *  {@link gitFetch}, which only touches the default remote. Used to sync a
  *  fork's `upstream`, which a bare fetch never reaches. */
 export const gitFetchRemote = (repoPath: string, remote: string) =>

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -749,9 +749,9 @@ export const gitCommitFileDiff = (
 export const gitFetch = (repoPath: string) =>
   invoke<void>("git_fetch", { repoPath });
 
-/** Fetch a single named remote (`git fetch --prune --no-prune-tags <remote>`) — unlike
- *  {@link gitFetch}, which only touches the default remote. Used to sync a
- *  fork's `upstream`, which a bare fetch never reaches. */
+/** Fetch a single named remote (`git fetch --prune --no-prune-tags <remote>`),
+ *  unlike {@link gitFetch}, which only touches the default remote. Used to
+ *  sync a fork's `upstream`, which a bare fetch never reaches. */
 export const gitFetchRemote = (repoPath: string, remote: string) =>
   invoke<void>("git_fetch_remote", { repoPath, remote });
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4950,7 +4950,7 @@ export function useMergePr(repo: string, lens: RemoteLens) {
         lens,
       );
       // The remote advanced but the local repo is now stale (ahead/behind, history,
-      // tracking refs). Kick off a background `git fetch --prune` so they catch up —
+      // tracking refs). Kick off a background pruning fetch so they catch up —
       // NOT awaited, so the merge toast fires the moment the call resolves, and
       // silent: the forge already accepted the merge (landed or queued), so a fetch
       // failure toast would misreport it (header Fetch stays the manual fallback).


### PR DESCRIPTION
A batch of git-plumbing fixes. Pulls and fetches stop deleting local tags on repositories configured to prune them and hand mirror-style refspecs back to bare `git pull` instead of hard-erroring; **Update from**'s throwaway checkout moves out of the OS temp dir so it stays out of the user-facing worktree surfaces; and the AI-ignore engine gains a byte-domain core that matches filenames on the bytes they really have rather than a lossy `String` spelling.

### Pull guard and fetch

- Both transfers in `src-tauri/src/git/pull_guard.rs` — `probe`'s fetch and `fetch_and_pin`'s — now pass `--no-prune-tags` alongside `--prune`, so the branch half of the prune (which the deleted-upstream stand-down rests on) still runs while a `fetch.pruneTags` / `remote.<name>.pruneTags` user keeps their local tags. The app's Fetch action (`git_fetch_core` / `git_fetch_remote` in `src-tauri/src/git/remote.rs`) carries the same flags for the same reason — the background auto-fetch runs it on a timer, and a transfer the user never asked for must not delete their refs.
- Drops the `pruneTags` pair from `plain_pull_config_stands_down` and deletes the now-unused `config_is_true` helper. With the flag on the command line the only difference left is a deliberate one: when a prune config (`fetch.prune` / `remote.<name>.prune`) is also set, bare pull deletes those tags and the split phases keep them — a divergence in the user's favor, stated as such in the code.
- `probe` now checks the fetch refspecs *before* fetching and returns `Ok(None)` for remotes whose refspec writes outside `refs/remotes/` (`fetch_writes_outside_remote_tracking`). Two reasons, both measured: a `refs/heads/` destination can make the fetch hard-refuse — git refuses only when a destination covers the *checked-out* branch ("refusing to fetch into branch") — and any destination outside remote-tracking space puts real local refs (tags, custom namespaces) in reach of `--prune`, which `--no-prune-tags` does not cover for explicit refspecs. The predicate deliberately over-approximates: standing down for refspecs whose fetch would succeed is the price of never hard-erroring and never pruning a user's own refs, and the stand-down hands those setups back to bare `git pull --rebase` — which gets through on the `--update-head-ok` its own fetch carries, a flag the probe deliberately does not adopt.
- New tests cover each arm: `the_plain_fetch_keeps_local_tags_and_still_prunes_branches` (both `pruneTags` spellings, with sibling-clone negative controls that *do* lose the tag), `the_probe_fetch_keeps_local_tags`, `the_probe_stands_down_on_a_refspec_that_writes_outside_remote_tracking` (heads, tags, and true-mirror shapes, with the measured deletions as in-test controls), and `fetch_keeps_local_tags_and_still_prunes_branches` for the Fetch action.

### Branch update worktree placement

- `update_branch_from` in `src-tauri/src/git/branches.rs` mints its temporary checkout through a new `update_worktree_path` helper — `<app-data>/worktrees/<repo-hash>/gd-update-<unique>` — instead of `std::env::temp_dir()`, so `is_session_worktree`'s app-data arm hides it from the Worktrees manager and the branch lists.
- `worktree_root_dir` in `src-tauri/src/git/ops.rs` becomes `pub(crate)` to support that resolution, and now reads the shared `APP_IDENTIFIER` const; `worktree_root_dir_uses_the_shipped_bundle_identifier` pins that identifier against `tauri.conf.json`, since a drift there would silently strand every hidden worktree family outside the filter.
- Adds `update_worktree_path_sits_under_the_app_data_root` (shape only, so it writes nothing under real app data) and a `gd-update-*` case to the `is_session_worktree` table in `src-tauri/src/git/worktree.rs`.

### AI-ignore byte-domain matching

- `run_check_ignore` in `src-tauri/src/git/ai_ignore.rs` now sends and receives path bytes, with a new public `filter_ignored_bytes` for callers that hold real names out of git's `-z` streams; `filter_ignored` keeps its `String` signature and delegates. No production caller migrates in this PR — the first one needs a byte-domain numstat parser, a recorded follow-up — so user-visible behavior is unchanged here.
- `git_ai_ignore_verdicts` converts its JSON-sourced paths to bytes and decodes the verbose records back, keeping the existing surface intact.
- `src-tauri/src/git/runner.rs` grows `run_git_raw_input_bytes`, with `run_git_raw_input` delegating to it, so a non-UTF-8 name reaches git unchanged.
- Two tests pin the behavior: `byte_names_match_on_their_own_bytes` (including a newline in a name and a prefix collision across the NUL-framed wire) and `a_literal_pattern_tells_the_two_spellings_apart`, which contrasts latin-1 and UTF-8 `café.env` and shows what the `String` path really decided.

### Remote-error canary

- `src-tauri/src/git/remote.rs` gains stderr fixtures (missing credentials, rejected credentials, a 403 permission refusal, an archived repository, a Gitea pull-mirror) — the marker-bearing `remote:` and credential `fatal:` lines measured or transcribed verbatim, the two composed `fatal:` shapes disclosed as such in the fixture docs — plus Rust mirrors of the frontend's `REMOTE_ACCESS_SUMMARIES` markers, and `remote_access_stderr_still_matches_the_frontend_markers` pins them together in table order — order being precedence, not layout. Negative cases assert the line anchors and word boundaries still refuse shapes the frontend leaves raw.

### Changelog

- `changelog.d/fixed-pull-fetch-tag-prune.md` and `changelog.d/fixed-branch-update-hidden-staging.md` cover the two user-visible fixes.

Relates to #289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Temporary checkouts created during branch updates are now hidden from Worktrees and branch lists.
  - Pull and fetch operations preserve local tags while continuing to prune stale remote-tracking branches.
  - Files with non-UTF-8 names are now handled and matched correctly by AI-ignore filtering.
  - Update checkouts are stored consistently within the application’s worktree area.
  - Fetch behavior now accurately reflects that explicitly configured tag refspecs may still be pruned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->