### PR TITLE
fix(ai,branches,discard): reuse review worktrees, widen update holds

### DIFF
--- a/changelog.d/changed-ai-review-workspace-reuse.md
+++ b/changelog.d/changed-ai-review-workspace-reuse.md
@@ -1,0 +1,4 @@
+- Repo-aware AI reviews now reuse a single review workspace per repository, shared
+  by all its worktrees, so "Preparing review workspace…" is near-instant on every
+  review after the first. A workspace left untouched for a week is reclaimed on
+  startup.

--- a/changelog.d/fixed-reserved-name-discard.md
+++ b/changelog.d/fixed-reserved-name-discard.md
@@ -1,3 +1,3 @@
 - Discarding a file whose name matches a Windows device (`nul`, `con`, `com1`,
-  and friends) now removes it. When the Recycle Bin won't accept such a name,
-  GitDesktop deletes the file directly.
+  and friends) removes it. When the Recycle Bin cannot accept such a name,
+  GitDesktop permanently deletes the file.

--- a/changelog.d/fixed-reserved-name-discard.md
+++ b/changelog.d/fixed-reserved-name-discard.md
@@ -1,0 +1,3 @@
+- Discarding a file whose name matches a Windows device (`nul`, `con`, `com1`,
+  and friends) now removes it. When the Recycle Bin won't accept such a name,
+  GitDesktop deletes the file directly.

--- a/changelog.d/fixed-update-guards-sibling-worktrees.md
+++ b/changelog.d/fixed-update-guards-sibling-worktrees.md
@@ -1,0 +1,4 @@
+- While a branch update runs, every worktree of the repository now sees the
+  hold: switching to, renaming, or deleting the updating branch from another
+  worktree gets the same clear wait-a-moment message as the worktree the update
+  started in.

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -67,6 +67,106 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
     Ok(())
 }
 
+/// True when `name`'s stem (everything before the first dot) is a reserved DOS
+/// device name. Windows resolves such a name to the DEVICE at any position in a
+/// path, extension or not, so `nul.txt` is as unopenable as `nul`. Win32 also
+/// strips trailing dots and SPACES off the final component, which makes `nul `
+/// the device too (measured); the first-dot split covers the dots, the trim
+/// covers the spaces. Only COM/LPT 1–9 are devices; `com0`, `com10` and
+/// `console` are ordinary names.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_reserved_device_name(name: &str) -> bool {
+    let stem = name
+        .split('.')
+        .next()
+        .unwrap_or(name)
+        .trim_end_matches(' ')
+        .to_ascii_uppercase();
+    match stem.as_str() {
+        "CON" | "PRN" | "AUX" | "NUL" => true,
+        _ => stem
+            .strip_prefix("COM")
+            .or_else(|| stem.strip_prefix("LPT"))
+            .is_some_and(|d| d.len() == 1 && matches!(d.as_bytes()[0], b'1'..=b'9')),
+    }
+}
+
+/// Rewrites an absolute path into its `\\?\` verbatim form, which the Win32 layer
+/// passes to the filesystem without the DOS-name resolution that turns `nul` into
+/// a device. Returns `None` for a relative path — resolving one against the
+/// process cwd would target a file the caller never named — and for a `\\.\`
+/// device-namespace path, which names a device rather than a file on disk.
+#[cfg(windows)]
+fn verbatim_path(path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+    // Verbatim paths take no forward slashes; repo paths arrive from the frontend
+    // with them. A non-UTF-8 name (unpaired surrogate) simply gets no verbatim form.
+    let text = path.to_str()?.replace('/', "\\");
+    if text.starts_with(r"\\.\") {
+        return None;
+    }
+    if text.starts_with(r"\\?\") {
+        return Some(PathBuf::from(text));
+    }
+    Some(PathBuf::from(match text.strip_prefix(r"\\") {
+        Some(share) => format!(r"\\?\UNC\{share}"),
+        None => format!(r"\\?\{text}"),
+    }))
+}
+
+/// Permanently removes a reserved-device-named entry through its verbatim path.
+/// Returns whether it did; a non-reserved name is left for the caller to report.
+#[cfg(windows)]
+fn permanent_delete_reserved(path: &Path) -> bool {
+    use std::os::windows::fs::FileTypeExt;
+
+    let reserved = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(is_reserved_device_name);
+    if !reserved {
+        return false;
+    }
+    let Some(verbatim) = verbatim_path(path) else {
+        return false;
+    };
+    // The dir-vs-file probe rides the verbatim path too: a plain-path probe would
+    // describe the device rather than the entry on disk.
+    // It also does not follow links: a reparse point is classified and removed as
+    // ITSELF, so a directory link unlinks with `remove_dir` and only a real
+    // directory earns the recursive sweep.
+    let kind = std::fs::symlink_metadata(&verbatim)
+        .map(|m| m.file_type())
+        .ok();
+    let removed = match kind {
+        Some(k) if k.is_symlink_dir() => std::fs::remove_dir(&verbatim),
+        Some(k) if k.is_dir() => std::fs::remove_dir_all(&verbatim),
+        // Plain file, file link, or an entry the probe couldn't describe — the
+        // file unlink is the only attempt left, and it fails harmlessly.
+        _ => std::fs::remove_file(&verbatim),
+    };
+    removed.is_ok()
+}
+
+/// Moves `path` to the OS trash. Trash is always tried first, so anything the
+/// recycle bin accepts stays recoverable; only on Windows, and only after trash
+/// has refused a reserved-device name (`nul`, `con`, `com3`, …), does the
+/// permanent verbatim-path unlink run. A failed fallback reports the original
+/// trash error — the second one names the same refusal with less context.
+pub(crate) fn trash_delete(path: &Path) -> std::io::Result<()> {
+    let err = match trash::delete(path) {
+        Ok(()) => return Ok(()),
+        Err(e) => std::io::Error::other(e.to_string()),
+    };
+    #[cfg(windows)]
+    if permanent_delete_reserved(path) {
+        return Ok(());
+    }
+    Err(err)
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DetectedEditor {
@@ -205,7 +305,7 @@ pub async fn delete_repo_folder(path: String) -> AppResult<()> {
 
         let mut cause = String::new();
         for attempt in 0..ATTEMPTS {
-            match trash::delete(&dir) {
+            match trash_delete(&dir) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     cause = e.to_string();
@@ -1098,6 +1198,73 @@ mod tests {
         // A trailing TAB is part of the pattern — git trims spaces only (measured,
         // 2.51.1: pattern `foo\t` matches `foo\t`, not `foo`).
         assert_eq!(trim_ignore_pattern("/notes.md\t"), "/notes.md\t");
+    }
+
+    #[test]
+    fn is_reserved_device_name_matches_dos_devices_only() {
+        for name in [
+            "nul", "NUL.txt", "Com3.log", "con", "PRN", "aux", "com1", "COM9", "lpt1", "LPT9",
+            "nul.tar.gz",
+            // Win32 strips trailing dots and spaces off the final component, so
+            // these spell the device too (measured).
+            "nul ", "nul .txt", "nul.",
+        ] {
+            assert!(is_reserved_device_name(name), "{name:?} is a device name");
+        }
+        for name in [
+            "nully", "null", "com0", "com10", "lpt10", "lpt0", "console", "prnt", "auxiliary",
+            "com", "lpt", "", "a.nul",
+            // Only TRAILING spaces are stripped — an interior one is part of the name.
+            "nul x", "nul x.txt",
+        ] {
+            assert!(!is_reserved_device_name(name), "{name:?} is an ordinary name");
+        }
+    }
+
+    /// Pins the premise the Windows fallback exists for: a file named after a
+    /// reserved device is unreachable by its plain path, so trash refuses it and
+    /// only the verbatim path can unlink it. A red here means the fallback is
+    /// dead code.
+    #[cfg(windows)]
+    #[test]
+    fn trash_delete_removes_a_reserved_device_name_the_recycle_bin_refuses() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let plain = tmp.path().join("nul");
+        let verbatim = verbatim_path(&plain).expect("a temp path is absolute");
+        std::fs::write(&verbatim, b"x").expect("the verbatim path creates the file");
+
+        assert!(
+            trash::delete(&plain).is_err(),
+            "the plain path resolves to the device, so trash cannot take it"
+        );
+        trash_delete(&plain).expect("the verbatim fallback removes it");
+        assert!(
+            std::fs::metadata(&verbatim).is_err(),
+            "the file is gone from disk"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn verbatim_path_normalizes_slashes_and_unc_and_refuses_relative() {
+        assert_eq!(
+            verbatim_path(Path::new("C:/repo/sub/nul")).unwrap(),
+            PathBuf::from(r"\\?\C:\repo\sub\nul")
+        );
+        assert_eq!(
+            verbatim_path(Path::new(r"\\server\share\nul")).unwrap(),
+            PathBuf::from(r"\\?\UNC\server\share\nul")
+        );
+        // An already-verbatim path is passed through, never re-prefixed.
+        assert_eq!(
+            verbatim_path(Path::new(r"\\?\C:\repo\nul")).unwrap(),
+            PathBuf::from(r"\\?\C:\repo\nul")
+        );
+        assert!(verbatim_path(Path::new("sub/nul")).is_none());
+        // A device-namespace path names a device, not a file on disk — no
+        // verbatim form, so the caller keeps the plain trash error.
+        assert!(verbatim_path(Path::new(r"\\.\nul")).is_none());
+        assert!(verbatim_path(Path::new(r"\\.\PhysicalDrive0")).is_none());
     }
 
     fn gitignore_test_repo() -> (tempfile::TempDir, PathBuf) {

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -72,8 +72,10 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
 /// path, extension or not, so `nul.txt` is as unopenable as `nul`. Win32 also
 /// strips trailing dots and SPACES off the final component, which makes `nul `
 /// the device too (measured); the first-dot split covers the dots, the trim
-/// covers the spaces. Only COM/LPT 1–9 are devices; `com0`, `com10` and
-/// `console` are ordinary names.
+/// covers the spaces. Only a single COM/LPT ordinal 1–9 is a device, written
+/// either as an ASCII digit or as a Latin-1 superscript (`com¹`, `com²`,
+/// `com³`); `com0`, `com10`, `com⁴` (U+2074, outside Latin-1) and `console` are
+/// ordinary names.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn is_reserved_device_name(name: &str) -> bool {
     let stem = name
@@ -87,7 +89,12 @@ fn is_reserved_device_name(name: &str) -> bool {
         _ => stem
             .strip_prefix("COM")
             .or_else(|| stem.strip_prefix("LPT"))
-            .is_some_and(|d| d.len() == 1 && matches!(d.as_bytes()[0], b'1'..=b'9')),
+            // Exactly one ordinal CHAR, not byte: a superscript is two bytes.
+            .is_some_and(|d| {
+                let mut ordinal = d.chars();
+                matches!(ordinal.next(), Some('1'..='9' | '¹' | '²' | '³'))
+                    && ordinal.next().is_none()
+            }),
     }
 }
 
@@ -1208,6 +1215,9 @@ mod tests {
             // Win32 strips trailing dots and spaces off the final component, so
             // these spell the device too (measured).
             "nul ", "nul .txt", "nul.",
+            // Latin-1 superscript ordinals are devices too (measured: `com¹`
+            // resolves to `\\.\com¹` and survives a plain-path delete).
+            "com\u{b9}", "LPT\u{b3}.txt", "com\u{b2}  ",
         ] {
             assert!(is_reserved_device_name(name), "{name:?} is a device name");
         }
@@ -1216,6 +1226,9 @@ mod tests {
             "com", "lpt", "", "a.nul",
             // Only TRAILING spaces are stripped — an interior one is part of the name.
             "nul x", "nul x.txt",
+            // U+2074 is outside Latin-1 and reserves nothing (measured: `com⁴` is
+            // an ordinary file); an ordinal is one char, so a suffix disqualifies.
+            "com\u{2074}", "com\u{b9}x",
         ] {
             assert!(!is_reserved_device_name(name), "{name:?} is an ordinary name");
         }
@@ -1229,19 +1242,22 @@ mod tests {
     #[test]
     fn trash_delete_removes_a_reserved_device_name_the_recycle_bin_refuses() {
         let tmp = tempfile::tempdir().expect("create temp dir");
-        let plain = tmp.path().join("nul");
-        let verbatim = verbatim_path(&plain).expect("a temp path is absolute");
-        std::fs::write(&verbatim, b"x").expect("the verbatim path creates the file");
+        // The superscript spelling rides the same path as the ASCII one.
+        for name in ["nul", "com\u{b9}"] {
+            let plain = tmp.path().join(name);
+            let verbatim = verbatim_path(&plain).expect("a temp path is absolute");
+            std::fs::write(&verbatim, b"x").expect("the verbatim path creates the file");
 
-        assert!(
-            trash::delete(&plain).is_err(),
-            "the plain path resolves to the device, so trash cannot take it"
-        );
-        trash_delete(&plain).expect("the verbatim fallback removes it");
-        assert!(
-            std::fs::metadata(&verbatim).is_err(),
-            "the file is gone from disk"
-        );
+            assert!(
+                trash::delete(&plain).is_err(),
+                "{name:?}: the plain path resolves to the device, so trash cannot take it"
+            );
+            trash_delete(&plain).expect("the verbatim fallback removes it");
+            assert!(
+                std::fs::metadata(&verbatim).is_err(),
+                "{name:?} is gone from disk"
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/git/branches.rs
+++ b/src-tauri/src/git/branches.rs
@@ -330,7 +330,7 @@ async fn clear_update_holder(
     use crate::git::update_marker::{self as marker, LockProbe};
     // Root-scoped: a `gd-update-*` worktree the USER made, outside our app-data root, is
     // their own and takes the ordinary path however its neighbours look.
-    if !marker::is_managed_update_worktree(repo_path, holder) {
+    if !marker::is_managed_update_worktree(repo_path, holder).await {
         return Ok(false);
     }
     match marker::update_worktree_probe(holder) {
@@ -366,7 +366,7 @@ pub(crate) async fn git_delete_branch_core(
     // Two halves of one window: the marker covers an update that has minted but not yet
     // registered its checkout (the `worktree add` is the long part), the porcelain arm
     // below covers it once registered. Heal-free — the healing lives in the claim arm.
-    crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, &name)?;
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, &name).await?;
     // Pre-mutation guard: git's own refusal for a branch checked out in a worktree
     // is terse. Detect the holding worktree here — shared by every caller, not just
     // the switcher's UI guard — and surface an actionable message.
@@ -1068,7 +1068,7 @@ pub(crate) async fn branch_reset_to_upstream(
     // Two halves of one window, as in `git_delete_branch_core`: the marker covers an
     // update that has minted but not yet registered its checkout, the porcelain arm
     // below covers it once registered. Heal-free — healing lives in the claim arm.
-    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch)?;
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch).await?;
     // Pre-mutation guards: git refuses both of these itself, but only after the
     // user has confirmed a destructive action, and its wording names neither
     // remedy. The linked-worktree probe excludes THIS checkout, so the current
@@ -1152,7 +1152,7 @@ pub(crate) async fn update_branch_from(
     // against a branch held by the first update's checkout. Heal-free deliberately —
     // this path's own `worktree add` takes the admin domain, and a detached sweep
     // fired here would win it first and time that bounded acquire out.
-    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch)?;
+    crate::git::update_marker::refuse_if_branch_updating_no_heal(repo_path, branch).await?;
     // Healing, in two tiers. THIS branch's provably-dead leftovers go first and
     // synchronously, so the first update after a crash clears its own predecessor
     // before the add rather than racing it; everything else waits for the age gate and
@@ -1259,7 +1259,7 @@ pub(crate) async fn update_branch_from(
     // Minted under the app-data worktrees root, never the OS temp dir: that
     // placement is what hides the checkout from the user-facing worktree listing
     // and the surfaces built on it (`is_session_worktree`'s app-data arm).
-    let tmp = update_worktree_path(repo_path)?;
+    let tmp = update_worktree_path(repo_path).await?;
     if let Some(root) = tmp.parent() {
         std::fs::create_dir_all(root).map_err(AppError::Io)?;
     }
@@ -1280,7 +1280,7 @@ pub(crate) async fn update_branch_from(
     .await
 }
 
-/// Where an update's throwaway checkout goes: `<app-data>/worktrees/<repo-hash>/
+/// Where an update's throwaway checkout goes: `<app-data>/worktrees/<identity-hash>/
 /// gd-update-<unique>`. Resolution only — creating the root is the caller's job.
 ///
 /// Through `update_marker::root_for`, not `ops::worktree_root_dir` directly, so the
@@ -1288,8 +1288,9 @@ pub(crate) async fn update_branch_from(
 /// Alone among that function's callers this one PROPAGATES an unresolvable root instead
 /// of failing open: a guard that cannot resolve simply stays quiet, but a mint that
 /// cannot would put a checkout where nothing is watching it.
-fn update_worktree_path(repo_path: &str) -> AppResult<std::path::PathBuf> {
-    Ok(crate::git::update_marker::root_for(repo_path)?
+async fn update_worktree_path(repo_path: &str) -> AppResult<std::path::PathBuf> {
+    Ok(crate::git::update_marker::root_for(repo_path)
+        .await?
         .join(format!("gd-update-{}", unique_suffix())))
 }
 
@@ -2708,15 +2709,18 @@ mod tests {
     /// the app-data one in production is `root_for`'s non-test arm, pinned by
     /// `ops::worktree_root_dir_uses_the_shipped_bundle_identifier`. Shape only: resolving
     /// a path creates nothing.
-    #[test]
-    fn update_worktree_path_sits_directly_under_the_marker_root() {
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn update_worktree_path_sits_directly_under_the_marker_root() {
         use crate::git::update_marker as marker;
         let (_temp, root) = temp_base("mint-root");
         let _serialized = marker::test_root_lock();
         let _override = marker::TestRootOverride::set(&root);
 
         let repo = "C:\\repos\\app";
-        let first = update_worktree_path(repo).expect("update path resolves");
+        let first = update_worktree_path(repo).await.expect("update path resolves");
         assert_eq!(first.parent(), Some(root.as_path()));
         let name = first
             .file_name()
@@ -2724,12 +2728,12 @@ mod tests {
             .expect("the mint has a basename");
         assert!(name.starts_with("gd-update-"), "{name}");
         assert!(
-            marker::is_managed_update_worktree(repo, &first.to_string_lossy()),
+            marker::is_managed_update_worktree(repo, &first.to_string_lossy()).await,
             "the mint must land inside the scope its own guards enforce"
         );
         assert_ne!(
             first,
-            update_worktree_path(repo).expect("update path resolves"),
+            update_worktree_path(repo).await.expect("update path resolves"),
             "two mints in one process must not collide"
         );
     }
@@ -3379,6 +3383,83 @@ mod tests {
             "git's own merge subject survives: {subject}"
         );
         assert!(!tmp.exists(), "the throwaway worktree is torn down");
+    }
+
+    /// The diverged arm end to end, from the public core: the merge lands on `feature`
+    /// while `main` stays checked out, and the update leaves nothing behind — no
+    /// checkout, no marker pair, no worktree registration. The regression net for the
+    /// whole marker path, every step of which resolves its root asynchronously.
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_diverged_update_leaves_no_trace_in_the_marker_root() {
+        use crate::git::update_marker as marker;
+        let (_guard, repo, repo_s, main) = diverged_repo("update-e2e").await;
+        let root = repo
+            .parent()
+            .expect("the repo lives under the temp base")
+            .join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let _serialized = marker::test_root_lock();
+        let _override = marker::TestRootOverride::set(&root);
+        // A branch name no other test uses: the override root is process-wide, and this
+        // test holds a LIVE marker for the length of a real merge, which would refuse a
+        // parallel test's guard on a shared name.
+        run(&repo_s, &["branch", "-m", "feature", "update-e2e"]).await;
+
+        let feature_tip = run(&repo_s, &["rev-parse", "refs/heads/update-e2e"])
+            .await
+            .trim()
+            .to_string();
+        let base_tip = run(&repo_s, &["rev-parse", &format!("{main}^{{commit}}")])
+            .await
+            .trim()
+            .to_string();
+        assert_eq!(
+            run(&repo_s, &["rev-parse", "--abbrev-ref", "HEAD"])
+                .await
+                .trim(),
+            main,
+            "the fixture must update a branch that is NOT the current one"
+        );
+
+        let state = AppState::default();
+        let outcome = update_branch_from(&state, &repo_s, "update-e2e", &main)
+            .await
+            .expect("a diverged update merges");
+        assert_eq!(outcome, "merge");
+
+        // A merge commit carrying exactly the two tips the update pinned.
+        let merged = run(
+            &repo_s,
+            &["rev-list", "--parents", "-n", "1", "refs/heads/update-e2e"],
+        )
+        .await;
+        let parents: Vec<&str> = merged.split_whitespace().skip(1).collect();
+        assert_eq!(
+            parents,
+            vec![feature_tip.as_str(), base_tip.as_str()],
+            "the updated branch merges its old tip and base, in that order: {merged}"
+        );
+
+        let leftovers: Vec<String> = std::fs::read_dir(&root)
+            .expect("the marker root is readable")
+            .flatten()
+            .filter_map(|e| e.file_name().to_str().map(str::to_string))
+            .filter(|name| name.starts_with("gd-update-"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no checkout and no marker pair survive the update: {leftovers:?}"
+        );
+        assert!(
+            !run(&repo_s, &["worktree", "list", "--porcelain"])
+                .await
+                .contains("gd-update-"),
+            "and git holds no registration for it either"
+        );
     }
 
     /// A repo with `feature` tracking the default branch through the local `.` remote,

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -1,12 +1,15 @@
 use serde::Serialize;
+use tauri::State;
 
 use crate::error::{AppError, AppResult};
 use crate::git::diff::{parse_numstat_z, truncate_at_char_boundary};
 use crate::git::history::{parse_commit_log, LOG_FORMAT};
 use crate::git::runner::{
-    run_git, run_git_raw, DEFAULT_TIMEOUT, NETWORK_TIMEOUT, WORKTREE_OP_TIMEOUT,
+    run_git, run_git_raw, try_acquire_repo_lock, DEFAULT_TIMEOUT, NETWORK_TIMEOUT,
+    WORKTREE_OP_TIMEOUT,
 };
 use crate::git::types::{CommitSummary, DiffStatEntry, FileDiff, StagedDiff};
+use crate::state::AppState;
 
 /// Commits that distinguish two branches, from the current branch's point of
 /// view: `ahead` are on `compare` but not `base`, `behind` are on `base` but
@@ -340,14 +343,311 @@ pub async fn git_branch_tips(
     Ok(map)
 }
 
-/// Creates a throwaway DETACHED worktree pinned at `sha`, so a repo-aware CLI
-/// review can read the PR head's files without moving the user's active branch.
-/// Returns `None` when a worktree isn't needed or possible — the repo is already
-/// on that commit (its own working tree matches), the object isn't local (an
-/// un-fetched remote PR), or the checkout fails — so the caller falls back to the
-/// repo root. Best-effort: never the source of a review failure.
+/// Basename of the single review worktree each repo reuses across reviews.
+const PERSISTENT_REVIEW_DIR: &str = "gd-review-persistent";
+
+/// In-process test override for the persistent review worktree's PARENT dir,
+/// consulted by [`persistent_review_path`] before the real app-data resolution
+/// (mirrors [`crate::git::update_marker`]'s; never process env, which races
+/// parallel tests' env reads).
+#[cfg(test)]
+static TEST_ROOT_DIR: std::sync::Mutex<Option<std::path::PathBuf>> = std::sync::Mutex::new(None);
+
+/// Serializes the tests that install [`TEST_ROOT_DIR`], since the override is
+/// process-wide. Test-only.
+#[cfg(test)]
+static TEST_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Installs (or clears) the in-process override, returning the previous value so a
+/// caller can restore it. Test-only.
+#[cfg(test)]
+fn swap_test_root_dir(dir: Option<std::path::PathBuf>) -> Option<std::path::PathBuf> {
+    let mut slot = TEST_ROOT_DIR
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::replace(&mut *slot, dir)
+}
+
+/// Takes the serializing guard for the process-wide root override. Test-only.
+#[cfg(test)]
+fn test_root_lock() -> std::sync::MutexGuard<'static, ()> {
+    TEST_ROOT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Points the persistent review root at `dir` for as long as it is held, restoring
+/// the prior override on drop — panics included, so a failing test cannot leave one
+/// standing for whichever test is next through the lock. Test-only.
+#[cfg(test)]
+struct TestRootOverride(Option<std::path::PathBuf>);
+
+#[cfg(test)]
+impl TestRootOverride {
+    fn set(dir: &std::path::Path) -> Self {
+        Self(swap_test_root_dir(Some(dir.to_path_buf())))
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestRootOverride {
+    fn drop(&mut self) {
+        swap_test_root_dir(self.0.take());
+    }
+}
+
+/// This repo's reused review worktree, or `None` when no root resolves — in which
+/// case the caller mints an ephemeral one rather than failing a review.
+///
+/// Keyed by repo IDENTITY (the common git dir), so every checkout of a repository —
+/// the main one and each linked worktree — shares a single warm review copy instead
+/// of minting one apiece.
+///
+/// The app-data worktrees root is the required placement: `is_session_worktree`'s
+/// app-data arm hides the checkout from every user-facing worktree surface, the
+/// OS-temp husk sweeper never scans app data, and [`is_review_worktree_temp_path`]
+/// still refuses it — so `git_remove_worktree`'s `remove_dir_all` fallback can
+/// never reach it either.
+///
+/// Under `cfg(test)` an installed override is the ONLY resolution: with none, this
+/// answers `None` so a test neither reads nor writes the developer's real app data.
+async fn persistent_review_path(repo_path: &str) -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    {
+        let _ = repo_path;
+        TEST_ROOT_DIR
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .map(|root| root.join(PERSISTENT_REVIEW_DIR))
+    }
+    #[cfg(not(test))]
+    {
+        let identity = crate::git::repo::repo_identity(repo_path).await;
+        crate::git::ops::identity_worktree_root_dir(&identity)
+            .ok()
+            .map(|root| root.join(PERSISTENT_REVIEW_DIR))
+    }
+}
+
+/// The sidecar whose OS lock claims the review worktree at `dir`, named for it and
+/// placed BESIDE it — inside the directory it would be destroyed by the demolish
+/// that precedes a rebuild, and the claim has to outlive that.
+fn persistent_review_lock_path(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let name = dir.file_name()?.to_str()?;
+    Some(dir.with_file_name(format!("{name}.lock")))
+}
+
+/// The persistent review worktrees THIS process holds, keyed by normalized path with
+/// the locked sidecar handle as the value — the map owns the handles, the OS lock
+/// does the excluding. A dev build beside a release build resolves the same app-data
+/// path, so the claim has to be visible across processes; on a crash the OS drops the
+/// lock, which is what makes a leaked claim self-healing.
+static REVIEW_WORKTREE_CLAIMS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::fs::File>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Claims the persistent worktree at `dir` for one review. `false` when another
+/// review holds it — in this process or another — or when the sidecar is unusable,
+/// in which case the caller mints an ephemeral worktree instead.
+fn try_claim_review_worktree(dir: &std::path::Path) -> bool {
+    let Some(lock_path) = persistent_review_lock_path(dir) else {
+        return false;
+    };
+    let Some(parent) = lock_path.parent() else {
+        return false;
+    };
+    let key = crate::git::worktree::normalize_wt_path(&dir.to_string_lossy());
+    let mut claims = REVIEW_WORKTREE_CLAIMS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if claims.contains_key(&key) {
+        return false;
+    }
+    if std::fs::create_dir_all(parent).is_err() {
+        return false;
+    }
+    // `create`, never `create_new`: the sidecar outlives every claim, so a leftover
+    // from an earlier review has to be re-lockable rather than fatal. No truncate —
+    // the file's CONTENT is nothing; its lock is the whole signal.
+    let Ok(file) = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+    else {
+        return false;
+    };
+    if file.try_lock().is_err() {
+        return false;
+    }
+    claims.insert(key, file);
+    true
+}
+
+/// Drops this process's claim on `path`, releasing the OS lock. `true` when a claim
+/// was actually held — the authoritative answer for a release, since it needs no
+/// path resolution to succeed.
+fn release_review_worktree(path: &str) -> bool {
+    let key = crate::git::worktree::normalize_wt_path(path);
+    REVIEW_WORKTREE_CLAIMS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&key)
+        .is_some()
+}
+
+/// Whether `path` is exactly this repo's persistent review worktree. Normalized on
+/// both sides: git prints forward slashes while the app carries native separators.
+async fn is_persistent_review_path(repo_path: &str, path: &str) -> bool {
+    let Some(persistent) = persistent_review_path(repo_path).await else {
+        return false;
+    };
+    crate::git::worktree::normalize_wt_path(&persistent.to_string_lossy())
+        == crate::git::worktree::normalize_wt_path(path)
+}
+
+/// Re-points an existing persistent review worktree at `sha`. `false` when it is
+/// absent, is no longer a worktree, or the checkout failed — the caller then
+/// rebuilds it.
+///
+/// The checkout runs UNCONDITIONALLY, even when HEAD already names `sha`: only a
+/// forcing checkout restores a tracked file a previous run left modified, and a
+/// review that reads content the PR does not contain is worse than a redundant
+/// near-free checkout. `checkout --detach`, never `reset --hard`: a reset would move
+/// a branch if HEAD ever ended up attached here, while a detaching checkout cannot
+/// move a ref.
+async fn reuse_persistent_review_worktree(path_str: &str, sha: &str) -> bool {
+    if !std::path::Path::new(path_str).exists() {
+        return false;
+    }
+    let git_dir = run_git_raw(Some(path_str), &["rev-parse", "--git-dir"], DEFAULT_TIMEOUT).await;
+    if !matches!(&git_dir, Ok(out) if out.code == 0) {
+        return false;
+    }
+    // Same budget as the `add` — a big tree is the same order of work.
+    let out = run_git_raw(
+        Some(path_str),
+        &["checkout", "--detach", "--force", sha],
+        NETWORK_TIMEOUT,
+    )
+    .await;
+    if !matches!(&out, Ok(out) if out.code == 0) {
+        return false;
+    }
+    // The forcing checkout restores tracked files; this clears the untracked ones a
+    // CLI agent may have strayed into the previous review's tree.
+    let _ = run_git_raw(Some(path_str), &["clean", "-fdx", "-q"], WORKTREE_OP_TIMEOUT).await;
+    true
+}
+
+/// Tears down an unusable persistent review worktree so a fresh `worktree add` can
+/// take its path. The unguarded delete is last and narrow — only a path that still
+/// exists AND is exactly this repo's persistent review dir.
+async fn demolish_persistent_review_worktree(repo_path: &str, path: &std::path::Path) {
+    let path_str = path.to_string_lossy().into_owned();
+    let _ = run_git_raw(
+        Some(repo_path),
+        &["worktree", "remove", "--force", &path_str],
+        WORKTREE_OP_TIMEOUT,
+    )
+    .await;
+    let _ = run_git_raw(Some(repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    if path.exists() && is_persistent_review_path(repo_path, &path_str).await {
+        let _ = std::fs::remove_dir_all(path);
+    }
+}
+
+/// Brings this repo's persistent review worktree to `sha`, rebuilding it when it is
+/// missing or unusable. `false` ⇒ the caller falls back to an ephemeral mint.
+///
+/// Only the rebuild takes the worktree-admin domain — `worktree add`/`remove`/`prune`
+/// write the shared registry a branch update also writes. The re-point above stays
+/// outside it: `checkout` in our own detached checkout is working-tree work on a tree
+/// nothing else owns. A busy domain answers `false` rather than queueing, so a review
+/// never waits behind a multi-minute removal.
+async fn prepare_persistent_review_worktree(
+    state: &AppState,
+    repo_path: &str,
+    path: &std::path::Path,
+    sha: &str,
+) -> bool {
+    let path_str = path.to_string_lossy().into_owned();
+    if reuse_persistent_review_worktree(&path_str, sha).await {
+        return true;
+    }
+    let domain = state.worktree_admin_lock(repo_path).await;
+    // Lock-free runners only from here down — the domain is not reentrant.
+    let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") else {
+        return false;
+    };
+    demolish_persistent_review_worktree(repo_path, path).await;
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return false;
+        }
+    }
+    matches!(
+        run_git_raw(
+            Some(repo_path),
+            &["worktree", "add", "--detach", &path_str, sha],
+            NETWORK_TIMEOUT,
+        )
+        .await,
+        Ok(out) if out.code == 0
+    )
+}
+
+/// A throwaway detached worktree in the OS temp dir, deleted whole by
+/// `git_remove_worktree`. The fallback whenever the persistent one is unavailable
+/// or already hosting a review.
+async fn ephemeral_review_worktree(repo_path: &str, sha: &str) -> AppResult<Option<String>> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let short = &sha[..sha.len().min(8)];
+    let path = std::env::temp_dir().join(format!("gd-review-{short}-{nanos}"));
+    let path_str = path.to_string_lossy().into_owned();
+    let out = run_git_raw(
+        Some(repo_path),
+        &["worktree", "add", "--detach", &path_str, sha],
+        NETWORK_TIMEOUT,
+    )
+    .await?;
+    if out.code != 0 {
+        return Ok(None);
+    }
+    Ok(Some(path_str))
+}
+
+/// Hands a repo-aware CLI review a DETACHED checkout of `sha`, so it reads the PR
+/// head's files without moving the user's active branch. One worktree per repository
+/// — shared by all its checkouts — is reused across reviews: a later run re-points it
+/// with `checkout --detach --force`, which rewrites only the files that differ. A
+/// review that finds it claimed gets a throwaway OS-temp mint instead. Returns `None`
+/// when a worktree isn't needed or possible — the repo is already on that commit (its
+/// own working tree matches), the object isn't local (an un-fetched remote PR), or
+/// both checkouts fail — so the caller falls back to the repo root. Best-effort:
+/// never the source of a review failure.
+///
+/// The claim taken here is released by `git_remove_worktree`, which the caller runs
+/// when the review settles.
 #[tauri::command]
-pub async fn git_review_worktree(repo_path: String, sha: String) -> AppResult<Option<String>> {
+pub async fn git_review_worktree(
+    state: State<'_, AppState>,
+    repo_path: String,
+    sha: String,
+) -> AppResult<Option<String>> {
+    git_review_worktree_core(state.inner(), repo_path, sha).await
+}
+
+/// [`git_review_worktree`] over a bare state, so tests drive it without a Tauri app.
+async fn git_review_worktree_core(
+    state: &AppState,
+    repo_path: String,
+    sha: String,
+) -> AppResult<Option<String>> {
     validate_ref(&sha)?;
     // Already on this commit → the repo's own working tree already matches.
     let head = run_git_raw(Some(&repo_path), &["rev-parse", "HEAD"], DEFAULT_TIMEOUT).await?;
@@ -362,23 +662,16 @@ pub async fn git_review_worktree(repo_path: String, sha: String) -> AppResult<Op
     if !present {
         return Ok(None);
     }
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let short = &sha[..sha.len().min(8)];
-    let path = std::env::temp_dir().join(format!("gd-review-{short}-{nanos}"));
-    let path_str = path.to_string_lossy().into_owned();
-    let out = run_git_raw(
-        Some(&repo_path),
-        &["worktree", "add", "--detach", &path_str, &sha],
-        NETWORK_TIMEOUT,
-    )
-    .await?;
-    if out.code != 0 {
-        return Ok(None);
+    if let Some(persistent) = persistent_review_path(&repo_path).await {
+        let path_str = persistent.to_string_lossy().into_owned();
+        if try_claim_review_worktree(&persistent) {
+            if prepare_persistent_review_worktree(state, &repo_path, &persistent, &sha).await {
+                return Ok(Some(path_str));
+            }
+            release_review_worktree(&path_str);
+        }
     }
-    Ok(Some(path_str))
+    ephemeral_review_worktree(&repo_path, &sha).await
 }
 
 /// Whether `path` is a `git_review_worktree`-shaped review temp dir: DIRECTLY under
@@ -406,17 +699,51 @@ fn is_review_worktree_temp_path(path: &std::path::Path) -> bool {
     name.to_ascii_lowercase().starts_with("gd-review-")
 }
 
-/// Removes a review worktree created by `git_review_worktree` and prunes stale
-/// administrative entries. Best-effort and idempotent.
+/// Releases the review workspace `git_review_worktree` handed out. The persistent
+/// per-repo worktree is only unclaimed — its checkout and registration stay in place
+/// for the next review to re-point — while an ephemeral mint is removed and its
+/// administrative entry pruned. Best-effort and idempotent.
 #[tauri::command]
-pub async fn git_remove_worktree(repo_path: String, worktree_path: String) -> AppResult<()> {
-    let _ = run_git_raw(
-        Some(&repo_path),
+pub async fn git_remove_worktree(
+    state: State<'_, AppState>,
+    repo_path: String,
+    worktree_path: String,
+) -> AppResult<()> {
+    git_remove_worktree_core(state.inner(), repo_path, worktree_path).await
+}
+
+/// [`git_remove_worktree`] over a bare state, so tests drive it without a Tauri app.
+async fn git_remove_worktree_core(
+    state: &AppState,
+    repo_path: String,
+    worktree_path: String,
+) -> AppResult<()> {
+    // A held claim is the authoritative answer: this process handed the path out, so
+    // releasing it needs no path resolution that a git failure could spoil.
+    if release_review_worktree(&worktree_path) {
+        return Ok(());
+    }
+    // Unclaimed but still ours — a claim lost to a restart. Keep the checkout anyway;
+    // the next review re-points it.
+    if is_persistent_review_path(&repo_path, &worktree_path).await {
+        return Ok(());
+    }
+    // Admin work on the shared registry: serialized against a branch update's own
+    // add/remove, with the same bounded wait every other worktree command takes.
+    let _ = crate::git::runner::run_git_worktree_admin(
+        state,
+        &repo_path,
         &["worktree", "remove", "--force", &worktree_path],
         WORKTREE_OP_TIMEOUT,
     )
     .await;
-    let _ = run_git_raw(Some(&repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
+    let _ = crate::git::runner::run_git_worktree_admin(
+        state,
+        &repo_path,
+        &["worktree", "prune"],
+        DEFAULT_TIMEOUT,
+    )
+    .await;
     // `git worktree remove` deletes the directory itself, but on Windows that
     // recursive delete can lose a handle race (antivirus/indexer still holding the
     // dir) and leave an EMPTY husk behind — and every result above is discarded, so
@@ -468,6 +795,89 @@ fn sweep_review_husks_in(dir: &std::path::Path) -> std::io::Result<usize> {
         // NEVER remove_dir_all here: `remove_dir` refuses a non-empty dir, which is
         // exactly the guard that keeps a live review's populated worktree safe.
         if std::fs::remove_dir(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+/// How long a persistent review worktree may sit untouched before the startup sweep
+/// reclaims its disk. Generous on purpose: a repo reviewed weekly keeps its warm
+/// checkout, and the cost of being wrong is one slow review, not lost work.
+const PERSISTENT_REVIEW_MAX_IDLE_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+
+/// Reclaim persistent review worktrees that no review has touched in a week — the
+/// only lifecycle they have, since nothing prunes them per repo (one bounded
+/// directory per repository, recreated on demand). Best-effort, fire-and-forget on
+/// startup.
+pub(crate) fn sweep_stale_persistent_review_worktrees() {
+    let Some(data) = dirs::data_dir() else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    // An unreadable clock authorizes no deletion at all.
+    let Ok(now_ms) = i64::try_from(now) else {
+        return;
+    };
+    let roots = data
+        .join(crate::local_prs::APP_IDENTIFIER)
+        .join("worktrees");
+    let _ = sweep_stale_persistent_reviews_in(&roots, now_ms);
+}
+
+/// Whether the sidecar at `lock_path` shows NO live claim. SHARED like
+/// `update_marker::probe_lock`, so two concurrent probes never read each other as a
+/// holder. Every doubt — an unreadable file, a lock error — answers `false`: this
+/// verdict authorizes a delete, so it fails toward leaving bytes on disk.
+fn persistent_review_lock_is_free(lock_path: &std::path::Path) -> bool {
+    match std::fs::File::open(lock_path) {
+        // The probe's own shared hold is released when `file` closes at end of scope,
+        // which also has to happen before any caller unlinks it on Windows.
+        Ok(file) => matches!(file.try_lock_shared(), Ok(())),
+        // No sidecar at all: nothing can be holding a claim.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
+}
+
+/// The testable core of [`sweep_stale_persistent_review_worktrees`], over an explicit
+/// worktrees root so a test never scans real app data. Only `<hash>/gd-review-persistent`
+/// is ever considered — the exact basename, one level down — and only when its git
+/// activity is older than [`PERSISTENT_REVIEW_MAX_IDLE_MS`] AND its sidecar carries no
+/// live claim. An unreadable age proves nothing and skips.
+///
+/// No git runs here: the source repo's stale registration is cleaned by its own
+/// `prune_worktrees_if_free`, the same division every other app-data checkout uses.
+/// Returns how many were reclaimed.
+fn sweep_stale_persistent_reviews_in(
+    worktrees_root: &std::path::Path,
+    now_ms: i64,
+) -> std::io::Result<usize> {
+    let mut removed = 0;
+    // "Can't list it" ⇒ skip the whole sweep conservatively.
+    for entry in std::fs::read_dir(worktrees_root)?.flatten() {
+        let dir = entry.path().join(PERSISTENT_REVIEW_DIR);
+        if !dir.is_dir() {
+            continue;
+        }
+        let Some(last_ms) = crate::git::worktree::worktree_last_activity_ms(&dir.to_string_lossy())
+        else {
+            continue;
+        };
+        if now_ms.saturating_sub(last_ms) < PERSISTENT_REVIEW_MAX_IDLE_MS {
+            continue;
+        }
+        let Some(lock_path) = persistent_review_lock_path(&dir) else {
+            continue;
+        };
+        if !persistent_review_lock_is_free(&lock_path) {
+            continue;
+        }
+        if std::fs::remove_dir_all(&dir).is_ok() {
+            let _ = std::fs::remove_file(&lock_path);
             removed += 1;
         }
     }
@@ -1131,6 +1541,13 @@ mod tests {
         let live = base.join("gd-review-def456-7");
         std::fs::create_dir(&live).unwrap();
         std::fs::write(live.join("file.txt"), b"content").unwrap();
+        // The reused per-repo review worktree matches the `gd-review-` prefix too, so
+        // the NAME filter does NOT spare it — being non-empty does, exactly as for any
+        // live review. (In production it is unreachable anyway: this sweep only ever
+        // scans the OS temp dir, and that worktree lives under app data.)
+        let persistent = base.join(super::PERSISTENT_REVIEW_DIR);
+        std::fs::create_dir(&persistent).unwrap();
+        std::fs::write(persistent.join("file.txt"), b"content").unwrap();
         // A non-matching empty dir → kept (name filter).
         let other = base.join("gd-resolve-xyz-1");
         std::fs::create_dir(&other).unwrap();
@@ -1139,7 +1556,395 @@ mod tests {
         assert_eq!(removed, 1, "exactly the one empty gd-review-* husk is removed");
         assert!(!empty_husk.exists(), "empty gd-review-* husk was removed");
         assert!(live.exists(), "non-empty gd-review-* (live review) is kept");
+        assert!(persistent.exists(), "the reused review worktree is kept");
         assert!(other.exists(), "non-matching name is kept");
+    }
+
+    /// Seeds a repo whose HEAD is on NEITHER review target — a commit on the default
+    /// branch, two more on a side branch, then back to the default — so
+    /// `git_review_worktree`'s "already on this commit" short-circuit never fires.
+    /// Returns `(guard, repo, sha1, sha2)`.
+    async fn seed_review_repo(tag: &str) -> (tempfile::TempDir, String, String, String) {
+        let (base, repo) = seed_repo(tag).await;
+        let root = std::path::Path::new(&repo).to_path_buf();
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        // `git init` picks the default branch name from the host's config.
+        let default_branch = run(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo, &["checkout", "-qb", "feature"]).await;
+        std::fs::write(root.join("one.txt"), "one\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "one"]).await;
+        let sha1 = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        std::fs::write(root.join("two.txt"), "two\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "two"]).await;
+        let sha2 = run(&repo, &["rev-parse", "HEAD"]).await.trim().to_string();
+
+        run(&repo, &["checkout", "-q", &default_branch]).await;
+        (base, repo, sha1, sha2)
+    }
+
+    /// Backdates a worktree's recorded git activity. `worktree_last_activity_ms` reads
+    /// its admin `index` and falls back to `HEAD`, so both move.
+    async fn age_worktree(worktree: &str, when: std::time::SystemTime) {
+        let admin = run(worktree, &["rev-parse", "--absolute-git-dir"]).await;
+        let admin = std::path::PathBuf::from(admin.trim());
+        for name in ["index", "HEAD"] {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(admin.join(name))
+                .expect("the worktree's admin file is writable")
+                .set_modified(when)
+                .expect("the mtime is settable");
+        }
+    }
+
+    /// Whether `path` is currently registered as a worktree of `repo`.
+    async fn is_registered_worktree(repo: &str, path: &str) -> bool {
+        let listed = run(repo, &["worktree", "list", "--porcelain"]).await;
+        let wanted = crate::git::worktree::normalize_wt_path(path);
+        listed
+            .lines()
+            .filter_map(|l| l.strip_prefix("worktree "))
+            .any(|p| crate::git::worktree::normalize_wt_path(p.trim()) == wanted)
+    }
+
+    /// The review workspace is ONE persistent per-repo checkout: a second review at a
+    /// DIFFERENT sha gets the same path re-pointed in place, with no add and no
+    /// removal in between. (Before reuse, every call minted a fresh nanos path.)
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn review_worktree_reuses_one_persistent_checkout() {
+        let (base, repo, sha1, sha2) = seed_review_repo("review-reuse").await;
+        let root = base.path().join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        let first = git_review_worktree_core(&state, repo.clone(), sha1.clone())
+            .await
+            .unwrap()
+            .expect("a repo checked out elsewhere gets a review worktree");
+        assert_eq!(
+            std::path::Path::new(&first),
+            root.join(PERSISTENT_REVIEW_DIR),
+            "the review worktree is the per-repo persistent one"
+        );
+        assert_eq!(run(&first, &["rev-parse", "HEAD"]).await.trim(), sha1);
+        assert_eq!(
+            run(&first, &["rev-parse", "--abbrev-ref", "HEAD"]).await.trim(),
+            "HEAD",
+            "the review checkout is detached"
+        );
+        assert!(is_registered_worktree(&repo, &first).await);
+
+        // Settling the review releases the claim without touching the checkout.
+        git_remove_worktree_core(&state, repo.clone(), first.clone())
+            .await
+            .unwrap();
+        assert!(std::path::Path::new(&first).exists());
+
+        let second = git_review_worktree_core(&state, repo.clone(), sha2.clone())
+            .await
+            .unwrap()
+            .expect("the released worktree is handed out again");
+        assert_eq!(second, first, "the same path, re-pointed rather than re-minted");
+        assert_eq!(run(&second, &["rev-parse", "HEAD"]).await.trim(), sha2);
+        assert!(is_registered_worktree(&repo, &second).await);
+        git_remove_worktree_core(&state, repo, second).await.unwrap();
+    }
+
+    /// A re-review of the SAME sha re-checks the tree out rather than trusting it: a
+    /// tracked file a previous run left modified is restored, so a review can never
+    /// read content the PR does not contain. The untracked stray beside it is cleaned.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn re_reviewing_the_same_sha_restores_the_prs_content() {
+        let (base, repo, _sha1, sha2) = seed_review_repo("review-samesha").await;
+        let root = base.path().join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        let first = git_review_worktree_core(&state, repo.clone(), sha2.clone())
+            .await
+            .unwrap()
+            .expect("a review worktree is handed out");
+        let tracked = std::path::Path::new(&first).join("one.txt");
+        // EOL-normalized: `core.autocrlf` checks the file out CRLF on this host.
+        let content = |p: &std::path::Path| std::fs::read_to_string(p).unwrap().replace("\r\n", "\n");
+        assert_eq!(content(&tracked), "one\n");
+        git_remove_worktree_core(&state, repo.clone(), first.clone())
+            .await
+            .unwrap();
+
+        // What a strayed agent run leaves behind between reviews.
+        std::fs::write(&tracked, "tampered\n").unwrap();
+        let stray = std::path::Path::new(&first).join("stray.txt");
+        std::fs::write(&stray, "stray\n").unwrap();
+
+        let second = git_review_worktree_core(&state, repo.clone(), sha2.clone())
+            .await
+            .unwrap()
+            .expect("the same head reuses the worktree");
+        assert_eq!(second, first, "still the same reused path");
+        assert_eq!(
+            content(&tracked),
+            "one\n",
+            "the modified TRACKED file is restored to the PR's content"
+        );
+        assert!(!stray.exists(), "the untracked stray is cleaned");
+        git_remove_worktree_core(&state, repo, second).await.unwrap();
+    }
+
+    /// Releasing the persistent worktree leaves the checkout AND its registration on
+    /// disk — the whole point of reusing it.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn removing_the_persistent_review_worktree_only_releases_it() {
+        let (base, repo, sha1, _sha2) = seed_review_repo("review-release").await;
+        let root = base.path().join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        let path = git_review_worktree_core(&state, repo.clone(), sha1)
+            .await
+            .unwrap()
+            .expect("a review worktree is handed out");
+        git_remove_worktree_core(&state, repo.clone(), path.clone())
+            .await
+            .unwrap();
+
+        assert!(std::path::Path::new(&path).exists(), "the directory survives");
+        let git_dir = run_git_raw(Some(&path), &["rev-parse", "--git-dir"], DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+        assert_eq!(git_dir.code, 0, "it is still a worktree: {}", git_dir.stderr);
+        assert!(
+            is_registered_worktree(&repo, &path).await,
+            "its administrative entry is left intact"
+        );
+    }
+
+    /// While one review holds the persistent worktree, a concurrent review gets a
+    /// throwaway OS-temp mint — which `git_remove_worktree` still deletes whole.
+    /// Once the first review settles, the persistent worktree is handed out again.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn review_worktree_falls_back_to_a_temp_mint_while_busy() {
+        let (base, repo, sha1, sha2) = seed_review_repo("review-busy").await;
+        let root = base.path().join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        // Acquired and deliberately never released — a review is running in it.
+        let held = git_review_worktree_core(&state, repo.clone(), sha1)
+            .await
+            .unwrap()
+            .expect("the first review takes the persistent worktree");
+
+        let fallback = git_review_worktree_core(&state, repo.clone(), sha2.clone())
+            .await
+            .unwrap()
+            .expect("a busy persistent worktree falls back to a mint");
+        assert_ne!(fallback, held, "the two reviews get different workspaces");
+        assert!(
+            is_review_worktree_temp_path(std::path::Path::new(&fallback)),
+            "the fallback is a gd-review-* mint in the OS temp dir: {fallback}"
+        );
+        assert_eq!(run(&fallback, &["rev-parse", "HEAD"]).await.trim(), sha2);
+
+        git_remove_worktree_core(&state, repo.clone(), fallback.clone())
+            .await
+            .unwrap();
+        assert!(
+            !std::path::Path::new(&fallback).exists(),
+            "the ephemeral mint is still deleted whole"
+        );
+
+        git_remove_worktree_core(&state, repo.clone(), held.clone())
+            .await
+            .unwrap();
+        let again = git_review_worktree_core(&state, repo.clone(), sha2)
+            .await
+            .unwrap()
+            .expect("the released worktree is available again");
+        assert_eq!(again, held, "the freed persistent worktree is reused");
+        git_remove_worktree_core(&state, repo, again).await.unwrap();
+    }
+
+    /// The claim is keyed on the exact path, so the release arms can't reach past
+    /// their own worktree: a same-BASENAME checkout under another parent still takes
+    /// the real removal path, and another root's persistent path never frees this
+    /// one's claim.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn review_worktree_release_is_scoped_to_its_own_path() {
+        let (base, repo, sha1, sha2) = seed_review_repo("review-scope").await;
+        let root = base.path().join("worktrees");
+        std::fs::create_dir_all(&root).unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        let held = git_review_worktree_core(&state, repo.clone(), sha1.clone())
+            .await
+            .unwrap()
+            .expect("the review takes the persistent worktree");
+
+        // (a) Same basename, DIFFERENT parent — not this repo's persistent worktree,
+        // so the removal runs and the checkout is gone.
+        let elsewhere = base.path().join("elsewhere").join(PERSISTENT_REVIEW_DIR);
+        std::fs::create_dir_all(elsewhere.parent().unwrap()).unwrap();
+        let elsewhere_s = elsewhere.to_string_lossy().into_owned();
+        run(&repo, &["worktree", "add", "--detach", &elsewhere_s, &sha2]).await;
+        assert!(elsewhere.exists(), "the decoy worktree was created");
+        git_remove_worktree_core(&state, repo.clone(), elsewhere_s)
+            .await
+            .unwrap();
+        assert!(
+            !elsewhere.exists(),
+            "a same-named checkout elsewhere still takes the removal path"
+        );
+
+        // (b) Another root's persistent path — the release-and-keep arm answers it,
+        // but it must not free THIS root's claim.
+        {
+            let other_root = base.path().join("worktrees-other");
+            let _other = TestRootOverride::set(&other_root);
+            let other_path = other_root.join(PERSISTENT_REVIEW_DIR);
+            git_remove_worktree_core(
+                &state,
+                repo.clone(),
+                other_path.to_string_lossy().into_owned(),
+            )
+            .await
+            .unwrap();
+        }
+        let still_busy = git_review_worktree_core(&state, repo.clone(), sha2.clone())
+            .await
+            .unwrap()
+            .expect("a review still gets a workspace");
+        assert_ne!(
+            still_busy, held,
+            "the claim survived another root's release, so this review is a mint"
+        );
+        git_remove_worktree_core(&state, repo.clone(), still_busy)
+            .await
+            .unwrap();
+
+        git_remove_worktree_core(&state, repo.clone(), held.clone())
+            .await
+            .unwrap();
+        let reused = git_review_worktree_core(&state, repo.clone(), sha2)
+            .await
+            .unwrap()
+            .expect("its own release frees it");
+        assert_eq!(reused, held);
+        git_remove_worktree_core(&state, repo, reused).await.unwrap();
+    }
+
+    /// With no root override installed, `cfg(test)` resolves NO persistent path, so a
+    /// test can never read or write real app data — the review falls open to an
+    /// ephemeral OS-temp mint rather than erroring.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn review_worktree_without_a_root_override_mints_in_temp() {
+        let (_base, repo, sha1, _sha2) = seed_review_repo("review-noroot").await;
+        let _serialized = test_root_lock();
+        let state = AppState::default();
+
+        let path = git_review_worktree_core(&state, repo.clone(), sha1.clone())
+            .await
+            .unwrap()
+            .expect("a review still gets a workspace with no root resolved");
+        assert!(
+            is_review_worktree_temp_path(std::path::Path::new(&path)),
+            "no override ⇒ the OS-temp mint: {path}"
+        );
+        assert_eq!(run(&path, &["rev-parse", "HEAD"]).await.trim(), sha1);
+
+        git_remove_worktree_core(&state, repo, path.clone())
+            .await
+            .unwrap();
+        assert!(!std::path::Path::new(&path).exists());
+    }
+
+    /// The idle sweep reclaims only what it can prove is idle AND unclaimed: a
+    /// week-old unclaimed checkout goes (sidecar included), while a fresh one, a
+    /// week-old one a live review still holds, and anything not named
+    /// `gd-review-persistent` all survive.
+    #[tokio::test]
+    async fn stale_review_worktree_sweep_is_age_and_claim_gated() {
+        let (base, repo, sha1, _sha2) = seed_review_repo("review-sweep").await;
+        let scan = base.path().join("scan");
+
+        // Four checkouts under their own hash dirs, as the real root holds them.
+        let mut made = Vec::new();
+        for (hash, name) in [
+            ("aged", PERSISTENT_REVIEW_DIR),
+            ("fresh", PERSISTENT_REVIEW_DIR),
+            ("locked", PERSISTENT_REVIEW_DIR),
+            ("other", "gd-review-something-else"),
+        ] {
+            let dir = scan.join(hash).join(name);
+            std::fs::create_dir_all(dir.parent().unwrap()).unwrap();
+            let dir_s = dir.to_string_lossy().into_owned();
+            run(&repo, &["worktree", "add", "--detach", &dir_s, &sha1]).await;
+            assert!(dir.exists(), "fixture worktree {hash} was created");
+            made.push(dir);
+        }
+        let (aged, fresh, locked, other) = (&made[0], &made[1], &made[2], &made[3]);
+
+        // Age three of them by eight days; `fresh` keeps its real mtime.
+        let eight_days_ago = std::time::SystemTime::now() - std::time::Duration::from_secs(8 * 86_400);
+        for dir in [aged, locked, other] {
+            age_worktree(&dir.to_string_lossy(), eight_days_ago).await;
+        }
+
+        // A live review holds `locked`'s sidecar for the whole sweep.
+        let locked_sidecar = persistent_review_lock_path(locked).unwrap();
+        let claim = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&locked_sidecar)
+            .unwrap();
+        claim.try_lock().expect("the fixture takes the claim");
+        // The aged one gets an UNCLAIMED sidecar, which the sweep must delete with it.
+        let aged_sidecar = persistent_review_lock_path(aged).unwrap();
+        std::fs::write(&aged_sidecar, b"").unwrap();
+
+        let now_ms = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        let removed = sweep_stale_persistent_reviews_in(&scan, now_ms).unwrap();
+
+        assert_eq!(removed, 1, "exactly the idle, unclaimed checkout is reclaimed");
+        assert!(!aged.exists(), "a week-idle unclaimed review worktree is reclaimed");
+        assert!(!aged_sidecar.exists(), "its sidecar goes with it");
+        assert!(fresh.exists(), "a recently used review worktree is kept");
+        assert!(locked.exists(), "a live claim outranks age");
+        assert!(other.exists(), "only the exact `gd-review-persistent` name is swept");
+        drop(claim);
     }
 
     /// The `remove_dir_all` fallback guard admits only `gd-review-*` dirs directly

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -730,7 +730,7 @@ async fn git_remove_worktree_core(
     }
     // Admin work on the shared registry: serialized against a branch update's own
     // add/remove, with the same bounded wait every other worktree command takes.
-    let _ = crate::git::runner::run_git_worktree_admin(
+    let removal = crate::git::runner::run_git_worktree_admin(
         state,
         &repo_path,
         &["worktree", "remove", "--force", &worktree_path],
@@ -744,9 +744,15 @@ async fn git_remove_worktree_core(
         DEFAULT_TIMEOUT,
     )
     .await;
+    // A `Busy` removal never reached git, so the registration still stands — deleting
+    // the directory underneath it would mint a prunable entry. Leave both halves for a
+    // later teardown or the husk sweep.
+    if matches!(removal, Err(AppError::Busy { .. })) {
+        return Ok(());
+    }
     // `git worktree remove` deletes the directory itself, but on Windows that
     // recursive delete can lose a handle race (antivirus/indexer still holding the
-    // dir) and leave an EMPTY husk behind — and every result above is discarded, so
+    // dir) and leave an EMPTY husk behind — and the results above are discarded, so
     // it would leak in %TEMP% forever. Finish the delete ourselves, best-effort with
     // a short backoff, GUARDED to the `gd-review-*` temp shape: an unguarded
     // `remove_dir_all` would turn this command into an arbitrary recursive-delete
@@ -843,11 +849,29 @@ fn persistent_review_lock_is_free(lock_path: &std::path::Path) -> bool {
     }
 }
 
+/// A file's mtime as epoch ms, or `None` when it is unreadable.
+fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
+    let ms = std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    i64::try_from(ms).ok()
+}
+
 /// The testable core of [`sweep_stale_persistent_review_worktrees`], over an explicit
 /// worktrees root so a test never scans real app data. Only `<hash>/gd-review-persistent`
 /// is ever considered — the exact basename, one level down — and only when its git
 /// activity is older than [`PERSISTENT_REVIEW_MAX_IDLE_MS`] AND its sidecar carries no
-/// live claim. An unreadable age proves nothing and skips.
+/// live claim.
+///
+/// Age comes from git activity, falling back to the `.git` pointer file's own mtime:
+/// a checkout whose SOURCE REPO was deleted has an unresolvable admin dir, so without
+/// that fallback its activity reads unknown forever and it could never age out. A live
+/// workspace answers from index/HEAD first, and a mid-review checkout is spared by its
+/// claim regardless.
 ///
 /// No git runs here: the source repo's stale registration is cleaned by its own
 /// `prune_worktrees_if_free`, the same division every other app-data checkout uses.
@@ -864,6 +888,7 @@ fn sweep_stale_persistent_reviews_in(
             continue;
         }
         let Some(last_ms) = crate::git::worktree::worktree_last_activity_ms(&dir.to_string_lossy())
+            .or_else(|| file_mtime_ms(&dir.join(".git")))
         else {
             continue;
         };
@@ -1607,14 +1632,20 @@ mod tests {
         }
     }
 
-    /// Whether `path` is currently registered as a worktree of `repo`.
+    /// Whether `path` is currently registered as a worktree of `repo`, compared in
+    /// BOTH spellings like `update_marker::is_managed_update_worktree_in`: porcelain
+    /// prints RESOLVED paths, so an app-built path never matches on its own where the
+    /// temp root is a symlink (macOS `/var` → `/private/var`) or carries an 8.3 short
+    /// component. The normalized form is the fallback for a path git can't resolve.
     async fn is_registered_worktree(repo: &str, path: &str) -> bool {
+        use crate::git::worktree::{canonical_wt_path, normalize_wt_path};
         let listed = run(repo, &["worktree", "list", "--porcelain"]).await;
-        let wanted = crate::git::worktree::normalize_wt_path(path);
+        let (want_canon, want_norm) = (canonical_wt_path(path), normalize_wt_path(path));
         listed
             .lines()
             .filter_map(|l| l.strip_prefix("worktree "))
-            .any(|p| crate::git::worktree::normalize_wt_path(p.trim()) == wanted)
+            .map(str::trim)
+            .any(|p| canonical_wt_path(p) == want_canon || normalize_wt_path(p) == want_norm)
     }
 
     /// The review workspace is ONE persistent per-repo checkout: a second review at a
@@ -1858,6 +1889,37 @@ mod tests {
         git_remove_worktree_core(&state, repo, reused).await.unwrap();
     }
 
+    /// A persistent path that EXISTS but is not a worktree — a plain directory a
+    /// crash or a half-finished `worktree add` left behind — is torn down and rebuilt
+    /// in place. This is the only route through the demolish arm's `remove_dir_all`.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn a_non_worktree_at_the_persistent_path_is_rebuilt() {
+        let (base, repo, sha1, _sha2) = seed_review_repo("review-rebuild").await;
+        let root = base.path().join("worktrees");
+        let planted = root.join(PERSISTENT_REVIEW_DIR);
+        std::fs::create_dir_all(&planted).unwrap();
+        let debris = planted.join("debris.txt");
+        std::fs::write(&debris, b"not a worktree").unwrap();
+        let _serialized = test_root_lock();
+        let _override = TestRootOverride::set(&root);
+        let state = AppState::default();
+
+        let path = git_review_worktree_core(&state, repo.clone(), sha1.clone())
+            .await
+            .unwrap()
+            .expect("a wreck at the persistent path is rebuilt, not refused");
+        assert_eq!(
+            std::path::Path::new(&path),
+            planted,
+            "rebuilt in place rather than falling back to a mint"
+        );
+        assert_eq!(run(&path, &["rev-parse", "HEAD"]).await.trim(), sha1);
+        assert!(!debris.exists(), "the planted debris was cleared by the rebuild");
+        assert!(is_registered_worktree(&repo, &path).await);
+        git_remove_worktree_core(&state, repo, path).await.unwrap();
+    }
+
     /// With no root override installed, `cfg(test)` resolves NO persistent path, so a
     /// test can never read or write real app data — the review falls open to an
     /// ephemeral OS-temp mint rather than erroring.
@@ -1885,36 +1947,55 @@ mod tests {
     }
 
     /// The idle sweep reclaims only what it can prove is idle AND unclaimed: a
-    /// week-old unclaimed checkout goes (sidecar included), while a fresh one, a
-    /// week-old one a live review still holds, and anything not named
-    /// `gd-review-persistent` all survive.
+    /// week-old unclaimed checkout goes, sidecar included, and so does one whose
+    /// source repo was deleted (its age comes from the dangling `.git` pointer). A
+    /// fresh checkout, one a live review still holds, and a differently-named sibling
+    /// in the SAME hash dir all survive.
     #[tokio::test]
     async fn stale_review_worktree_sweep_is_age_and_claim_gated() {
         let (base, repo, sha1, _sha2) = seed_review_repo("review-sweep").await;
         let scan = base.path().join("scan");
 
-        // Four checkouts under their own hash dirs, as the real root holds them.
+        // Checkouts under their own hash dirs, as the real root holds them — plus a
+        // differently-named sibling INSIDE the aged one, which the sweep must leave
+        // standing while it reclaims its neighbour.
         let mut made = Vec::new();
         for (hash, name) in [
             ("aged", PERSISTENT_REVIEW_DIR),
             ("fresh", PERSISTENT_REVIEW_DIR),
             ("locked", PERSISTENT_REVIEW_DIR),
-            ("other", "gd-review-something-else"),
+            ("dangling", PERSISTENT_REVIEW_DIR),
+            ("aged", "gd-review-something-else"),
         ] {
             let dir = scan.join(hash).join(name);
             std::fs::create_dir_all(dir.parent().unwrap()).unwrap();
             let dir_s = dir.to_string_lossy().into_owned();
             run(&repo, &["worktree", "add", "--detach", &dir_s, &sha1]).await;
-            assert!(dir.exists(), "fixture worktree {hash} was created");
+            assert!(dir.exists(), "fixture worktree {hash}/{name} was created");
             made.push(dir);
         }
-        let (aged, fresh, locked, other) = (&made[0], &made[1], &made[2], &made[3]);
+        let (aged, fresh, locked, dangling, sibling) =
+            (&made[0], &made[1], &made[2], &made[3], &made[4]);
 
-        // Age three of them by eight days; `fresh` keeps its real mtime.
-        let eight_days_ago = std::time::SystemTime::now() - std::time::Duration::from_secs(8 * 86_400);
-        for dir in [aged, locked, other] {
+        // Age all but `fresh` by eight days.
+        let eight_days_ago =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(8 * 86_400);
+        for dir in [aged, locked, sibling] {
             age_worktree(&dir.to_string_lossy(), eight_days_ago).await;
         }
+        // `dangling` loses its source repo: the admin dir behind the pointer is gone,
+        // so only the pointer FILE's own mtime can age it.
+        std::fs::write(dangling.join(".git"), b"gitdir: /nonexistent/gd-gone\n").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(dangling.join(".git"))
+            .unwrap()
+            .set_modified(eight_days_ago)
+            .unwrap();
+        assert!(
+            crate::git::worktree::worktree_last_activity_ms(&dangling.to_string_lossy()).is_none(),
+            "the fixture's activity probe really is unreadable"
+        );
 
         // A live review holds `locked`'s sidecar for the whole sweep.
         let locked_sidecar = persistent_review_lock_path(locked).unwrap();
@@ -1938,12 +2019,19 @@ mod tests {
         .unwrap();
         let removed = sweep_stale_persistent_reviews_in(&scan, now_ms).unwrap();
 
-        assert_eq!(removed, 1, "exactly the idle, unclaimed checkout is reclaimed");
+        assert_eq!(removed, 2, "the idle unclaimed checkout and the dangling one");
         assert!(!aged.exists(), "a week-idle unclaimed review worktree is reclaimed");
         assert!(!aged_sidecar.exists(), "its sidecar goes with it");
+        assert!(
+            !dangling.exists(),
+            "a checkout whose source repo is gone still ages out"
+        );
         assert!(fresh.exists(), "a recently used review worktree is kept");
         assert!(locked.exists(), "a live claim outranks age");
-        assert!(other.exists(), "only the exact `gd-review-persistent` name is swept");
+        assert!(
+            sibling.exists(),
+            "only the exact `gd-review-persistent` name is swept, even beside one that is"
+        );
         drop(claim);
     }
 

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -508,8 +508,8 @@ async fn is_persistent_review_path(repo_path: &str, path: &str) -> bool {
 }
 
 /// Re-points an existing persistent review worktree at `sha`. `false` when it is
-/// absent, is no longer a worktree, or the checkout failed — the caller then
-/// rebuilds it.
+/// absent, is no longer a worktree, the forcing checkout failed, or the tree
+/// could not be cleaned — the caller then rebuilds it.
 ///
 /// The checkout runs UNCONDITIONALLY, even when HEAD already names `sha`: only a
 /// forcing checkout restores a tracked file a previous run left modified, and a
@@ -741,13 +741,17 @@ async fn git_remove_worktree_core(
         WORKTREE_OP_TIMEOUT,
     )
     .await;
-    let _ = crate::git::runner::run_git_worktree_admin(
-        state,
-        &repo_path,
-        &["worktree", "prune"],
-        DEFAULT_TIMEOUT,
-    )
-    .await;
+    // Skipped when the removal already read `Busy`: the same held domain would charge
+    // this prune a second full bounded wait, and the lock-free arm below re-runs both.
+    if !matches!(removal, Err(AppError::Busy { .. })) {
+        let _ = crate::git::runner::run_git_worktree_admin(
+            state,
+            &repo_path,
+            &["worktree", "prune"],
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+    }
     // A `Busy` removal never reached git — the domain was held past the bounded wait.
     // Retry WITHOUT the domain rather than leave the mint registered: nothing else
     // would ever reclaim it (the husk sweep takes only EMPTY dirs, prune only absent

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -536,9 +536,13 @@ async fn reuse_persistent_review_worktree(path_str: &str, sha: &str) -> bool {
         return false;
     }
     // The forcing checkout restores tracked files; this clears the untracked ones a
-    // CLI agent may have strayed into the previous review's tree.
-    let _ = run_git_raw(Some(path_str), &["clean", "-fdx", "-q"], WORKTREE_OP_TIMEOUT).await;
-    true
+    // CLI agent may have strayed into the previous review's tree. `-ff`, not `-f`:
+    // single-force SKIPS an untracked nested git repository (a repo the agent cloned
+    // in) and still exits 0, so it would survive every reuse and contaminate later
+    // reviews. A tree we failed to clean is one we cannot vouch for — refusing here
+    // sends the caller to a full rebuild, which is the cheap safe direction.
+    let cleaned = run_git_raw(Some(path_str), &["clean", "-ffdx", "-q"], WORKTREE_OP_TIMEOUT).await;
+    matches!(&cleaned, Ok(out) if out.code == 0)
 }
 
 /// Tears down an unusable persistent review worktree so a fresh `worktree add` can
@@ -744,11 +748,19 @@ async fn git_remove_worktree_core(
         DEFAULT_TIMEOUT,
     )
     .await;
-    // A `Busy` removal never reached git, so the registration still stands — deleting
-    // the directory underneath it would mint a prunable entry. Leave both halves for a
-    // later teardown or the husk sweep.
+    // A `Busy` removal never reached git — the domain was held past the bounded wait.
+    // Retry WITHOUT the domain rather than leave the mint registered: nothing else
+    // would ever reclaim it (the husk sweep takes only EMPTY dirs, prune only absent
+    // ones), and an OS-temp worktree passes every session filter, so it would render
+    // as one of the user's own worktrees forever. A lock-free run cannot report Busy.
     if matches!(removal, Err(AppError::Busy { .. })) {
-        return Ok(());
+        let _ = run_git_raw(
+            Some(&repo_path),
+            &["worktree", "remove", "--force", &worktree_path],
+            WORKTREE_OP_TIMEOUT,
+        )
+        .await;
+        let _ = run_git_raw(Some(&repo_path), &["worktree", "prune"], DEFAULT_TIMEOUT).await;
     }
     // `git worktree remove` deletes the directory itself, but on Windows that
     // recursive delete can lose a handle race (antivirus/indexer still holding the
@@ -849,29 +861,18 @@ fn persistent_review_lock_is_free(lock_path: &std::path::Path) -> bool {
     }
 }
 
-/// A file's mtime as epoch ms, or `None` when it is unreadable.
-fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
-    let ms = std::fs::metadata(path)
-        .ok()?
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_millis();
-    i64::try_from(ms).ok()
-}
-
 /// The testable core of [`sweep_stale_persistent_review_worktrees`], over an explicit
 /// worktrees root so a test never scans real app data. Only `<hash>/gd-review-persistent`
 /// is ever considered — the exact basename, one level down — and only when its git
 /// activity is older than [`PERSISTENT_REVIEW_MAX_IDLE_MS`] AND its sidecar carries no
 /// live claim.
 ///
-/// Age comes from git activity, falling back to the `.git` pointer file's own mtime:
-/// a checkout whose SOURCE REPO was deleted has an unresolvable admin dir, so without
-/// that fallback its activity reads unknown forever and it could never age out. A live
-/// workspace answers from index/HEAD first, and a mid-review checkout is spared by its
-/// claim regardless.
+/// Age comes from git activity, falling back to the `.git` pointer file's mtime and
+/// finally to the directory's own. Each fallback covers a shape that would otherwise
+/// read unknown forever and could never age out: a checkout whose SOURCE REPO was
+/// deleted has an unresolvable admin dir, and a bare wreck (a half-finished add, no
+/// `.git` at all) answers neither probe. A live workspace answers from index/HEAD
+/// first, and a mid-review checkout is spared by its claim regardless.
 ///
 /// No git runs here: the source repo's stale registration is cleaned by its own
 /// `prune_worktrees_if_free`, the same division every other app-data checkout uses.
@@ -888,7 +889,8 @@ fn sweep_stale_persistent_reviews_in(
             continue;
         }
         let Some(last_ms) = crate::git::worktree::worktree_last_activity_ms(&dir.to_string_lossy())
-            .or_else(|| file_mtime_ms(&dir.join(".git")))
+            .or_else(|| crate::git::worktree::file_mtime_ms(&dir.join(".git")))
+            .or_else(|| crate::git::worktree::file_mtime_ms(&dir))
         else {
             continue;
         };
@@ -1617,6 +1619,17 @@ mod tests {
         (base, repo, sha1, sha2)
     }
 
+    /// Epoch ms now — the clock the sweep's age gate subtracts a fixture's mtime from.
+    fn now_epoch_ms() -> i64 {
+        i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("the clock is past the epoch")
+                .as_millis(),
+        )
+        .expect("epoch ms fits an i64")
+    }
+
     /// Backdates a worktree's recorded git activity. `worktree_last_activity_ms` reads
     /// its admin `index` and falls back to `HEAD`, so both move.
     async fn age_worktree(worktree: &str, when: std::time::SystemTime) {
@@ -1719,10 +1732,19 @@ mod tests {
             .await
             .unwrap();
 
-        // What a strayed agent run leaves behind between reviews.
+        // What a strayed agent run leaves behind between reviews. The nested repo is
+        // the case single-force `clean` skips while still exiting 0 — it has to be
+        // gone whether the reuse cleaned it or the caller rebuilt the workspace.
         std::fs::write(&tracked, "tampered\n").unwrap();
         let stray = std::path::Path::new(&first).join("stray.txt");
         std::fs::write(&stray, "stray\n").unwrap();
+        // A REAL nested repo, not a bare `.git` folder: git only skips a subdirectory
+        // it recognizes as a repository, so an empty `.git` would be swept by plain
+        // `-fdx` and the case would go untested.
+        let nested = std::path::Path::new(&first).join("cloned-repo");
+        std::fs::create_dir_all(&nested).unwrap();
+        run(&nested.to_string_lossy(), &["init", "-q"]).await;
+        std::fs::write(nested.join("README.md"), "cloned by an agent\n").unwrap();
 
         let second = git_review_worktree_core(&state, repo.clone(), sha2.clone())
             .await
@@ -1735,6 +1757,10 @@ mod tests {
             "the modified TRACKED file is restored to the PR's content"
         );
         assert!(!stray.exists(), "the untracked stray is cleaned");
+        assert!(
+            !nested.exists(),
+            "an untracked nested git repo is cleaned too — single-force `clean` skips it"
+        );
         git_remove_worktree_core(&state, repo, second).await.unwrap();
     }
 
@@ -2010,14 +2036,7 @@ mod tests {
         let aged_sidecar = persistent_review_lock_path(aged).unwrap();
         std::fs::write(&aged_sidecar, b"").unwrap();
 
-        let now_ms = i64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-        let removed = sweep_stale_persistent_reviews_in(&scan, now_ms).unwrap();
+        let removed = sweep_stale_persistent_reviews_in(&scan, now_epoch_ms()).unwrap();
 
         assert_eq!(removed, 2, "the idle unclaimed checkout and the dangling one");
         assert!(!aged.exists(), "a week-idle unclaimed review worktree is reclaimed");
@@ -2033,6 +2052,27 @@ mod tests {
             "only the exact `gd-review-persistent` name is swept, even beside one that is"
         );
         drop(claim);
+
+        // A bare wreck — a half-finished add with no `.git` at all — answers neither
+        // git probe, so only the directory's own mtime can age it. Its own scan root
+        // and an advanced clock, because setting a DIRECTORY mtime is not portable in
+        // std; the gate subtracts the same either way.
+        let bare_scan = base.path().join("scan-bare");
+        let bare = bare_scan.join("wreck").join(PERSISTENT_REVIEW_DIR);
+        std::fs::create_dir_all(&bare).unwrap();
+        std::fs::write(bare.join("debris.txt"), b"not a worktree").unwrap();
+        assert!(
+            crate::git::worktree::worktree_last_activity_ms(&bare.to_string_lossy()).is_none(),
+            "the fixture really has no git activity to read"
+        );
+        // Read the clock AFTER planting it, so the fixture's own mtime can't outrun it.
+        let later_ms = now_epoch_ms() + PERSISTENT_REVIEW_MAX_IDLE_MS + 1;
+        assert_eq!(
+            sweep_stale_persistent_reviews_in(&bare_scan, later_ms).unwrap(),
+            1,
+            "a `.git`-less wreck still ages out on the directory's own mtime"
+        );
+        assert!(!bare.exists());
     }
 
     /// The `remove_dir_all` fallback guard admits only `gd-review-*` dirs directly

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1025,8 +1025,7 @@ pub(crate) async fn git_discard_all_core(state: &AppState, repo_path: String) ->
         tauri::async_runtime::spawn_blocking(move || {
             for path in untracked {
                 let full = Path::new(&repo).join(&path);
-                trash::delete(&full)
-                    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?;
+                crate::fsops::trash_delete(&full).map_err(AppError::Io)?;
             }
             Ok::<(), AppError>(())
         })
@@ -1116,8 +1115,7 @@ pub(crate) async fn git_discard_paths_core(
         tauri::async_runtime::spawn_blocking(move || {
             for path in untracked {
                 let full = Path::new(&repo).join(&path);
-                trash::delete(&full)
-                    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))?;
+                crate::fsops::trash_delete(&full).map_err(AppError::Io)?;
             }
             Ok::<(), AppError>(())
         })
@@ -2482,31 +2480,51 @@ pub(crate) async fn classify_failure(
     }
 }
 
-/// A short, stable hash of the repo path, kept in sync BY HAND with
-/// `worktree.rs::repo_hash` (both hash the lower-cased path with `DefaultHasher`).
+/// A short, stable hash of a repo key, kept in sync BY HAND with
+/// `worktree.rs::repo_hash` (both hash the lower-cased key with `DefaultHasher`) —
+/// `ops_and_worktree_repo_hash_agree` is what enforces that by-hand sync.
 /// Resolve worktrees — and `branches.rs`'s `gd-update-*` checkouts — must land
-/// under the same `<app_data>/worktrees/<repo-hash>` root, because that placement
+/// under the same `<app_data>/worktrees/<hash>` root, because that placement
 /// is what makes `git_worktree_list_user` hide them from the user-facing worktree
 /// manager (`is_session_worktree`'s app-data check).
-fn repo_hash(repo_path: &str) -> String {
+pub(crate) fn repo_hash(repo_path: &str) -> String {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     repo_path.to_lowercase().hash(&mut h);
     format!("{:016x}", h.finish())
 }
 
-/// The app-data worktree root for a repo — `<data_dir>/<identifier>/worktrees/
-/// <repo-hash>`. Mirrors `worktree.rs::worktree_root`, but resolved via
+/// The app-data worktree root for a repo KEY — `<data_dir>/<identifier>/worktrees/
+/// <hash>`. Mirrors `worktree.rs::worktree_root`, but resolved via
 /// `dirs::data_dir()` (as `local_prs.rs` / `oplog.rs` do) since the local-PR
 /// merge commands carry no `AppHandle`. Tauri's `app_data_dir()` is exactly
 /// `dirs::data_dir()/<identifier>`, so this points at the same directory.
-pub(crate) fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf> {
+///
+/// Two keys are in use, and the base path must never differ between them: the checkout
+/// path ([`worktree_root_dir`]) and the repository's worktree-stable identity
+/// ([`identity_worktree_root_dir`]).
+fn worktree_root_for_key(key: &str) -> AppResult<std::path::PathBuf> {
     let data = dirs::data_dir()
         .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
     Ok(data
         .join(crate::local_prs::APP_IDENTIFIER)
         .join("worktrees")
-        .join(repo_hash(repo_path)))
+        .join(repo_hash(key)))
+}
+
+/// The checkout-path-keyed worktree root: resolve worktrees, agent-session worktrees,
+/// and the pre-rekey update-marker root all live here.
+pub(crate) fn worktree_root_dir(repo_path: &str) -> AppResult<std::path::PathBuf> {
+    worktree_root_for_key(repo_path)
+}
+
+/// The worktree root every checkout of a repository SHARES, keyed on `identity`
+/// ([`crate::git::repo::repo_identity`]'s output, the absolute common git dir) rather
+/// than the checkout path. `update_marker` mints and guards here so a sibling worktree
+/// resolves the same directory and sees the same markers. Takes the resolved identity
+/// so the mapping stays callable without a repo on disk.
+pub(crate) fn identity_worktree_root_dir(identity: &str) -> AppResult<std::path::PathBuf> {
+    worktree_root_for_key(identity)
 }
 
 /// Tears down a resolve worktree: `git worktree remove --force <path>` then
@@ -2694,11 +2712,17 @@ async fn finalize_base(
 
     use crate::git::update_marker::{self as marker, LockProbe};
 
+    // Resolved once, up front: the `managed` predicate below sits in a closure that
+    // cannot await, and both arms must read the same root set the refusal did.
+    let marker_roots = marker::roots_for(repo_path).await.ok();
+
     // An update that has minted its marker but not yet registered its checkout is
     // invisible to the porcelain read below, so the marker covers that half of the
     // window and the arm below covers it once registered. Heal-free: this call's own
     // continuation takes the admin domain to tear the resolve worktree down.
-    marker::refuse_if_branch_updating_no_heal(repo_path, base)?;
+    if let Some(roots) = marker_roots.as_ref() {
+        marker::refuse_if_branch_updating_in(roots, base)?;
+    }
 
     // Is `base` checked out in some OTHER worktree? Our resolve worktree is detached,
     // so it never carries `base` as a branch and is safely excluded.
@@ -2716,7 +2740,11 @@ async fn finalize_base(
     // a marker that proves neither — and any `gd-update-*` worktree outside our own
     // root, which is the user's — leaves this routing exactly as it was before markers
     // existed, which the update's own pin verify already makes data-safe.
-    let managed = |w: &&str| marker::is_managed_update_worktree(repo_path, w);
+    let managed = |w: &&str| {
+        marker_roots
+            .as_ref()
+            .is_some_and(|roots| marker::is_managed_update_worktree_in(roots, w))
+    };
     if let Some(holder) = owning_worktree.as_deref().filter(managed).map(str::to_string) {
         match marker::update_worktree_probe(&holder) {
             LockProbe::Live => return Err(marker::branch_update_refusal(base)),
@@ -7346,6 +7374,31 @@ detached
         );
     }
 
+    /// `repo_hash` exists twice — here and in `worktree.rs` — and the comment on each
+    /// says "kept in sync BY HAND". This is that sync, mechanized: a drift would split
+    /// one repo's hidden checkouts across two roots, so the guards, the sweeps, and the
+    /// filter that hides them from the worktree manager would each read a different
+    /// directory. Mixed case and both separators, since the hash lower-cases but does
+    /// not normalize separators.
+    #[test]
+    fn ops_and_worktree_repo_hash_agree() {
+        for key in [
+            "C:\\repos\\app",
+            "C:/repos/app",
+            "C:\\Repos\\App",
+            "c:/repos/APP",
+            "C:\\repos\\app\\.git",
+            "/home/u/repos/app/.git",
+            "",
+        ] {
+            assert_eq!(
+                repo_hash(key),
+                crate::git::worktree::repo_hash(key),
+                "the two hand-kept copies disagree on {key:?}"
+            );
+        }
+    }
+
     #[test]
     fn orphaned_resolve_worktrees_picks_gd_resolve_paths_not_kept() {
         let all = vec![
@@ -9182,6 +9235,58 @@ detached
             "PRECIOUS\n",
             "the glob-sibling keeps its uncommitted work"
         );
+    }
+
+    /// Both discard cores remove an untracked file named after a reserved DOS
+    /// device. Such a file enumerates normally but resolves to the DEVICE for
+    /// every open/stat/unlink by its plain path, so the recycle bin refuses it
+    /// and only a `\\?\` verbatim unlink gets rid of it.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn discard_removes_reserved_device_named_files() {
+        // Creating and probing these names is only possible through the verbatim
+        // path — the plain one answers for the device, not the file.
+        fn verbatim(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+            std::path::PathBuf::from(format!(
+                r"\\?\{}",
+                dir.join(name).to_string_lossy().replace('/', "\\")
+            ))
+        }
+
+        let (dir, repo) = setup_repo("discard-reserved").await;
+        let root = dir.path().to_path_buf();
+        for name in ["nul", "nul.txt"] {
+            std::fs::write(verbatim(&root, name), b"x\n").expect("verbatim write");
+        }
+
+        let state = AppState::default();
+        git_discard_paths_core(
+            &state,
+            repo.clone(),
+            vec![DiscardPath {
+                path: "nul".into(),
+                untracked: true,
+            }],
+        )
+        .await
+        .expect("the selected reserved-name file is discarded");
+        // `git_discard_all_core` takes the remaining one off the untracked list.
+        git_discard_all_core(&state, repo.clone())
+            .await
+            .expect("discard-all clears the reserved-name file");
+
+        let listed: Vec<String> = std::fs::read_dir(&root)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        for name in ["nul", "nul.txt"] {
+            assert!(
+                std::fs::metadata(verbatim(&root, name)).is_err(),
+                "{name} is gone from disk"
+            );
+            assert!(!listed.contains(&name.to_string()), "{name} is not listed");
+        }
     }
 
     // --- git_stash_paths_core: selective stash must not leak unselected staged files ---

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -2714,6 +2714,9 @@ async fn finalize_base(
 
     // Resolved once, up front: the `managed` predicate below sits in a closure that
     // cannot await, and both arms must read the same root set the refusal did.
+    // Fail-open per `update_marker`'s contract — a root this process cannot resolve
+    // must never block the merge, and the update's own pin verify is what keeps the
+    // fast-forward data-safe without it.
     let marker_roots = marker::roots_for(repo_path).await.ok();
 
     // An update that has minted its marker but not yet registered its checkout is

--- a/src-tauri/src/git/update_marker.rs
+++ b/src-tauri/src/git/update_marker.rs
@@ -7,10 +7,16 @@
 //! with git's own message naming a hidden app-data path. A marker minted before the
 //! `worktree add` turns those collisions into one sentence the user can act on, and
 //! the signal is filesystem state, not process state, so it reaches every process
-//! bound to the same checkout path (the MCP server runs these same functions). The
-//! recorded limit: the root is keyed on that path, so a SIBLING worktree of the same
-//! repository resolves its own root and sees no marker — those callers keep pre-marker
-//! behavior until the root is keyed by git common dir.
+//! bound to the same repository (the MCP server runs these same functions).
+//!
+//! The root is keyed on the repository's worktree-stable identity — its absolute
+//! common git dir — so the main checkout and every linked worktree of a repository
+//! share one marker root, and a branch operation run from one sees the other's live
+//! update. Mints go to that root alone; refusals, claims and sweeps ALSO read the
+//! pre-rekey root keyed on the checkout path, because a not-yet-restarted process
+//! still mints under it and its live locks must still refuse. That second scan is the
+//! migration as well: leftovers a pre-rekey build stranded keep being found and healed
+//! rather than going invisible.
 //!
 //! The marker is two files beside the checkout, sharing its stem: an unlocked `.json`
 //! manifest and an exclusively-locked `.lock`. Two files is forced by Windows —
@@ -120,26 +126,66 @@ impl Drop for TestRootOverride {
     }
 }
 
-/// The worktree root this module works in. Every entry point — and the mint in
+/// The worktree roots this module works in for one repository.
+pub(crate) struct MarkerRoots {
+    /// Keyed on the repository's identity, so every worktree of it resolves this same
+    /// directory. The only root a MINT may use.
+    primary: PathBuf,
+    /// The pre-rekey root, keyed on the checkout path. `None` when it IS `primary`,
+    /// which is what an unresolvable identity degrades to.
+    legacy: Option<PathBuf>,
+}
+
+impl MarkerRoots {
+    /// Collapses to ONE root when the identity resolution fell back to the checkout
+    /// path, which is exactly the pre-rekey keying — there is no second place to look.
+    fn new(primary: PathBuf, legacy: PathBuf) -> Self {
+        Self {
+            legacy: (legacy != primary).then_some(legacy),
+            primary,
+        }
+    }
+
+    /// Where a mint goes — never the pre-rekey root, since a new marker belongs where
+    /// every worktree of the repository is looking.
+    fn mint_root(&self) -> &Path {
+        &self.primary
+    }
+
+    /// Every root a scan reads, primary first — the first refusal wins, so the root
+    /// this build mints under is the one that gets to answer.
+    fn all(&self) -> impl Iterator<Item = &Path> {
+        std::iter::once(self.primary.as_path()).chain(self.legacy.as_deref())
+    }
+}
+
+/// The roots this module works in. Every entry point — and the mint in
 /// `branches.rs::update_worktree_path` — resolves through here, so a test can point the
-/// whole module at a temp directory. Outside tests it is exactly
-/// `ops::worktree_root_dir`.
+/// whole module at a temp directory.
 ///
-/// Under `cfg(test)` an installed override is the ONLY resolution: with none, this
-/// ERRORS instead of falling through to the real app data, mirroring
-/// [`crate::app_store`]'s "under `cfg!(test)`, NO store, whatever the environment says".
-/// The override is process-wide, so a test that never installed one must neither read a
-/// concurrently-scheduled sibling's root nor mint under the developer's own app data.
-/// Every GUARD caller fails open on an unresolvable root — refusals answer `Ok`, claims
-/// and sweeps return, `is_managed_update_worktree` answers `false` — which is exactly
-/// what an un-overridden test should see. The MINT is the loud exception:
-/// `branches.rs::update_worktree_path` propagates the error rather than place a
-/// checkout somewhere nobody is guarding.
-pub(crate) fn root_for(repo_path: &str) -> AppResult<PathBuf> {
+/// Outside tests the primary root hashes [`crate::git::repo::repo_identity`]'s output,
+/// the ONE shared resolver the MCP server uses too, so two processes can never key a
+/// repository differently. Deliberately uncached: a stale identity would re-open the
+/// cross-worktree blindness this keying closes, and these are user-action paths where
+/// one `rev-parse` is affordable. `repo_identity` answers with its input when git
+/// cannot resolve it, so a failure degrades to plain checkout-path keying and the two
+/// roots collapse into one.
+///
+/// Under `cfg(test)` an installed override is the ONLY resolution and is the whole root
+/// set: with none, this ERRORS instead of falling through to the real app data,
+/// mirroring [`crate::app_store`]'s "under `cfg!(test)`, NO store, whatever the
+/// environment says". The override is process-wide, so a test that never installed one
+/// must neither read a concurrently-scheduled sibling's root nor mint under the
+/// developer's own app data. Every GUARD caller fails open on an unresolvable root —
+/// refusals answer `Ok`, claims and sweeps return, `is_managed_update_worktree` answers
+/// `false` — which is exactly what an un-overridden test should see. The MINT is the
+/// loud exception: `branches.rs::update_worktree_path` propagates the error rather than
+/// place a checkout somewhere nobody is guarding.
+pub(crate) async fn roots_for(repo_path: &str) -> AppResult<MarkerRoots> {
     #[cfg(test)]
     {
         let _ = repo_path;
-        TEST_ROOT_DIR
+        let primary = TEST_ROOT_DIR
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
@@ -147,12 +193,25 @@ pub(crate) fn root_for(repo_path: &str) -> AppResult<PathBuf> {
                 AppError::Command(
                     "no update-marker root override is installed for this test".to_string(),
                 )
-            })
+            })?;
+        Ok(MarkerRoots {
+            primary,
+            legacy: None,
+        })
     }
     #[cfg(not(test))]
     {
-        crate::git::ops::worktree_root_dir(repo_path)
+        let identity = crate::git::repo::repo_identity(repo_path).await;
+        Ok(MarkerRoots::new(
+            crate::git::ops::identity_worktree_root_dir(&identity)?,
+            crate::git::ops::worktree_root_dir(repo_path)?,
+        ))
     }
+}
+
+/// Where a mint goes ([`MarkerRoots::mint_root`]).
+pub(crate) async fn root_for(repo_path: &str) -> AppResult<PathBuf> {
+    Ok(roots_for(repo_path).await?.mint_root().to_path_buf())
 }
 
 /// The marker manifest. Plain readable JSON so a probe in another process can answer
@@ -343,27 +402,40 @@ fn is_update_worktree_path(path: &str) -> bool {
         .is_some_and(|name| name.starts_with(MARKER_PREFIX))
 }
 
-/// Whether `path` is an update checkout THIS app manages for `repo_path`: the mint
-/// basename AND a parent that is the repo's own worktree root. The root scope is what
+/// Whether `path` is an update checkout THIS app manages, over already-resolved
+/// `roots`: the mint basename AND a parent that is one of them. The root scope is what
 /// keeps a user's own worktree that merely happens to be named `gd-update-*` — with
 /// some stray unlocked `.lock` beside it — out of every marker arm, refusal and
-/// removal alike.
+/// removal alike. Both roots count, so a leftover a pre-rekey build minted stays ours
+/// to claim.
 ///
 /// Compared through the repo's two path spellings (`canonical_wt_path` resolves
 /// symlinks and Windows short names, `normalize_wt_path` is the second chance for a
 /// path that no longer exists), since porcelain prints resolved paths while the root is
 /// app-built. Any resolution failure answers `false`: cleanup fails CLOSED.
-pub(crate) fn is_managed_update_worktree(repo_path: &str, path: &str) -> bool {
+pub(crate) fn is_managed_update_worktree_in(roots: &MarkerRoots, path: &str) -> bool {
     use crate::git::worktree::{canonical_wt_path, normalize_wt_path};
     if !is_update_worktree_path(path) {
         return false;
     }
-    let (Ok(root), Some(parent)) = (root_for(repo_path), Path::new(path).parent()) else {
+    let Some(parent) = Path::new(path).parent() else {
         return false;
     };
-    let (parent, root) = (parent.to_string_lossy(), root.to_string_lossy());
-    canonical_wt_path(&parent) == canonical_wt_path(&root)
-        || normalize_wt_path(&parent) == normalize_wt_path(&root)
+    let parent = parent.to_string_lossy();
+    let (parent_canon, parent_norm) = (canonical_wt_path(&parent), normalize_wt_path(&parent));
+    roots.all().any(|root| {
+        let root = root.to_string_lossy();
+        canonical_wt_path(&root) == parent_canon || normalize_wt_path(&root) == parent_norm
+    })
+}
+
+/// [`is_managed_update_worktree_in`] resolving the roots itself, for a single-call site
+/// that has no other use for them.
+pub(crate) async fn is_managed_update_worktree(repo_path: &str, path: &str) -> bool {
+    match roots_for(repo_path).await {
+        Ok(roots) => is_managed_update_worktree_in(&roots, path),
+        Err(_) => false,
+    }
 }
 
 /// The lock state of the `gd-update-*` checkout at `path`. Callers match on all four
@@ -437,6 +509,25 @@ fn refuse_in(root: &Path, branch: Option<&str>) -> RefuseOutcome {
     outcome
 }
 
+/// [`refuse_in`] over the whole root set. The first refusal wins and stops the scan,
+/// while `saw_dead` ORs across every root reached — a leftover in either one is worth
+/// the same sweep.
+fn refuse_across(roots: &MarkerRoots, branch: Option<&str>) -> RefuseOutcome {
+    let mut acc = RefuseOutcome {
+        refusal: None,
+        saw_dead: false,
+    };
+    for root in roots.all() {
+        let outcome = refuse_in(root, branch);
+        acc.saw_dead |= outcome.saw_dead;
+        if outcome.refusal.is_some() {
+            acc.refusal = outcome.refusal;
+            return acc;
+        }
+    }
+    acc
+}
+
 /// Refuses when a live update is bringing `branch` up to date, and schedules a sweep
 /// if the scan met a crash orphan on the way. Every guarded site is therefore also a
 /// healing trigger.
@@ -456,21 +547,30 @@ pub(crate) async fn refuse_if_any_updating(state: &AppState, repo_path: &str) ->
 /// The same refusal WITHOUT the healing sweep, for a caller whose very next step takes
 /// the worktree-admin domain: a detached sweep fired here would win that domain by
 /// milliseconds and turn an operation that would have succeeded into a `Busy`.
-pub(crate) fn refuse_if_branch_updating_no_heal(repo_path: &str, branch: &str) -> AppResult<()> {
-    let Ok(root) = root_for(repo_path) else {
+pub(crate) async fn refuse_if_branch_updating_no_heal(
+    repo_path: &str,
+    branch: &str,
+) -> AppResult<()> {
+    let Ok(roots) = roots_for(repo_path).await else {
         return Ok(());
     };
-    match refuse_in(&root, Some(branch)).refusal {
+    refuse_if_branch_updating_in(&roots, branch)
+}
+
+/// The heal-free refusal over already-resolved `roots`, for a site that resolves them
+/// once and reuses them across arms that cannot await.
+pub(crate) fn refuse_if_branch_updating_in(roots: &MarkerRoots, branch: &str) -> AppResult<()> {
+    match refuse_across(roots, Some(branch)).refusal {
         Some(err) => Err(err),
         None => Ok(()),
     }
 }
 
 async fn refuse_and_heal(state: &AppState, repo_path: &str, branch: Option<&str>) -> AppResult<()> {
-    let Ok(root) = root_for(repo_path) else {
+    let Ok(roots) = roots_for(repo_path).await else {
         return Ok(());
     };
-    let outcome = refuse_in(&root, branch);
+    let outcome = refuse_across(&roots, branch);
     if outcome.saw_dead {
         spawn_orphan_sweep(state, repo_path).await;
     }
@@ -519,15 +619,16 @@ pub(crate) async fn spawn_orphan_sweep(state: &AppState, repo_path: &str) {
 /// be running the update right now (a stale MCP-server exe beside a rebuilt GUI), so it
 /// is refused here and left to the age-gated background sweep.
 ///
-/// Root-scoped: only a checkout directly under THIS repo's app-data worktree root is
-/// ours to force-remove. A user's own worktree that happens to be named `gd-update-*`
-/// is never touched, whatever sits beside it.
+/// Root-scoped: only a checkout directly under one of THIS repository's app-data
+/// worktree roots is ours to force-remove, and the leftover is claimed in whichever of
+/// them it sits. A user's own worktree that happens to be named `gd-update-*` is never
+/// touched, whatever sits beside it.
 pub(crate) async fn claim_dead_update_worktree(
     state: &AppState,
     repo_path: &str,
     holder: &str,
 ) -> bool {
-    if !is_managed_update_worktree(repo_path, holder) {
+    if !is_managed_update_worktree(repo_path, holder).await {
         return false;
     }
     let path = Path::new(holder);
@@ -563,19 +664,25 @@ pub(crate) async fn claim_dead_update_worktree(
 /// markerless checkout is never claimed here. No porcelain read is needed — the lock
 /// file alone carries the proof.
 pub(crate) async fn claim_dead_updates_for_branch(state: &AppState, repo_path: &str, branch: &str) {
-    let Ok(root) = root_for(repo_path) else {
+    let Ok(roots) = roots_for(repo_path).await else {
         return;
     };
     // Nothing to heal is the overwhelmingly common case; answer it without paying for
     // the domain resolution or its lock.
-    if dead_stems_for_branch(&root, branch).is_empty() {
+    let holding: Vec<&Path> = roots
+        .all()
+        .filter(|root| !dead_stems_for_branch(root, branch).is_empty())
+        .collect();
+    if holding.is_empty() {
         return;
     }
     let domain = state.worktree_admin_lock(repo_path).await;
     let Some(_admin) = try_acquire_repo_lock(&domain, "a worktree operation") else {
         return;
     };
-    claim_dead_stems_for_branch_locked(repo_path, &root, branch).await;
+    for root in holding {
+        claim_dead_stems_for_branch_locked(repo_path, root, branch).await;
+    }
 }
 
 /// The body of [`claim_dead_updates_for_branch`], over an explicit root so tests can
@@ -633,10 +740,19 @@ pub(crate) async fn sweep_orphaned_update_worktrees(state: &AppState, repo_path:
 /// `run_git_worktree_admin` would re-acquire it and deadlock, so the runners here are
 /// the lock-free ones, exactly as `branches.rs::remove_tmp_worktree` does.
 async fn sweep_update_orphans_locked(repo_path: &str) {
-    let Ok(root) = root_for(repo_path) else {
+    let Ok(roots) = roots_for(repo_path).await else {
         return;
     };
-    sweep_in(repo_path, &root, ORPHAN_MIN_AGE).await;
+    sweep_roots(repo_path, &roots, ORPHAN_MIN_AGE).await;
+}
+
+/// The sweep across every root, over an explicit age threshold so tests can drive it.
+/// The pre-rekey root is included because it is where a build from before the re-key
+/// stranded its leftovers, and this pass is the only thing that will ever find them.
+async fn sweep_roots(repo_path: &str, roots: &MarkerRoots, min_age: Duration) {
+    for root in roots.all() {
+        sweep_in(repo_path, root, min_age).await;
+    }
 }
 
 /// The sweep over an explicit root and age threshold, so tests can drive it against a
@@ -918,6 +1034,127 @@ mod tests {
             .stdout_lossy()
     }
 
+    /// The production primary-root composition — the resolver plus the mapping that
+    /// [`roots_for`]'s non-test arm chains. Callable here because the mapping takes an
+    /// already-resolved identity, so the `cfg(test)` override never stands in the way.
+    async fn primary_root_of(repo_path: &str) -> PathBuf {
+        let identity = crate::git::repo::repo_identity(repo_path).await;
+        crate::git::ops::identity_worktree_root_dir(&identity).expect("the marker root resolves")
+    }
+
+    /// The re-key, against a real repository: a linked worktree and the main checkout
+    /// resolve ONE primary root, where the checkout-path keying gives them two. Path
+    /// computation only — nothing is created under the real app data.
+    #[tokio::test]
+    async fn sibling_worktrees_resolve_one_marker_root() {
+        let (_guard, base) = temp_root("sibling-root");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let repo_s = repo.to_string_lossy().into_owned();
+
+        git(&repo_s, &["init", "-q"]).await;
+        git(&repo_s, &["config", "user.email", "t@t.local"]).await;
+        git(&repo_s, &["config", "user.name", "T"]).await;
+        std::fs::write(repo.join("a.txt"), "hello\n").unwrap();
+        git(&repo_s, &["add", "-A"]).await;
+        git(&repo_s, &["commit", "-qm", "seed"]).await;
+
+        let linked = base.join("linked");
+        let linked_s = linked.to_string_lossy().into_owned();
+        git(
+            &repo_s,
+            &["worktree", "add", "--quiet", "-b", "sibling", &linked_s],
+        )
+        .await;
+
+        let main_root = primary_root_of(&repo_s).await;
+        assert_eq!(
+            main_root,
+            primary_root_of(&linked_s).await,
+            "a linked worktree must guard the same root as its main checkout"
+        );
+        assert_ne!(
+            main_root,
+            crate::git::ops::worktree_root_dir(&repo_s).expect("the legacy root resolves"),
+            "and the re-key genuinely moved the key off the checkout path"
+        );
+    }
+
+    /// The pre-rekey root stays a first-class scan target: a build that has not been
+    /// restarted still mints there, so its LIVE lock must refuse from the new root's
+    /// side, and its crash leftovers must stay claimable and sweepable. Driven through
+    /// the explicit-root cores, since `roots_for` under `cfg(test)` is the single-root
+    /// override.
+    #[tokio::test]
+    async fn a_legacy_root_marker_refuses_and_is_still_healed() {
+        let (_guard, base) = temp_root("two-root");
+        let primary = base.join("primary");
+        let legacy = base.join("legacy");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+        let roots = MarkerRoots::new(primary.clone(), legacy.clone());
+        assert_eq!(
+            roots.all().collect::<Vec<_>>(),
+            vec![primary.as_path(), legacy.as_path()],
+            "both roots are scanned, the mint root first"
+        );
+        assert_eq!(
+            roots.mint_root(),
+            primary.as_path(),
+            "and a mint never lands in the pre-rekey root"
+        );
+        assert_eq!(
+            MarkerRoots::new(primary.clone(), primary.clone())
+                .all()
+                .count(),
+            1,
+            "an identity that fell back to the checkout path leaves one root, not two"
+        );
+
+        // LIVE in the pre-rekey root, nothing in the primary one.
+        let live =
+            UpdateMarker::create_for(&legacy.join("gd-update-old"), "feature").expect("mints");
+        assert!(
+            refuse_in(&primary, Some("feature")).refusal.is_none(),
+            "the fixture's primary root is clean, so only the second scan can refuse"
+        );
+        assert_eq!(
+            refuse_across(&roots, Some("feature"))
+                .refusal
+                .expect("a pre-rekey process's live update still refuses")
+                .to_string(),
+            branch_update_refusal("feature").to_string()
+        );
+        assert!(
+            is_managed_update_worktree_in(&roots, &legacy.join("gd-update-old").to_string_lossy()),
+            "a checkout in either root is ours to arbitrate"
+        );
+        drop(live);
+
+        // RELEASED in the pre-rekey root: taken by the branch-scoped, age-free claim.
+        // The repo path is bogus on purpose — every git call fails and the filesystem
+        // fallback finishes the job, as in the single-root claim test.
+        std::fs::create_dir_all(legacy.join("gd-update-dead")).unwrap();
+        write_released_marker(&legacy, "gd-update-dead", "feature");
+        claim_dead_stems_for_branch_locked("C:/nonexistent-repo", &legacy, "feature").await;
+        assert!(
+            !legacy.join("gd-update-dead").exists()
+                && !legacy.join("gd-update-dead.lock").exists()
+                && !legacy.join("gd-update-dead.json").exists(),
+            "a pre-rekey leftover is claimed for its branch"
+        );
+
+        // And by the background sweep, which reads both roots in one pass.
+        write_released_marker(&legacy, "gd-update-stale", "feature");
+        write_released_marker(&primary, "gd-update-fresh", "feature");
+        sweep_roots("C:/nonexistent-repo", &roots, Duration::ZERO).await;
+        assert!(
+            !legacy.join("gd-update-stale.lock").exists()
+                && !primary.join("gd-update-fresh.lock").exists(),
+            "the sweep clears leftovers in both roots"
+        );
+    }
+
     /// End to end against a real repo, with every kind of neighbour present: the
     /// crash-orphaned update worktree is removed, its admin entry pruned, its marker
     /// files deleted, and the branch it held is free again — while a live update, a
@@ -1080,11 +1317,14 @@ mod tests {
     /// The seam fails CLOSED: with no override installed, in-test resolution errors
     /// rather than reaching the developer's real app data. Holding `test_root_lock` is
     /// what makes the premise true — it is the guarantee no sibling has one installed.
-    #[test]
-    fn root_for_refuses_to_resolve_without_a_test_override() {
+    // The serializing guard MUST span the await — it is what makes "no override is
+    // installed" true for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn root_for_refuses_to_resolve_without_a_test_override() {
         let _serialized = test_root_lock();
         assert!(
-            root_for("C:/repos/app").is_err(),
+            root_for("C:/repos/app").await.is_err(),
             "an un-overridden test must never resolve the real worktree root"
         );
     }
@@ -1270,8 +1510,11 @@ mod tests {
     /// Root scope: a `gd-update-*` worktree the USER made, outside our app-data root, is
     /// theirs. Even with a stray unlocked `.lock` beside it — which would otherwise read
     /// `Released` — no marker arm may claim or refuse on it.
-    #[test]
-    fn a_user_worktree_outside_the_root_is_never_managed() {
+    // The serializing guard MUST span the awaits — it is what keeps the process-wide
+    // root override installed for the whole body.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn a_user_worktree_outside_the_root_is_never_managed() {
         let (_guard, base) = temp_root("scope");
         let root = base.join("worktrees");
         let elsewhere = base.join("user-repos");
@@ -1284,7 +1527,7 @@ mod tests {
 
         let mine = root.join("gd-update-1-2");
         std::fs::create_dir_all(&mine).unwrap();
-        assert!(is_managed_update_worktree(repo, &mine.to_string_lossy()));
+        assert!(is_managed_update_worktree(repo, &mine.to_string_lossy()).await);
 
         // Same basename, same stray sidecar, different parent.
         let theirs = elsewhere.join("gd-update-1-2");
@@ -1296,14 +1539,17 @@ mod tests {
             "the fixture must reproduce the tempting shape"
         );
         assert!(
-            !is_managed_update_worktree(repo, &theirs.to_string_lossy()),
+            !is_managed_update_worktree(repo, &theirs.to_string_lossy()).await,
             "a user's own worktree is out of scope however its neighbours look"
         );
         // A nested path under our root is not a direct child, so it is not ours either.
-        assert!(!is_managed_update_worktree(
-            repo,
-            &root.join("nested").join("gd-update-1-2").to_string_lossy()
-        ));
+        assert!(
+            !is_managed_update_worktree(
+                repo,
+                &root.join("nested").join("gd-update-1-2").to_string_lossy()
+            )
+            .await
+        );
     }
 
     /// The markerless shape's age gate must read a signal git actually MOVES. A

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -810,7 +810,7 @@ fn is_session_worktree(
 }
 
 /// A file's mtime as epoch ms, or `None` when it is unreadable.
-fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
+pub(crate) fn file_mtime_ms(path: &std::path::Path) -> Option<i64> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
     let ms = modified
         .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -64,8 +64,9 @@ pub(crate) fn normalize_wt_path(p: &str) -> String {
 }
 
 /// A short, stable hash of the repo path, used to namespace a repo's session
-/// worktrees. Lower-cased first since Windows paths are case-insensitive.
-fn repo_hash(repo_path: &str) -> String {
+/// worktrees. Lower-cased first since Windows paths are case-insensitive. Kept in sync
+/// BY HAND with `ops::repo_hash`, which `ops_and_worktree_repo_hash_agree` enforces.
+pub(crate) fn repo_hash(repo_path: &str) -> String {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     repo_path.to_lowercase().hash(&mut h);
@@ -278,7 +279,7 @@ pub async fn git_worktree_add_user(
         // update's hidden checkout, which git names by an app-data path. Heal-free:
         // the `worktree add` below takes the admin domain, and a sweep fired here
         // would win it first and turn a would-succeed add into a `Busy`.
-        crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, branch)?;
+        crate::git::update_marker::refuse_if_branch_updating_no_heal(&repo_path, branch).await?;
         args.extend_from_slice(&[path, branch]);
     }
     run_git_worktree_admin(&state, &repo_path, &args, WORKTREE_OP_TIMEOUT).await?;

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -327,8 +327,7 @@ pub async fn git_hook_delete(repo_path: String, name: String) -> AppResult<()> {
     for path in [dir.join(&name), dir.join(format!("{name}.disabled"))] {
         if path.exists() {
             tauri::async_runtime::spawn_blocking(move || {
-                trash::delete(&path)
-                    .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))
+                crate::fsops::trash_delete(&path).map_err(AppError::Io)
             })
             .await
             .map_err(|e| AppError::Io(std::io::Error::other(e.to_string())))??;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,6 +107,13 @@ pub fn run() {
                 tauri::async_runtime::spawn_blocking(|| {
                     git::compare::sweep_review_worktree_husks();
                 });
+                // Reclaim persistent review worktrees a week idle (see
+                // `git::compare::sweep_stale_persistent_review_worktrees`) — their
+                // only lifecycle. Same fire-and-forget shape: plain fs work, and a
+                // live review's claim keeps its own checkout out of the sweep.
+                tauri::async_runtime::spawn_blocking(|| {
+                    git::compare::sweep_stale_persistent_review_worktrees();
+                });
             }
             Ok(())
         })

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -580,8 +580,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   its remote* is available from the command palette too.
 - **While an update runs, its branch is held.** Switching to that branch, renaming or
   deleting it, or starting a second update is turned away with a short message until the
-  merge lands. Every worktree of the repository sees the same hold, and an update that a
-  crash or a quit cut short is cleaned up on the next branch action.
+  update completes. Every worktree of the repository sees the same hold. An update a crash
+  or a quit cut short doesn't stay in the way: the next update, delete, or reset of that
+  branch clears it on the spot, and a background pass catches the rest.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
   of the remote it tracks offers **Push to _its remote/…_** in its context menu — so a
   branch tracking a fork's _upstream_ is pushed there, not to origin. An unpushed or

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -442,7 +442,9 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
   it has no parent to fall back to, so the branch ref goes with it.
 
 > Discarding an **untracked** file moves it to the recycle bin, so it's recoverable —
-> it isn't deleted outright.`,
+> it isn't deleted outright. The exception is a name Windows reserves for a device
+> (\`nul\`, \`con\`, \`com3\`): the recycle bin can't take one, so those are removed
+> permanently.`,
   },
   {
     id: "history",
@@ -576,6 +578,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   every branch's row shows its own push/pull state (↑/↓ vs. its upstream) after a fetch, so
   the branches with commits to pull are visible at a glance, and *Update default branch from
   its remote* is available from the command palette too.
+- **While an update runs, its branch is held.** Switching to that branch, renaming or
+  deleting it, or starting a second update is turned away with a short message until the
+  merge lands. Every worktree of the repository sees the same hold, and an update that a
+  crash or a quit cut short is cleaned up on the next branch action.
 - **Push a branch without switching to it** — the outbound counterpart: a branch ahead
   of the remote it tracks offers **Push to _its remote/…_** in its context menu — so a
   branch tracking a fork's _upstream_ is pushed there, not to origin. An unpushed or

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -20,8 +20,8 @@ export interface CliStreamOpts {
   /** Working directory the CLI agent runs in (also its repo-aware root). */
   repoPath: string;
   /** PR head SHA. When repo-aware and this isn't the active checkout, the agent
-   *  runs in a throwaway detached worktree at this commit, so it reads the PR's
-   *  files instead of the user's current branch. Removed when the run settles. */
+   *  runs in a detached review worktree pinned at this commit, so it reads the PR's
+   *  files instead of the user's current branch. Released when the run settles. */
   headSha?: string;
   setText: (text: string) => void;
   setStatus: (status: string) => void;
@@ -103,8 +103,10 @@ export async function runCliStream({
   registerId(reviewId);
 
   // Repo-aware reviews read files from the working tree. When the PR head isn't
-  // the active checkout, run the agent in a throwaway detached worktree pinned at
-  // that commit so it reads the PR's files, not the user's current branch.
+  // the active checkout, run the agent in a detached review worktree pinned at that
+  // commit so it reads the PR's files, not the user's current branch. The backend
+  // hands out one reused per-repo worktree, and a throwaway mint when another
+  // review already holds it.
   let cwd = repoPath;
   let worktree: string | null = null;
   if (ai.cliRepoAware && headSha) {
@@ -197,7 +199,8 @@ export async function runCliStream({
         .catch(reject);
     });
   } finally {
-    // Tear down the ephemeral worktree on every exit (done/cancel/error).
+    // Release the review workspace on every exit (done/cancel/error): the reused
+    // per-repo worktree is unclaimed for the next review, a throwaway mint deleted.
     if (worktree) {
       void gitRemoveWorktree(repoPath, worktree).catch(() => undefined);
     }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1442,14 +1442,16 @@ export const gitTodoScan = (
 export const gitBranchTips = (repoPath: string, branches: string[]) =>
   invoke<Record<string, string>>("git_branch_tips", { repoPath, branches });
 
-/** Creates a throwaway detached worktree at `sha` so a repo-aware CLI review
- *  reads the PR head's files without moving the active branch. Returns the
- *  worktree path, or null when one isn't needed/possible (already on that
- *  commit, object not local, or checkout failed) — caller uses the repo root. */
+/** Hands a repo-aware CLI review a detached checkout of `sha` so it reads the
+ *  PR head's files without moving the active branch: one reused worktree per
+ *  repository, or a throwaway mint when that one is unavailable. Returns the
+ *  path, or null when one isn't needed/possible (already on that commit, object
+ *  not local, or both checkouts failed) — caller uses the repo root. */
 export const gitReviewWorktree = (repoPath: string, sha: string) =>
   invoke<string | null>("git_review_worktree", { repoPath, sha });
 
-/** Removes a review worktree (best-effort, idempotent). */
+/** Releases the review workspace: the reused per-repo worktree is unclaimed, a
+ *  throwaway mint is removed. Best-effort, idempotent. */
 export const gitRemoveWorktree = (repoPath: string, worktreePath: string) =>
   invoke<void>("git_remove_worktree", { repoPath, worktreePath });
 


### PR DESCRIPTION
Three backend fixes in the app-data worktree area. Repo-aware AI reviews minted a throwaway checkout per run, so every review paid the "Preparing review workspace…" cost; branch-update guards were keyed on the checkout path, so a sibling worktree never saw a running update's hold; and discarding a file named for a Windows device failed outright because the recycle bin refuses such names.

### Reused AI review workspaces
- `src-tauri/src/git/compare.rs`: `git_review_worktree` now resolves one reusable per-repository checkout, `gd-review-persistent`, through `persistent_review_path()`. It is keyed on repo identity (the common git dir via `repo::repo_identity`), so the main checkout and every linked worktree share a single warm copy, and it lives under the app-data worktrees root so `is_session_worktree` keeps hiding it from user-facing worktree surfaces.
- Ownership rides an OS-locked sidecar placed beside the directory (`persistent_review_lock_path`), which survives the demolish that precedes a rebuild; a second concurrent review falls back to an ephemeral mint. The module now pulls in `State<AppState>` and `try_acquire_repo_lock`, plus a `TEST_ROOT_DIR` / `TestRootOverride` seam mirroring `update_marker`'s so tests never touch real app data.
- `sweep_stale_persistent_review_worktrees()` reclaims a workspace left idle for a week; it is wired at startup in `src-tauri/src/lib.rs` as a second `spawn_blocking` beside the existing husk sweep.
- `src/lib/ai/stream.ts`: updates the `CliStreamOpts.headSha` doc and the `runCliStream` comments — the `finally` block now releases a claim on the shared worktree rather than always deleting a throwaway.

### Update holds across sibling worktrees
- `src-tauri/src/git/update_marker.rs`: adds `MarkerRoots`, holding a `primary` root keyed on the repository's identity and a `legacy` root keyed on the checkout path (collapsed to one when identity resolution degrades). `roots_for()` is now async, mints go only to `primary`, and refusals, claims and sweeps scan both roots, so a not-yet-restarted process's live markers still refuse and pre-rekey leftovers still get healed instead of going invisible.
- `src-tauri/src/git/ops.rs`: factors `worktree_root_for_key()` out of `worktree_root_dir()` and adds `identity_worktree_root_dir()` for the shared, identity-keyed root. `finalize_base` resolves `marker::roots_for` once up front and switches to `refuse_if_branch_updating_in` / `is_managed_update_worktree_in`, so its non-async `managed` closure reads exactly the root set the refusal did.
- `src-tauri/src/git/branches.rs` and `src-tauri/src/git/worktree.rs`: await the now-async marker calls (`refuse_if_branch_updating_no_heal`, `is_managed_update_worktree`, `update_worktree_path`), and `repo_hash` becomes `pub(crate)` in both `ops.rs` and `worktree.rs` with the by-hand sync between them pinned by `ops_and_worktree_repo_hash_agree`.

### Discarding reserved Windows device names
- `src-tauri/src/fsops.rs`: adds `trash_delete()`, which always tries the recycle bin first and only then, on Windows and only after trash refuses, falls back to `permanent_delete_reserved()`. That removes the entry through its `\\?\` verbatim path (`verbatim_path()`), classifying it with `symlink_metadata` so a directory link is unlinked rather than swept recursively; a failed fallback reports the original trash error.
- `is_reserved_device_name()` matches CON/PRN/AUX/NUL and COM/LPT 1–9 against the pre-dot stem with trailing spaces trimmed, so `nul.txt` and `nul ` count while `com0`, `com10` and `console` do not. Unit tests cover the matcher and pin the Win32 behavior it depends on.
- `src-tauri/src/git/ops.rs` (`git_discard_all_core`, `git_discard_paths_core`) and `src-tauri/src/hooks.rs` (`git_hook_delete`) now route through `fsops::trash_delete` instead of calling `trash::delete` directly.

### Documentation
- `src/features/help/content.ts`: the discard note records the reserved-name exception, and the branch section gains a bullet on the update hold — every worktree of the repository sees it, and an interrupted update is cleaned up on the next branch action.
- Changelog fragments: `changelog.d/changed-ai-review-workspace-reuse.md`, `changelog.d/fixed-update-guards-sibling-worktrees.md`, `changelog.d/fixed-reserved-name-discard.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI reviews now reuse a shared workspace per repository, making subsequent reviews faster.
  - Shared review workspaces are automatically reclaimed after a week of inactivity.

- **Bug Fixes**
  - Windows-reserved filenames are reliably discarded, including when the Recycle Bin cannot process them.
  - Branch-update protections now apply consistently across all worktrees, including when switching, renaming, or deleting the updating branch.

- **Documentation**
  - Updated guidance explains review workspace reuse, cleanup behavior, branch-update holds, and reserved Windows filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->