### PR TITLE
fix(branches,worktrees): guard branch ops during an in-flight update

### DIFF
--- a/changelog.d/fixed-update-collision-guards.md
+++ b/changelog.d/fixed-update-collision-guards.md
@@ -1,0 +1,4 @@
+- Acting on a branch while **Update from** is bringing it up to date (switching to
+  it, renaming, deleting, or cherry-picking onto it) now says exactly that, and asks
+  you to try again when the update finishes. After a crash or a forced quit, the app
+  clears the update's leftover hidden checkout and frees the branch it was holding.

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -74,12 +74,6 @@ const REFSPEC_ALLOWLIST = [
       "validates each pair's head/base with validate_branch_name inline",
   },
   {
-    file: "git/branches.rs",
-    fn: "repo_with_local_upstream",
-    rationale:
-      "#[cfg(test)] fixture — interpolates the default-branch name read back from git's own rev-parse on a repo the test creates; no user-named ref reaches it",
-  },
-  {
     file: "git/ops.rs",
     fn: "branch_tip",
     rationale:

--- a/scripts/check-rust-invariants.mjs
+++ b/scripts/check-rust-invariants.mjs
@@ -74,6 +74,12 @@ const REFSPEC_ALLOWLIST = [
       "validates each pair's head/base with validate_branch_name inline",
   },
   {
+    file: "git/branches.rs",
+    fn: "repo_with_local_upstream",
+    rationale:
+      "#[cfg(test)] fixture — interpolates the default-branch name read back from git's own rev-parse on a repo the test creates; no user-named ref reaches it",
+  },
+  {
     file: "git/ops.rs",
     fn: "branch_tip",
     rationale:

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -1782,4 +1782,42 @@ mod tests {
             other => panic!("expected two conflicts, got {other:?}"),
         }
     }
+
+    /// The guard runs BEFORE `autostash_push`, which is the whole point of its
+    /// placement: a refused switch must not have pushed and popped the user's changes
+    /// on the way to reporting the refusal. An empty stash list after the refusal is
+    /// what proves the ordering — a guard placed after the push would leave a stash
+    /// entry behind on any pop failure, and would churn the working tree regardless.
+    // The serializing guard MUST span the awaits — it keeps the process-wide root
+    // override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_refused_switch_never_stashes() {
+        use crate::git::update_marker as marker;
+        let (dir, repo) = setup_repo("update-guard-order").await;
+        git(&repo, &["branch", "feature"]).await;
+        // Uncommitted work: without the guard this is exactly what would be stashed.
+        write(dir.path(), "a.txt", "dirty\n");
+
+        let root = dir.path().join("gd-worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+        let _live = marker::UpdateMarker::create_for(&root.join("gd-update-live"), "feature")
+            .expect("the marker mints");
+
+        let state = AppState::default();
+        let err = git_switch_autostash_core(&state, repo.clone(), "feature".into(), None, true)
+            .await
+            .expect_err("switching to a branch an update holds is refused");
+        assert_eq!(
+            err.to_string(),
+            marker::branch_update_refusal("feature").to_string()
+        );
+        assert!(
+            git(&repo, &["stash", "list"]).await.trim().is_empty(),
+            "a refused switch must not have touched the stash"
+        );
+        assert_eq!(read(dir.path(), "a.txt"), "dirty\n", "nor the working tree");
+    }
 }

--- a/src-tauri/src/git/autostash.rs
+++ b/src-tauri/src/git/autostash.rs
@@ -368,6 +368,9 @@ pub(crate) async fn git_switch_autostash_core(
     let domain = state.working_tree_lock(&repo_path).await;
     let _guard = acquire_repo_lock(&domain, LOCK_WAIT_TIMEOUT, "a checkout").await?;
     crate::git::ops::refuse_mid_op(&repo_path).await?;
+    // Ahead of the stash: the switch would fail on the update's hold anyway, after
+    // pushing and popping the user's changes for nothing.
+    crate::git::update_marker::refuse_if_branch_updating(state, &repo_path, &name).await?;
 
     let stashed = autostash_push(&repo_path).await?;
     let args: Vec<&str> = match &tracking {

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -251,6 +251,10 @@ pub(crate) async fn git_rename_branch_core(
 ) -> AppResult<()> {
     validate_ref_name(&old_name)?;
     validate_ref_name(&new_name)?;
+    // `branch -m` does NOT refuse a branch checked out elsewhere — it retargets that
+    // worktree's HEAD silently, which under a running update means renaming the branch
+    // out from under it.
+    crate::git::update_marker::refuse_if_branch_updating(state, &repo_path, &old_name).await?;
     run_git_mutating(
         state,
         &repo_path,
@@ -311,6 +315,32 @@ async fn worktree_holding_branch(repo_path: &str, name: &str) -> Option<String> 
         .map(|(path, _)| path)
 }
 
+/// Arbitrates a `worktree_holding_branch` hit that turns out to be an UPDATE's hidden
+/// `gd-update-*` checkout: a running one is refused in the update's own words, and a
+/// dead one is cleared on the spot — no age gate, since the porcelain hit itself proves
+/// the mint completed. `true` means "cleared — re-probe"; `false` leaves the caller's
+/// own message to speak for a worktree the user owns.
+async fn clear_update_holder(
+    state: &AppState,
+    repo_path: &str,
+    branch: &str,
+    holder: &str,
+) -> AppResult<bool> {
+    use crate::git::update_marker as marker;
+    if !marker::is_update_worktree_path(holder) {
+        return Ok(false);
+    }
+    if marker::update_worktree_is_live(holder) {
+        return Err(marker::branch_update_refusal(branch));
+    }
+    if marker::claim_dead_update_worktree(state, repo_path, holder).await {
+        return Ok(true);
+    }
+    // Dead but unclaimable (admin busy, or the lock could not be probed) — the hidden
+    // path is nothing the user can act on, so name the state instead of that path.
+    Err(marker::interrupted_update_refusal(branch))
+}
+
 /// Force-deletes a local branch (the UI confirms first, GitHub Desktop style).
 #[tauri::command]
 pub async fn git_delete_branch(
@@ -331,10 +361,20 @@ pub(crate) async fn git_delete_branch_core(
     // is terse. Detect the holding worktree here — shared by every caller, not just
     // the switcher's UI guard — and surface an actionable message.
     if let Some(path) = worktree_holding_branch(&repo_path, &name).await {
-        return Err(AppError::Command(format!(
-            "{name} is checked out in the worktree at {path} — remove that worktree \
-             (or switch it to another branch) before deleting {name}."
-        )));
+        // An update's hidden checkout is nothing the user can act on by that path, so
+        // it takes its own arm: refused while live, swept and re-probed once dead.
+        let swept = clear_update_holder(state, &repo_path, &name, &path).await?;
+        let held = if swept {
+            worktree_holding_branch(&repo_path, &name).await
+        } else {
+            Some(path)
+        };
+        if let Some(path) = held {
+            return Err(AppError::Command(format!(
+                "{name} is checked out in the worktree at {path} — remove that worktree \
+                 (or switch it to another branch) before deleting {name}."
+            )));
+        }
     }
     run_git_mutating(
         state,
@@ -476,6 +516,7 @@ pub(crate) async fn git_checkout_branch_core(
     name: String,
 ) -> AppResult<()> {
     validate_ref_name(&name)?;
+    crate::git::update_marker::refuse_if_branch_updating(state, &repo_path, &name).await?;
     run_git_mutating(state, &repo_path, &["switch", &name], DEFAULT_TIMEOUT).await?;
     Ok(())
 }
@@ -495,6 +536,9 @@ pub async fn git_checkout_remote_branch(
 ) -> AppResult<()> {
     validate_ref_name(&remote)?;
     validate_ref_name(&name)?;
+    // A live update means a LOCAL `name` already exists and is held, so this switch
+    // collides on it rather than creating anything.
+    crate::git::update_marker::refuse_if_branch_updating(&state, &repo_path, &name).await?;
     run_git_mutating(
         &state,
         &repo_path,
@@ -1016,10 +1060,20 @@ pub(crate) async fn branch_reset_to_upstream(
     // remedy. The linked-worktree probe excludes THIS checkout, so the current
     // branch takes its own arm.
     if let Some(path) = worktree_holding_branch(repo_path, branch).await {
-        return Err(AppError::Command(format!(
-            "{branch} is checked out in the worktree at {path} — switch that worktree \
-             to another branch (or remove it) before resetting {branch}."
-        )));
+        // An update's hidden checkout names no remedy the user can follow; it is
+        // refused while live and swept once dead (see `clear_update_holder`).
+        let swept = clear_update_holder(state, repo_path, branch, &path).await?;
+        let held = if swept {
+            worktree_holding_branch(repo_path, branch).await
+        } else {
+            Some(path)
+        };
+        if let Some(path) = held {
+            return Err(AppError::Command(format!(
+                "{branch} is checked out in the worktree at {path} — switch that worktree \
+                 to another branch (or remove it) before resetting {branch}."
+            )));
+        }
     }
     let current = run_git_raw(
         Some(repo_path),
@@ -1079,6 +1133,13 @@ pub(crate) async fn update_branch_from(
             "a branch can't be updated from itself".to_string(),
         ));
     }
+    // One guard covers both self-collisions: a second update of the same branch, and
+    // the fast-forward arm's `fetch . <base>:<branch>`, which git refuses outright
+    // against a branch held by the first update's checkout.
+    crate::git::update_marker::refuse_if_branch_updating(state, repo_path, branch).await?;
+    // Each update clears its predecessors' crash leftovers, so the orphan a killed
+    // run leaves behind never outlives the next one. Self-skips when admin is busy.
+    crate::git::update_marker::sweep_orphaned_update_worktrees(state, repo_path).await;
 
     // Mutating refs — serialize against other writes to this repo's working tree.
     let domain = state.working_tree_lock(repo_path).await;
@@ -1183,8 +1244,21 @@ pub(crate) async fn update_branch_from(
     if let Some(root) = tmp.parent() {
         std::fs::create_dir_all(root).map_err(AppError::Io)?;
     }
+    // Before the `worktree add`, which is the longest part of the window this marker
+    // exists to announce. A failure to mint refuses the update: an app-data write that
+    // fails is the same failure domain as materializing the checkout itself.
+    let marker = crate::git::update_marker::UpdateMarker::create_for(&tmp, branch)?;
     let tmp_str = tmp.to_string_lossy().to_string();
-    merge_diverged_in_worktree(state, repo_path, &tmp_str, branch, base, &pins).await
+    merge_diverged_in_worktree(
+        state,
+        repo_path,
+        &tmp_str,
+        branch,
+        base,
+        &pins,
+        Some(marker),
+    )
+    .await
 }
 
 /// Where an update's throwaway checkout goes: `<app-data>/worktrees/<repo-hash>/
@@ -1239,6 +1313,7 @@ async fn merge_diverged_in_worktree(
     branch: &str,
     base: &str,
     pins: &UpdatePins,
+    marker: Option<crate::git::update_marker::UpdateMarker>,
 ) -> AppResult<String> {
     run_git_worktree_admin(
         state,
@@ -1253,18 +1328,22 @@ async fn merge_diverged_in_worktree(
     // Try-then-detach is the only teardown shape with no bad arm: a bounded acquire
     // that gave up on `Busy` would leak the throwaway worktree, and a synchronous
     // unbounded one holds a finished update's command hostage for the minutes a
-    // node_modules-scale removal can hold the shared admin domain. A quit or crash
-    // while the detached task waits leaks the `gd-update-*` DIRECTORY — the registry
-    // entry self-heals through `worktree::prune_worktrees_if_free` only once the
-    // directory is gone; a surviving directory keeps the entry and the branch hold.
+    // node_modules-scale removal can hold the shared admin domain. On both arms the
+    // marker outlives the checkout, since the branch stays held until the directory is
+    // gone; a quit or crash leaks that directory with its marker dead beside it, which
+    // the orphan sweep claims once it ages out.
     let domain = state.worktree_admin_lock(repo_path).await;
     match try_acquire_repo_lock(&domain, "a worktree operation") {
-        Some(_admin) => remove_tmp_worktree(repo_path, tmp).await,
+        Some(_admin) => {
+            remove_tmp_worktree(repo_path, tmp).await;
+            drop(marker);
+        }
         None => {
             let (repo, tmp) = (repo_path.to_string(), tmp.to_string());
             tauri::async_runtime::spawn(async move {
                 let _admin = acquire_repo_lock_unbounded(&domain, "a worktree operation").await;
                 remove_tmp_worktree(&repo, &tmp).await;
+                drop(marker);
             });
         }
     }
@@ -2694,6 +2773,7 @@ mod tests {
                 branch_tip: base_sha.clone(),
                 base_sha,
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -2808,6 +2888,7 @@ mod tests {
                 branch_tip: feature_tip.clone(),
                 base_sha: pinned_base,
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -2887,6 +2968,7 @@ mod tests {
                 branch_tip: feature_tip.clone(),
                 base_sha: pinned_base,
             },
+            None,
         )
         .await;
         assert!(
@@ -2959,6 +3041,7 @@ mod tests {
                 branch_tip: feature_tip.clone(),
                 base_sha: alien_tip,
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -3022,6 +3105,7 @@ mod tests {
                 branch_tip: feature_tip.clone(),
                 base_sha: pinned_base,
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -3080,6 +3164,7 @@ mod tests {
                 branch_tip: feature_tip.clone(),
                 base_sha: pinned_base,
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -3144,6 +3229,7 @@ mod tests {
                 branch_tip: feature_tip,
                 base_sha: pinned_base,
             },
+            None,
         )
         .await
         .expect("a fast-forwarded base still merges");
@@ -3199,6 +3285,7 @@ mod tests {
                 branch_tip: feature_tip,
                 base_sha: pinned_base.clone(),
             },
+            None,
         )
         .await
         .expect("an unmoved base merges cleanly");

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -328,7 +328,9 @@ async fn clear_update_holder(
     holder: &str,
 ) -> AppResult<bool> {
     use crate::git::update_marker::{self as marker, LockProbe};
-    if !marker::is_update_worktree_path(holder) {
+    // Root-scoped: a `gd-update-*` worktree the USER made, outside our app-data root, is
+    // their own and takes the ordinary path however its neighbours look.
+    if !marker::is_managed_update_worktree(repo_path, holder) {
         return Ok(false);
     }
     match marker::update_worktree_probe(holder) {
@@ -1332,13 +1334,20 @@ async fn merge_diverged_in_worktree(
     pins: &UpdatePins,
     marker: Option<crate::git::update_marker::UpdateMarker>,
 ) -> AppResult<String> {
-    run_git_worktree_admin(
+    // A killed add can still leave a registered entry over a partial directory, so its
+    // early return settles the marker rather than dropping it: the checkout it may have
+    // left behind needs a recoverable marker exactly as much as a finished one does.
+    if let Err(e) = run_git_worktree_admin(
         state,
         repo_path,
         &["worktree", "add", "--quiet", tmp, branch],
         WORKTREE_OP_TIMEOUT,
     )
-    .await?;
+    .await
+    {
+        settle_marker(marker, tmp);
+        return Err(e);
+    }
 
     let result = verify_pin_and_merge(state, repo_path, tmp, branch, base, pins).await;
 
@@ -1347,25 +1356,37 @@ async fn merge_diverged_in_worktree(
     // unbounded one holds a finished update's command hostage for the minutes a
     // node_modules-scale removal can hold the shared admin domain. On both arms the
     // marker outlives the checkout, since the branch stays held until the directory is
-    // gone; a quit or crash leaks that directory with its marker dead beside it, which
-    // the orphan sweep claims once it ages out.
+    // gone, and `settle_marker` keeps it on disk when the removal did not finish. A
+    // quit or crash leaks the directory with its marker still beside it — released, so
+    // the next branch operation clears it without waiting out the age gate.
     let domain = state.worktree_admin_lock(repo_path).await;
     match try_acquire_repo_lock(&domain, "a worktree operation") {
         Some(_admin) => {
             remove_tmp_worktree(repo_path, tmp).await;
-            drop(marker);
+            settle_marker(marker, tmp);
         }
         None => {
             let (repo, tmp) = (repo_path.to_string(), tmp.to_string());
             tauri::async_runtime::spawn(async move {
                 let _admin = acquire_repo_lock_unbounded(&domain, "a worktree operation").await;
                 remove_tmp_worktree(&repo, &tmp).await;
-                drop(marker);
+                settle_marker(marker, &tmp);
             });
         }
     }
 
     result
+}
+
+/// Drops `marker` after a teardown attempt. Its files go only when the checkout is
+/// confirmed gone; a surviving directory keeps them, unlocked, so the age-free claims
+/// can recover it on the next branch operation. Deleting them there would leave a
+/// markerless holder instead, which nothing may clear until the age gate expires.
+fn settle_marker(marker: Option<crate::git::update_marker::UpdateMarker>, tmp: &str) {
+    let Some(mut marker) = marker else { return };
+    if std::path::Path::new(tmp).exists() {
+        marker.retain_for_recovery();
+    }
 }
 
 /// `worktree remove --force` then `prune`, both best-effort and both lock-free: every
@@ -1549,7 +1570,8 @@ mod tests {
     use super::{
         branch_reset_to_upstream, branch_rewrite_status, build_create_branch_args,
         divergence_out_of_range, git_branch_merge_states, git_branches, git_create_branch_core,
-        git_default_branch, git_rename_branch_core, merge_diverged_in_worktree,
+        git_default_branch, git_delete_branch_core, git_rename_branch_core,
+        merge_diverged_in_worktree,
         parse_cherry_counts, parse_upstream_track, update_branch_from, update_worktree_path,
         validate_branch_name, validate_ref_name, BranchRewriteStatus, MergePair, UpdatePins,
     };
@@ -3339,5 +3361,131 @@ mod tests {
             "git's own merge subject survives: {subject}"
         );
         assert!(!tmp.exists(), "the throwaway worktree is torn down");
+    }
+
+    /// A repo with `feature` tracking `master` through the local `.` remote, so
+    /// `feature@{upstream}` resolves without a network or a second repo. Returns the
+    /// temp guard, the repo path, the default branch name, and its tip.
+    async fn repo_with_local_upstream(tag: &str) -> (tempfile::TempDir, String, String, String) {
+        let (guard, base_dir) = temp_base(tag);
+        let repo = base_dir.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+        init_repo(&repo_s, "a.txt").await;
+        let main = run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+        run(&repo_s, &["branch", "feature"]).await;
+        run(&repo_s, &["config", "branch.feature.remote", "."]).await;
+        run(
+            &repo_s,
+            &["config", "branch.feature.merge", &format!("refs/heads/{main}")],
+        )
+        .await;
+        let tip = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+        (guard, repo_s, main, tip)
+    }
+
+    /// The PRE-ADD window: an update has minted its marker but its `worktree add` has
+    /// not registered anything yet, so `worktree list` is empty. Both porcelain-only
+    /// sites must still refuse — without this guard a delete succeeds here and the
+    /// update dies moments later on a missing ref.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_live_marker_refuses_delete_and_reset_before_the_checkout_exists() {
+        use crate::git::update_marker as marker;
+        let (_guard, repo_s, _main, tip) = repo_with_local_upstream("premint-guard").await;
+        let root = std::path::Path::new(&repo_s)
+            .parent()
+            .unwrap()
+            .join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+        // Minted, not yet added: nothing is in the worktree registry.
+        let _live = marker::UpdateMarker::create_for(&root.join("gd-update-live"), "feature")
+            .expect("the marker mints");
+
+        let state = AppState::default();
+        let expected = marker::branch_update_refusal("feature").to_string();
+        let deleted = git_delete_branch_core(&state, repo_s.clone(), "feature".into())
+            .await
+            .expect_err("a delete during the pre-add window is refused");
+        assert_eq!(deleted.to_string(), expected);
+        let reset = branch_reset_to_upstream(&state, &repo_s, "feature", &tip)
+            .await
+            .expect_err("a reset during the pre-add window is refused");
+        assert_eq!(reset.to_string(), expected);
+        assert!(
+            !run(&repo_s, &["branch", "--list", "feature"])
+                .await
+                .trim()
+                .is_empty(),
+            "and the branch is still there"
+        );
+    }
+
+    /// The post-add half, both outcomes. A RELEASED marker over a registered checkout is
+    /// claimed age-free and the delete then succeeds; a MARKERLESS one (a pre-marker
+    /// build's checkout, which may still be running) is left alone and takes the
+    /// pre-existing generic message naming the holding worktree.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_registered_holder_is_claimed_when_released_and_left_when_markerless() {
+        use crate::git::update_marker as marker;
+        let (_guard, repo_s, _main, _tip) = repo_with_local_upstream("registered-holder").await;
+        let root = std::path::Path::new(&repo_s)
+            .parent()
+            .unwrap()
+            .join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        // MARKERLESS: registered, no sidecars — the generic message, unchanged.
+        let bare = root.join("gd-update-premarker");
+        let bare_s = bare.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "--quiet", &bare_s, "feature"]).await;
+        let err = git_delete_branch_core(&state, repo_s.clone(), "feature".into())
+            .await
+            .expect_err("a markerless holder still blocks the delete");
+        assert!(
+            err.to_string().starts_with("feature is checked out in the worktree at")
+                && err.to_string().ends_with(
+                    "(or switch it to another branch) before deleting feature."
+                ),
+            "the pre-marker path keeps its original wording: {err}"
+        );
+        assert!(bare.exists(), "and its checkout is untouched");
+        run(&repo_s, &["worktree", "remove", "--force", &bare_s]).await;
+
+        // RELEASED: registered, sidecars present, lock free — claimed with no age gate.
+        let dead = root.join("gd-update-crashed");
+        let dead_s = dead.to_string_lossy().into_owned();
+        run(&repo_s, &["worktree", "add", "--quiet", &dead_s, "feature"]).await;
+        let mut minted = marker::UpdateMarker::create_for(&dead, "feature").expect("mints");
+        minted.retain_for_recovery();
+        drop(minted);
+
+        git_delete_branch_core(&state, repo_s.clone(), "feature".into())
+            .await
+            .expect("a released holder is cleared and the delete proceeds");
+        assert!(!dead.exists(), "the orphaned checkout was removed");
+        assert!(
+            run(&repo_s, &["branch", "--list", "feature"])
+                .await
+                .trim()
+                .is_empty(),
+            "and the branch it was holding is gone"
+        );
     }
 }

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -316,29 +316,33 @@ async fn worktree_holding_branch(repo_path: &str, name: &str) -> Option<String> 
 }
 
 /// Arbitrates a `worktree_holding_branch` hit that turns out to be an UPDATE's hidden
-/// `gd-update-*` checkout: a running one is refused in the update's own words, and a
-/// dead one is cleared on the spot — no age gate, since the porcelain hit itself proves
-/// the mint completed. `true` means "cleared — re-probe"; `false` leaves the caller's
-/// own message to speak for a worktree the user owns.
+/// `gd-update-*` checkout. `true` means "cleared — re-probe"; `false` leaves the
+/// caller's own message to speak, which is also the answer whenever the marker proves
+/// nothing: an unreadable lock, or a checkout from a pre-marker build that may still be
+/// mid-update. Only a lock that EXISTS and is acquirable authorizes the age-free
+/// removal, and only a HELD one authorizes a refusal.
 async fn clear_update_holder(
     state: &AppState,
     repo_path: &str,
     branch: &str,
     holder: &str,
 ) -> AppResult<bool> {
-    use crate::git::update_marker as marker;
+    use crate::git::update_marker::{self as marker, LockProbe};
     if !marker::is_update_worktree_path(holder) {
         return Ok(false);
     }
-    if marker::update_worktree_is_live(holder) {
-        return Err(marker::branch_update_refusal(branch));
+    match marker::update_worktree_probe(holder) {
+        LockProbe::Live => Err(marker::branch_update_refusal(branch)),
+        LockProbe::Released => {
+            if marker::claim_dead_update_worktree(state, repo_path, holder).await {
+                return Ok(true);
+            }
+            // Provably dead but unclaimable (the admin domain was busy) — the hidden
+            // path is nothing the user can act on, so name the state instead.
+            Err(marker::interrupted_update_refusal(branch))
+        }
+        LockProbe::Missing | LockProbe::Unknown => Ok(false),
     }
-    if marker::claim_dead_update_worktree(state, repo_path, holder).await {
-        return Ok(true);
-    }
-    // Dead but unclaimable (admin busy, or the lock could not be probed) — the hidden
-    // path is nothing the user can act on, so name the state instead of that path.
-    Err(marker::interrupted_update_refusal(branch))
 }
 
 /// Force-deletes a local branch (the UI confirms first, GitHub Desktop style).
@@ -357,6 +361,10 @@ pub(crate) async fn git_delete_branch_core(
     name: String,
 ) -> AppResult<()> {
     validate_ref_name(&name)?;
+    // Two halves of one window: the marker covers an update that has minted but not yet
+    // registered its checkout (the `worktree add` is the long part), the porcelain arm
+    // below covers it once registered. Heal-free — the healing lives in the claim arm.
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, &name)?;
     // Pre-mutation guard: git's own refusal for a branch checked out in a worktree
     // is terse. Detect the holding worktree here — shared by every caller, not just
     // the switcher's UI guard — and surface an actionable message.
@@ -1055,6 +1063,10 @@ pub(crate) async fn branch_reset_to_upstream(
         )));
     }
 
+    // Two halves of one window, as in `git_delete_branch_core`: the marker covers an
+    // update that has minted but not yet registered its checkout, the porcelain arm
+    // below covers it once registered. Heal-free — healing lives in the claim arm.
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch)?;
     // Pre-mutation guards: git refuses both of these itself, but only after the
     // user has confirmed a destructive action, and its wording names neither
     // remedy. The linked-worktree probe excludes THIS checkout, so the current
@@ -1135,10 +1147,15 @@ pub(crate) async fn update_branch_from(
     }
     // One guard covers both self-collisions: a second update of the same branch, and
     // the fast-forward arm's `fetch . <base>:<branch>`, which git refuses outright
-    // against a branch held by the first update's checkout.
-    crate::git::update_marker::refuse_if_branch_updating(state, repo_path, branch).await?;
-    // Each update clears its predecessors' crash leftovers, so the orphan a killed
-    // run leaves behind never outlives the next one. Self-skips when admin is busy.
+    // against a branch held by the first update's checkout. Heal-free deliberately —
+    // this path's own `worktree add` takes the admin domain, and a detached sweep
+    // fired here would win it first and time that bounded acquire out.
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch)?;
+    // Healing, in two tiers. THIS branch's provably-dead leftovers go first and
+    // synchronously, so the first update after a crash clears its own predecessor
+    // before the add rather than racing it; everything else waits for the age gate and
+    // is skipped outright while the admin domain is busy.
+    crate::git::update_marker::claim_dead_updates_for_branch(state, repo_path, branch).await;
     crate::git::update_marker::sweep_orphaned_update_worktrees(state, repo_path).await;
 
     // Mutating refs — serialize against other writes to this repo's working tree.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1389,7 +1389,9 @@ async fn merge_diverged_in_worktree(
 /// markerless holder instead, which nothing may clear until the age gate expires.
 fn settle_marker(marker: Option<crate::git::update_marker::UpdateMarker>, tmp: &str) {
     let Some(mut marker) = marker else { return };
-    if std::path::Path::new(tmp).exists() {
+    // try_exists: an UNREADABLE answer must retain (the sidecars' deletion is the one
+    // destructive direction here); only a confirmed-gone checkout lets them go.
+    if std::path::Path::new(tmp).try_exists().unwrap_or(true) {
         marker.retain_for_recovery();
     }
 }
@@ -3449,6 +3451,8 @@ mod tests {
     /// claimed age-free and the delete then succeeds; a MARKERLESS one (a pre-marker
     /// build's checkout, which may still be running) is left alone and takes the
     /// pre-existing generic message naming the holding worktree.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_registered_holder_is_claimed_when_released_and_left_when_markerless() {

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1281,8 +1281,7 @@ pub(crate) async fn update_branch_from(
 }
 
 /// Where an update's throwaway checkout goes: `<app-data>/worktrees/<repo-hash>/
-/// gd-update-<unique>`. Resolution only — creating the root is the caller's job,
-/// which keeps this callable from a test without writing under the real app data.
+/// gd-update-<unique>`. Resolution only — creating the root is the caller's job.
 ///
 /// Through `update_marker::root_for`, not `ops::worktree_root_dir` directly, so the
 /// mint and the guards that police it can never disagree about which root they mean.

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1286,6 +1286,9 @@ pub(crate) async fn update_branch_from(
 ///
 /// Through `update_marker::root_for`, not `ops::worktree_root_dir` directly, so the
 /// mint and the guards that police it can never disagree about which root they mean.
+/// Alone among that function's callers this one PROPAGATES an unresolvable root instead
+/// of failing open: a guard that cannot resolve simply stays quiet, but a mint that
+/// cannot would put a checkout where nothing is watching it.
 fn update_worktree_path(repo_path: &str) -> AppResult<std::path::PathBuf> {
     Ok(crate::git::update_marker::root_for(repo_path)?
         .join(format!("gd-update-{}", unique_suffix())))
@@ -3391,12 +3394,9 @@ mod tests {
             .trim()
             .to_string();
         run(&repo_s, &["branch", "feature"]).await;
-        run(&repo_s, &["config", "branch.feature.remote", "."]).await;
-        run(
-            &repo_s,
-            &["config", "branch.feature.merge", &format!("refs/heads/{main}")],
-        )
-        .await;
+        // One call sets both `branch.feature.remote` (`.`) and `.merge`, which keeps
+        // any `refs/heads/<name>` template out of this fixture entirely.
+        run(&repo_s, &["branch", "--set-upstream-to", &main, "feature"]).await;
         let tip = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
             .await
             .trim()
@@ -3483,12 +3483,13 @@ mod tests {
         run(&repo_s, &["worktree", "remove", "--force", &bare_s]).await;
 
         // RELEASED: registered, sidecars present, lock free — claimed with no age gate.
+        // The pair is WRITTEN, not minted-and-dropped: a crashed update's lock is
+        // released by the OS, and on Linux `drop` cannot be relied on to release one in
+        // a process-spawning test binary (see `write_released_marker`).
         let dead = root.join("gd-update-crashed");
         let dead_s = dead.to_string_lossy().into_owned();
         run(&repo_s, &["worktree", "add", "--quiet", &dead_s, "feature"]).await;
-        let mut minted = marker::UpdateMarker::create_for(&dead, "feature").expect("mints");
-        minted.retain_for_recovery();
-        drop(minted);
+        marker::write_released_marker(&root, "gd-update-crashed", "feature");
 
         git_delete_branch_core(&state, repo_s.clone(), "feature".into())
             .await

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -1283,8 +1283,11 @@ pub(crate) async fn update_branch_from(
 /// Where an update's throwaway checkout goes: `<app-data>/worktrees/<repo-hash>/
 /// gd-update-<unique>`. Resolution only — creating the root is the caller's job,
 /// which keeps this callable from a test without writing under the real app data.
+///
+/// Through `update_marker::root_for`, not `ops::worktree_root_dir` directly, so the
+/// mint and the guards that police it can never disagree about which root they mean.
 fn update_worktree_path(repo_path: &str) -> AppResult<std::path::PathBuf> {
-    Ok(crate::git::ops::worktree_root_dir(repo_path)?
+    Ok(crate::git::update_marker::root_for(repo_path)?
         .join(format!("gd-update-{}", unique_suffix())))
 }
 
@@ -2695,13 +2698,20 @@ mod tests {
         }
     }
 
-    /// The throwaway checkout is minted under the app-data worktrees root, which is
-    /// what keeps it out of the worktree manager, with a unique `gd-update-` name.
-    /// Shape only — resolving a path creates nothing under the real app data.
+    /// The throwaway checkout is minted as a direct child of the SAME root the marker
+    /// guards read, with a unique `gd-update-` name — which is what keeps it out of the
+    /// worktree manager and inside `is_managed_update_worktree`'s scope. That root being
+    /// the app-data one in production is `root_for`'s non-test arm, pinned by
+    /// `ops::worktree_root_dir_uses_the_shipped_bundle_identifier`. Shape only: resolving
+    /// a path creates nothing.
     #[test]
-    fn update_worktree_path_sits_under_the_app_data_root() {
+    fn update_worktree_path_sits_directly_under_the_marker_root() {
+        use crate::git::update_marker as marker;
+        let (_temp, root) = temp_base("mint-root");
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+
         let repo = "C:\\repos\\app";
-        let root = crate::git::ops::worktree_root_dir(repo).expect("app-data root resolves");
         let first = update_worktree_path(repo).expect("update path resolves");
         assert_eq!(first.parent(), Some(root.as_path()));
         let name = first
@@ -2709,6 +2719,10 @@ mod tests {
             .and_then(|s| s.to_str())
             .expect("the mint has a basename");
         assert!(name.starts_with("gd-update-"), "{name}");
+        assert!(
+            marker::is_managed_update_worktree(repo, &first.to_string_lossy()),
+            "the mint must land inside the scope its own guards enforce"
+        );
         assert_ne!(
             first,
             update_worktree_path(repo).expect("update path resolves"),
@@ -3363,10 +3377,10 @@ mod tests {
         assert!(!tmp.exists(), "the throwaway worktree is torn down");
     }
 
-    /// A repo with `feature` tracking `master` through the local `.` remote, so
-    /// `feature@{upstream}` resolves without a network or a second repo. Returns the
-    /// temp guard, the repo path, the default branch name, and its tip.
-    async fn repo_with_local_upstream(tag: &str) -> (tempfile::TempDir, String, String, String) {
+    /// A repo with `feature` tracking the default branch through the local `.` remote,
+    /// so `feature@{upstream}` resolves without a network or a second repo. Returns the
+    /// temp guard, the repo path, and the upstream tip.
+    async fn repo_with_local_upstream(tag: &str) -> (tempfile::TempDir, String, String) {
         let (guard, base_dir) = temp_base(tag);
         let repo = base_dir.join("repo");
         std::fs::create_dir_all(&repo).unwrap();
@@ -3387,7 +3401,7 @@ mod tests {
             .await
             .trim()
             .to_string();
-        (guard, repo_s, main, tip)
+        (guard, repo_s, tip)
     }
 
     /// The PRE-ADD window: an update has minted its marker but its `worktree add` has
@@ -3400,7 +3414,7 @@ mod tests {
     #[tokio::test]
     async fn a_live_marker_refuses_delete_and_reset_before_the_checkout_exists() {
         use crate::git::update_marker as marker;
-        let (_guard, repo_s, _main, tip) = repo_with_local_upstream("premint-guard").await;
+        let (_guard, repo_s, tip) = repo_with_local_upstream("premint-guard").await;
         let root = std::path::Path::new(&repo_s)
             .parent()
             .unwrap()
@@ -3440,7 +3454,7 @@ mod tests {
     #[tokio::test]
     async fn a_registered_holder_is_claimed_when_released_and_left_when_markerless() {
         use crate::git::update_marker as marker;
-        let (_guard, repo_s, _main, _tip) = repo_with_local_upstream("registered-holder").await;
+        let (_guard, repo_s, _tip) = repo_with_local_upstream("registered-holder").await;
         let root = std::path::Path::new(&repo_s)
             .parent()
             .unwrap()

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -19,4 +19,5 @@ pub mod status;
 pub mod submodule;
 pub mod todos;
 pub mod types;
+pub mod update_marker;
 pub mod worktree;

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -723,6 +723,10 @@ pub(crate) async fn cherry_pick_onto_with_timeouts(
     // uncommitted work when target is the current branch — refuse first.
     ensure_clean_tree(repo_path).await?;
 
+    // With the other pre-flight guards, so nothing is journaled or switched before an
+    // update holding `target` is ruled out.
+    crate::git::update_marker::refuse_if_branch_updating(state, repo_path, target_branch).await?;
+
     // Where we are now, so we can return on failure. A detached HEAD has no
     // branch name, so fall back to restoring its commit directly.
     let original_ref = run_git(
@@ -2552,6 +2556,18 @@ pub(crate) fn parse_worktree_paths(porcelain: &str) -> Vec<String> {
         .collect()
 }
 
+/// The worktree checking `branch` out, from one `worktree list --porcelain` read.
+/// Both parsers emit one entry per stanza in list order, so the zip pairs each path
+/// with its own branch; a detached stanza (our resolve worktrees) carries an empty
+/// name and never matches.
+fn worktree_holding(porcelain: &str, branch: &str) -> Option<String> {
+    parse_worktree_paths(porcelain)
+        .into_iter()
+        .zip(parse_worktree_branches(porcelain))
+        .find(|(_, b)| b == branch)
+        .map(|(path, _)| path)
+}
+
 /// Whether a worktree path is one of our resolve worktrees — its final path
 /// segment starts with `gd-resolve-`. The basename is the reliable signal:
 /// `git_merge_local_pr` names them `gd-resolve-<id>`, and porcelain may
@@ -2686,12 +2702,39 @@ async fn finalize_base(
         DEFAULT_TIMEOUT,
     )
     .await?;
-    let porcelain = listed.stdout_lossy();
-    let owning_worktree = parse_worktree_paths(&porcelain)
-        .into_iter()
-        .zip(parse_worktree_branches(&porcelain))
-        .find(|(_, branch)| branch == base)
-        .map(|(path, _)| path);
+    let mut owning_worktree = worktree_holding(&listed.stdout_lossy(), base);
+
+    // An update's hidden checkout is never a fast-forward target: advancing `base`
+    // under a running update moves the branch it pinned and kills it at its pin
+    // verify. Live refuses; a dead one is cleared on the spot and the scan retried
+    // once, and anything still holding `base` afterwards refuses as INTERRUPTED —
+    // claiming a running update would be a state this arm just disproved.
+    if let Some(holder) = owning_worktree
+        .as_deref()
+        .filter(|w| crate::git::update_marker::is_update_worktree_path(w))
+        .map(str::to_string)
+    {
+        if crate::git::update_marker::update_worktree_is_live(&holder) {
+            return Err(crate::git::update_marker::branch_update_refusal(base));
+        }
+        if !crate::git::update_marker::claim_dead_update_worktree(state, repo_path, &holder).await
+        {
+            return Err(crate::git::update_marker::interrupted_update_refusal(base));
+        }
+        let relisted = run_git(
+            Some(repo_path),
+            &["worktree", "list", "--porcelain"],
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+        owning_worktree = worktree_holding(&relisted.stdout_lossy(), base);
+        if owning_worktree
+            .as_deref()
+            .is_some_and(crate::git::update_marker::is_update_worktree_path)
+        {
+            return Err(crate::git::update_marker::interrupted_update_refusal(base));
+        }
+    }
 
     if let Some(worktree) = owning_worktree {
         // Route the fast-forward INTO the worktree holding `base` so its index and

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2692,16 +2692,16 @@ async fn finalize_base(
         return Ok(());
     }
 
-    // Is `base` checked out in some OTHER worktree? `paths` and `branches` come
-    // from the same porcelain stanzas in list order, so they line up per stanza.
-    // Our resolve worktree is detached, so it never carries `base` as a branch and
-    // is safely excluded.
+    use crate::git::update_marker::{self as marker, LockProbe};
+
     // An update that has minted its marker but not yet registered its checkout is
     // invisible to the porcelain read below, so the marker covers that half of the
     // window and the arm below covers it once registered. Heal-free: this call's own
     // continuation takes the admin domain to tear the resolve worktree down.
-    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, base)?;
+    marker::refuse_if_branch_updating_no_heal(repo_path, base)?;
 
+    // Is `base` checked out in some OTHER worktree? Our resolve worktree is detached,
+    // so it never carries `base` as a branch and is safely excluded.
     let listed = run_git(
         Some(repo_path),
         &["worktree", "list", "--porcelain"],
@@ -2713,24 +2713,16 @@ async fn finalize_base(
     // An update's hidden checkout is never a fast-forward target: advancing `base`
     // under a running update moves the branch it pinned and kills it at its pin verify.
     // Only a HELD lock refuses and only a RELEASED one authorizes the age-free removal;
-    // a marker that proves neither leaves this routing exactly as it was before markers
+    // a marker that proves neither — and any `gd-update-*` worktree outside our own
+    // root, which is the user's — leaves this routing exactly as it was before markers
     // existed, which the update's own pin verify already makes data-safe.
-    if let Some(holder) = owning_worktree
-        .as_deref()
-        .filter(|w| crate::git::update_marker::is_update_worktree_path(w))
-        .map(str::to_string)
-    {
-        match crate::git::update_marker::update_worktree_probe(&holder) {
-            crate::git::update_marker::LockProbe::Live => {
-                return Err(crate::git::update_marker::branch_update_refusal(base));
-            }
-            crate::git::update_marker::LockProbe::Released => {
-                if !crate::git::update_marker::claim_dead_update_worktree(
-                    state, repo_path, &holder,
-                )
-                .await
-                {
-                    return Err(crate::git::update_marker::interrupted_update_refusal(base));
+    let managed = |w: &&str| marker::is_managed_update_worktree(repo_path, w);
+    if let Some(holder) = owning_worktree.as_deref().filter(managed).map(str::to_string) {
+        match marker::update_worktree_probe(&holder) {
+            LockProbe::Live => return Err(marker::branch_update_refusal(base)),
+            LockProbe::Released => {
+                if !marker::claim_dead_update_worktree(state, repo_path, &holder).await {
+                    return Err(marker::interrupted_update_refusal(base));
                 }
                 let relisted = run_git(
                     Some(repo_path),
@@ -2742,26 +2734,17 @@ async fn finalize_base(
                 // Another update may hold `base` by now. Same rule as above, so each
                 // message stays true: a held lock says running, a released one says
                 // interrupted, and an unprovable one routes as it always did.
-                if let Some(next) = owning_worktree
-                    .as_deref()
-                    .filter(|w| crate::git::update_marker::is_update_worktree_path(w))
-                {
-                    match crate::git::update_marker::update_worktree_probe(next) {
-                        crate::git::update_marker::LockProbe::Live => {
-                            return Err(crate::git::update_marker::branch_update_refusal(base));
+                if let Some(next) = owning_worktree.as_deref().filter(managed) {
+                    match marker::update_worktree_probe(next) {
+                        LockProbe::Live => return Err(marker::branch_update_refusal(base)),
+                        LockProbe::Released => {
+                            return Err(marker::interrupted_update_refusal(base))
                         }
-                        crate::git::update_marker::LockProbe::Released => {
-                            return Err(crate::git::update_marker::interrupted_update_refusal(
-                                base,
-                            ));
-                        }
-                        crate::git::update_marker::LockProbe::Missing
-                        | crate::git::update_marker::LockProbe::Unknown => {}
+                        LockProbe::Missing | LockProbe::Unknown => {}
                     }
                 }
             }
-            crate::git::update_marker::LockProbe::Missing
-            | crate::git::update_marker::LockProbe::Unknown => {}
+            LockProbe::Missing | LockProbe::Unknown => {}
         }
     }
 
@@ -9805,5 +9788,44 @@ detached
 
         assert!(created);
         assert_eq!(stash_count(&repo).await, 1);
+    }
+
+    /// A local-PR merge must never advance `base` while an update holds it. The marker
+    /// alone is the signal in the PRE-ADD window — nothing is in `worktree list` yet —
+    /// so `finalize_base` has to refuse before it reads the porcelain at all.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn finalize_base_refuses_while_an_update_holds_the_base_branch() {
+        use crate::git::update_marker as marker;
+        let (dir, repo) = setup_repo("finalize-update-guard").await;
+        git(&repo, &["branch", "feature"]).await;
+        let tip = rev(&repo, "refs/heads/feature").await;
+        let root = dir.path().join("gd-worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+        let _live = marker::UpdateMarker::create_for(&root.join("gd-update-live"), "feature")
+            .expect("the marker mints");
+
+        let state = AppState::default();
+        let current = git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+        let err = finalize_base(&state, &repo, "feature", &tip, &current, Some(&tip))
+            .await
+            .expect_err("advancing a branch an update is merging is refused");
+        assert_eq!(
+            err.to_string(),
+            marker::branch_update_refusal("feature").to_string()
+        );
+        assert_eq!(
+            rev(&repo, "refs/heads/feature").await,
+            tip,
+            "and the branch is exactly where it was"
+        );
     }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2696,6 +2696,12 @@ async fn finalize_base(
     // from the same porcelain stanzas in list order, so they line up per stanza.
     // Our resolve worktree is detached, so it never carries `base` as a branch and
     // is safely excluded.
+    // An update that has minted its marker but not yet registered its checkout is
+    // invisible to the porcelain read below, so the marker covers that half of the
+    // window and the arm below covers it once registered. Heal-free: this call's own
+    // continuation takes the admin domain to tear the resolve worktree down.
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, base)?;
+
     let listed = run_git(
         Some(repo_path),
         &["worktree", "list", "--porcelain"],
@@ -2705,34 +2711,57 @@ async fn finalize_base(
     let mut owning_worktree = worktree_holding(&listed.stdout_lossy(), base);
 
     // An update's hidden checkout is never a fast-forward target: advancing `base`
-    // under a running update moves the branch it pinned and kills it at its pin
-    // verify. Live refuses; a dead one is cleared on the spot and the scan retried
-    // once, and anything still holding `base` afterwards refuses as INTERRUPTED —
-    // claiming a running update would be a state this arm just disproved.
+    // under a running update moves the branch it pinned and kills it at its pin verify.
+    // Only a HELD lock refuses and only a RELEASED one authorizes the age-free removal;
+    // a marker that proves neither leaves this routing exactly as it was before markers
+    // existed, which the update's own pin verify already makes data-safe.
     if let Some(holder) = owning_worktree
         .as_deref()
         .filter(|w| crate::git::update_marker::is_update_worktree_path(w))
         .map(str::to_string)
     {
-        if crate::git::update_marker::update_worktree_is_live(&holder) {
-            return Err(crate::git::update_marker::branch_update_refusal(base));
-        }
-        if !crate::git::update_marker::claim_dead_update_worktree(state, repo_path, &holder).await
-        {
-            return Err(crate::git::update_marker::interrupted_update_refusal(base));
-        }
-        let relisted = run_git(
-            Some(repo_path),
-            &["worktree", "list", "--porcelain"],
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
-        owning_worktree = worktree_holding(&relisted.stdout_lossy(), base);
-        if owning_worktree
-            .as_deref()
-            .is_some_and(crate::git::update_marker::is_update_worktree_path)
-        {
-            return Err(crate::git::update_marker::interrupted_update_refusal(base));
+        match crate::git::update_marker::update_worktree_probe(&holder) {
+            crate::git::update_marker::LockProbe::Live => {
+                return Err(crate::git::update_marker::branch_update_refusal(base));
+            }
+            crate::git::update_marker::LockProbe::Released => {
+                if !crate::git::update_marker::claim_dead_update_worktree(
+                    state, repo_path, &holder,
+                )
+                .await
+                {
+                    return Err(crate::git::update_marker::interrupted_update_refusal(base));
+                }
+                let relisted = run_git(
+                    Some(repo_path),
+                    &["worktree", "list", "--porcelain"],
+                    DEFAULT_TIMEOUT,
+                )
+                .await?;
+                owning_worktree = worktree_holding(&relisted.stdout_lossy(), base);
+                // Another update may hold `base` by now. Same rule as above, so each
+                // message stays true: a held lock says running, a released one says
+                // interrupted, and an unprovable one routes as it always did.
+                if let Some(next) = owning_worktree
+                    .as_deref()
+                    .filter(|w| crate::git::update_marker::is_update_worktree_path(w))
+                {
+                    match crate::git::update_marker::update_worktree_probe(next) {
+                        crate::git::update_marker::LockProbe::Live => {
+                            return Err(crate::git::update_marker::branch_update_refusal(base));
+                        }
+                        crate::git::update_marker::LockProbe::Released => {
+                            return Err(crate::git::update_marker::interrupted_update_refusal(
+                                base,
+                            ));
+                        }
+                        crate::git::update_marker::LockProbe::Missing
+                        | crate::git::update_marker::LockProbe::Unknown => {}
+                    }
+                }
+            }
+            crate::git::update_marker::LockProbe::Missing
+            | crate::git::update_marker::LockProbe::Unknown => {}
         }
     }
 

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -60,10 +60,34 @@ static TEST_ROOT_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(
 #[cfg(test)]
 static TEST_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Writes a RELEASED marker pair — the manifest plus an unlocked `.lock` — which is
+/// exactly what a crashed update leaves behind: the OS drops the flock when the process
+/// dies, so the file simply exists with no holder.
+///
+/// Fixtures build this shape by writing rather than by minting and dropping a real
+/// marker, because on Linux `drop` does not reliably release the lock in a
+/// process-spawning test binary: an `flock` belongs to the open file description, and a
+/// concurrently forked child inherits the fd, holding the lock alive until its copy
+/// closes at exec (measured: 157 spurious `WouldBlock` in 20k mint/drop/probe cycles
+/// with 3 forking threads, 0 with none, 0 on Windows at any rate).
+#[cfg(test)]
+pub(crate) fn write_released_marker(root: &Path, stem: &str, branch: &str) {
+    std::fs::write(
+        root.join(format!("{stem}.json")),
+        serde_json::to_vec(&UpdateManifest {
+            branch: branch.to_string(),
+            pid: 4242,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(root.join(format!("{stem}.lock")), b"").unwrap();
+}
+
 /// Installs (or clears) the in-process override, returning the previous value so a
 /// caller can restore it. Test-only.
 #[cfg(test)]
-pub(crate) fn swap_test_root_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+fn swap_test_root_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
     let mut slot = TEST_ROOT_DIR
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -108,9 +132,11 @@ impl Drop for TestRootOverride {
 /// [`crate::app_store`]'s "under `cfg!(test)`, NO store, whatever the environment says".
 /// The override is process-wide, so a test that never installed one must neither read a
 /// concurrently-scheduled sibling's root nor mint under the developer's own app data.
-/// Every caller already fails open on an unresolvable root — refusals answer `Ok`,
-/// claims and sweeps return, `is_managed_update_worktree` answers `false` — which is
-/// exactly what an un-overridden test should see.
+/// Every GUARD caller fails open on an unresolvable root — refusals answer `Ok`, claims
+/// and sweeps return, `is_managed_update_worktree` answers `false` — which is exactly
+/// what an un-overridden test should see. The MINT is the loud exception:
+/// `branches.rs::update_worktree_path` propagates the error rather than place a
+/// checkout somewhere nobody is guarding.
 pub(crate) fn root_for(repo_path: &str) -> AppResult<PathBuf> {
     #[cfg(test)]
     {
@@ -312,7 +338,7 @@ fn read_manifest(json_path: &Path) -> Option<UpdateManifest> {
 /// Whether `path` names an update's throwaway checkout — its basename starts with
 /// `gd-update-`. Modeled on `ops::is_resolve_worktree_path`: the basename is the
 /// reliable signal, since porcelain may print a normalized leading path.
-pub(crate) fn is_update_worktree_path(path: &str) -> bool {
+fn is_update_worktree_path(path: &str) -> bool {
     Path::new(path)
         .file_name()
         .and_then(|s| s.to_str())
@@ -750,21 +776,6 @@ mod tests {
         (dir, root)
     }
 
-    /// A DEAD marker pair: the manifest plus an unlocked `.lock`, the shape a crashed
-    /// update leaves behind once the OS drops its lock.
-    fn write_dead_marker(root: &Path, stem: &str, branch: &str) {
-        std::fs::write(
-            root.join(format!("{stem}.json")),
-            serde_json::to_vec(&UpdateManifest {
-                branch: branch.to_string(),
-                pid: 4242,
-            })
-            .unwrap(),
-        )
-        .unwrap();
-        std::fs::write(root.join(format!("{stem}.lock")), b"").unwrap();
-    }
-
     #[test]
     fn create_writes_a_readable_manifest_and_holds_the_lock() {
         let (_guard, root) = temp_root("create");
@@ -816,7 +827,7 @@ mod tests {
     #[test]
     fn a_dead_marker_refuses_nothing_and_flags_a_sweep() {
         let (_guard, root) = temp_root("dead");
-        write_dead_marker(&root, "gd-update-dead", "feature");
+        write_released_marker(&root, "gd-update-dead", "feature");
 
         for query in [Some("feature"), None] {
             let outcome = refuse_in(&root, query);
@@ -862,7 +873,7 @@ mod tests {
         let (_guard, root) = temp_root("claims");
 
         std::fs::create_dir_all(root.join("gd-update-dead")).unwrap();
-        write_dead_marker(&root, "gd-update-dead", "feature");
+        write_released_marker(&root, "gd-update-dead", "feature");
 
         // A live update — its lock is held for the length of this test.
         std::fs::create_dir_all(root.join("gd-update-busy")).unwrap();
@@ -875,7 +886,7 @@ mod tests {
         std::fs::create_dir_all(root.join("gd-update-markerless")).unwrap();
 
         // The marker pair whose checkout is already gone.
-        write_dead_marker(&root, "gd-update-pruned", "feature");
+        write_released_marker(&root, "gd-update-pruned", "feature");
 
         // Decoys: an agent-session worktree (named by session id) and a near-miss.
         std::fs::create_dir_all(root.join("1a2b3c4d")).unwrap();
@@ -938,7 +949,7 @@ mod tests {
             &["worktree", "add", "--quiet", &orphan_s, "feature"],
         )
         .await;
-        write_dead_marker(&root, "gd-update-crashed", "feature");
+        write_released_marker(&root, "gd-update-crashed", "feature");
         assert!(
             run_git_raw(Some(&repo_s), &["branch", "-D", "feature"], DEFAULT_TIMEOUT)
                 .await
@@ -960,7 +971,7 @@ mod tests {
             .expect("the live marker mints");
         // A dead leftover that is simply too young to claim.
         std::fs::create_dir_all(root.join("gd-update-young")).unwrap();
-        write_dead_marker(&root, "gd-update-young", "feature");
+        write_released_marker(&root, "gd-update-young", "feature");
 
         // The production age gate spares everything here: every fixture is seconds old,
         // which is exactly the young-dead case.
@@ -1068,6 +1079,18 @@ mod tests {
         }
     }
 
+    /// The seam fails CLOSED: with no override installed, in-test resolution errors
+    /// rather than reaching the developer's real app data. Holding `test_root_lock` is
+    /// what makes the premise true — it is the guarantee no sibling has one installed.
+    #[test]
+    fn root_for_refuses_to_resolve_without_a_test_override() {
+        let _serialized = test_root_lock();
+        assert!(
+            root_for("C:/repos/app").is_err(),
+            "an un-overridden test must never resolve the real worktree root"
+        );
+    }
+
     /// Negative control for the guard MECHANISM: the root holds a live marker and no
     /// worktree at all, so nothing but the marker scan can produce this refusal —
     /// delete the scan and the same fixture answers `Ok`.
@@ -1106,7 +1129,7 @@ mod tests {
         let (_guard, root) = temp_root("branch-claim");
 
         std::fs::create_dir_all(root.join("gd-update-dead")).unwrap();
-        write_dead_marker(&root, "gd-update-dead", "feature");
+        write_released_marker(&root, "gd-update-dead", "feature");
 
         // A live update of the same branch.
         std::fs::create_dir_all(root.join("gd-update-busy")).unwrap();
@@ -1114,7 +1137,7 @@ mod tests {
             .expect("the live marker mints");
 
         // A dead update of a DIFFERENT branch.
-        write_dead_marker(&root, "gd-update-other", "release");
+        write_released_marker(&root, "gd-update-other", "release");
 
         // A pre-marker build's checkout: no lock file at all.
         std::fs::create_dir_all(root.join("gd-update-markerless")).unwrap();
@@ -1189,12 +1212,17 @@ mod tests {
         );
     }
 
-    /// A teardown that could not remove the checkout must leave the marker RECOVERABLE:
-    /// sidecars retained and unlocked, i.e. `Released`, so the next branch operation
-    /// clears it age-free. Deleting them there would leave a markerless holder that
-    /// nothing may touch until the age gate expires.
+    /// A teardown that could not remove the checkout must RETAIN both sidecars, where
+    /// the success path deletes them — that retention is what later lets an age-free
+    /// claim recover the holder rather than leaving a markerless one nothing may touch.
+    ///
+    /// File survival only. The lock's post-drop state is deliberately NOT asserted here:
+    /// on Linux a concurrently forked child inherits the fd and holds the flock past
+    /// `drop`, so that verdict is scheduling-dependent in a test binary that spawns git.
+    /// The released-marker consequences are pinned on WRITTEN fixtures instead, which
+    /// take no lock at all — see `the_branch_claim_takes_only_released_locks_for_that_branch`.
     #[test]
-    fn a_failed_teardown_retains_the_marker_as_released() {
+    fn a_failed_teardown_retains_both_sidecars() {
         let (_guard, root) = temp_root("retain");
         let dir = root.join("gd-update-stuck");
         std::fs::create_dir_all(&dir).unwrap();
@@ -1213,15 +1241,15 @@ mod tests {
                 && root.join("gd-update-stuck.json").exists(),
             "both sidecars survive a failed teardown"
         );
-        assert_eq!(
-            probe_lock(&root.join("gd-update-stuck.lock")),
-            LockProbe::Released,
-            "and the lock is released, so a claim can recover it immediately"
-        );
-        assert_eq!(
-            dead_stems_for_branch(&root, "feature"),
-            vec!["gd-update-stuck".to_string()],
-            "the age-free branch claim picks it up with no waiting"
+
+        // The control: the SUCCESS path, with no retain, deletes the very same pair.
+        let clean = root.join("gd-update-clean");
+        std::fs::create_dir_all(&clean).unwrap();
+        drop(UpdateMarker::create_for(&clean, "feature").expect("the marker mints"));
+        assert!(
+            !root.join("gd-update-clean.lock").exists()
+                && !root.join("gd-update-clean.json").exists(),
+            "a confirmed teardown still cleans up after itself"
         );
     }
 

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -16,8 +16,9 @@
 //! itself: the OS releases it when the owning process dies, so a probe that can
 //! acquire it is looking at a crash orphan.
 //!
-//! Every probe failure fails OPEN — no refusal, git's own error speaks, which is
-//! exactly today's behavior. An IO hiccup must never block a user's action.
+//! A probe that establishes nothing fails OPEN in BOTH directions — no refusal and no
+//! removal, leaving the caller exactly where it stood before markers existed. An IO
+//! hiccup must never block a user's action, nor authorize deleting a checkout.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -67,9 +68,10 @@ fn any_update_refusal() -> AppError {
     AppError::Command("A branch update is running — try again when it finishes.".to_string())
 }
 
-/// The refusal when a DEAD update's leftover still holds `branch` and this attempt
-/// could not clear it — the worktree-admin domain was busy, or the lock could not be
-/// probed. Never says an update is running: that would be a claim we just disproved.
+/// The refusal when a PROVABLY dead update's leftover still holds `branch` and this
+/// attempt could not clear it, which now means only one thing: the worktree-admin
+/// domain was busy. Raised solely off a `Released` probe, so it never says an update is
+/// running — that would be a claim the probe just disproved.
 pub(crate) fn interrupted_update_refusal(branch: &str) -> AppError {
     AppError::Command(format!(
         "An interrupted branch update is still holding {branch} — try again in a moment."
@@ -153,33 +155,39 @@ impl Drop for UpdateMarker {
     }
 }
 
-/// What a lock probe could establish. `Unknown` exists because the two consumers need
-/// opposite defaults: a refusal may only fire on `Live` (an unreadable lock must never
-/// block a user's action), while a REMOVAL may only fire on `Dead` (an antivirus
-/// scanner holding a live update's lock file open for a moment must never get that
-/// update's checkout force-removed mid-merge).
+/// What a lock probe could establish. Four states because the consumers need different
+/// defaults, and each state authorizes exactly one thing:
+/// - only `Live` may say an update is RUNNING — an unreadable lock must never block a
+///   user's action on a guess;
+/// - only `Released` may authorize an AGE-FREE removal, and its refusal when that
+///   removal cannot proceed says INTERRUPTED, which is what it just proved;
+/// - `Missing` and `Unknown` prove nothing, so they authorize neither and leave every
+///   caller at exactly the behavior it had before markers existed.
 #[derive(Debug, PartialEq, Eq)]
-enum LockProbe {
+pub(crate) enum LockProbe {
     /// Someone holds the lock — the update that minted it is still running.
     Live,
-    /// Provably nobody holds it: acquirable, or the file is gone (the pre-marker
-    /// orphan shape, which the background sweep still age-gates).
-    Dead,
-    /// The probe could not establish either — a transient IO failure.
+    /// The lock file exists and was acquirable: its owner is provably gone, since the
+    /// OS releases file locks on process death.
+    Released,
+    /// No lock file at all. NOT proof of death: a pre-marker binary mints no marker,
+    /// and a stale one can still be running an update (a not-yet-restarted MCP server
+    /// beside a rebuilt GUI). Only age can settle this shape.
+    Missing,
+    /// The probe established nothing — a transient IO failure.
     Unknown,
 }
 
-/// Probes the marker lock at `lock_path`. The OS releases an exclusive file lock when
-/// the holding process dies, so acquiring one is proof its owner is gone.
+/// Probes the marker lock at `lock_path`.
 fn probe_lock(lock_path: &Path) -> LockProbe {
     match std::fs::File::open(lock_path) {
         // The probe's own acquisition is released when `file` closes at end of scope.
         Ok(file) => match file.try_lock() {
-            Ok(()) => LockProbe::Dead,
+            Ok(()) => LockProbe::Released,
             Err(std::fs::TryLockError::WouldBlock) => LockProbe::Live,
             Err(std::fs::TryLockError::Error(_)) => LockProbe::Unknown,
         },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LockProbe::Dead,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LockProbe::Missing,
         Err(_) => LockProbe::Unknown,
     }
 }
@@ -201,10 +209,15 @@ pub(crate) fn is_update_worktree_path(path: &str) -> bool {
         .is_some_and(|name| name.starts_with(MARKER_PREFIX))
 }
 
-/// Whether the update owning the `gd-update-*` checkout at `path` is provably still
-/// running. Only `Live` answers `true`, so an unreadable lock never raises a refusal.
-pub(crate) fn update_worktree_is_live(path: &str) -> bool {
-    sidecar(Path::new(path), "lock").is_some_and(|lock| probe_lock(&lock) == LockProbe::Live)
+/// The lock state of the `gd-update-*` checkout at `path`. Every caller needs all four
+/// answers apart — `Live` refuses, `Released` claims, and `Missing`/`Unknown` prove
+/// nothing and behave exactly as if markers did not exist — so this replaces the
+/// is-live predicate a two-state probe could afford. An unusable path reads `Unknown`.
+pub(crate) fn update_worktree_probe(path: &str) -> LockProbe {
+    match sidecar(Path::new(path), "lock") {
+        Some(lock) => probe_lock(&lock),
+        None => LockProbe::Unknown,
+    }
 }
 
 /// One scan of a worktree root's markers.
@@ -241,7 +254,9 @@ pub(crate) fn refuse_in(root: &Path, branch: Option<&str>) -> RefuseOutcome {
         }
         match probe_lock(&entry.path()) {
             LockProbe::Live => {}
-            LockProbe::Dead => {
+            // `Missing` here means the file vanished between the listing and the open,
+            // which is a finished update either way — both are sweepable leftovers.
+            LockProbe::Released | LockProbe::Missing => {
                 outcome.saw_dead = true;
                 continue;
             }
@@ -337,11 +352,15 @@ pub(crate) async fn spawn_orphan_sweep(state: &AppState, repo_path: &str) {
 /// re-probe; `false` means it must not proceed (still live, unprobeable, or the admin
 /// domain was busy).
 ///
-/// No age gate, unlike the background sweep, and that is sound HERE specifically: the
-/// mint writes and locks the marker BEFORE `worktree add`, so a `gd-update-*` checkout
-/// appearing in porcelain proves the marker already existed. An acquirable lock is
-/// therefore direct proof its owner died, not a mint-order race — the window the age
-/// gate exists to cover cannot be open once the checkout is registered.
+/// No age gate, unlike the background sweep, and `Released` is what buys that: the mint
+/// writes and locks the marker BEFORE `worktree add`, so a registered checkout whose
+/// lock file EXISTS was minted by a marker-era process, and the OS having released that
+/// lock is direct proof the process died — never a mint-order race.
+///
+/// That proof covers only checkouts whose lock file exists. A `Missing` lock at a
+/// registered holder means a pre-marker binary minted it, and such a binary can still
+/// be running the update right now (a stale MCP-server exe beside a rebuilt GUI), so it
+/// is refused here and left to the age-gated background sweep.
 pub(crate) async fn claim_dead_update_worktree(
     state: &AppState,
     repo_path: &str,
@@ -358,7 +377,7 @@ pub(crate) async fn claim_dead_update_worktree(
     ) else {
         return false;
     };
-    if probe_lock(&lock) != LockProbe::Dead {
+    if probe_lock(&lock) != LockProbe::Released {
         return false;
     }
     let domain = state.worktree_admin_lock(repo_path).await;
@@ -367,11 +386,74 @@ pub(crate) async fn claim_dead_update_worktree(
     };
     // Re-probe under the hold: the first probe raced anything that could have started
     // an update on this stem in between.
-    if probe_lock(&lock) != LockProbe::Dead {
+    if probe_lock(&lock) != LockProbe::Released {
         return false;
     }
     remove_update_leftover(repo_path, root, stem).await;
     true
+}
+
+/// Clears the leftovers of DEAD updates of `branch` specifically, age-free, so the very
+/// next update of a branch a crash interrupted heals its own predecessor synchronously
+/// instead of racing a detached sweep for the worktree-admin domain.
+///
+/// Same proof as [`claim_dead_update_worktree`] and the same limit: only a lock file
+/// that EXISTS and is acquirable authorizes a removal, so a pre-marker build's
+/// markerless checkout is never claimed here. No porcelain read is needed — the lock
+/// file alone carries the proof.
+pub(crate) async fn claim_dead_updates_for_branch(state: &AppState, repo_path: &str, branch: &str) {
+    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+        return;
+    };
+    // Nothing to heal is the overwhelmingly common case; answer it without paying for
+    // the domain resolution or its lock.
+    if dead_stems_for_branch(&root, branch).is_empty() {
+        return;
+    }
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+        return;
+    };
+    claim_dead_stems_for_branch_locked(repo_path, &root, branch).await;
+}
+
+/// The body of [`claim_dead_updates_for_branch`], over an explicit root so tests can
+/// drive it. The caller MUST hold the repo's worktree-admin domain.
+async fn claim_dead_stems_for_branch_locked(repo_path: &str, root: &Path, branch: &str) {
+    for stem in dead_stems_for_branch(root, branch) {
+        // Re-probe under the hold, as the single-holder claim does.
+        if probe_lock(&root.join(format!("{stem}.lock"))) != LockProbe::Released {
+            continue;
+        }
+        remove_update_leftover(repo_path, root, &stem).await;
+    }
+}
+
+/// The stems under `root` whose lock file exists, probes `Released`, and whose manifest
+/// names `branch`. Age-free by construction: an existing-but-released lock is the
+/// proof, so a markerless (`Missing`) stem is never a candidate here.
+fn dead_stems_for_branch(root: &Path, branch: &str) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut stems = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(stem) = name.strip_suffix(".lock") else {
+            continue;
+        };
+        if !stem.starts_with(MARKER_PREFIX) {
+            continue;
+        }
+        if probe_lock(&entry.path()) != LockProbe::Released {
+            continue;
+        }
+        if read_manifest(&root.join(format!("{stem}.json"))).is_some_and(|m| m.branch == branch) {
+            stems.push(stem.to_string());
+        }
+    }
+    stems
 }
 
 /// Removes the `gd-update-*` leftovers a crashed or killed update left behind, so the
@@ -463,8 +545,14 @@ fn orphaned_update_stems(root: &Path, min_age: Duration) -> Vec<String> {
     let now = SystemTime::now();
     candidates
         .into_iter()
-        // Only a PROVEN-dead lock authorizes a removal — `Unknown` is spared.
-        .filter(|(stem, _)| probe_lock(&root.join(format!("{stem}.lock"))) == LockProbe::Dead)
+        // `Missing` is claimable HERE and nowhere else: the age gate is what stands in
+        // for the proof a lock file would have given. `Unknown` and `Live` are spared.
+        .filter(|(stem, _)| {
+            matches!(
+                probe_lock(&root.join(format!("{stem}.lock"))),
+                LockProbe::Released | LockProbe::Missing
+            )
+        })
         .filter(|(_, paths)| {
             // The NEWEST mtime of anything the stem owns: the most recent sign of life
             // is what has to be old, not the oldest.
@@ -772,15 +860,15 @@ mod tests {
         drop(marker);
         assert_eq!(
             probe_lock(&root.join("gd-update-held.lock")),
-            LockProbe::Dead,
-            "a missing lock is the pre-marker orphan shape"
+            LockProbe::Missing,
+            "no lock file at all is the pre-marker orphan shape, not proof of death"
         );
 
         std::fs::write(root.join("gd-update-freed.lock"), b"").unwrap();
         assert_eq!(
             probe_lock(&root.join("gd-update-freed.lock")),
-            LockProbe::Dead,
-            "an acquirable lock proves its owner is gone"
+            LockProbe::Released,
+            "an existing, acquirable lock proves its owner is gone"
         );
 
         // An open that fails as something OTHER than NotFound. There is no one
@@ -820,6 +908,11 @@ mod tests {
     /// Negative control for the guard MECHANISM: the root holds a live marker and no
     /// worktree at all, so nothing but the marker scan can produce this refusal —
     /// delete the scan and the same fixture answers `Ok`.
+    ///
+    /// This fixture IS the pre-add window: minted, `worktree add` not yet run, nothing
+    /// in porcelain. It is the only thing standing between a delete or a reset and an
+    /// update that dies on a missing ref, which is why those sites guard on the marker
+    /// before their porcelain read.
     #[test]
     fn the_refusal_comes_from_the_marker_not_from_git() {
         let (_guard, root) = temp_root("negative-control");
@@ -830,5 +923,106 @@ mod tests {
             "no checkout exists — git would have nothing to refuse"
         );
         assert!(refuse_in(&root, Some("feature")).refusal.is_some());
+        // The no-heal form the pre-add guards use reaches the same verdict through the
+        // same scan; only its healing differs.
+        assert_eq!(
+            refuse_in(&root, Some("feature"))
+                .refusal
+                .expect("the pre-add window refuses")
+                .to_string(),
+            branch_update_refusal("feature").to_string()
+        );
+        assert!(refuse_in(&root, Some("other")).refusal.is_none());
+    }
+
+    /// The targeted, age-free claim: only a lock that EXISTS and is acquirable, and
+    /// only for the branch asked about. The markerless case is the one that matters —
+    /// a pre-marker binary mints no lock and may still be running that update.
+    #[test]
+    fn the_branch_claim_takes_only_released_locks_for_that_branch() {
+        let (_guard, root) = temp_root("branch-claim");
+
+        std::fs::create_dir_all(root.join("gd-update-dead")).unwrap();
+        write_dead_marker(&root, "gd-update-dead", "feature");
+
+        // A live update of the same branch.
+        std::fs::create_dir_all(root.join("gd-update-busy")).unwrap();
+        let live = UpdateMarker::create_for(&root.join("gd-update-busy"), "feature")
+            .expect("the live marker mints");
+
+        // A dead update of a DIFFERENT branch.
+        write_dead_marker(&root, "gd-update-other", "release");
+
+        // A pre-marker build's checkout: no lock file at all.
+        std::fs::create_dir_all(root.join("gd-update-markerless")).unwrap();
+
+        assert_eq!(
+            dead_stems_for_branch(&root, "feature"),
+            vec!["gd-update-dead".to_string()],
+            "live, other-branch, and markerless stems are all spared"
+        );
+        assert!(
+            dead_stems_for_branch(&root, "nothing-here").is_empty(),
+            "a branch with no leftovers claims nothing"
+        );
+
+        // And the removal it authorizes takes only that stem, with no age gate — the
+        // headline crash-recovery case, where the next update heals its predecessor.
+        // The repo path is bogus on purpose: every git call fails and the filesystem
+        // fallback finishes the job, which is the arm that must not touch a neighbour.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(claim_dead_stems_for_branch_locked(
+                "C:/nonexistent-repo",
+                &root,
+                "feature",
+            ));
+        assert!(
+            !root.join("gd-update-dead").exists(),
+            "the leftover is gone"
+        );
+        assert!(
+            !root.join("gd-update-dead.lock").exists()
+                && !root.join("gd-update-dead.json").exists(),
+            "with its marker pair"
+        );
+        assert!(
+            root.join("gd-update-busy").exists()
+                && root.join("gd-update-other.lock").exists()
+                && root.join("gd-update-markerless").exists(),
+            "the live, other-branch, and markerless neighbours are untouched"
+        );
+        drop(live);
+    }
+
+    /// Regression pin: a REGISTERED `gd-update-*` checkout with no lock file must never
+    /// take the age-free claim. Its minter was a pre-marker binary, which can still be
+    /// running the update — only the age-gated sweep may ever touch it.
+    #[tokio::test]
+    async fn a_markerless_holder_is_never_claimed_age_free() {
+        let (_guard, root) = temp_root("markerless-claim");
+        let orphan = root.join("gd-update-premarker");
+        std::fs::create_dir_all(&orphan).unwrap();
+        assert_eq!(
+            update_worktree_probe(&orphan.to_string_lossy()),
+            LockProbe::Missing
+        );
+
+        let state = AppState::default();
+        assert!(
+            !claim_dead_update_worktree(&state, "C:/nonexistent-repo", &orphan.to_string_lossy())
+                .await,
+            "a markerless holder is refused before any git runs"
+        );
+        assert!(orphan.exists(), "and its checkout is left untouched");
+
+        // The age-gated sweep is the ONLY thing that may claim it.
+        assert_eq!(
+            orphaned_update_stems(&root, Duration::ZERO),
+            vec!["gd-update-premarker".to_string()],
+            "the background sweep still owns this shape"
+        );
     }
 }

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -1,0 +1,834 @@
+//! In-flight markers for `update_branch_from`'s hidden `gd-update-*` checkout, plus
+//! the sweep that clears the ones a crash left behind.
+//!
+//! An update checks the target branch out in a throwaway worktree under the app-data
+//! worktrees root for the whole merge. Everything else that wants that branch —
+//! switching, renaming, deleting, cherry-picking onto it — would otherwise collide
+//! with git's own message naming a hidden app-data path. A marker minted before the
+//! `worktree add` turns those collisions into one sentence the user can act on, and
+//! it works ACROSS PROCESSES (the MCP server runs these same functions) because the
+//! signal is filesystem state, not process state.
+//!
+//! The marker is two files beside the checkout, sharing its stem: an unlocked `.json`
+//! manifest and an exclusively-locked `.lock`. Two files is forced by Windows —
+//! `LockFileEx` blocks cross-process READS of a locked range, so a single locked
+//! manifest would be unreadable by the very probes that need it. Liveness is the lock
+//! itself: the OS releases it when the owning process dies, so a probe that can
+//! acquire it is looking at a crash orphan.
+//!
+//! Every probe failure fails OPEN — no refusal, git's own error speaks, which is
+//! exactly today's behavior. An IO hiccup must never block a user's action.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+use crate::git::runner::{
+    run_git_raw, try_acquire_repo_lock, DEFAULT_TIMEOUT, WORKTREE_OP_TIMEOUT,
+};
+use crate::state::AppState;
+
+/// The basename prefix every update mint carries (`branches.rs::update_worktree_path`).
+/// The sweep claims on this prefix ALONE, so it must never widen: the same root holds
+/// the user's `gd/session/*` agent worktrees.
+const MARKER_PREFIX: &str = "gd-update-";
+
+/// How stale a leftover must be before the sweep claims it. Uniform and generous: the
+/// age gate is what closes every mint-order race (a marker written microseconds before
+/// its `worktree add`), and a live update is spared at any age by its held lock anyway.
+const ORPHAN_MIN_AGE: Duration = Duration::from_secs(600);
+
+/// One detached sweep at a time across the process — the healing pass is best-effort
+/// and idempotent, so a second concurrent run would only contend for the admin domain.
+static SWEEP_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// The marker manifest. Plain readable JSON so a probe in another process can answer
+/// "which branch?" while the update still holds the lock beside it.
+#[derive(Serialize, Deserialize)]
+struct UpdateManifest {
+    branch: String,
+    /// The owning process, so a leftover marker can be traced by hand. Never a
+    /// liveness signal — the OS recycles pids, and the lock answers that question.
+    pid: u32,
+}
+
+/// The refusal a site raises when a live update holds `branch`.
+pub(crate) fn branch_update_refusal(branch: &str) -> AppError {
+    AppError::Command(format!(
+        "A branch update is bringing {branch} up to date — try again when it finishes."
+    ))
+}
+
+/// The refusal for a site that cannot know which branch it is about to touch.
+fn any_update_refusal() -> AppError {
+    AppError::Command("A branch update is running — try again when it finishes.".to_string())
+}
+
+/// The refusal when a DEAD update's leftover still holds `branch` and this attempt
+/// could not clear it — the worktree-admin domain was busy, or the lock could not be
+/// probed. Never says an update is running: that would be a claim we just disproved.
+pub(crate) fn interrupted_update_refusal(branch: &str) -> AppError {
+    AppError::Command(format!(
+        "An interrupted branch update is still holding {branch} — try again in a moment."
+    ))
+}
+
+/// A marker sidecar beside `worktree_dir`, sharing its basename: `<dir>.<ext>`. Built
+/// from the whole basename rather than `with_extension`, which would eat a suffix the
+/// mint's own name already carries.
+fn sidecar(worktree_dir: &Path, ext: &str) -> Option<PathBuf> {
+    let name = worktree_dir.file_name()?.to_str()?;
+    Some(worktree_dir.with_file_name(format!("{name}.{ext}")))
+}
+
+/// The marker pair an update holds for its whole window, released by `Drop` — and by
+/// the OS if the process dies first, which is what makes the sweep safe.
+pub(crate) struct UpdateMarker {
+    json_path: PathBuf,
+    lock_path: PathBuf,
+    /// The locked handle. `Option` only so `Drop` can close it BEFORE the deletes:
+    /// Windows refuses to unlink a file with an open handle.
+    handle: Option<std::fs::File>,
+}
+
+impl UpdateMarker {
+    /// Mints the marker for the checkout about to be created at `worktree_dir`.
+    /// Callers create it BEFORE the `worktree add` — that add is the longest part of
+    /// the collision window, so the signal has to predate it. A creation failure
+    /// refuses the update: an app-data write that fails is the same failure domain as
+    /// materializing the checkout itself.
+    pub(crate) fn create_for(worktree_dir: &Path, branch: &str) -> AppResult<UpdateMarker> {
+        let (Some(json_path), Some(lock_path)) =
+            (sidecar(worktree_dir, "json"), sidecar(worktree_dir, "lock"))
+        else {
+            return Err(AppError::Command(format!(
+                "could not place an update marker beside {}",
+                worktree_dir.display()
+            )));
+        };
+        let manifest = serde_json::to_vec(&UpdateManifest {
+            branch: branch.to_string(),
+            pid: std::process::id(),
+        })
+        .map_err(|e| AppError::Command(format!("could not record the update marker: {e}")))?;
+        std::fs::write(&json_path, manifest)?;
+
+        let opened = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path);
+        let file = match opened {
+            Ok(file) => file,
+            Err(e) => {
+                let _ = std::fs::remove_file(&json_path);
+                return Err(AppError::Io(e));
+            }
+        };
+        if let Err(e) = file.try_lock() {
+            drop(file);
+            let _ = std::fs::remove_file(&lock_path);
+            let _ = std::fs::remove_file(&json_path);
+            return Err(AppError::Command(format!(
+                "could not claim the update marker at {}: {e}",
+                lock_path.display()
+            )));
+        }
+        Ok(UpdateMarker {
+            json_path,
+            lock_path,
+            handle: Some(file),
+        })
+    }
+}
+
+impl Drop for UpdateMarker {
+    fn drop(&mut self) {
+        // Closing releases the lock and, on Windows, is what makes the unlink legal.
+        drop(self.handle.take());
+        let _ = std::fs::remove_file(&self.lock_path);
+        let _ = std::fs::remove_file(&self.json_path);
+    }
+}
+
+/// What a lock probe could establish. `Unknown` exists because the two consumers need
+/// opposite defaults: a refusal may only fire on `Live` (an unreadable lock must never
+/// block a user's action), while a REMOVAL may only fire on `Dead` (an antivirus
+/// scanner holding a live update's lock file open for a moment must never get that
+/// update's checkout force-removed mid-merge).
+#[derive(Debug, PartialEq, Eq)]
+enum LockProbe {
+    /// Someone holds the lock — the update that minted it is still running.
+    Live,
+    /// Provably nobody holds it: acquirable, or the file is gone (the pre-marker
+    /// orphan shape, which the background sweep still age-gates).
+    Dead,
+    /// The probe could not establish either — a transient IO failure.
+    Unknown,
+}
+
+/// Probes the marker lock at `lock_path`. The OS releases an exclusive file lock when
+/// the holding process dies, so acquiring one is proof its owner is gone.
+fn probe_lock(lock_path: &Path) -> LockProbe {
+    match std::fs::File::open(lock_path) {
+        // The probe's own acquisition is released when `file` closes at end of scope.
+        Ok(file) => match file.try_lock() {
+            Ok(()) => LockProbe::Dead,
+            Err(std::fs::TryLockError::WouldBlock) => LockProbe::Live,
+            Err(std::fs::TryLockError::Error(_)) => LockProbe::Unknown,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LockProbe::Dead,
+        Err(_) => LockProbe::Unknown,
+    }
+}
+
+/// The manifest beside a marker, or `None` when it is missing, unreadable, or not the
+/// shape this module writes — untrusted JSON is never allowed to panic or to refuse.
+fn read_manifest(json_path: &Path) -> Option<UpdateManifest> {
+    let bytes = std::fs::read(json_path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Whether `path` names an update's throwaway checkout — its basename starts with
+/// `gd-update-`. Modeled on `ops::is_resolve_worktree_path`: the basename is the
+/// reliable signal, since porcelain may print a normalized leading path.
+pub(crate) fn is_update_worktree_path(path: &str) -> bool {
+    Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .is_some_and(|name| name.starts_with(MARKER_PREFIX))
+}
+
+/// Whether the update owning the `gd-update-*` checkout at `path` is provably still
+/// running. Only `Live` answers `true`, so an unreadable lock never raises a refusal.
+pub(crate) fn update_worktree_is_live(path: &str) -> bool {
+    sidecar(Path::new(path), "lock").is_some_and(|lock| probe_lock(&lock) == LockProbe::Live)
+}
+
+/// One scan of a worktree root's markers.
+pub(crate) struct RefuseOutcome {
+    /// The ready-to-return refusal, when a LIVE update matches the query.
+    pub(crate) refusal: Option<AppError>,
+    /// A dead marker was seen — its leftovers are worth sweeping.
+    pub(crate) saw_dead: bool,
+}
+
+/// Core of the refusal guards, over an explicit `root` so tests never write under the
+/// real app data. `branch` scopes the query; `None` asks "is ANY update running", the
+/// only honest question for a site that learns its branch name after the fact.
+///
+/// Deliberately liveness-only in `None` mode: an unreadable manifest still proves an
+/// update is running, and that mode needs nothing else. In branch mode the manifest is
+/// the match, so an unreadable one fails open.
+pub(crate) fn refuse_in(root: &Path, branch: Option<&str>) -> RefuseOutcome {
+    let mut outcome = RefuseOutcome {
+        refusal: None,
+        saw_dead: false,
+    };
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return outcome;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(stem) = name.strip_suffix(".lock") else {
+            continue;
+        };
+        if !stem.starts_with(MARKER_PREFIX) {
+            continue;
+        }
+        match probe_lock(&entry.path()) {
+            LockProbe::Live => {}
+            LockProbe::Dead => {
+                outcome.saw_dead = true;
+                continue;
+            }
+            LockProbe::Unknown => continue,
+        }
+        match branch {
+            None => {
+                outcome.refusal = Some(any_update_refusal());
+                return outcome;
+            }
+            Some(want) => {
+                if read_manifest(&root.join(format!("{stem}.json")))
+                    .is_some_and(|m| m.branch == want)
+                {
+                    outcome.refusal = Some(branch_update_refusal(want));
+                    return outcome;
+                }
+            }
+        }
+    }
+    outcome
+}
+
+/// Refuses when a live update is bringing `branch` up to date, and schedules a sweep
+/// if the scan met a crash orphan on the way. Every guarded site is therefore also a
+/// healing trigger.
+pub(crate) async fn refuse_if_branch_updating(
+    state: &AppState,
+    repo_path: &str,
+    branch: &str,
+) -> AppResult<()> {
+    refuse_and_heal(state, repo_path, Some(branch)).await
+}
+
+/// The repo-scoped form, for a site that cannot name the branch it is about to touch.
+pub(crate) async fn refuse_if_any_updating(state: &AppState, repo_path: &str) -> AppResult<()> {
+    refuse_and_heal(state, repo_path, None).await
+}
+
+/// The same refusal WITHOUT the healing sweep, for a caller whose very next step takes
+/// the worktree-admin domain: a detached sweep fired here would win that domain by
+/// milliseconds and turn an operation that would have succeeded into a `Busy`.
+pub(crate) fn refuse_if_branch_updating_no_heal(repo_path: &str, branch: &str) -> AppResult<()> {
+    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+        return Ok(());
+    };
+    match refuse_in(&root, Some(branch)).refusal {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+async fn refuse_and_heal(state: &AppState, repo_path: &str, branch: Option<&str>) -> AppResult<()> {
+    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+        return Ok(());
+    };
+    let outcome = refuse_in(&root, branch);
+    if outcome.saw_dead {
+        spawn_orphan_sweep(state, repo_path).await;
+    }
+    match outcome.refusal {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+/// Fires one background sweep, never blocking the caller on it. The domain is resolved
+/// here and MOVED into the task, so the acquisition happens off this stack — a caller
+/// may already hold the working-tree lock, or the admin domain itself, and neither may
+/// nest with the other.
+///
+/// A caller holding the admin domain must RELEASE it before calling: the task's own
+/// try-acquire would otherwise lose to that hold and the sweep would never run.
+pub(crate) async fn spawn_orphan_sweep(state: &AppState, repo_path: &str) {
+    let domain = state.worktree_admin_lock(repo_path).await;
+    // The flag is process-global rather than per-repo — healing is best-effort and one
+    // pass at a time is enough. Set with no await between here and the spawn, so a
+    // caller cancelled mid-fn can never leave it set with no task to clear it.
+    if SWEEP_RUNNING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let repo = repo_path.to_string();
+    tauri::async_runtime::spawn(async move {
+        if let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") {
+            sweep_update_orphans_locked(&repo).await;
+        }
+        SWEEP_RUNNING.store(false, Ordering::SeqCst);
+    });
+}
+
+/// Clears the ONE dead `gd-update-*` leftover at `holder`, a path a caller just read
+/// out of `worktree list --porcelain`. `true` means it is gone and the caller should
+/// re-probe; `false` means it must not proceed (still live, unprobeable, or the admin
+/// domain was busy).
+///
+/// No age gate, unlike the background sweep, and that is sound HERE specifically: the
+/// mint writes and locks the marker BEFORE `worktree add`, so a `gd-update-*` checkout
+/// appearing in porcelain proves the marker already existed. An acquirable lock is
+/// therefore direct proof its owner died, not a mint-order race — the window the age
+/// gate exists to cover cannot be open once the checkout is registered.
+pub(crate) async fn claim_dead_update_worktree(
+    state: &AppState,
+    repo_path: &str,
+    holder: &str,
+) -> bool {
+    if !is_update_worktree_path(holder) {
+        return false;
+    }
+    let path = Path::new(holder);
+    let (Some(root), Some(stem), Some(lock)) = (
+        path.parent(),
+        path.file_name().and_then(|s| s.to_str()),
+        sidecar(path, "lock"),
+    ) else {
+        return false;
+    };
+    if probe_lock(&lock) != LockProbe::Dead {
+        return false;
+    }
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+        return false;
+    };
+    // Re-probe under the hold: the first probe raced anything that could have started
+    // an update on this stem in between.
+    if probe_lock(&lock) != LockProbe::Dead {
+        return false;
+    }
+    remove_update_leftover(repo_path, root, stem).await;
+    true
+}
+
+/// Removes the `gd-update-*` leftovers a crashed or killed update left behind, so the
+/// branches they still hold come free. Skipped entirely when the worktree-admin domain
+/// is busy: a removal is in flight, healing is never urgent, and queueing would stall
+/// the caller behind a multi-minute hold.
+pub(crate) async fn sweep_orphaned_update_worktrees(state: &AppState, repo_path: &str) {
+    let domain = state.worktree_admin_lock(repo_path).await;
+    let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+        return;
+    };
+    sweep_update_orphans_locked(repo_path).await;
+}
+
+/// The sweep body. The caller MUST already hold the repo's worktree-admin domain —
+/// `run_git_worktree_admin` would re-acquire it and deadlock, so the runners here are
+/// the lock-free ones, exactly as `branches.rs::remove_tmp_worktree` does.
+async fn sweep_update_orphans_locked(repo_path: &str) {
+    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+        return;
+    };
+    sweep_in(repo_path, &root, ORPHAN_MIN_AGE).await;
+}
+
+/// The sweep over an explicit root and age threshold, so tests can drive it against a
+/// temp directory without waiting out the real one.
+async fn sweep_in(repo_path: &str, root: &Path, min_age: Duration) {
+    for stem in orphaned_update_stems(root, min_age) {
+        remove_update_leftover(repo_path, root, &stem).await;
+    }
+}
+
+/// Removes one claimed leftover: its checkout, git's admin entry, and the marker pair.
+/// Lock-free runners — every caller already holds the worktree-admin domain.
+async fn remove_update_leftover(repo_path: &str, root: &Path, stem: &str) {
+    let dir = root.join(stem);
+    if dir.exists() {
+        let dir_str = dir.to_string_lossy().into_owned();
+        let _ = run_git_raw(
+            Some(repo_path),
+            &["worktree", "remove", "--force", &dir_str],
+            WORKTREE_OP_TIMEOUT,
+        )
+        .await;
+        let _ = run_git_raw(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+        // git's own recursive delete mishandles Windows reparse points, and an
+        // unregistered leftover is never its job at all.
+        if dir.exists() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+    let _ = std::fs::remove_file(root.join(format!("{stem}.lock")));
+    let _ = std::fs::remove_file(root.join(format!("{stem}.json")));
+}
+
+/// The claim decision: which `gd-update-<stem>` leftovers under `root` a sweep may
+/// take. Three conditions, all required — the basename prefix (this root also holds
+/// the user's agent-session worktrees, and a mis-claim would delete one), a dead or
+/// absent lock, and an age past `min_age`. Anything unreadable is left alone.
+fn orphaned_update_stems(root: &Path, min_age: Duration) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    // Stem → the paths it owns, since a crash leaves any subset of dir/json/lock.
+    let mut candidates: std::collections::BTreeMap<String, Vec<PathBuf>> =
+        std::collections::BTreeMap::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        let stem = if kind.is_dir() {
+            name
+        } else if let Some(stem) = name.strip_suffix(".lock").or(name.strip_suffix(".json")) {
+            stem
+        } else {
+            continue;
+        };
+        if !stem.starts_with(MARKER_PREFIX) {
+            continue;
+        }
+        candidates
+            .entry(stem.to_string())
+            .or_default()
+            .push(entry.path());
+    }
+
+    let now = SystemTime::now();
+    candidates
+        .into_iter()
+        // Only a PROVEN-dead lock authorizes a removal — `Unknown` is spared.
+        .filter(|(stem, _)| probe_lock(&root.join(format!("{stem}.lock"))) == LockProbe::Dead)
+        .filter(|(_, paths)| {
+            // The NEWEST mtime of anything the stem owns: the most recent sign of life
+            // is what has to be old, not the oldest.
+            newest_mtime(paths)
+                .is_some_and(|m| now.duration_since(m).unwrap_or(Duration::ZERO) >= min_age)
+        })
+        .map(|(stem, _)| stem)
+        .collect()
+}
+
+/// The latest mtime among `paths`, or `None` when none of them can be read — which
+/// leaves the entry unclaimed, the safe direction.
+fn newest_mtime(paths: &[PathBuf]) -> Option<SystemTime> {
+    paths
+        .iter()
+        .filter_map(|p| std::fs::metadata(p).ok()?.modified().ok())
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::runner::run_git;
+
+    fn temp_root(tag: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("gd-marker-{tag}-"))
+            .tempdir()
+            .expect("create temp dir");
+        let root = dir.path().to_path_buf();
+        (dir, root)
+    }
+
+    /// A DEAD marker pair: the manifest plus an unlocked `.lock`, the shape a crashed
+    /// update leaves behind once the OS drops its lock.
+    fn write_dead_marker(root: &Path, stem: &str, branch: &str) {
+        std::fs::write(
+            root.join(format!("{stem}.json")),
+            serde_json::to_vec(&UpdateManifest {
+                branch: branch.to_string(),
+                pid: 4242,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(root.join(format!("{stem}.lock")), b"").unwrap();
+    }
+
+    #[test]
+    fn create_writes_a_readable_manifest_and_holds_the_lock() {
+        let (_guard, root) = temp_root("create");
+        let wt = root.join("gd-update-1234-99");
+        let marker = UpdateMarker::create_for(&wt, "feature").expect("the marker mints");
+
+        let json = root.join("gd-update-1234-99.json");
+        let lock = root.join("gd-update-1234-99.lock");
+        // The manifest stays readable while the update runs — the whole reason the
+        // lock lives in a SEPARATE file on Windows.
+        let manifest = read_manifest(&json).expect("the manifest parses");
+        assert_eq!(manifest.branch, "feature");
+        assert_eq!(manifest.pid, std::process::id());
+        assert_eq!(probe_lock(&lock), LockProbe::Live, "a held marker is live");
+
+        drop(marker);
+        assert!(!json.exists(), "the manifest is cleaned up");
+        assert!(!lock.exists(), "the lock file is cleaned up");
+    }
+
+    #[test]
+    fn refusal_matches_the_live_branch_and_nothing_else() {
+        let (_guard, root) = temp_root("refuse");
+        let _marker =
+            UpdateMarker::create_for(&root.join("gd-update-live"), "feature").expect("mints");
+
+        let hit = refuse_in(&root, Some("feature"));
+        assert_eq!(
+            hit.refusal.expect("the live branch is refused").to_string(),
+            "A branch update is bringing feature up to date — try again when it finishes."
+        );
+        assert!(!hit.saw_dead);
+
+        assert!(
+            refuse_in(&root, Some("other")).refusal.is_none(),
+            "another branch is untouched by this update"
+        );
+        assert_eq!(
+            refuse_in(&root, None)
+                .refusal
+                .expect("any-mode refuses on liveness alone")
+                .to_string(),
+            "A branch update is running — try again when it finishes."
+        );
+    }
+
+    /// A crash orphan refuses nothing — it holds no update — but it IS the signal
+    /// that flips a guard site into a healing trigger.
+    #[test]
+    fn a_dead_marker_refuses_nothing_and_flags_a_sweep() {
+        let (_guard, root) = temp_root("dead");
+        write_dead_marker(&root, "gd-update-dead", "feature");
+
+        for query in [Some("feature"), None] {
+            let outcome = refuse_in(&root, query);
+            assert!(outcome.refusal.is_none(), "{query:?} must not refuse");
+            assert!(outcome.saw_dead, "{query:?} must flag the sweep");
+        }
+    }
+
+    /// Untrusted JSON never decides a refusal: a manifest that doesn't parse leaves
+    /// the branch query unmatched, and git's own error speaks as it does today.
+    #[test]
+    fn an_unparseable_manifest_fails_open() {
+        let (_guard, root) = temp_root("badjson");
+        let _marker =
+            UpdateMarker::create_for(&root.join("gd-update-bad"), "feature").expect("mints");
+        std::fs::write(root.join("gd-update-bad.json"), b"{\"branch\": 7}").unwrap();
+
+        let outcome = refuse_in(&root, Some("feature"));
+        assert!(outcome.refusal.is_none(), "a wrong-typed field fails open");
+        assert!(
+            !outcome.saw_dead,
+            "the lock is still held, so nothing is dead"
+        );
+    }
+
+    #[test]
+    fn is_update_worktree_path_matches_the_mint_basename_only() {
+        assert!(is_update_worktree_path("C:/data/worktrees/h/gd-update-1-2"));
+        assert!(is_update_worktree_path(
+            "/home/u/.local/share/w/h/gd-update-x"
+        ));
+        // A PARENT named like a mint must not make a child one.
+        assert!(!is_update_worktree_path("C:/repos/gd-update-ish/feature"));
+        assert!(!is_update_worktree_path("C:/data/worktrees/h/gd-resolve-1"));
+        assert!(!is_update_worktree_path("C:/repos/app"));
+    }
+
+    /// The claim discipline, fixture by fixture. The decoys matter most: this root is
+    /// shared with the user's agent-session worktrees, and claiming one would delete
+    /// work the app promises to keep.
+    #[test]
+    fn the_sweep_claims_only_aged_dead_update_leftovers() {
+        let (_guard, root) = temp_root("claims");
+
+        std::fs::create_dir_all(root.join("gd-update-dead")).unwrap();
+        write_dead_marker(&root, "gd-update-dead", "feature");
+
+        // A live update — its lock is held for the length of this test.
+        std::fs::create_dir_all(root.join("gd-update-busy")).unwrap();
+        let live = UpdateMarker::create_for(&root.join("gd-update-busy"), "feature")
+            .expect("the live marker mints");
+
+        // A pre-marker build's orphan: the checkout with no marker at all.
+        std::fs::create_dir_all(root.join("gd-update-markerless")).unwrap();
+
+        // The marker pair whose checkout is already gone.
+        write_dead_marker(&root, "gd-update-pruned", "feature");
+
+        // Decoys: an agent-session worktree (named by session id) and a near-miss.
+        std::fs::create_dir_all(root.join("1a2b3c4d")).unwrap();
+        std::fs::create_dir_all(root.join("gd-resolve-9")).unwrap();
+        std::fs::create_dir_all(root.join("gd-updater-tool")).unwrap();
+
+        let mut claimed = orphaned_update_stems(&root, Duration::ZERO);
+        claimed.sort();
+        assert_eq!(
+            claimed,
+            vec![
+                "gd-update-dead".to_string(),
+                "gd-update-markerless".to_string(),
+                "gd-update-pruned".to_string(),
+            ],
+            "a live marker and every non-mint basename are spared"
+        );
+
+        assert!(
+            orphaned_update_stems(&root, ORPHAN_MIN_AGE).is_empty(),
+            "nothing this fresh is claimed at the production age gate"
+        );
+
+        drop(live);
+        for decoy in ["1a2b3c4d", "gd-resolve-9", "gd-updater-tool"] {
+            assert!(root.join(decoy).exists(), "{decoy} survives the decision");
+        }
+    }
+
+    async fn git(repo: &str, args: &[&str]) -> String {
+        run_git(Some(repo), args, DEFAULT_TIMEOUT)
+            .await
+            .unwrap()
+            .stdout_lossy()
+    }
+
+    /// End to end against a real repo, with every kind of neighbour present: the
+    /// crash-orphaned update worktree is removed, its admin entry pruned, its marker
+    /// files deleted, and the branch it held is free again — while a live update, a
+    /// resolve worktree, and an agent-session checkout holding real content all come
+    /// through the DELETING pass untouched.
+    #[tokio::test]
+    async fn the_sweep_frees_the_branch_an_orphaned_update_was_holding() {
+        let (_guard, base) = temp_root("sweep-e2e");
+        let repo = base.join("repo");
+        let root = base.join("worktrees");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&root).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+        git(&repo_s, &["branch", "feature"]).await;
+
+        let orphan = root.join("gd-update-crashed");
+        let orphan_s = orphan.to_string_lossy().into_owned();
+        git(
+            &repo_s,
+            &["worktree", "add", "--quiet", &orphan_s, "feature"],
+        )
+        .await;
+        write_dead_marker(&root, "gd-update-crashed", "feature");
+        assert!(
+            run_git_raw(Some(&repo_s), &["branch", "-D", "feature"], DEFAULT_TIMEOUT)
+                .await
+                .unwrap()
+                .code
+                != 0,
+            "the fixture must reproduce the branch hold"
+        );
+
+        // An agent session's checkout, with content the app promises to keep.
+        let session = root.join("1a2b3c4d");
+        std::fs::create_dir_all(&session).unwrap();
+        let session_file = session.join("notes.txt");
+        std::fs::write(&session_file, b"agent work in progress\n").unwrap();
+        // A local-PR resolve worktree, and a live update of another branch.
+        std::fs::create_dir_all(root.join("gd-resolve-77")).unwrap();
+        std::fs::create_dir_all(root.join("gd-update-busy")).unwrap();
+        let live = UpdateMarker::create_for(&root.join("gd-update-busy"), "other")
+            .expect("the live marker mints");
+        // A dead leftover that is simply too young to claim.
+        std::fs::create_dir_all(root.join("gd-update-young")).unwrap();
+        write_dead_marker(&root, "gd-update-young", "feature");
+
+        // The production age gate spares everything here: every fixture is seconds old,
+        // which is exactly the young-dead case.
+        sweep_in(&repo_s, &root, ORPHAN_MIN_AGE).await;
+        assert!(
+            orphan.exists() && root.join("gd-update-young").exists(),
+            "nothing this fresh is removed at the production age gate"
+        );
+
+        // Now the deleting pass, with every neighbour still in place.
+        sweep_in(&repo_s, &root, Duration::ZERO).await;
+
+        assert!(!orphan.exists(), "the orphaned checkout is gone");
+        assert!(
+            !root.join("gd-update-crashed.lock").exists()
+                && !root.join("gd-update-crashed.json").exists(),
+            "the marker pair is gone with it"
+        );
+        assert!(
+            !git(&repo_s, &["worktree", "list", "--porcelain"])
+                .await
+                .contains("gd-update-crashed"),
+            "and its admin entry is pruned"
+        );
+        assert_eq!(
+            run_git_raw(Some(&repo_s), &["branch", "-D", "feature"], DEFAULT_TIMEOUT)
+                .await
+                .unwrap()
+                .code,
+            0,
+            "the branch the orphan was holding is free again"
+        );
+
+        // The neighbours: the session checkout keeps its bytes, the resolve worktree
+        // stands, and the LIVE update survives a pass that would otherwise claim it.
+        assert_eq!(
+            std::fs::read(&session_file).expect("the session file survives"),
+            b"agent work in progress\n",
+            "an agent session's content is byte-identical after the sweep"
+        );
+        assert!(root.join("gd-resolve-77").exists(), "resolve worktree kept");
+        assert!(
+            root.join("gd-update-busy").exists() && root.join("gd-update-busy.lock").exists(),
+            "a live update is spared at any age"
+        );
+        drop(live);
+    }
+
+    /// The three-state probe. `Unknown` is the arm that matters: it must never read as
+    /// dead, because only `Dead` authorizes a removal.
+    #[test]
+    fn the_lock_probe_separates_live_dead_and_unreadable() {
+        let (_guard, root) = temp_root("probe");
+        let marker = UpdateMarker::create_for(&root.join("gd-update-held"), "feature")
+            .expect("the marker mints");
+        assert_eq!(
+            probe_lock(&root.join("gd-update-held.lock")),
+            LockProbe::Live
+        );
+        drop(marker);
+        assert_eq!(
+            probe_lock(&root.join("gd-update-held.lock")),
+            LockProbe::Dead,
+            "a missing lock is the pre-marker orphan shape"
+        );
+
+        std::fs::write(root.join("gd-update-freed.lock"), b"").unwrap();
+        assert_eq!(
+            probe_lock(&root.join("gd-update-freed.lock")),
+            LockProbe::Dead,
+            "an acquirable lock proves its owner is gone"
+        );
+
+        // An open that fails as something OTHER than NotFound. There is no one
+        // portable way to produce that, so each platform uses its own real shape.
+        #[cfg(windows)]
+        {
+            // A directory where the lock file should be: Windows refuses to open one
+            // as a file with ERROR_ACCESS_DENIED (measured, os error 5) — the same
+            // class a transient share violation lands in.
+            let blocked = root.join("gd-update-blocked.lock");
+            std::fs::create_dir(&blocked).unwrap();
+            assert_eq!(
+                probe_lock(&blocked),
+                LockProbe::Unknown,
+                "an unreadable lock is never treated as dead"
+            );
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let blocked = root.join("gd-update-blocked.lock");
+            std::fs::write(&blocked, b"").unwrap();
+            std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+            // Root ignores the mode bits, and there is no second portable way to make
+            // an open fail as anything but NotFound — so that case asserts nothing
+            // rather than asserting something untrue.
+            if std::fs::File::open(&blocked).is_err() {
+                assert_eq!(
+                    probe_lock(&blocked),
+                    LockProbe::Unknown,
+                    "an unreadable lock is never treated as dead"
+                );
+            }
+        }
+    }
+
+    /// Negative control for the guard MECHANISM: the root holds a live marker and no
+    /// worktree at all, so nothing but the marker scan can produce this refusal —
+    /// delete the scan and the same fixture answers `Ok`.
+    #[test]
+    fn the_refusal_comes_from_the_marker_not_from_git() {
+        let (_guard, root) = temp_root("negative-control");
+        let _marker =
+            UpdateMarker::create_for(&root.join("gd-update-solo"), "feature").expect("mints");
+        assert!(
+            !root.join("gd-update-solo").exists(),
+            "no checkout exists — git would have nothing to refuse"
+        );
+        assert!(refuse_in(&root, Some("feature")).refusal.is_some());
+    }
+}

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -98,19 +98,37 @@ impl Drop for TestRootOverride {
     }
 }
 
-/// The worktree root this module works in. Every entry point resolves through here so a
-/// test can point the whole module at a temp directory; outside tests it is exactly
+/// The worktree root this module works in. Every entry point — and the mint in
+/// `branches.rs::update_worktree_path` — resolves through here, so a test can point the
+/// whole module at a temp directory. Outside tests it is exactly
 /// `ops::worktree_root_dir`.
-fn root_for(repo_path: &str) -> AppResult<PathBuf> {
+///
+/// Under `cfg(test)` an installed override is the ONLY resolution: with none, this
+/// ERRORS instead of falling through to the real app data, mirroring
+/// [`crate::app_store`]'s "under `cfg!(test)`, NO store, whatever the environment says".
+/// The override is process-wide, so a test that never installed one must neither read a
+/// concurrently-scheduled sibling's root nor mint under the developer's own app data.
+/// Every caller already fails open on an unresolvable root — refusals answer `Ok`,
+/// claims and sweeps return, `is_managed_update_worktree` answers `false` — which is
+/// exactly what an un-overridden test should see.
+pub(crate) fn root_for(repo_path: &str) -> AppResult<PathBuf> {
     #[cfg(test)]
-    if let Some(dir) = TEST_ROOT_DIR
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .clone()
     {
-        return Ok(dir);
+        let _ = repo_path;
+        TEST_ROOT_DIR
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .ok_or_else(|| {
+                AppError::Command(
+                    "no update-marker root override is installed for this test".to_string(),
+                )
+            })
     }
-    crate::git::ops::worktree_root_dir(repo_path)
+    #[cfg(not(test))]
+    {
+        crate::git::ops::worktree_root_dir(repo_path)
+    }
 }
 
 /// The marker manifest. Plain readable JSON so a probe in another process can answer
@@ -338,9 +356,9 @@ pub(crate) fn update_worktree_probe(path: &str) -> LockProbe {
 /// One scan of a worktree root's markers.
 struct RefuseOutcome {
     /// The ready-to-return refusal, when a LIVE update matches the query.
-    pub(crate) refusal: Option<AppError>,
+    refusal: Option<AppError>,
     /// A dead marker was seen — its leftovers are worth sweeping.
-    pub(crate) saw_dead: bool,
+    saw_dead: bool,
 }
 
 /// Core of the refusal guards, over an explicit `root` so tests never write under the

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -60,16 +60,11 @@ static TEST_ROOT_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(
 #[cfg(test)]
 static TEST_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Writes a RELEASED marker pair — the manifest plus an unlocked `.lock` — which is
-/// exactly what a crashed update leaves behind: the OS drops the flock when the process
-/// dies, so the file simply exists with no holder.
-///
-/// Fixtures build this shape by writing rather than by minting and dropping a real
-/// marker, because on Linux `drop` does not reliably release the lock in a
-/// process-spawning test binary: an `flock` belongs to the open file description, and a
-/// concurrently forked child inherits the fd, holding the lock alive until its copy
-/// closes at exec (measured: 157 spurious `WouldBlock` in 20k mint/drop/probe cycles
-/// with 3 forking threads, 0 with none, 0 on Windows at any rate).
+/// Writes a RELEASED marker pair — the manifest plus an unlocked `.lock` — the shape a
+/// crashed update leaves once the OS drops its flock. Written, never minted-and-dropped:
+/// a Linux flock rides `fork()` into concurrently spawned children until their exec, so
+/// a post-drop probe can read a live lock (157 spurious `WouldBlock` per 20k cycles
+/// under 3 forking threads, 0 without, 0 on Windows — PR #297's container experiment).
 #[cfg(test)]
 pub(crate) fn write_released_marker(root: &Path, stem: &str, branch: &str) {
     std::fs::write(
@@ -1185,10 +1180,15 @@ mod tests {
 
     /// Regression pin: a REGISTERED `gd-update-*` checkout with no lock file must never
     /// take the age-free claim. Its minter was a pre-marker binary, which can still be
-    /// running the update — only the age-gated sweep may ever touch it.
+    /// running the update — only the age-gated sweep may ever touch it. The override is
+    /// what lets the claim pass its managed-root gate and reach the Missing probe this
+    /// test exists to pin — without it the refusal is the seam's, not the probe's.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_markerless_holder_is_never_claimed_age_free() {
         let (_guard, root) = temp_root("markerless-claim");
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
         let orphan = root.join("gd-update-premarker");
         std::fs::create_dir_all(&orphan).unwrap();
         assert_eq!(
@@ -1216,11 +1216,13 @@ mod tests {
     /// the success path deletes them — that retention is what later lets an age-free
     /// claim recover the holder rather than leaving a markerless one nothing may touch.
     ///
-    /// File survival only. The lock's post-drop state is deliberately NOT asserted here:
-    /// on Linux a concurrently forked child inherits the fd and holds the flock past
-    /// `drop`, so that verdict is scheduling-dependent in a test binary that spawns git.
-    /// The released-marker consequences are pinned on WRITTEN fixtures instead, which
-    /// take no lock at all — see `the_branch_claim_takes_only_released_locks_for_that_branch`.
+    /// File survival everywhere; the lock's post-drop state is asserted on Windows only
+    /// (its per-handle locks measured 0 spurious `WouldBlock` at any fork rate), which is
+    /// what pins `Drop`'s close-before-early-return ordering — reordered, a retained
+    /// marker would keep its lock for the life of the process and probe `Live` forever.
+    /// On Linux that verdict is scheduling-dependent (forked children inherit the fd), so
+    /// the released-marker consequences are pinned on WRITTEN fixtures instead — see
+    /// `the_branch_claim_takes_only_released_locks_for_that_branch`.
     #[test]
     fn a_failed_teardown_retains_both_sidecars() {
         let (_guard, root) = temp_root("retain");
@@ -1235,6 +1237,13 @@ mod tests {
         // The teardown could not confirm the directory was gone.
         marker.retain_for_recovery();
         drop(marker);
+
+        #[cfg(windows)]
+        assert_eq!(
+            probe_lock(&root.join("gd-update-stuck.lock")),
+            LockProbe::Released,
+            "a retained marker releases its lock on drop"
+        );
 
         assert!(
             root.join("gd-update-stuck.lock").exists()

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -33,8 +33,10 @@ use crate::git::runner::{
 use crate::state::AppState;
 
 /// The basename prefix every update mint carries (`branches.rs::update_worktree_path`).
-/// The sweep claims on this prefix ALONE, so it must never widen: the same root holds
-/// the user's `gd/session/*` agent worktrees.
+/// It is the NAME filter for every claim and must never widen — the same root holds the
+/// user's `gd/session/*` agent worktrees. It is only the first gate: a claim also has to
+/// pass the root-scope check, the lock probe, and (for the markerless shape) the age
+/// gate before anything is removed.
 const MARKER_PREFIX: &str = "gd-update-";
 
 /// How stale a leftover must be before the sweep claims it. Uniform and generous: the
@@ -45,6 +47,71 @@ const ORPHAN_MIN_AGE: Duration = Duration::from_secs(600);
 /// One detached sweep at a time across the process — the healing pass is best-effort
 /// and idempotent, so a second concurrent run would only contend for the admin domain.
 static SWEEP_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// In-process test override, consulted by [`root_for`] before the real app-data
+/// resolution — the ONLY seam a test may use to reach this module's entry points
+/// (mirrors [`crate::local_issues`]'s; never process env, which races parallel tests'
+/// env reads).
+#[cfg(test)]
+static TEST_ROOT_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+/// Serializes the tests that install [`TEST_ROOT_DIR`], since the override is
+/// process-wide. Test-only.
+#[cfg(test)]
+static TEST_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Installs (or clears) the in-process override, returning the previous value so a
+/// caller can restore it. Test-only.
+#[cfg(test)]
+pub(crate) fn swap_test_root_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
+    let mut slot = TEST_ROOT_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut *slot, dir)
+}
+
+/// Takes the serializing guard for the process-wide root override. Test-only.
+#[cfg(test)]
+pub(crate) fn test_root_lock() -> std::sync::MutexGuard<'static, ()> {
+    TEST_ROOT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Points this module's root resolution at `dir` for as long as it is held, restoring
+/// the prior override on drop — panics included, so a failing test cannot leave one
+/// standing for whichever test is next through the lock. Test-only.
+#[cfg(test)]
+pub(crate) struct TestRootOverride(Option<PathBuf>);
+
+#[cfg(test)]
+impl TestRootOverride {
+    pub(crate) fn set(dir: &Path) -> Self {
+        Self(swap_test_root_dir(Some(dir.to_path_buf())))
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestRootOverride {
+    fn drop(&mut self) {
+        swap_test_root_dir(self.0.take());
+    }
+}
+
+/// The worktree root this module works in. Every entry point resolves through here so a
+/// test can point the whole module at a temp directory; outside tests it is exactly
+/// `ops::worktree_root_dir`.
+fn root_for(repo_path: &str) -> AppResult<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = TEST_ROOT_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return Ok(dir);
+    }
+    crate::git::ops::worktree_root_dir(repo_path)
+}
 
 /// The marker manifest. Plain readable JSON so a probe in another process can answer
 /// "which branch?" while the update still holds the lock beside it.
@@ -94,6 +161,8 @@ pub(crate) struct UpdateMarker {
     /// The locked handle. `Option` only so `Drop` can close it BEFORE the deletes:
     /// Windows refuses to unlink a file with an open handle.
     handle: Option<std::fs::File>,
+    /// When cleared, `Drop` releases the lock but LEAVES both sidecars on disk.
+    delete_on_drop: bool,
 }
 
 impl UpdateMarker {
@@ -142,7 +211,19 @@ impl UpdateMarker {
             json_path,
             lock_path,
             handle: Some(file),
+            delete_on_drop: true,
         })
+    }
+
+    /// Keeps both sidecars on disk when this marker drops, releasing only the lock.
+    ///
+    /// For a teardown that could not confirm the checkout is gone: deleting the sidecars
+    /// there would turn a surviving directory into the `Missing` shape, which no
+    /// age-free claim may touch and which therefore sits holding its branch until the
+    /// age gate expires. Retained, it is a `Released` marker the very next branch
+    /// operation can clear.
+    pub(crate) fn retain_for_recovery(&mut self) {
+        self.delete_on_drop = false;
     }
 }
 
@@ -150,6 +231,9 @@ impl Drop for UpdateMarker {
     fn drop(&mut self) {
         // Closing releases the lock and, on Windows, is what makes the unlink legal.
         drop(self.handle.take());
+        if !self.delete_on_drop {
+            return;
+        }
         let _ = std::fs::remove_file(&self.lock_path);
         let _ = std::fs::remove_file(&self.json_path);
     }
@@ -179,10 +263,18 @@ pub(crate) enum LockProbe {
 }
 
 /// Probes the marker lock at `lock_path`.
+///
+/// SHARED, not exclusive: an exclusive probe excludes other PROBES, so two running
+/// concurrently would have one read `WouldBlock` and call a dead marker `Live`. A shared
+/// request still blocks against the minter's exclusive hold, which is the only signal
+/// this needs. Two probes may now both read `Released` at once, which is harmless —
+/// every destructive path re-probes under the worktree-admin domain, and
+/// `remove_update_leftover` is idempotent.
 fn probe_lock(lock_path: &Path) -> LockProbe {
     match std::fs::File::open(lock_path) {
-        // The probe's own acquisition is released when `file` closes at end of scope.
-        Ok(file) => match file.try_lock() {
+        // The probe's own SHARED acquisition is released when `file` closes at end of
+        // scope.
+        Ok(file) => match file.try_lock_shared() {
             Ok(()) => LockProbe::Released,
             Err(std::fs::TryLockError::WouldBlock) => LockProbe::Live,
             Err(std::fs::TryLockError::Error(_)) => LockProbe::Unknown,
@@ -209,10 +301,33 @@ pub(crate) fn is_update_worktree_path(path: &str) -> bool {
         .is_some_and(|name| name.starts_with(MARKER_PREFIX))
 }
 
-/// The lock state of the `gd-update-*` checkout at `path`. Every caller needs all four
-/// answers apart — `Live` refuses, `Released` claims, and `Missing`/`Unknown` prove
-/// nothing and behave exactly as if markers did not exist — so this replaces the
-/// is-live predicate a two-state probe could afford. An unusable path reads `Unknown`.
+/// Whether `path` is an update checkout THIS app manages for `repo_path`: the mint
+/// basename AND a parent that is the repo's own worktree root. The root scope is what
+/// keeps a user's own worktree that merely happens to be named `gd-update-*` — with
+/// some stray unlocked `.lock` beside it — out of every marker arm, refusal and
+/// removal alike.
+///
+/// Compared through the repo's two path spellings (`canonical_wt_path` resolves
+/// symlinks and Windows short names, `normalize_wt_path` is the second chance for a
+/// path that no longer exists), since porcelain prints resolved paths while the root is
+/// app-built. Any resolution failure answers `false`: cleanup fails CLOSED.
+pub(crate) fn is_managed_update_worktree(repo_path: &str, path: &str) -> bool {
+    use crate::git::worktree::{canonical_wt_path, normalize_wt_path};
+    if !is_update_worktree_path(path) {
+        return false;
+    }
+    let (Ok(root), Some(parent)) = (root_for(repo_path), Path::new(path).parent()) else {
+        return false;
+    };
+    let (parent, root) = (parent.to_string_lossy(), root.to_string_lossy());
+    canonical_wt_path(&parent) == canonical_wt_path(&root)
+        || normalize_wt_path(&parent) == normalize_wt_path(&root)
+}
+
+/// The lock state of the `gd-update-*` checkout at `path`. Callers match on all four
+/// answers rather than a predicate: `Live` refuses, `Released` claims, and
+/// `Missing`/`Unknown` prove nothing and behave exactly as if markers did not exist.
+/// An unusable path reads `Unknown`.
 pub(crate) fn update_worktree_probe(path: &str) -> LockProbe {
     match sidecar(Path::new(path), "lock") {
         Some(lock) => probe_lock(&lock),
@@ -221,7 +336,7 @@ pub(crate) fn update_worktree_probe(path: &str) -> LockProbe {
 }
 
 /// One scan of a worktree root's markers.
-pub(crate) struct RefuseOutcome {
+struct RefuseOutcome {
     /// The ready-to-return refusal, when a LIVE update matches the query.
     pub(crate) refusal: Option<AppError>,
     /// A dead marker was seen — its leftovers are worth sweeping.
@@ -235,7 +350,7 @@ pub(crate) struct RefuseOutcome {
 /// Deliberately liveness-only in `None` mode: an unreadable manifest still proves an
 /// update is running, and that mode needs nothing else. In branch mode the manifest is
 /// the match, so an unreadable one fails open.
-pub(crate) fn refuse_in(root: &Path, branch: Option<&str>) -> RefuseOutcome {
+fn refuse_in(root: &Path, branch: Option<&str>) -> RefuseOutcome {
     let mut outcome = RefuseOutcome {
         refusal: None,
         saw_dead: false,
@@ -300,7 +415,7 @@ pub(crate) async fn refuse_if_any_updating(state: &AppState, repo_path: &str) ->
 /// the worktree-admin domain: a detached sweep fired here would win that domain by
 /// milliseconds and turn an operation that would have succeeded into a `Busy`.
 pub(crate) fn refuse_if_branch_updating_no_heal(repo_path: &str, branch: &str) -> AppResult<()> {
-    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+    let Ok(root) = root_for(repo_path) else {
         return Ok(());
     };
     match refuse_in(&root, Some(branch)).refusal {
@@ -310,7 +425,7 @@ pub(crate) fn refuse_if_branch_updating_no_heal(repo_path: &str, branch: &str) -
 }
 
 async fn refuse_and_heal(state: &AppState, repo_path: &str, branch: Option<&str>) -> AppResult<()> {
-    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+    let Ok(root) = root_for(repo_path) else {
         return Ok(());
     };
     let outcome = refuse_in(&root, branch);
@@ -361,12 +476,16 @@ pub(crate) async fn spawn_orphan_sweep(state: &AppState, repo_path: &str) {
 /// registered holder means a pre-marker binary minted it, and such a binary can still
 /// be running the update right now (a stale MCP-server exe beside a rebuilt GUI), so it
 /// is refused here and left to the age-gated background sweep.
+///
+/// Root-scoped: only a checkout directly under THIS repo's app-data worktree root is
+/// ours to force-remove. A user's own worktree that happens to be named `gd-update-*`
+/// is never touched, whatever sits beside it.
 pub(crate) async fn claim_dead_update_worktree(
     state: &AppState,
     repo_path: &str,
     holder: &str,
 ) -> bool {
-    if !is_update_worktree_path(holder) {
+    if !is_managed_update_worktree(repo_path, holder) {
         return false;
     }
     let path = Path::new(holder);
@@ -402,7 +521,7 @@ pub(crate) async fn claim_dead_update_worktree(
 /// markerless checkout is never claimed here. No porcelain read is needed — the lock
 /// file alone carries the proof.
 pub(crate) async fn claim_dead_updates_for_branch(state: &AppState, repo_path: &str, branch: &str) {
-    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+    let Ok(root) = root_for(repo_path) else {
         return;
     };
     // Nothing to heal is the overwhelmingly common case; answer it without paying for
@@ -472,7 +591,7 @@ pub(crate) async fn sweep_orphaned_update_worktrees(state: &AppState, repo_path:
 /// `run_git_worktree_admin` would re-acquire it and deadlock, so the runners here are
 /// the lock-free ones, exactly as `branches.rs::remove_tmp_worktree` does.
 async fn sweep_update_orphans_locked(repo_path: &str) {
-    let Ok(root) = crate::git::ops::worktree_root_dir(repo_path) else {
+    let Ok(root) = root_for(repo_path) else {
         return;
     };
     sweep_in(repo_path, &root, ORPHAN_MIN_AGE).await;
@@ -511,8 +630,11 @@ async fn remove_update_leftover(repo_path: &str, root: &Path, stem: &str) {
 
 /// The claim decision: which `gd-update-<stem>` leftovers under `root` a sweep may
 /// take. Three conditions, all required — the basename prefix (this root also holds
-/// the user's agent-session worktrees, and a mis-claim would delete one), a dead or
+/// the user's agent-session worktrees, and a mis-claim would delete one), a released or
 /// absent lock, and an age past `min_age`. Anything unreadable is left alone.
+///
+/// The two shapes measure age from different things, because for a markerless checkout
+/// the sidecars that would carry a mint time do not exist (see [`stem_age`]).
 fn orphaned_update_stems(root: &Path, min_age: Duration) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(root) else {
         return Vec::new();
@@ -545,31 +667,55 @@ fn orphaned_update_stems(root: &Path, min_age: Duration) -> Vec<String> {
     let now = SystemTime::now();
     candidates
         .into_iter()
-        // `Missing` is claimable HERE and nowhere else: the age gate is what stands in
-        // for the proof a lock file would have given. `Unknown` and `Live` are spared.
-        .filter(|(stem, _)| {
-            matches!(
-                probe_lock(&root.join(format!("{stem}.lock"))),
-                LockProbe::Released | LockProbe::Missing
-            )
+        .filter_map(|(stem, paths)| {
+            // `Missing` is claimable HERE and nowhere else: the age gate is what stands
+            // in for the proof a lock file would have given. `Unknown` and `Live` are
+            // spared.
+            let probe = probe_lock(&root.join(format!("{stem}.lock")));
+            if !matches!(probe, LockProbe::Released | LockProbe::Missing) {
+                return None;
+            }
+            let age = stem_age(root, &stem, &probe, &paths, now)?;
+            (age >= min_age).then_some(stem)
         })
-        .filter(|(_, paths)| {
-            // The NEWEST mtime of anything the stem owns: the most recent sign of life
-            // is what has to be old, not the oldest.
-            newest_mtime(paths)
-                .is_some_and(|m| now.duration_since(m).unwrap_or(Duration::ZERO) >= min_age)
-        })
-        .map(|(stem, _)| stem)
         .collect()
 }
 
-/// The latest mtime among `paths`, or `None` when none of them can be read — which
-/// leaves the entry unclaimed, the safe direction.
-fn newest_mtime(paths: &[PathBuf]) -> Option<SystemTime> {
-    paths
+/// How long ago a stem last showed a sign of life. `None` whenever nothing readable can
+/// answer, which leaves it unclaimed — the safe direction in every shape.
+///
+/// A marker-bearing (`Released`) stem measures from its own files: the sidecars are
+/// written at mint time and never rewritten, so their mtime IS the update's start.
+///
+/// A markerless checkout has no such file, and its directory's mtime cannot stand in —
+/// a directory's mtime does not move when git writes inside its SUBdirectories, so a
+/// pre-marker binary's hours-long merge would read as untouched and be force-removed
+/// mid-flight. It measures from the worktree's own git activity instead, via the
+/// worktree manager's probe: the `index` (HEAD as fallback) inside the admin directory
+/// its `.git` pointer names, which git rewrites on checkout, merge and commit alike.
+/// Following the pointer also sidesteps guessing the admin directory's name, which git
+/// de-duplicates. A checkout with no readable git state answers `None`.
+fn stem_age(
+    root: &Path,
+    stem: &str,
+    probe: &LockProbe,
+    paths: &[PathBuf],
+    now: SystemTime,
+) -> Option<Duration> {
+    let dir = root.join(stem);
+    if *probe == LockProbe::Missing && dir.is_dir() {
+        let ms = crate::git::worktree::worktree_last_activity_ms(&dir.to_string_lossy())?;
+        let last =
+            SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(u64::try_from(ms).ok()?))?;
+        return Some(now.duration_since(last).unwrap_or(Duration::ZERO));
+    }
+    // The NEWEST mtime of anything the stem owns: the most recent sign of life is what
+    // has to be old, not the oldest.
+    let newest = paths
         .iter()
         .filter_map(|p| std::fs::metadata(p).ok()?.modified().ok())
-        .max()
+        .max()?;
+    Some(now.duration_since(newest).unwrap_or(Duration::ZERO))
 }
 
 #[cfg(test)]
@@ -705,7 +851,9 @@ mod tests {
         let live = UpdateMarker::create_for(&root.join("gd-update-busy"), "feature")
             .expect("the live marker mints");
 
-        // A pre-marker build's orphan: the checkout with no marker at all.
+        // A pre-marker build's orphan: the checkout with no marker at all. This bare
+        // directory has no git state, so no activity signal can be read from it — and
+        // the markerless shape claims only on that signal.
         std::fs::create_dir_all(root.join("gd-update-markerless")).unwrap();
 
         // The marker pair whose checkout is already gone.
@@ -720,12 +868,9 @@ mod tests {
         claimed.sort();
         assert_eq!(
             claimed,
-            vec![
-                "gd-update-dead".to_string(),
-                "gd-update-markerless".to_string(),
-                "gd-update-pruned".to_string(),
-            ],
-            "a live marker and every non-mint basename are spared"
+            vec!["gd-update-dead".to_string(), "gd-update-pruned".to_string()],
+            "a live marker, every non-mint basename, and a checkout whose activity \
+             cannot be read are all spared"
         );
 
         assert!(
@@ -846,10 +991,10 @@ mod tests {
         drop(live);
     }
 
-    /// The three-state probe. `Unknown` is the arm that matters: it must never read as
-    /// dead, because only `Dead` authorizes a removal.
+    /// All four probe states. `Missing` and `Unknown` are the arms that matter: neither
+    /// may read as released, because only `Released` authorizes an age-free removal.
     #[test]
-    fn the_lock_probe_separates_live_dead_and_unreadable() {
+    fn the_lock_probe_separates_all_four_states() {
         let (_guard, root) = temp_root("probe");
         let marker = UpdateMarker::create_for(&root.join("gd-update-held"), "feature")
             .expect("the marker mints");
@@ -1018,11 +1163,132 @@ mod tests {
         );
         assert!(orphan.exists(), "and its checkout is left untouched");
 
-        // The age-gated sweep is the ONLY thing that may claim it.
+        // Nor does the background sweep take it on this fixture: a bare directory has no
+        // git state, and the markerless shape is claimable only off an activity signal.
+        assert!(
+            orphaned_update_stems(&root, Duration::ZERO).is_empty(),
+            "an unreadable checkout is never claimed, at any age"
+        );
+    }
+
+    /// A teardown that could not remove the checkout must leave the marker RECOVERABLE:
+    /// sidecars retained and unlocked, i.e. `Released`, so the next branch operation
+    /// clears it age-free. Deleting them there would leave a markerless holder that
+    /// nothing may touch until the age gate expires.
+    #[test]
+    fn a_failed_teardown_retains_the_marker_as_released() {
+        let (_guard, root) = temp_root("retain");
+        let dir = root.join("gd-update-stuck");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut marker = UpdateMarker::create_for(&dir, "feature").expect("the marker mints");
+        assert_eq!(
+            probe_lock(&root.join("gd-update-stuck.lock")),
+            LockProbe::Live
+        );
+
+        // The teardown could not confirm the directory was gone.
+        marker.retain_for_recovery();
+        drop(marker);
+
+        assert!(
+            root.join("gd-update-stuck.lock").exists()
+                && root.join("gd-update-stuck.json").exists(),
+            "both sidecars survive a failed teardown"
+        );
+        assert_eq!(
+            probe_lock(&root.join("gd-update-stuck.lock")),
+            LockProbe::Released,
+            "and the lock is released, so a claim can recover it immediately"
+        );
+        assert_eq!(
+            dead_stems_for_branch(&root, "feature"),
+            vec!["gd-update-stuck".to_string()],
+            "the age-free branch claim picks it up with no waiting"
+        );
+    }
+
+    /// Root scope: a `gd-update-*` worktree the USER made, outside our app-data root, is
+    /// theirs. Even with a stray unlocked `.lock` beside it — which would otherwise read
+    /// `Released` — no marker arm may claim or refuse on it.
+    #[test]
+    fn a_user_worktree_outside_the_root_is_never_managed() {
+        let (_guard, base) = temp_root("scope");
+        let root = base.join("worktrees");
+        let elsewhere = base.join("user-repos");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&elsewhere).unwrap();
+
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let repo = "C:/repos/app";
+
+        let mine = root.join("gd-update-1-2");
+        std::fs::create_dir_all(&mine).unwrap();
+        assert!(is_managed_update_worktree(repo, &mine.to_string_lossy()));
+
+        // Same basename, same stray sidecar, different parent.
+        let theirs = elsewhere.join("gd-update-1-2");
+        std::fs::create_dir_all(&theirs).unwrap();
+        std::fs::write(elsewhere.join("gd-update-1-2.lock"), b"").unwrap();
+        assert_eq!(
+            probe_lock(&elsewhere.join("gd-update-1-2.lock")),
+            LockProbe::Released,
+            "the fixture must reproduce the tempting shape"
+        );
+        assert!(
+            !is_managed_update_worktree(repo, &theirs.to_string_lossy()),
+            "a user's own worktree is out of scope however its neighbours look"
+        );
+        // A nested path under our root is not a direct child, so it is not ours either.
+        assert!(!is_managed_update_worktree(
+            repo,
+            &root.join("nested").join("gd-update-1-2").to_string_lossy()
+        ));
+    }
+
+    /// The markerless shape's age gate must read a signal git actually MOVES. A
+    /// directory's own mtime does not change when git writes inside its subdirectories,
+    /// so measuring from it would call a pre-marker binary's hours-long merge idle and
+    /// force-remove it mid-flight. This drives a REAL worktree, where the activity probe
+    /// has something to read.
+    #[tokio::test]
+    async fn a_markerless_checkout_ages_from_its_git_activity() {
+        let (_guard, base) = temp_root("markerless-age");
+        let repo = base.join("repo");
+        let root = base.join("worktrees");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&root).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+        git(&repo_s, &["branch", "feature"]).await;
+
+        // A pre-marker binary's checkout: registered, no sidecars anywhere.
+        let wt = root.join("gd-update-premarker");
+        let wt_s = wt.to_string_lossy().into_owned();
+        git(&repo_s, &["worktree", "add", "--quiet", &wt_s, "feature"]).await;
+        assert_eq!(update_worktree_probe(&wt_s), LockProbe::Missing);
+        assert!(
+            crate::git::worktree::worktree_last_activity_ms(&wt_s).is_some(),
+            "the fixture must give the probe an index to read"
+        );
+
+        // Freshly checked out, so at the production gate it reads BUSY, not orphaned —
+        // this is the arm that protects a still-running pre-marker update.
+        assert!(
+            orphaned_update_stems(&root, ORPHAN_MIN_AGE).is_empty(),
+            "a checkout git touched moments ago is never claimed"
+        );
+        // And it stays reachable: with the threshold dropped, the same signal claims it.
         assert_eq!(
             orphaned_update_stems(&root, Duration::ZERO),
             vec!["gd-update-premarker".to_string()],
-            "the background sweep still owns this shape"
+            "the shape still heals once it is genuinely stale"
         );
     }
 }

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -6,8 +6,11 @@
 //! switching, renaming, deleting, cherry-picking onto it — would otherwise collide
 //! with git's own message naming a hidden app-data path. A marker minted before the
 //! `worktree add` turns those collisions into one sentence the user can act on, and
-//! it works ACROSS PROCESSES (the MCP server runs these same functions) because the
-//! signal is filesystem state, not process state.
+//! the signal is filesystem state, not process state, so it reaches every process
+//! bound to the same checkout path (the MCP server runs these same functions). The
+//! recorded limit: the root is keyed on that path, so a SIBLING worktree of the same
+//! repository resolves its own root and sees no marker — those callers keep pre-marker
+//! behavior until the root is keyed by git common dir.
 //!
 //! The marker is two files beside the checkout, sharing its stem: an unlocked `.json`
 //! manifest and an exclusively-locked `.lock`. Two files is forced by Windows —
@@ -1183,6 +1186,8 @@ mod tests {
     /// running the update — only the age-gated sweep may ever touch it. The override is
     /// what lets the claim pass its managed-root gate and reach the Missing probe this
     /// test exists to pin — without it the refusal is the seam's, not the probe's.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_markerless_holder_is_never_claimed_age_free() {

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -153,10 +153,17 @@ pub async fn git_worktree_list(repo_path: String) -> AppResult<Vec<WorktreeInfo>
 /// `true` when the prune ran.
 pub(crate) async fn prune_worktrees_if_free(state: &AppState, repo_path: &str) -> bool {
     let domain = state.worktree_admin_lock(repo_path).await;
-    let Some(_guard) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+    let Some(guard) = try_acquire_repo_lock(&domain, "a worktree operation") else {
         return false;
     };
     let _ = run_git(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    // Released before the sweep is fired, and the sweep detached: it heals what prune
+    // cannot (an interrupted update's checkout is never prunable, still holds a branch,
+    // and is filtered from every listing), but removing one runs for minutes, which
+    // this read must never wait on — and a task spawned under our own hold would lose
+    // its try-acquire to us and do nothing.
+    drop(guard);
+    crate::git::update_marker::spawn_orphan_sweep(state, repo_path).await;
     true
 }
 
@@ -264,6 +271,12 @@ pub async fn git_worktree_add_user(
     if new_branch {
         args.extend_from_slice(&["-b", branch, path, base]);
     } else {
+        // Existing-branch arm only: `-b` creates the name, so a collision there is
+        // already git's clear "already exists". Here the branch may be held by an
+        // update's hidden checkout, which git names by an app-data path. Heal-free:
+        // the `worktree add` below takes the admin domain, and a sweep fired here
+        // would win it first and turn a would-succeed add into a `Busy`.
+        crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, branch)?;
         args.extend_from_slice(&[path, branch]);
     }
     run_git_worktree_admin(&state, &repo_path, &args, WORKTREE_OP_TIMEOUT).await?;

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -150,6 +150,8 @@ pub async fn git_worktree_list(repo_path: String) -> AppResult<Vec<WorktreeInfo>
 /// Contended means an admin op (a removal) is in flight, and this prune is
 /// skippable: its result is discarded either way, a removal runs its own prune when
 /// it ends, and queueing would stall the list read behind a multi-minute hold.
+/// Having pruned, it releases the hold and fires a DETACHED sweep for interrupted
+/// updates' orphaned checkouts, which prune itself cannot reach.
 /// `true` when the prune ran.
 pub(crate) async fn prune_worktrees_if_free(state: &AppState, repo_path: &str) -> bool {
     let domain = state.worktree_admin_lock(repo_path).await;

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1789,7 +1789,7 @@ pub async fn gh_pr_checkout(
     // block checkouts of every OTHER branch for all of it. Any failure of this extra
     // read (offline, no such PR, an older gh) falls back to the repo-scoped guard
     // rather than failing the checkout on a guard's behalf.
-    let head_branch = run_gh(
+    let view = run_gh(
         Some(&repo_path),
         &[
             "pr",
@@ -1798,20 +1798,26 @@ pub async fn gh_pr_checkout(
             "--repo",
             &slug,
             "--json",
-            "headRefName",
-            "-q",
-            ".headRefName",
+            "headRefName,isCrossRepository",
         ],
         GH_TIMEOUT,
     )
     .await
     .ok()
-    .map(|out| out.stdout_lossy().trim().to_string())
-    .filter(|b| !b.is_empty());
-    match head_branch {
+    .and_then(|out| serde_json::from_str::<serde_json::Value>(&out.stdout_lossy()).ok());
+    // Only a PR from this same repo checks out under its own `headRefName`; gh gives a
+    // fork's branch a prefixed local name whose shape has changed between gh versions,
+    // so guessing it is not worth the guard — a cross-repository PR keeps repo scope.
+    // `isCrossRepository` must say false explicitly: an absent field proves nothing.
+    let branch = view
+        .as_ref()
+        .filter(|v| v["isCrossRepository"].as_bool() == Some(false))
+        .and_then(|v| v["headRefName"].as_str())
+        .map(str::trim)
+        .filter(|b| !b.is_empty());
+    match branch {
         Some(branch) => {
-            crate::git::update_marker::refuse_if_branch_updating(&state, &repo_path, &branch)
-                .await?
+            crate::git::update_marker::refuse_if_branch_updating(&state, &repo_path, branch).await?
         }
         None => crate::git::update_marker::refuse_if_any_updating(&state, &repo_path).await?,
     }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1776,7 +1776,15 @@ pub async fn gh_pr_unminimize_comment(repo_path: String, comment_id: String) -> 
 
 /// Checks out a PR's branch locally (handles fork-sourced PRs too).
 #[tauri::command]
-pub async fn gh_pr_checkout(repo_path: String, number: u64, lens: Option<String>) -> AppResult<()> {
+pub async fn gh_pr_checkout(
+    state: tauri::State<'_, crate::state::AppState>,
+    repo_path: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<()> {
+    // Repo-scoped: gh resolves the PR's local branch name, so this side can't know it
+    // before the checkout runs.
+    crate::git::update_marker::refuse_if_any_updating(&state, &repo_path).await?;
     let n = number.to_string();
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
     run_gh(

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1782,11 +1782,39 @@ pub async fn gh_pr_checkout(
     number: u64,
     lens: Option<String>,
 ) -> AppResult<()> {
-    // Repo-scoped: gh resolves the PR's local branch name, so this side can't know it
-    // before the checkout runs.
-    crate::git::update_marker::refuse_if_any_updating(&state, &repo_path).await?;
     let n = number.to_string();
     let slug = crate::github::gh_lens_slug(&repo_path, lens.as_deref()).await?;
+    // Ask gh which branch this PR lands on, so the guard can name it: an update's
+    // window runs to minutes on the diverged path, and a repo-scoped refusal would
+    // block checkouts of every OTHER branch for all of it. Any failure of this extra
+    // read (offline, no such PR, an older gh) falls back to the repo-scoped guard
+    // rather than failing the checkout on a guard's behalf.
+    let head_branch = run_gh(
+        Some(&repo_path),
+        &[
+            "pr",
+            "view",
+            &n,
+            "--repo",
+            &slug,
+            "--json",
+            "headRefName",
+            "-q",
+            ".headRefName",
+        ],
+        GH_TIMEOUT,
+    )
+    .await
+    .ok()
+    .map(|out| out.stdout_lossy().trim().to_string())
+    .filter(|b| !b.is_empty());
+    match head_branch {
+        Some(branch) => {
+            crate::git::update_marker::refuse_if_branch_updating(&state, &repo_path, &branch)
+                .await?
+        }
+        None => crate::git::update_marker::refuse_if_any_updating(&state, &repo_path).await?,
+    }
     run_gh(
         Some(&repo_path),
         &["pr", "checkout", &n, "--repo", &slug],


### PR DESCRIPTION
`update_branch_from` checks the target branch out in a hidden `gd-update-*` worktree under app data for the length of the merge, so anything else touching that branch during the window failed with git's own message naming a path the user can't act on, and a crash or forced quit left the checkout behind holding the branch indefinitely. This adds a cross-process in-flight marker beside that checkout, turns every colliding operation into one actionable sentence, and sweeps the leftovers an interrupted update leaves behind.

### In-flight marker (`src-tauri/src/git/update_marker.rs`)

- New module (registered in `src-tauri/src/git/mod.rs`) that mints an `UpdateMarker` pair beside the throwaway checkout: a readable `.json` manifest carrying the branch and owning pid, plus an exclusively locked `.lock`. Two files rather than one because Windows `LockFileEx` blocks cross-process reads of a locked range, which would make the manifest unreadable by the probes that need it.
- Liveness is the lock itself, so the signal survives process death and works across processes (the MCP server runs these same functions). `probe_lock` returns a three-state `LockProbe`: `Unknown` never raises a refusal and never authorizes a removal, so an IO hiccup or an antivirus scanner holding the file open can neither block a user action nor get a running update's checkout deleted.
- Guard entry points `refuse_if_branch_updating`, `refuse_if_any_updating`, and `refuse_if_branch_updating_no_heal` over the shared `refuse_in` scan, with `branch_update_refusal` and `interrupted_update_refusal` as the two message shapes. Branch-mode matching reads the manifest and fails open when it is missing or malformed; any-mode refuses on liveness alone.
- `is_update_worktree_path` and `update_worktree_is_live` let call sites classify a `worktree list --porcelain` holder as one of ours.

### Guarded operations

- `src-tauri/src/git/branches.rs`: `update_branch_from` now mints the marker before the `worktree add` (the longest part of the window) and hands it to `merge_diverged_in_worktree`, which drops it on both teardown arms so it outlives the checkout exactly as the branch hold does. The same function guards against a second update of the same branch, which also covers the fast-forward arm's `fetch . <base>:<branch>`.
- Switch and rename paths refuse up front: `git_checkout_branch_core`, `git_checkout_remote_branch`, and `git_rename_branch_core` — `branch -m` does not refuse a branch checked out elsewhere, it silently retargets that worktree's HEAD.
- `git_delete_branch_core` and `branch_reset_to_upstream` route a `worktree_holding_branch` hit through the new `clear_update_holder` helper: a live update refuses in its own words, a dead one is cleared and the hold re-probed, and anything the user actually owns keeps the existing "remove that worktree" message.
- `src-tauri/src/git/autostash.rs`: `git_switch_autostash_core` guards ahead of `autostash_push`, so the user's changes are not pushed and popped for a switch that would fail anyway.
- `src-tauri/src/git/ops.rs`: `cherry_pick_onto_with_timeouts` guards alongside the other pre-flight checks, before anything is journaled or switched. `finalize_base` refuses to fast-forward a base held by a running update (advancing it would move the pinned branch and kill the update at its pin verify), clears a dead holder and rescans once via the extracted `worktree_holding` helper, then refuses as interrupted if the hold persists.
- `src-tauri/src/git/worktree.rs`: `git_worktree_add_user` guards only the existing-branch arm, using the heal-free form because the `worktree add` that follows needs the admin domain a spawned sweep would take first.
- `src-tauri/src/github/pr.rs`: `gh_pr_checkout` now takes `AppState` and uses the repo-scoped refusal, since gh resolves the PR's local branch name only after the checkout runs.

### Crash-leftover recovery

- `sweep_orphaned_update_worktrees` runs at the top of `update_branch_from`, so each update clears its predecessors' leftovers; `spawn_orphan_sweep` fires a detached best-effort pass whenever a guard scan meets a dead marker, gated by the process-wide `SWEEP_RUNNING` flag and skipped when the worktree-admin domain is busy.
- `prune_worktrees_if_free` in `worktree.rs` drops its own admin guard before firing the detached sweep: an interrupted update's checkout is never prunable, still holds its branch, and a task spawned under our own hold would lose its try-acquire and do nothing.
- Claim discipline in `orphaned_update_stems` requires all three of the `gd-update-` basename prefix, a proven-dead lock, and a newest-mtime older than `ORPHAN_MIN_AGE` (10 minutes), since the same root holds the user's `gd/session/*` agent worktrees. `claim_dead_update_worktree` skips the age gate for a single porcelain-confirmed holder, where the registered checkout already proves the mint completed, and re-probes under the admin hold before removing.

### Tests and changelog

- `update_marker.rs` tests cover mint and drop, live-branch vs other-branch vs any-mode refusals, a dead marker refusing nothing while flagging a sweep, an unparseable manifest failing open, basename matching (including a parent directory named like a mint), and the claim decision against agent-session, `gd-resolve-`, and near-miss decoys.
- An end-to-end `tokio` test builds a real repo with a crash-orphaned update worktree and asserts the fixture reproduces the branch hold, that the production age gate spares it, and that the deleting pass removes the checkout, prunes the admin entry, frees the branch, and leaves a live update, a resolve worktree, and an agent session's bytes untouched. The lock-probe test asserts the `Unknown` arm with a platform-specific unreadable-lock shape, and a negative control proves the refusal comes from the marker scan rather than from git.
- `changelog.d/fixed-update-collision-guards.md` records the user-facing behavior; existing `merge_diverged_in_worktree` tests in `branches.rs` pass `None` for the new marker argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented branch switching, renaming, deletion, cherry-picking, and worktree creation while a branch is being updated.
  * Added clear guidance to retry actions after the update finishes.
  * Improved recovery after crashes or forced quits by cleaning up interrupted update worktrees and releasing held branches.
  * Preserved recovery information when cleanup is interrupted or fails.
  * Improved GitHub pull request checkout handling, including pull requests from forks and incomplete metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->