### PR TITLE
fix(sessions,history,plan,research): use the running container engine

### DIFF
--- a/changelog.d/fixed-blame-hovercard-exclusivity.md
+++ b/changelog.d/fixed-blame-hovercard-exclusivity.md
@@ -1,0 +1,3 @@
+- Blame's commit hovercards now show one card at a time: opening one by keyboard
+  or by hover closes any other, scrolling the file dismisses it, and Escape
+  closes the card while the blame view stays open.

--- a/changelog.d/fixed-blame-hovercard-exclusivity.md
+++ b/changelog.d/fixed-blame-hovercard-exclusivity.md
@@ -1,3 +1,2 @@
 - Blame's commit hovercards now show one card at a time: opening one by keyboard
-  or by hover closes any other, scrolling the file dismisses it, and Escape
-  closes the card while the blame view stays open.
+  or by hover closes any other, and scrolling the file dismisses the open card.

--- a/changelog.d/fixed-container-runtime-fallback.md
+++ b/changelog.d/fixed-container-runtime-fallback.md
@@ -1,0 +1,3 @@
+- Container sessions, image builds, the Test shell, and cleanup now use whichever
+  container engine is actually running: with both Docker and Podman installed, a
+  stopped Docker no longer blocks a running Podman (and vice versa).

--- a/changelog.d/fixed-ensemble-arm-image-warning.md
+++ b/changelog.d/fixed-ensemble-arm-image-warning.md
@@ -1,0 +1,2 @@
+- Best-of-N runs in a container now flag, per arm, an agent the image wasn't
+  built with, so you can fix the arm before you spend on the run.

--- a/changelog.d/fixed-plan-research-default-agent.md
+++ b/changelog.d/fixed-plan-research-default-agent.md
@@ -1,0 +1,2 @@
+- Plan and Research now respect your Default agent setting from the very first
+  submit after launch, matching the session composer.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -565,6 +565,9 @@ export const CHECKS = [
       // Scroll/resize-close listeners for the open hovercard; add/remove pair,
       // and re-subscribing after an Activity re-show is the wanted behavior.
       "src/features/repository/insights/DependenciesCard.tsx",
+      // Same class: the blame gutter's scroll-close listener for its open
+      // hovercard — add/remove pair, idempotent to re-subscribe.
+      "src/features/history/BlameDialog.tsx",
     ],
     message:
       "an open-transition reset must ride useSeedOnOpen (src/lib/use-seed-on-open.ts) — a hidden <Activity> tab re-mounts its effects on show, so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires and wipes the user's draft; a data-arrival or otherwise idempotent seed needs an allowlist entry with rationale",

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -2737,28 +2737,35 @@ pub async fn agent_session(
     // worktree-confined container. The agent CLI lives in the image, so we don't
     // resolve a host binary; the runtime drives it.
     if container {
-        let (runtime, runtime_name) = crate::agent_sandbox::detect_runtime().await.ok_or_else(|| {
-            AppError::Command("Container isolation is on for this session, but Docker/Podman isn't available. Install and start it — or start a new session with Isolation set to Worktree (composer → Options), or turn container isolation off in Settings → AI.".to_string())
-        })?;
-        if !crate::agent_sandbox::image_present(&runtime).await {
-            // `image inspect` needs the daemon, so a stopped engine fails here too — but
-            // this whole branch runs on EVERY turn, so the daemon probe is deliberately on
-            // the failure path only: a healthy session pays nothing, and a failing one
-            // still tells "engine stopped" apart from "image never built".
-            if !crate::agent_sandbox::runtime_ready(&runtime).await {
-                let label = if runtime_name == "podman" {
-                    "Podman"
-                } else {
-                    "Docker"
-                };
-                return Err(AppError::Command(format!(
-                    "{label} is installed but its engine isn't running. Start it, then try again."
-                )));
-            }
-            return Err(AppError::Command(
-                "The agent container image isn't built yet. Open Settings → AI and click \"Build image\", then try again.".to_string(),
-            ));
-        }
+        // This branch runs on EVERY turn, so the preferred runtime holding the image
+        // settles the choice in ONE subprocess — `image inspect` needs the daemon, so
+        // it also proves the engine is up. Only its failure pays for the wider walk,
+        // which is what tells "wrong engine" / "engine stopped" / "never built" apart.
+        let preferred = crate::agent_sandbox::preferred_runtime().await;
+        let preferred_has_image = match &preferred {
+            Some((bin, _)) => crate::agent_sandbox::image_present(bin).await,
+            None => false,
+        };
+        let (runtime, runtime_name) = match preferred.filter(|_| preferred_has_image) {
+            Some(pair) => pair,
+            None => match crate::agent_sandbox::pick_runtime().await {
+                crate::agent_sandbox::RuntimePick::WithImage(bin, name) => (bin, name),
+                crate::agent_sandbox::RuntimePick::ReadyNoImage(..) => {
+                    return Err(AppError::Command(
+                        "The agent container image isn't built yet. Open Settings → AI and click \"Build image\", then try again.".to_string(),
+                    ));
+                }
+                crate::agent_sandbox::RuntimePick::NotReady(_, name) => {
+                    let label = if name == "podman" { "Podman" } else { "Docker" };
+                    return Err(AppError::Command(format!(
+                        "{label} is installed but its engine isn't running. Start it, then try again."
+                    )));
+                }
+                crate::agent_sandbox::RuntimePick::Missing => {
+                    return Err(AppError::Command("Container isolation is on for this session, but Docker/Podman isn't available. Install and start it — or start a new session with Isolation set to Worktree (composer → Options), or turn container isolation off in Settings → AI.".to_string()));
+                }
+            },
+        };
         // The image may have been built without this agent (provider selection) —
         // fail clearly instead of a cryptic in-container "command not found".
         if !crate::agent_sandbox::image_has_agent(&runtime, agent_name).await {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -2756,9 +2756,9 @@ pub async fn agent_session(
                     ));
                 }
                 crate::agent_sandbox::RuntimePick::NotReady(_, name) => {
-                    let label = if name == "podman" { "Podman" } else { "Docker" };
                     return Err(AppError::Command(format!(
-                        "{label} is installed but its engine isn't running. Start it, then try again."
+                        "{} is installed but its engine isn't running. Start it, then try again.",
+                        crate::agent_sandbox::runtime_label(&name)
                     )));
                 }
                 crate::agent_sandbox::RuntimePick::Missing => {

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -468,7 +468,7 @@ async fn runtime_for_build() -> AppResult<PathBuf> {
     match pick_runtime().await {
         RuntimePick::WithImage(bin, _) | RuntimePick::ReadyNoImage(bin, _) => Ok(bin),
         RuntimePick::NotReady(_, name) => Err(AppError::Command(format!(
-            "{} is installed but its engine isn't running. Start it and try again.",
+            "{} is installed but its engine isn't running. Start it, then try again.",
             runtime_label(&name)
         ))),
         RuntimePick::Missing => Err(AppError::Command(

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -212,28 +212,59 @@ pub(crate) fn global_skills_dir() -> Option<PathBuf> {
         .filter(|p| p.is_dir())
 }
 
-/// Finds Docker or Podman on PATH (Docker preferred). Returns (binary, name).
-pub(crate) async fn detect_runtime() -> Option<(PathBuf, String)> {
-    if let Some(bin) = resolve_named(&["docker"], None).await {
-        return Some((bin, "docker".to_string()));
+/// Preference slots [`candidate_at`] can fill.
+const RUNTIME_SLOTS: usize = 2;
+
+/// The installed runtime in preference slot `i` as `(binary, name)`: 0 is Docker on
+/// PATH, 1 is Podman on PATH else (Windows) Podman Desktop's install dir. Resolved
+/// ONE SLOT AT A TIME because on macOS/Linux `resolve_named` answers for an absent
+/// binary by spawning a login shell (up to `DETECT_TIMEOUT`), so a hot path that
+/// settles on slot 0 must never reach slot 1.
+async fn candidate_at(i: usize) -> Option<(PathBuf, String)> {
+    match i {
+        0 => resolve_named(&["docker"], None)
+            .await
+            .map(|bin| (bin, "docker".to_string())),
+        1 => {
+            let podman = resolve_named(&["podman"], None).await;
+            // Windows: Podman Desktop installs here but isn't on PATH until the app
+            // is relaunched after install — check the known location so a
+            // just-installed Podman is found without a restart.
+            #[cfg(windows)]
+            let podman = podman.or_else(|| {
+                let p = PathBuf::from(std::env::var_os("LOCALAPPDATA")?)
+                    .join("Programs")
+                    .join("Podman")
+                    .join("podman.exe");
+                p.is_file().then_some(p)
+            });
+            podman.map(|bin| (bin, "podman".to_string()))
+        }
+        _ => None,
     }
-    if let Some(bin) = resolve_named(&["podman"], None).await {
-        return Some((bin, "podman".to_string()));
-    }
-    // Windows: Podman Desktop installs here but isn't on PATH until the app is
-    // relaunched after install — check the known location so a just-installed
-    // Podman is found without a restart.
-    #[cfg(windows)]
-    if let Some(local) = std::env::var_os("LOCALAPPDATA") {
-        let p = PathBuf::from(local)
-            .join("Programs")
-            .join("Podman")
-            .join("podman.exe");
-        if p.is_file() {
-            return Some((p, "podman".to_string()));
+}
+
+/// The preferred installed runtime — the first filled slot, resolved no further.
+pub(crate) async fn preferred_runtime() -> Option<(PathBuf, String)> {
+    for i in 0..RUNTIME_SLOTS {
+        if let Some(c) = candidate_at(i).await {
+            return Some(c);
         }
     }
     None
+}
+
+/// Every installed runtime in preference order, for operations that must act on ALL
+/// of them. Resolving each slot has a cost (see [`candidate_at`]), so callers that
+/// only need one runtime take [`pick_runtime`] or [`preferred_runtime`] instead.
+pub(crate) async fn runtime_candidates() -> Vec<(PathBuf, String)> {
+    let mut out: Vec<(PathBuf, String)> = Vec::new();
+    for i in 0..RUNTIME_SLOTS {
+        if let Some(c) = candidate_at(i).await {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// True when `<rt> version` exits 0 (engine reachable, not just the client).
@@ -249,6 +280,128 @@ pub(crate) async fn image_present(bin: &Path) -> bool {
         run_capture(bin, &["image", "inspect", IMAGE], DETECT_TIMEOUT).await,
         Ok((0, _))
     )
+}
+
+/// What a container operation that RUNS something should use.
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimePick {
+    /// Ready engine that has the managed image built.
+    WithImage(PathBuf, String),
+    /// Ready engine, but no candidate's engine holds the image.
+    ReadyNoImage(PathBuf, String),
+    /// Something is installed but no engine answered.
+    NotReady(PathBuf, String),
+    Missing,
+}
+
+/// Where the preference policy landed, as an index into the candidate list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Choice {
+    WithImage(usize),
+    ReadyNoImage(usize),
+    NotReady(usize),
+    Missing,
+}
+
+/// The preference policy over probed candidate states `(ready, has_image)`, in
+/// candidate order. Images are per-engine (Docker's store isn't Podman's), so a
+/// ready engine holding the managed image outranks a merely-ready one; with none
+/// ready the first INSTALLED candidate names the "start your engine" message.
+fn choose(states: &[(bool, bool)]) -> Choice {
+    let mut first_ready = None;
+    for (i, &(ready, has_image)) in states.iter().enumerate() {
+        if !ready {
+            continue;
+        }
+        if has_image {
+            return Choice::WithImage(i);
+        }
+        first_ready.get_or_insert(i);
+    }
+    match first_ready {
+        Some(i) => Choice::ReadyNoImage(i),
+        None if states.is_empty() => Choice::Missing,
+        None => Choice::NotReady(0),
+    }
+}
+
+/// One candidate's `(ready, has_image)` state. `image inspect` needs the daemon, so
+/// only a ready engine gets the second probe.
+async fn probe_runtime(bin: &Path) -> (bool, bool) {
+    let ready = runtime_ready(bin).await;
+    (ready, ready && image_present(bin).await)
+}
+
+/// Maps a settled [`Choice`] back onto the candidate it indexes.
+fn verdict(mut candidates: Vec<(PathBuf, String)>, states: &[(bool, bool)]) -> RuntimePick {
+    match choose(states) {
+        Choice::WithImage(i) => {
+            let (bin, name) = candidates.swap_remove(i);
+            RuntimePick::WithImage(bin, name)
+        }
+        Choice::ReadyNoImage(i) => {
+            let (bin, name) = candidates.swap_remove(i);
+            RuntimePick::ReadyNoImage(bin, name)
+        }
+        Choice::NotReady(i) => {
+            let (bin, name) = candidates.swap_remove(i);
+            RuntimePick::NotReady(bin, name)
+        }
+        Choice::Missing => RuntimePick::Missing,
+    }
+}
+
+/// The runtime a container operation should run on, per [`choose`]. Both the
+/// candidate resolution and its probes are lazy, so a ready Docker holding the image
+/// costs one `version` plus one `image inspect` and never looks for Podman. Sweeps
+/// that remove containers by their stable names take [`runtime_candidates`] instead:
+/// a container created under one engine must still be cleaned up when a different
+/// engine is picked later.
+pub(crate) async fn pick_runtime() -> RuntimePick {
+    let mut candidates: Vec<(PathBuf, String)> = Vec::new();
+    let mut states: Vec<(bool, bool)> = Vec::new();
+    for i in 0..RUNTIME_SLOTS {
+        let Some(candidate) = candidate_at(i).await else {
+            continue;
+        };
+        states.push(probe_runtime(&candidate.0).await);
+        candidates.push(candidate);
+        // Nothing later can beat a ready engine that already holds the image.
+        if matches!(choose(&states), Choice::WithImage(_)) {
+            break;
+        }
+    }
+    verdict(candidates, &states)
+}
+
+/// [`pick_runtime`] over an already-resolved candidate list, so a caller holding one
+/// doesn't pay [`candidate_at`]'s resolution a second time.
+pub(crate) async fn pick_from(known: Vec<(PathBuf, String)>) -> RuntimePick {
+    let mut candidates: Vec<(PathBuf, String)> = Vec::with_capacity(known.len());
+    let mut states: Vec<(bool, bool)> = Vec::with_capacity(known.len());
+    for candidate in known {
+        states.push(probe_runtime(&candidate.0).await);
+        candidates.push(candidate);
+        if matches!(choose(&states), Choice::WithImage(_)) {
+            break;
+        }
+    }
+    verdict(candidates, &states)
+}
+
+/// The runtime to build an image on: the engine already holding the managed image
+/// when there is one, so a rebuild lands where the image lives.
+async fn runtime_for_build() -> AppResult<PathBuf> {
+    match pick_runtime().await {
+        RuntimePick::WithImage(bin, _) | RuntimePick::ReadyNoImage(bin, _) => Ok(bin),
+        RuntimePick::NotReady(..) => Err(AppError::Command(
+            "Docker/Podman is installed but its engine isn't running. Start it and try again."
+                .into(),
+        )),
+        RuntimePick::Missing => Err(AppError::Command(
+            "Docker or Podman is not installed.".into(),
+        )),
+    }
 }
 
 /// Reads the built image's `gdconfig` label (`None` if the image/label is absent).
@@ -288,17 +441,19 @@ pub async fn agent_container_detect(
     node_version: String,
     providers: Vec<String>,
 ) -> AppResult<ContainerStatus> {
-    let Some((bin, name)) = detect_runtime().await else {
-        return Ok(ContainerStatus {
-            runtime: None,
-            ready: false,
-            image_present: false,
-            image_matches: false,
-        });
+    let (bin, name, ready, image_present) = match pick_runtime().await {
+        RuntimePick::WithImage(bin, name) => (bin, name, true, true),
+        RuntimePick::ReadyNoImage(bin, name) => (bin, name, true, false),
+        RuntimePick::NotReady(bin, name) => (bin, name, false, false),
+        RuntimePick::Missing => {
+            return Ok(ContainerStatus {
+                runtime: None,
+                ready: false,
+                image_present: false,
+                image_matches: false,
+            });
+        }
     };
-    let ready = runtime_ready(&bin).await;
-    // Only probe the image if the engine is up (inspect needs the daemon).
-    let image_present = ready && image_present(&bin).await;
     let image_matches = image_present
         && image_config_label(&bin).await.as_deref()
             == Some(config_signature(&node_version, &providers).as_str());
@@ -318,15 +473,7 @@ pub async fn agent_container_prepare(
     providers: Vec<String>,
     force: bool,
 ) -> AppResult<()> {
-    let (bin, _) = detect_runtime()
-        .await
-        .ok_or_else(|| AppError::Command("Docker or Podman is not installed.".into()))?;
-    if !runtime_ready(&bin).await {
-        return Err(AppError::Command(
-            "Docker/Podman is installed but its engine isn't running. Start it and try again."
-                .into(),
-        ));
-    }
+    let bin = runtime_for_build().await?;
 
     // Render + validate the Dockerfile for the selected Node version + providers,
     // and stamp the config as a label so detect can spot a stale image.
@@ -586,12 +733,13 @@ pub async fn agent_custom_image_status(worktree_path: String) -> AppResult<Custo
         });
     }
     // Valid → is it built? Needs the runtime + the base image to compute the tag.
-    let built = match detect_runtime().await {
-        Some((bin, _)) => match base_image_id(&bin).await {
+    let built = match pick_runtime().await {
+        RuntimePick::WithImage(bin, _) => match base_image_id(&bin).await {
             Some(id) => image_exists(&bin, &derived_tag(&id, &dockerfile)).await,
             None => false,
         },
-        None => false,
+        // No engine holds the base image, so no derived image can exist either.
+        _ => false,
     };
     Ok(CustomImageStatus {
         state: if built { "built" } else { "needsBuild" },
@@ -625,15 +773,7 @@ pub async fn agent_build_custom_image(
         ));
     }
     validate_custom_dockerfile(&dockerfile).map_err(AppError::InvalidArgument)?;
-    let (bin, _) = detect_runtime()
-        .await
-        .ok_or_else(|| AppError::Command("Docker or Podman is not installed.".into()))?;
-    if !runtime_ready(&bin).await {
-        return Err(AppError::Command(
-            "Docker/Podman is installed but its engine isn't running. Start it and try again."
-                .into(),
-        ));
-    }
+    let bin = runtime_for_build().await?;
     let id = base_image_id(&bin).await.ok_or_else(|| {
         AppError::Command(
             "Build the base agent image first (Settings → container isolation), then build the custom image."
@@ -768,8 +908,10 @@ pub async fn agent_sandbox_cleanup(app: AppHandle, session_id: String) -> AppRes
     }
     // Drop the generated MCP config too (it may hold resolved secrets).
     crate::mcp::cleanup_host_config(&app, &session_id);
-    if let Some((bin, _)) = detect_runtime().await {
-        let name = container_name(&session_id);
+    // Sweep every installed runtime: the container name is stable, so a session
+    // created under one engine must still be removed when another is preferred now.
+    let name = container_name(&session_id);
+    for (bin, _) in runtime_candidates().await {
         let _ = run_capture(&bin, &["rm", "-f", &name], DETECT_TIMEOUT).await;
     }
     Ok(())
@@ -896,23 +1038,40 @@ pub(crate) async fn container_shell_command(
     worktree_path: &str,
     ports: &[String],
 ) -> AppResult<(String, Vec<String>, String)> {
-    let (bin_path, rt) = detect_runtime().await.ok_or_else(|| {
-        AppError::Command(
-            "Docker or Podman not found on PATH — install one to test a container session."
-                .into(),
-        )
-    })?;
+    let candidates = runtime_candidates().await;
     let name = test_container_name(worktree_path);
-    let bin = bin_path.to_string_lossy().to_string();
 
     // Already running (its terminal was closed without `exit`) → reconnect a fresh
     // shell into it; its server + published ports are untouched. `exec` takes no
-    // ports/mount — those belong to the original `run`.
-    if container_running(&bin_path, &name).await {
-        let args = vec!["exec".into(), "-it".into(), name, "bash".into()];
-        let tip = "Tip: reconnected to the container that is still running - your server and ports are unchanged. Use Stop test container to shut it down.".to_string();
-        return Ok((bin, args, tip));
+    // ports/mount — those belong to the original `run`. Asked of every ready
+    // candidate, since it may sit on an engine other than the preferred one.
+    for (bin_path, _) in &candidates {
+        if runtime_ready(bin_path).await && container_running(bin_path, &name).await {
+            let args = vec!["exec".into(), "-it".into(), name.clone(), "bash".into()];
+            let tip = "Tip: reconnected to the container that is still running - your server and ports are unchanged. Use Stop test container to shut it down.".to_string();
+            return Ok((bin_path.to_string_lossy().to_string(), args, tip));
+        }
     }
+
+    // The Test shell falls back to the base image, so a ready engine without the
+    // managed image still launches; the terminal shows the engine's own error if
+    // neither image is there.
+    let (bin_path, rt) = match pick_from(candidates).await {
+        RuntimePick::WithImage(bin, rt) | RuntimePick::ReadyNoImage(bin, rt) => (bin, rt),
+        RuntimePick::NotReady(..) => {
+            return Err(AppError::Command(
+                "Docker/Podman is installed but its engine isn't running. Start it, then try again."
+                    .into(),
+            ));
+        }
+        RuntimePick::Missing => {
+            return Err(AppError::Command(
+                "Docker or Podman not found on PATH — install one to test a container session."
+                    .into(),
+            ));
+        }
+    };
+    let bin = bin_path.to_string_lossy().to_string();
 
     // Validate the ports before touching anything, so a bad spec fails before we
     // remove/start a container.
@@ -964,23 +1123,26 @@ pub(crate) async fn container_shell_command(
 /// offer to reconnect to it or stop it instead of starting a new one.
 #[tauri::command]
 pub async fn agent_test_container_running(worktree_path: String) -> AppResult<bool> {
-    let Some((bin, _)) = detect_runtime().await else {
-        return Ok(false);
-    };
-    Ok(container_running(&bin, &test_container_name(&worktree_path)).await)
+    let name = test_container_name(&worktree_path);
+    // The container may live on an engine other than the preferred one, so ask each
+    // ready candidate; probes stop at the first hit.
+    for (bin, _) in runtime_candidates().await {
+        if runtime_ready(&bin).await && container_running(&bin, &name).await {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Force-stops + removes this worktree's test-shell container, freeing its
 /// published ports. Best-effort — a no-op if it isn't running / doesn't exist.
 #[tauri::command]
 pub async fn agent_stop_test_container(worktree_path: String) -> AppResult<()> {
-    if let Some((bin, _)) = detect_runtime().await {
-        let _ = run_capture(
-            &bin,
-            &["rm", "-f", &test_container_name(&worktree_path)],
-            DETECT_TIMEOUT,
-        )
-        .await;
+    // Sweep every installed runtime — the name is stable, so the container may sit
+    // on an engine other than the one a fresh Test shell would pick.
+    let name = test_container_name(&worktree_path);
+    for (bin, _) in runtime_candidates().await {
+        let _ = run_capture(&bin, &["rm", "-f", &name], DETECT_TIMEOUT).await;
     }
     Ok(())
 }
@@ -1361,6 +1523,33 @@ mod tests {
         assert!(podman.iter().any(|a| a == "--userns=keep-id"));
         let docker = build_run_args("docker", "claude", "/repos/wt", &home, "n", IMAGE, None, None, &[], &inner);
         assert!(!docker.iter().any(|a| a == "--userns=keep-id"));
+    }
+
+    #[test]
+    fn choose_prefers_the_ready_engine_holding_the_image() {
+        // The preferred candidate, ready and holding the image, wins outright.
+        assert_eq!(choose(&[(true, true), (true, true)]), Choice::WithImage(0));
+        // A stopped engine yields to a running one, image or not.
+        assert_eq!(choose(&[(false, false), (true, true)]), Choice::WithImage(1));
+        assert_eq!(
+            choose(&[(false, false), (true, false)]),
+            Choice::ReadyNoImage(1)
+        );
+        // Between two ready engines the image decides — images are per-engine, so
+        // running on the one that lacks it would launch nothing.
+        assert_eq!(choose(&[(true, false), (true, true)]), Choice::WithImage(1));
+        // No engine holds the image → the first ready one (build/Test shell land there).
+        assert_eq!(
+            choose(&[(true, false), (true, false)]),
+            Choice::ReadyNoImage(0)
+        );
+        // Installed but nothing running → the first installed names the message.
+        assert_eq!(
+            choose(&[(false, false), (false, false)]),
+            Choice::NotReady(0)
+        );
+        // Nothing installed at all.
+        assert_eq!(choose(&[]), Choice::Missing);
     }
 
     #[test]

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -21,7 +21,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
@@ -215,12 +216,73 @@ pub(crate) fn global_skills_dir() -> Option<PathBuf> {
 /// Preference slots [`candidate_at`] can fill.
 const RUNTIME_SLOTS: usize = 2;
 
-/// The installed runtime in preference slot `i` as `(binary, name)`: 0 is Docker on
-/// PATH, 1 is Podman on PATH else (Windows) Podman Desktop's install dir. Resolved
-/// ONE SLOT AT A TIME because on macOS/Linux `resolve_named` answers for an absent
-/// binary by spawning a login shell (up to `DETECT_TIMEOUT`), so a hot path that
-/// settles on slot 0 must never reach slot 1.
+/// How long a slot's resolution is reused. It buys the one-shot callers (session
+/// discard, Test panel mount, shell open) and a turn burst ONE resolution instead of
+/// one per call, which matters because resolving an ABSENT binary costs a login-shell
+/// spawn on macOS/Linux. Matched to the sandbox status view's 15s recovery poll: a
+/// cached MISS is what holds the "not installed" copy up, so a longer TTL would keep
+/// that copy past the very tick meant to clear it once an engine is installed.
+const CANDIDATE_TTL: Duration = Duration::from_secs(15);
+
+type CandidateCache = [Option<(Instant, Option<(PathBuf, String)>)>; RUNTIME_SLOTS];
+
+fn candidate_cache() -> &'static Mutex<CandidateCache> {
+    static CACHE: OnceLock<Mutex<CandidateCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(std::array::from_fn(|_| None)))
+}
+
+/// Per-slot single-flight gate. Per SLOT, never one shared gate: the per-turn slot-0
+/// path must not queue behind a slot-1 resolve, which can run to `DETECT_TIMEOUT`.
+fn slot_lock(i: usize) -> &'static tokio::sync::Mutex<()> {
+    static LOCKS: OnceLock<[tokio::sync::Mutex<()>; RUNTIME_SLOTS]> = OnceLock::new();
+    &LOCKS.get_or_init(|| std::array::from_fn(|_| tokio::sync::Mutex::new(())))[i]
+}
+
+/// Whether a cache entry stamped at `at` is still usable at `now`. Pure so the TTL
+/// boundary is testable without waiting on a clock.
+fn cache_entry_fresh(at: Instant, now: Instant, ttl: Duration) -> bool {
+    now.saturating_duration_since(at) < ttl
+}
+
+/// The slot's still-fresh cached resolution. The nesting is meaningful: the outer
+/// `None` is "cold or expired", the inner one is a cached "not installed". A poisoned
+/// cache reads as cold, so resolution falls through rather than failing.
+fn cached_slot(i: usize) -> Option<Option<(PathBuf, String)>> {
+    let entry = {
+        let guard = candidate_cache().lock().ok();
+        guard.and_then(|c| c[i].clone())
+    };
+    let (at, value) = entry?;
+    cache_entry_fresh(at, Instant::now(), CANDIDATE_TTL).then_some(value)
+}
+
+/// The installed runtime in preference slot `i` as `(binary, name)`, memoized for
+/// [`CANDIDATE_TTL`]. Slots resolve INDEPENDENTLY — a hot path that settles on slot 0
+/// must never reach slot 1 — and a cold slot resolves once no matter how many callers
+/// race it.
 async fn candidate_at(i: usize) -> Option<(PathBuf, String)> {
+    if i >= RUNTIME_SLOTS {
+        return None;
+    }
+    if let Some(value) = cached_slot(i) {
+        return value;
+    }
+    // Cold or expired: hold this slot's gate across the resolve and re-check, so N
+    // racing callers spend one resolution rather than N login-shell spawns.
+    let _flight = slot_lock(i).lock().await;
+    if let Some(value) = cached_slot(i) {
+        return value;
+    }
+    let resolved = resolve_slot(i).await;
+    if let Ok(mut c) = candidate_cache().lock() {
+        c[i] = Some((Instant::now(), resolved.clone()));
+    }
+    resolved
+}
+
+/// Resolves preference slot `i` for real: 0 is Docker on PATH, 1 is Podman on PATH,
+/// else (Windows) Podman Desktop's install dir.
+async fn resolve_slot(i: usize) -> Option<(PathBuf, String)> {
     match i {
         0 => resolve_named(&["docker"], None)
             .await
@@ -244,6 +306,17 @@ async fn candidate_at(i: usize) -> Option<(PathBuf, String)> {
     }
 }
 
+/// The engine's display name for user-facing copy. `resolve_slot` emits exactly
+/// "docker"/"podman"; an unknown name deliberately reads as Docker, so a future slot
+/// must be added here too rather than inheriting that default.
+pub(crate) fn runtime_label(name: &str) -> &'static str {
+    if name == "podman" {
+        "Podman"
+    } else {
+        "Docker"
+    }
+}
+
 /// The preferred installed runtime — the first filled slot, resolved no further.
 pub(crate) async fn preferred_runtime() -> Option<(PathBuf, String)> {
     for i in 0..RUNTIME_SLOTS {
@@ -255,7 +328,7 @@ pub(crate) async fn preferred_runtime() -> Option<(PathBuf, String)> {
 }
 
 /// Every installed runtime in preference order, for operations that must act on ALL
-/// of them. Resolving each slot has a cost (see [`candidate_at`]), so callers that
+/// of them. A cold slot costs a real resolve (see [`candidate_at`]), so callers that
 /// only need one runtime take [`pick_runtime`] or [`preferred_runtime`] instead.
 pub(crate) async fn runtime_candidates() -> Vec<(PathBuf, String)> {
     let mut out: Vec<(PathBuf, String)> = Vec::new();
@@ -394,10 +467,10 @@ pub(crate) async fn pick_from(known: Vec<(PathBuf, String)>) -> RuntimePick {
 async fn runtime_for_build() -> AppResult<PathBuf> {
     match pick_runtime().await {
         RuntimePick::WithImage(bin, _) | RuntimePick::ReadyNoImage(bin, _) => Ok(bin),
-        RuntimePick::NotReady(..) => Err(AppError::Command(
-            "Docker/Podman is installed but its engine isn't running. Start it and try again."
-                .into(),
-        )),
+        RuntimePick::NotReady(_, name) => Err(AppError::Command(format!(
+            "{} is installed but its engine isn't running. Start it and try again.",
+            runtime_label(&name)
+        ))),
         RuntimePick::Missing => Err(AppError::Command(
             "Docker or Podman is not installed.".into(),
         )),
@@ -1044,10 +1117,11 @@ pub(crate) async fn container_shell_command(
 
     // Already running (its terminal was closed without `exit`) → reconnect a fresh
     // shell into it; its server + published ports are untouched. `exec` takes no
-    // ports/mount — those belong to the original `run`. Asked of every ready
-    // candidate, since it may sit on an engine other than the preferred one.
+    // ports/mount — those belong to the original `run`. Asked of every candidate,
+    // since it may sit on an engine other than the preferred one; `ps` on a stopped
+    // engine already answers false, so no separate readiness probe.
     for (bin_path, _) in &candidates {
-        if runtime_ready(bin_path).await && container_running(bin_path, &name).await {
+        if container_running(bin_path, &name).await {
             let args = vec!["exec".into(), "-it".into(), name.clone(), "bash".into()];
             let tip = "Tip: reconnected to the container that is still running - your server and ports are unchanged. Use Stop test container to shut it down.".to_string();
             return Ok((bin_path.to_string_lossy().to_string(), args, tip));
@@ -1059,11 +1133,11 @@ pub(crate) async fn container_shell_command(
     // neither image is there.
     let (bin_path, rt) = match pick_from(candidates).await {
         RuntimePick::WithImage(bin, rt) | RuntimePick::ReadyNoImage(bin, rt) => (bin, rt),
-        RuntimePick::NotReady(..) => {
-            return Err(AppError::Command(
-                "Docker/Podman is installed but its engine isn't running. Start it, then try again."
-                    .into(),
-            ));
+        RuntimePick::NotReady(_, engine) => {
+            return Err(AppError::Command(format!(
+                "{} is installed but its engine isn't running. Start it, then try again.",
+                runtime_label(&engine)
+            )));
         }
         RuntimePick::Missing => {
             return Err(AppError::Command(
@@ -1126,9 +1200,9 @@ pub(crate) async fn container_shell_command(
 pub async fn agent_test_container_running(worktree_path: String) -> AppResult<bool> {
     let name = test_container_name(&worktree_path);
     // The container may live on an engine other than the preferred one, so ask each
-    // ready candidate; probes stop at the first hit.
+    // candidate; `ps` on a stopped engine answers false, and probes stop at the first hit.
     for (bin, _) in runtime_candidates().await {
-        if runtime_ready(&bin).await && container_running(&bin, &name).await {
+        if container_running(&bin, &name).await {
             return Ok(true);
         }
     }
@@ -1551,6 +1625,49 @@ mod tests {
         );
         // Nothing installed at all.
         assert_eq!(choose(&[]), Choice::Missing);
+    }
+
+    #[test]
+    fn verdict_carries_the_chosen_candidate_not_the_first() {
+        // Stopped Docker beside a running Podman that holds the image: the pick must
+        // carry slot 1's binary and name, so the run lands on the engine that answered.
+        let candidates = vec![
+            (PathBuf::from("dk"), "docker".to_string()),
+            (PathBuf::from("pm"), "podman".to_string()),
+        ];
+        match verdict(candidates, &[(false, false), (true, true)]) {
+            RuntimePick::WithImage(bin, name) => {
+                assert_eq!(bin, PathBuf::from("pm"));
+                assert_eq!(name, "podman");
+            }
+            other => panic!("expected WithImage(podman), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_entry_expires_at_the_ttl_boundary() {
+        let at = Instant::now();
+        assert!(cache_entry_fresh(at, at, CANDIDATE_TTL));
+        assert!(cache_entry_fresh(
+            at,
+            at + CANDIDATE_TTL - Duration::from_millis(1),
+            CANDIDATE_TTL
+        ));
+        // The boundary is exclusive, so a just-installed engine is rediscovered no
+        // later than the status view's next recovery poll.
+        assert!(!cache_entry_fresh(at, at + CANDIDATE_TTL, CANDIDATE_TTL));
+        // A clock that appears to move backwards reads as fresh, never as expired.
+        assert!(cache_entry_fresh(
+            at + Duration::from_secs(1),
+            at,
+            CANDIDATE_TTL
+        ));
+    }
+
+    #[test]
+    fn runtime_label_names_the_engine() {
+        assert_eq!(runtime_label("podman"), "Podman");
+        assert_eq!(runtime_label("docker"), "Docker");
     }
 
     #[test]

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -738,7 +738,8 @@ pub async fn agent_custom_image_status(worktree_path: String) -> AppResult<Custo
             Some(id) => image_exists(&bin, &derived_tag(&id, &dockerfile)).await,
             None => false,
         },
-        // No engine holds the base image, so no derived image can exist either.
+        // No ready engine holding the managed image to derive from (or nothing
+        // answered, so it can't be confirmed) — report "needs build" either way.
         _ => false,
     };
     Ok(CustomImageStatus {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2214,7 +2214,9 @@ others.
 **Best-of-N** runs the same task across 2–5 arms, each with its own agent, model, and
 effort — so different providers attack the problem from different angles. Each arm runs in
 its own worktree; review them side by side and **keep the best one** (it discards the
-rest). Because fanning out costs real money, you get an upfront cost estimate first.
+rest). Because fanning out costs real money, you get an upfront cost estimate first. For a
+container run, an arm whose agent isn't in the built image gets a warning right in the
+dialog, so you can switch that arm (or rebuild the image) before spending.
 
 ## Isolation
 

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import hljs from "highlight.js/lib/common";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { diffLang } from "@/features/diff/diff-lang";
 import { useBlame } from "@/lib/git/queries";
 import type { BlameLine } from "@/lib/git/types";
+import { createCardLatch } from "@/lib/hover-card-latch";
 import { useUiStore } from "@/lib/stores/ui";
 import { validEpochMs } from "@/lib/time";
 import "@/features/diff/code-highlight.css";
@@ -30,6 +31,25 @@ import "@/features/diff/code-highlight.css";
 function isRealCommit(hash: string): boolean {
   return !/^0+$/.test(hash);
 }
+
+/** A row's handle on its own card — `setOpen` is stable for the row's life, so
+ *  the object doubles as the row's identity in the latch below. */
+interface CardOwner {
+  setOpen: (open: boolean) => void;
+}
+
+/** Teardown for a row the latch is taking the card away from. It ends by
+ *  releasing, so the surface's own close paths can call it directly too. */
+function resetCard(owner: CardOwner) {
+  owner.setOpen(false);
+  releaseCard(owner);
+}
+
+/** This family is the blame gutter's rows — a card opened by keyboard closes
+ *  only on blur or dismissal, so opening one elsewhere in the list fires none of
+ *  its close routes and both would float. */
+const { claim: claimCard, release: releaseCard } =
+  createCardLatch<CardOwner>(resetCard);
 
 /** One code line, syntax-highlighted when the language is recognized. */
 function BlameCode({
@@ -147,6 +167,110 @@ export function BlameDialog({
   );
 }
 
+/** The gutter cell for a row that starts a new commit: the trigger, plus the
+ *  card describing that commit. The card is controlled — and every open route
+ *  claims the latch — so the list can only ever show one at a time; the state
+ *  and its owner identity are per row, which is what lets an evicted row give up
+ *  its claim without clearing the card of the row that replaced it. */
+function BlameCommitCell({
+  line,
+  short,
+  scrollEl,
+  onGoToCommit,
+}: {
+  line: BlameLine;
+  short: string;
+  scrollEl: HTMLDivElement | null;
+  onGoToCommit: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // Built once: the latch compares rows by this object's identity, so it has to
+  // outlive every render.
+  const [card] = useState<CardOwner>(() => ({ setOpen }));
+  const whenIso =
+    line.time && validEpochMs(line.time * 1000)
+      ? new Date(line.time * 1000).toISOString()
+      : "";
+
+  // The virtualizer evicts rows mid-dwell, and an evicted row that still held
+  // the latch would tear down whichever card claims it next. Release only — a
+  // row on its way out has no state left to settle.
+  useEffect(() => () => releaseCard(card), [card]);
+
+  // Scrolling takes the row out from under the pointer or the focus that opened
+  // its card, so the scroll ends it rather than leaving one nobody holds.
+  useEffect(() => {
+    if (!open || !scrollEl) return;
+    const close = () => resetCard(card);
+    scrollEl.addEventListener("scroll", close);
+    return () => scrollEl.removeEventListener("scroll", close);
+  }, [open, scrollEl, card]);
+
+  return (
+    <HoverCard
+      open={open}
+      // Both open routes land here — the pointer's dwell and keyboard focus —
+      // so claiming here is what keeps the list to one card. Re-opening this
+      // row's own card is not a takeover.
+      onOpenChange={(next) => {
+        if (!next) {
+          resetCard(card);
+          return;
+        }
+        claimCard(card);
+        setOpen(true);
+      }}
+    >
+      <HoverCardTrigger
+        render={
+          <button
+            type="button"
+            aria-label={`View commit ${short}: ${line.summary}`}
+          />
+        }
+        onClick={onGoToCommit}
+        className="w-40 shrink-0 cursor-pointer truncate border-r px-2 text-left text-muted-foreground hover:text-foreground hover:underline focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
+      >
+        {`${short} ${line.author}`}
+      </HoverCardTrigger>
+      <HoverCardContent className="w-72">
+        <div className="flex flex-col gap-1.5">
+          <p className="font-mono text-muted-foreground">{short}</p>
+          <p className="line-clamp-2 font-medium break-words">{line.summary}</p>
+          <p className="text-muted-foreground">
+            {line.author}
+            {whenIso && (
+              <>
+                {" · "}
+                <RelativeTime date={whenIso} />
+              </>
+            )}
+          </p>
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="xs" onClick={onGoToCommit}>
+              View commit
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(line.hash);
+                  toast.success("Commit SHA copied");
+                } catch {
+                  toast.error("Could not copy to clipboard");
+                }
+              }}
+            >
+              Copy SHA
+            </Button>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
 /** The virtualized blame rows. Isolated in its own leaf so useVirtualizer
  *  doesn't bail the dialog host out of the React Compiler, and so it mounts
  *  only once `lines` is non-empty. hljs highlighting now runs only for the
@@ -189,10 +313,6 @@ function BlameLines({
         // inside virtual rows.
         const newCommit =
           vi.index === 0 || lines[vi.index - 1].hash !== line.hash;
-        const whenIso =
-          line.time && validEpochMs(line.time * 1000)
-            ? new Date(line.time * 1000).toISOString()
-            : "";
         const short = line.hash.slice(0, 7);
         // Only real commits get the interactive commit reference; uncommitted
         // (all-zero sha) rows and continuation rows keep the plain gutter cell.
@@ -216,56 +336,12 @@ function BlameLines({
             style={{ transform: `translateY(${vi.start}px)` }}
           >
             {interactive ? (
-              <HoverCard>
-                <HoverCardTrigger
-                  render={
-                    <button
-                      type="button"
-                      aria-label={`View commit ${short}: ${line.summary}`}
-                    />
-                  }
-                  onClick={goToCommit}
-                  className="w-40 shrink-0 cursor-pointer truncate border-r px-2 text-left text-muted-foreground hover:text-foreground hover:underline focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
-                >
-                  {`${short} ${line.author}`}
-                </HoverCardTrigger>
-                <HoverCardContent className="w-72">
-                  <div className="flex flex-col gap-1.5">
-                    <p className="font-mono text-muted-foreground">{short}</p>
-                    <p className="line-clamp-2 font-medium break-words">
-                      {line.summary}
-                    </p>
-                    <p className="text-muted-foreground">
-                      {line.author}
-                      {whenIso && (
-                        <>
-                          {" · "}
-                          <RelativeTime date={whenIso} />
-                        </>
-                      )}
-                    </p>
-                    <div className="flex items-center gap-1">
-                      <Button variant="ghost" size="xs" onClick={goToCommit}>
-                        View commit
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        onClick={async () => {
-                          try {
-                            await navigator.clipboard.writeText(line.hash);
-                            toast.success("Commit SHA copied");
-                          } catch {
-                            toast.error("Could not copy to clipboard");
-                          }
-                        }}
-                      >
-                        Copy SHA
-                      </Button>
-                    </div>
-                  </div>
-                </HoverCardContent>
-              </HoverCard>
+              <BlameCommitCell
+                line={line}
+                short={short}
+                scrollEl={scrollEl}
+                onGoToCommit={goToCommit}
+              />
             ) : (
               <span className="w-40 shrink-0 truncate border-r px-2 text-muted-foreground">
                 {newCommit ? `${short} ${line.author}` : ""}

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -187,10 +187,9 @@ function BlameCommitCell({
   // Built once: the latch compares rows by this object's identity, so it has to
   // outlive every render.
   const [card] = useState<CardOwner>(() => ({ setOpen }));
-  const whenIso =
-    line.time && validEpochMs(line.time * 1000)
-      ? new Date(line.time * 1000).toISOString()
-      : "";
+  const whenIso = validEpochMs(line.time * 1000)
+    ? new Date(line.time * 1000).toISOString()
+    : "";
 
   // The virtualizer evicts rows mid-dwell, and an evicted row that still held
   // the latch would tear down whichever card claims it next. Release only — a

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -122,7 +122,11 @@ export function PlanComposer({
   const modelForAgent = modelAgent === agent ? model : "";
 
   const planningIssue = Boolean(seed?.issueTitle || seed?.issueBody);
-  const canPlan = goal.trim().length > 0 || planningIssue;
+  // `agent` follows the Settings default until an explicit pick, so a submit
+  // before settings resolve would run the fallback agent. Held silently for those
+  // milliseconds; a load that FAILED is deliberately NOT pending.
+  const settingsPending = !settings.data && !settings.isError;
+  const canPlan = (goal.trim().length > 0 || planningIssue) && !settingsPending;
 
   const submit = () => {
     if (!canPlan) return;

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -232,7 +232,11 @@ export function ResearchComposer({
   // Derived, so a default-agent change drops a model that agent wasn't given.
   const modelForAgent = modelAgent === agent ? model : "";
 
-  const canRun = topic.trim().length > 0;
+  // `agent` follows the Settings default until an explicit pick, so a submit
+  // before settings resolve would run the fallback agent. Held silently for those
+  // milliseconds; a load that FAILED is deliberately NOT pending.
+  const settingsPending = !settings.data && !settings.isError;
+  const canRun = topic.trim().length > 0 && !settingsPending;
   const copy = INTENT_COPY[depth];
 
   const submit = () => {

--- a/src/features/sessions/AgentPickers.tsx
+++ b/src/features/sessions/AgentPickers.tsx
@@ -48,6 +48,12 @@ export const AGENT_LABELS: Record<AgentKind, string> = {
   opencode: "opencode",
 };
 
+/** The warning shown when a container session's agent isn't baked into the image.
+ *  One source so the composer's isolation note and the best-of-N arms can't drift. */
+export function imageMissingAgentText(agent: AgentKind): string {
+  return `The agent image wasn't built with ${AGENT_LABELS[agent]} — add it under Settings → AI and rebuild.`;
+}
+
 /** The model for a run: the agent's models are searchable — its live catalog
  *  where the CLI can list one (opencode), else that CLI's static suggestions —
  *  and any other id typed here reaches the CLI verbatim (custom providers publish

--- a/src/features/sessions/EnsembleRunDialog.tsx
+++ b/src/features/sessions/EnsembleRunDialog.tsx
@@ -53,7 +53,8 @@ export function EnsembleRunDialog({
   seed: EnsembleArm;
   estimate: RunCostEstimate;
   /** Agent CLIs the saved image config bakes in — set ONLY when this run starts
-   *  containerized; `undefined` (worktree isolation) means no arm can miss. */
+   *  containerized AND settings resolved; `undefined` (worktree isolation, or an
+   *  unknown config) means no arm can be judged, so none warns. */
   imageAgents?: readonly AgentKind[];
   onRun: (arms: EnsembleArm[]) => void;
 }) {

--- a/src/features/sessions/EnsembleRunDialog.tsx
+++ b/src/features/sessions/EnsembleRunDialog.tsx
@@ -1,5 +1,5 @@
-import { PlusIcon, XIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { PlusIcon, WarningIcon, XIcon } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,7 +11,12 @@ import {
 } from "@/components/ui/dialog";
 import type { AgentKind } from "@/lib/ai/agent";
 import { formatUsd, type RunCostEstimate } from "@/lib/ai/cost";
-import { AgentPicker, EffortPicker, ModelPicker } from "./AgentPickers";
+import {
+  AgentPicker,
+  EffortPicker,
+  imageMissingAgentText,
+  ModelPicker,
+} from "./AgentPickers";
 
 /** One arm of a best-of-N run: which agent/model/effort attacks the task. */
 export interface EnsembleArm {
@@ -39,6 +44,7 @@ export function EnsembleRunDialog({
   onOpenChange,
   seed,
   estimate,
+  imageAgents,
   onRun,
 }: {
   open: boolean;
@@ -46,6 +52,9 @@ export function EnsembleRunDialog({
   /** Config the arms start from (the composer's current agent/model/effort). */
   seed: EnsembleArm;
   estimate: RunCostEstimate;
+  /** Agent CLIs the saved image config bakes in — set ONLY when this run starts
+   *  containerized; `undefined` (worktree isolation) means no arm can miss. */
+  imageAgents?: readonly AgentKind[];
   onRun: (arms: EnsembleArm[]) => void;
 }) {
   return (
@@ -64,6 +73,7 @@ export function EnsembleRunDialog({
           <EnsembleArms
             seed={seed}
             estimate={estimate}
+            imageAgents={imageAgents}
             onCancel={() => onOpenChange(false)}
             onRun={(arms) => {
               onOpenChange(false);
@@ -79,11 +89,13 @@ export function EnsembleRunDialog({
 function EnsembleArms({
   seed,
   estimate,
+  imageAgents,
   onCancel,
   onRun,
 }: {
   seed: EnsembleArm;
   estimate: RunCostEstimate;
+  imageAgents?: readonly AgentKind[];
   onCancel: () => void;
   onRun: (arms: EnsembleArm[]) => void;
 }) {
@@ -110,8 +122,31 @@ function EnsembleArms({
   const total = perSession != null ? perSession * arms.length : null;
   const usesCopilot = arms.some((a) => a.agent === "copilot");
 
+  // Warn per arm, never block: a stale image can legitimately carry MORE agents
+  // than the saved config lists, and the backend rejects turn 1 anyway.
+  const missingFromImage = (agent: AgentKind) =>
+    imageAgents !== undefined && !imageAgents.includes(agent);
+  const missingSummary = arms
+    .map((arm, i) =>
+      missingFromImage(arm.agent)
+        ? `Arm ${i + 1}: ${imageMissingAgentText(arm.agent)}`
+        : "",
+    )
+    .filter(Boolean)
+    .join(" ");
+  // Content already present when a live region enters the a11y tree is never
+  // announced, and this dialog remounts on every open — so the region mounts empty
+  // and takes its text from an effect. The visible lines stay render-derived.
+  const [announced, setAnnounced] = useState("");
+  useEffect(() => {
+    setAnnounced(missingSummary);
+  }, [missingSummary]);
+
   return (
     <>
+      <p role="status" aria-live="polite" className="sr-only">
+        {announced}
+      </p>
       <div className="space-y-1.5">
         {arms.map((arm, i) => (
           <div
@@ -144,6 +179,18 @@ function EnsembleArms({
             >
               <XIcon />
             </Button>
+            {missingFromImage(arm.agent) && (
+              // `basis-full` wraps the line under the row's controls; the text
+              // carries the meaning, the token only tones it.
+              <p className="flex basis-full items-center gap-1.5 text-[11px] text-warning">
+                <WarningIcon
+                  weight="fill"
+                  className="size-3.5 shrink-0"
+                  aria-hidden
+                />
+                {imageMissingAgentText(arm.agent)}
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -35,11 +35,11 @@ import { useRepoKeys, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import {
-  AGENT_LABELS,
   AgentPicker,
   ComposerOptions,
   type Isolation,
   type IsolationNote,
+  imageMissingAgentText,
   ModelPicker,
   type RunMode,
 } from "./AgentPickers";
@@ -136,7 +136,7 @@ function isolationNoteFor({
   if (!agentInImage && perAgentCopy)
     return {
       tone: "warn",
-      text: `The agent image wasn't built with ${AGENT_LABELS[agent]} — add it under Settings → AI and rebuild.`,
+      text: imageMissingAgentText(agent),
       settingsAction: true,
     };
   if (!status.imageMatches)
@@ -1059,6 +1059,11 @@ export function SessionComposer({
           effort: startEffort,
         }}
         estimate={costEstimate}
+        // Only a containerized run can fail on image membership; undefined means
+        // the arms run on the host, where every agent is fair game.
+        imageAgents={
+          isContainer ? (settings.data?.agentImageProviders ?? []) : undefined
+        }
         onRun={runEnsemble}
       />
     </>

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -1060,9 +1060,13 @@ export function SessionComposer({
         }}
         estimate={costEstimate}
         // Only a containerized run can fail on image membership; undefined means
-        // the arms run on the host, where every agent is fair game.
+        // the arms run on the host, where every agent is fair game — or settings
+        // never loaded (an errored load doesn't hold submit), where a defined []
+        // would falsely flag every arm.
         imageAgents={
-          isContainer ? (settings.data?.agentImageProviders ?? []) : undefined
+          isContainer && settings.data
+            ? (settings.data.agentImageProviders ?? [])
+            : undefined
         }
         onRun={runEnsemble}
       />


### PR DESCRIPTION
A patch batch of four independent fixes. The largest reworks how container operations choose between Docker and Podman: engine selection now probes which engine is actually running and which one holds the managed image, instead of taking the first binary found on PATH — so a stopped Docker no longer blocks a running Podman. The other three close gaps in the blame hovercards, best-of-N arms, and the Plan/Research default agent.

### Container runtime selection (Rust)

- Replaces `detect_runtime` in `src-tauri/src/agent_sandbox.rs` with a lazy candidate model: `candidate_at` resolves one preference slot at a time (Docker on PATH, then Podman on PATH or, on Windows, Podman Desktop's install dir), with `preferred_runtime` for the first filled slot and `runtime_candidates` for operations that must touch all of them. Slot-at-a-time resolution is deliberate — `resolve_named` can spawn a login shell for an absent binary.
- Adds the `RuntimePick` verdict (`WithImage` / `ReadyNoImage` / `NotReady` / `Missing`) and `pick_runtime` / `pick_from`, built on `probe_runtime` (`version`, then `image inspect` only when the engine is up). The preference policy itself is factored into the pure `choose` function over `(ready, has_image)` states, with `verdict` mapping the resulting `Choice` index back onto a candidate.
- New `runtime_for_build` sends `agent_container_prepare` and `agent_build_custom_image` to the engine that already holds the image; `agent_container_detect` and `agent_custom_image_status` now derive their status from `pick_runtime`.
- Operations keyed on stable container names sweep every installed runtime, since a container can outlive the preference that created it: `agent_sandbox_cleanup`, `agent_stop_test_container`, `agent_test_container_running`, and the reconnect probe in `container_shell_command`. The Test shell also accepts a `ReadyNoImage` engine, falling back to the base image.
- `agent_session` in `src-tauri/src/agent.rs` keeps the per-turn hot path at a single subprocess — `image_present` against the preferred runtime — and only pays for the wider walk on failure, which is what separates "wrong engine" from "engine stopped" from "image never built".
- Adds `choose_prefers_the_ready_engine_holding_the_image`, a table test over the policy including the empty and nothing-running cases.

### Blame commit hovercards

- Extracts `BlameCommitCell` in `src/features/history/BlameDialog.tsx` and makes `HoverCard` controlled, claiming a shared latch (`createCardLatch` from `@/lib/hover-card-latch`) on every open route so the gutter can only ever show one card — a keyboard-opened card fires none of its close routes when another row opens.
- Per-row identity (`CardOwner`) lets an evicted row release its claim on unmount without tearing down the card that replaced it, and an effect closes the card when `scrollEl` scrolls the row out from under the pointer or focus.

### Best-of-N arm warnings

- `src/features/sessions/AgentPickers.tsx` exports `imageMissingAgentText` as the single source of the "image wasn't built with this agent" copy; `SessionComposer.tsx` now uses it in `isolationNoteFor` instead of building the string inline.
- `SessionComposer.tsx` passes `imageAgents` (from `settings.data?.agentImageProviders`) into `EnsembleRunDialog` only for containerized runs, leaving it `undefined` for worktree isolation.
- `EnsembleRunDialog.tsx` renders a per-arm warning line for agents missing from the image and mirrors the summary into an `sr-only` `role="status"` region populated from an effect, so a freshly mounted dialog still announces. Warn-only by design — a stale image can carry more agents than the saved config lists, and the backend rejects turn 1 regardless.

### Plan / Research default agent

- `PlanView.tsx` and `ResearchView.tsx` gate `canPlan` / `canRun` on the settings query resolving (`!settings.data && !settings.isError`), so the first submit after launch runs the configured Default agent rather than the fallback. A failed load is explicitly not treated as pending.

### Changelog

- Adds `changelog.d/fixed-container-runtime-fallback.md`, `fixed-blame-hovercard-exclusivity.md`, `fixed-ensemble-arm-image-warning.md`, and `fixed-plan-research-default-agent.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blame commit hovercards now show only one card at a time and close when scrolling.
  * Plan and Research submissions now honor the selected default agent after settings resolve.
  * Container operations select the available running engine and provide clearer status messages.
  * Best-of-N runs warn when an agent is unavailable in the selected container image.

* **User Experience**
  * Missing agents are identified per Best-of-N run, with guidance to rebuild the container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->