### PR TITLE
fix(pulls,github,agents,settings): surface unfinished GitHub reviews

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -271,11 +271,13 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
 - Multi-toggle settings batch behind a Save/Discard bar (draft + dirty), not
   per-toggle auto-save; a single discrete select may apply-on-change.
 - A stored note/verdict that DESCRIBES form-draft values carries the draft
-  signature it was produced under and renders only while the current signature
-  matches (`testConfig` and `warn` in AiProviderSection, `note` in
-  KeyboardSection) — never clear-at-every-writer: the footer's Discard
-  `form.reset()`s from outside the section, which no in-file clear can reach.
-  Imperative clears only for validity axes the signature can't see (typed input).
+  signature it was produced under — never clear-at-every-writer: the footer's
+  Discard `form.reset()`s from outside the section, which no in-file clear can
+  reach. An advisory NOTICE is retired — state cleared — on the first mismatch,
+  so a draft returning to that signature can't resurrect a dismissed one (`note`
+  in KeyboardSection, `warn` in AllowedHostsField); a VERDICT stays render-gated
+  (`testConfig` in AiProviderSection), being valid again on return. Imperative
+  clears only for validity axes the signature can't see (typed input).
 - Repo-content config features (FUNDING.yml, CODEOWNERS, …) scaffold the
   local file for the user to commit — never write repo content via an API.
 - A mutation whose host can unmount mid-flight (a dialog closable by Esc / ✕ /

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -270,6 +270,12 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   mount the virtualizer in a child gated on data (`docs/list-virtualization.md`).
 - Multi-toggle settings batch behind a Save/Discard bar (draft + dirty), not
   per-toggle auto-save; a single discrete select may apply-on-change.
+- A stored note/verdict that DESCRIBES form-draft values carries the draft
+  signature it was produced under and renders only while the current signature
+  matches (`testConfig` and `warn` in AiProviderSection, `note` in
+  KeyboardSection) — never clear-at-every-writer: the footer's Discard
+  `form.reset()`s from outside the section, which no in-file clear can reach.
+  Imperative clears only for validity axes the signature can't see (typed input).
 - Repo-content config features (FUNDING.yml, CODEOWNERS, …) scaffold the
   local file for the user to commit — never write repo content via an API.
 - A mutation whose host can unmount mid-flight (a dialog closable by Esc / ✕ /

--- a/changelog.d/added-pending-review-strip.md
+++ b/changelog.d/added-pending-review-strip.md
@@ -1,0 +1,3 @@
+- A pull request where you have an unfinished review now says so up front: a
+  notice at the top of the pull request offers **Finish on GitHub** and
+  **Discard on GitHub** actions, so a started review is never stranded.

--- a/changelog.d/fixed-agent-resolution-probes.md
+++ b/changelog.d/fixed-agent-resolution-probes.md
@@ -1,4 +1,3 @@
 - Agent CLI detection and the container-engine fallback probe less: an absent
-  CLI is remembered briefly instead of re-spawning a login shell on every
-  check, and when the preferred engine is stopped, turns land on the running
-  engine without re-probing the stopped one each time.
+  CLI is remembered briefly, and when the preferred engine is stopped, turns
+  land directly on the running one.

--- a/changelog.d/fixed-agent-resolution-probes.md
+++ b/changelog.d/fixed-agent-resolution-probes.md
@@ -1,0 +1,4 @@
+- Agent CLI detection and the container-engine fallback probe less: an absent
+  CLI is remembered briefly instead of re-spawning a login shell on every
+  check, and when the preferred engine is stopped, turns land on the running
+  engine without re-probing the stopped one each time.

--- a/changelog.d/fixed-gh-endpoint-slug-guard.md
+++ b/changelog.d/fixed-gh-endpoint-slug-guard.md
@@ -1,3 +1,2 @@
-- GitHub API calls refuse a repository slug carrying URL-template characters
-  (`{`, `}`, `?`, `#`), so a crafted remote URL can't retarget them at a
-  different repository.
+- GitHub API calls refuse a repository path that isn't a plain `owner/repo`
+  slug, so a crafted remote URL can't retarget them at a different repository.

--- a/changelog.d/fixed-gh-endpoint-slug-guard.md
+++ b/changelog.d/fixed-gh-endpoint-slug-guard.md
@@ -1,2 +1,3 @@
-- GitHub API calls refuse a repository path that isn't a plain `owner/repo`
-  slug, so a crafted remote URL can't retarget them at a different repository.
+- GitHub API calls aimed at the open repository refuse a slug
+  that isn't plain `owner/repo`, so a crafted remote URL can't
+  retarget them at a different repository.

--- a/changelog.d/fixed-gh-endpoint-slug-guard.md
+++ b/changelog.d/fixed-gh-endpoint-slug-guard.md
@@ -1,0 +1,3 @@
+- GitHub API calls refuse a repository slug carrying URL-template characters
+  (`{`, `}`, `?`, `#`), so a crafted remote URL can't retarget them at a
+  different repository.

--- a/changelog.d/fixed-pending-review-pr-load.md
+++ b/changelog.d/fixed-pending-review-pr-load.md
@@ -1,3 +1,2 @@
 - Pull requests with an in-progress review load normally: a review you've
-  started but not yet submitted surfaces as an unfinished-review notice instead
-  of keeping the whole PR view from displaying.
+  started but not yet submitted surfaces as an unfinished-review notice.

--- a/changelog.d/fixed-pending-review-pr-load.md
+++ b/changelog.d/fixed-pending-review-pr-load.md
@@ -1,0 +1,3 @@
+- Pull requests with an in-progress review load normally: a review you've
+  started but not yet submitted shows as pending instead of keeping the whole
+  PR view from displaying.

--- a/changelog.d/fixed-pending-review-pr-load.md
+++ b/changelog.d/fixed-pending-review-pr-load.md
@@ -1,3 +1,3 @@
 - Pull requests with an in-progress review load normally: a review you've
-  started but not yet submitted shows as pending instead of keeping the whole
-  PR view from displaying.
+  started but not yet submitted surfaces as an unfinished-review notice instead
+  of keeping the whole PR view from displaying.

--- a/changelog.d/fixed-settings-notices-discard.md
+++ b/changelog.d/fixed-settings-notices-discard.md
@@ -1,0 +1,3 @@
+- Transient notices in Settings clear when you discard your changes: the
+  Keyboard "was taken from…" warning and the AI provider's "already allowed"
+  host note both track the draft they described instead of outliving it.

--- a/changelog.d/fixed-settings-notices-discard.md
+++ b/changelog.d/fixed-settings-notices-discard.md
@@ -1,3 +1,3 @@
 - Transient notices in Settings clear when you discard your changes: the
   Keyboard "was taken from…" warning and the AI provider's "already allowed"
-  host note both track the draft they described instead of outliving it.
+  host note both track the draft they described.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -236,6 +236,11 @@ export const capabilities: Capability[] = [
     label:
       "Retarget a pull request's base branch from the edit dialog — on GitHub, GitLab, and Bitbucket",
   },
+  {
+    group: "Pull requests & review",
+    label:
+      "Unfinished-review notice — a review you started on GitHub surfaces on the PR, to finish or discard",
+  },
 
   // — Forges & trackers —
   {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -9,8 +9,8 @@ use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
@@ -128,6 +128,17 @@ impl AgentKind {
             AgentKind::Codex => "Codex",
             AgentKind::Copilot => "GitHub Copilot",
             AgentKind::Opencode => "opencode",
+        }
+    }
+
+    /// This kind's index into [`RESOLVE_SLOTS`]-wide caches. Spelled out rather than
+    /// derived, so adding a kind is a compile error here instead of a silent collision.
+    fn slot(self) -> usize {
+        match self {
+            AgentKind::Claude => 0,
+            AgentKind::Codex => 1,
+            AgentKind::Copilot => 2,
+            AgentKind::Opencode => 3,
         }
     }
 }
@@ -679,9 +690,68 @@ pub(crate) async fn resolve_named(names: &[&str], bin_path: Option<&str>) -> Opt
     }
 }
 
-/// Resolves the agent CLI's binary (override → PATH → login shell).
+/// One cache slot per [`AgentKind`].
+const RESOLVE_SLOTS: usize = 4;
+
+type ResolveCache = [Option<(Instant, Option<PathBuf>)>; RESOLVE_SLOTS];
+
+/// Per-kind memo of the no-override resolution, held for
+/// [`crate::agent_sandbox::CANDIDATE_TTL`]. Caching the MISS is the point — an absent
+/// CLI costs a login-shell spawn per resolution on macOS/Linux — so a just-installed CLI
+/// can read "not installed" until the entry expires, on the same cadence as the container
+/// runtimes' recovery.
+fn resolve_cache() -> &'static Mutex<ResolveCache> {
+    static CACHE: OnceLock<Mutex<ResolveCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(std::array::from_fn(|_| None)))
+}
+
+/// Per-slot single-flight gate. Per SLOT, never one shared gate: a resolve that runs to
+/// `DETECT_TIMEOUT` for one agent must not queue another agent's detection behind it.
+fn resolve_lock(i: usize) -> &'static tokio::sync::Mutex<()> {
+    static LOCKS: OnceLock<[tokio::sync::Mutex<()>; RESOLVE_SLOTS]> = OnceLock::new();
+    &LOCKS.get_or_init(|| std::array::from_fn(|_| tokio::sync::Mutex::new(())))[i]
+}
+
+/// The slot's still-fresh cached resolution. The nesting is meaningful: the outer `None`
+/// is "cold or expired", the inner one a cached "not installed". A poisoned cache reads
+/// as cold, so resolution falls through rather than failing.
+fn cached_resolve(i: usize) -> Option<Option<PathBuf>> {
+    let entry = {
+        let guard = resolve_cache().lock().ok();
+        guard.and_then(|c| c[i].clone())
+    };
+    let (at, value) = entry?;
+    crate::agent_sandbox::cache_entry_fresh(
+        at,
+        Instant::now(),
+        crate::agent_sandbox::CANDIDATE_TTL,
+    )
+    .then_some(value)
+}
+
+/// Resolves the agent CLI's binary (override → PATH → login shell). The override arm
+/// bypasses the cache in both directions — it is a bare `is_file()`, and a Settings path
+/// edit must take effect on the next call rather than after a TTL.
 async fn resolve(kind: AgentKind, bin_path: Option<&str>) -> Option<PathBuf> {
-    resolve_named(kind.binary_names(), bin_path).await
+    let override_path = bin_path.map(str::trim).filter(|s| !s.is_empty());
+    if override_path.is_some() {
+        return resolve_named(kind.binary_names(), override_path).await;
+    }
+    let i = kind.slot();
+    if let Some(value) = cached_resolve(i) {
+        return value;
+    }
+    // Cold or expired: hold this slot's gate across the resolve and re-check, so N
+    // racing callers spend one resolution rather than N login-shell spawns.
+    let _flight = resolve_lock(i).lock().await;
+    if let Some(value) = cached_resolve(i) {
+        return value;
+    }
+    let resolved = resolve_named(kind.binary_names(), None).await;
+    if let Ok(mut c) = resolve_cache().lock() {
+        c[i] = Some((Instant::now(), resolved.clone()));
+    }
+    resolved
 }
 
 // --- detection -------------------------------------------------------------
@@ -2737,11 +2807,16 @@ pub async fn agent_session(
     // worktree-confined container. The agent CLI lives in the image, so we don't
     // resolve a host binary; the runtime drives it.
     if container {
-        // This branch runs on EVERY turn, so the preferred runtime holding the image
-        // settles the choice in ONE subprocess — `image inspect` needs the daemon, so
-        // it also proves the engine is up. Only its failure pays for the wider walk,
-        // which is what tells "wrong engine" / "engine stopped" / "never built" apart.
-        let preferred = crate::agent_sandbox::preferred_runtime().await;
+        // This branch runs on EVERY turn, so one candidate holding the image settles the
+        // choice in ONE subprocess — `image inspect` needs the daemon, so it also proves
+        // the engine is up. That candidate is the engine a recent fallback walk settled
+        // on when there is one (a stopped preferred engine would otherwise re-probe to
+        // its timeout every turn), else the preferred one. Only its failure pays for the
+        // wider walk, which tells "wrong engine" / "engine stopped" / "never built" apart.
+        let preferred = match crate::agent_sandbox::settled_runtime() {
+            Some(engine) => Some(engine),
+            None => crate::agent_sandbox::preferred_runtime().await,
+        };
         let preferred_has_image = match &preferred {
             Some((bin, _)) => crate::agent_sandbox::image_present(bin).await,
             None => false,
@@ -2749,7 +2824,12 @@ pub async fn agent_session(
         let (runtime, runtime_name) = match preferred.filter(|_| preferred_has_image) {
             Some(pair) => pair,
             None => match crate::agent_sandbox::pick_runtime().await {
-                crate::agent_sandbox::RuntimePick::WithImage(bin, name) => (bin, name),
+                crate::agent_sandbox::RuntimePick::WithImage(bin, name) => {
+                    // Only the fallback outcome is memoized: the happy path above needs no
+                    // memo, so its behavior stays exactly one subprocess either way.
+                    crate::agent_sandbox::remember_settled_runtime(&bin, &name);
+                    (bin, name)
+                }
                 crate::agent_sandbox::RuntimePick::ReadyNoImage(..) => {
                     return Err(AppError::Command(
                         "The agent container image isn't built yet. Open Settings → AI and click \"Build image\", then try again.".to_string(),
@@ -3184,6 +3264,46 @@ mod child_env_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_agent_kind_owns_a_distinct_cache_slot() {
+        let kinds = [
+            AgentKind::Claude,
+            AgentKind::Codex,
+            AgentKind::Copilot,
+            AgentKind::Opencode,
+        ];
+        let mut slots: Vec<usize> = kinds.iter().map(|k| k.slot()).collect();
+        assert!(slots.iter().all(|&i| i < RESOLVE_SLOTS));
+        slots.sort_unstable();
+        slots.dedup();
+        assert_eq!(slots.len(), kinds.len(), "two kinds share a cache slot");
+    }
+
+    #[tokio::test]
+    async fn resolve_serves_the_cache_but_an_override_bypasses_it() {
+        // A planted path that no real resolution could produce (it doesn't exist), so
+        // getting it back proves the cached value was served without re-resolving.
+        let kind = AgentKind::Opencode;
+        let planted = std::env::temp_dir().join("gd-planted-opencode-never-resolved");
+        {
+            let mut cache = resolve_cache().lock().unwrap();
+            cache[kind.slot()] = Some((Instant::now(), Some(planted.clone())));
+        }
+        assert_eq!(resolve(kind, None).await, Some(planted));
+        // An override is a bare `is_file()` check that never reads the cache, so a
+        // Settings path edit takes effect immediately.
+        let override_file =
+            std::env::temp_dir().join(format!("gd-override-cli-{}.bin", std::process::id()));
+        std::fs::write(&override_file, b"x").unwrap();
+        let found = resolve(kind, override_file.to_str()).await;
+        let _ = std::fs::remove_file(&override_file);
+        {
+            let mut cache = resolve_cache().lock().unwrap();
+            cache[kind.slot()] = None;
+        }
+        assert_eq!(found, Some(override_file));
+    }
 
     #[tokio::test]
     async fn capture_capped_round_trips_both_streams_under_cap() {

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -216,12 +216,14 @@ pub(crate) fn global_skills_dir() -> Option<PathBuf> {
 /// Preference slots [`candidate_at`] can fill.
 const RUNTIME_SLOTS: usize = 2;
 
-/// How long a slot's resolution is reused. It buys the one-shot callers (session
-/// discard, Test panel mount, shell open) and a turn burst ONE resolution instead of
-/// one per call, which matters because resolving an ABSENT binary costs a login-shell
-/// spawn on macOS/Linux. Matched to the sandbox status view's 15s recovery poll: a
-/// cached MISS is what holds the "not installed" copy up, so a longer TTL would keep
-/// that copy past the very tick meant to clear it once an engine is installed.
+/// How long a cached resolution is reused — by the runtime-candidate slots here, by
+/// `agent.rs`'s per-kind CLI resolve cache, and by the settled-runtime memo, so tuning
+/// it moves all three. It buys the one-shot callers (session discard, Test panel
+/// mount, shell open) and a turn burst ONE resolution instead of one per call, which
+/// matters because resolving an ABSENT binary costs a login-shell spawn on
+/// macOS/Linux. Matched to the sandbox status view's 15s recovery poll: a cached MISS
+/// is what holds the "not installed" copy up, so a longer TTL would keep that copy
+/// past the very tick meant to clear it once an engine is installed.
 pub(crate) const CANDIDATE_TTL: Duration = Duration::from_secs(15);
 
 type CandidateCache = [Option<(Instant, Option<(PathBuf, String)>)>; RUNTIME_SLOTS];

--- a/src-tauri/src/agent_sandbox.rs
+++ b/src-tauri/src/agent_sandbox.rs
@@ -222,7 +222,7 @@ const RUNTIME_SLOTS: usize = 2;
 /// spawn on macOS/Linux. Matched to the sandbox status view's 15s recovery poll: a
 /// cached MISS is what holds the "not installed" copy up, so a longer TTL would keep
 /// that copy past the very tick meant to clear it once an engine is installed.
-const CANDIDATE_TTL: Duration = Duration::from_secs(15);
+pub(crate) const CANDIDATE_TTL: Duration = Duration::from_secs(15);
 
 type CandidateCache = [Option<(Instant, Option<(PathBuf, String)>)>; RUNTIME_SLOTS];
 
@@ -240,7 +240,7 @@ fn slot_lock(i: usize) -> &'static tokio::sync::Mutex<()> {
 
 /// Whether a cache entry stamped at `at` is still usable at `now`. Pure so the TTL
 /// boundary is testable without waiting on a clock.
-fn cache_entry_fresh(at: Instant, now: Instant, ttl: Duration) -> bool {
+pub(crate) fn cache_entry_fresh(at: Instant, now: Instant, ttl: Duration) -> bool {
     now.saturating_duration_since(at) < ttl
 }
 
@@ -325,6 +325,44 @@ pub(crate) async fn preferred_runtime() -> Option<(PathBuf, String)> {
         }
     }
     None
+}
+
+type SettledMemo = Option<(Instant, (PathBuf, String))>;
+
+/// The engine a turn-path fallback walk last settled on, with the stamp it settled at.
+/// Set ONLY when the walk lands on [`RuntimePick::WithImage`], so a turn taking the
+/// preferred engine stays byte-identical (one `image inspect`); a config whose preferred
+/// engine is stopped then pays that doomed double-probe once per [`CANDIDATE_TTL`] window
+/// instead of every turn, and expiry — never a refresh — re-prefers a recovered engine.
+fn settled_runtime_memo() -> &'static Mutex<SettledMemo> {
+    static MEMO: OnceLock<Mutex<SettledMemo>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(None))
+}
+
+/// The memoized settled engine while it is still fresh. A poisoned memo reads as absent,
+/// so the caller falls through to the full walk rather than failing.
+pub(crate) fn settled_runtime() -> Option<(PathBuf, String)> {
+    let (at, engine) = {
+        let guard = settled_runtime_memo().lock().ok();
+        guard.and_then(|m| m.clone())
+    }?;
+    cache_entry_fresh(at, Instant::now(), CANDIDATE_TTL).then_some(engine)
+}
+
+/// Records the engine a fallback walk settled on. The stamp is taken here and never
+/// refreshed on a later confirm — its expiry IS the recheck of the preferred engine.
+pub(crate) fn remember_settled_runtime(bin: &Path, name: &str) {
+    if let Ok(mut m) = settled_runtime_memo().lock() {
+        *m = Some((Instant::now(), (bin.to_path_buf(), name.to_string())));
+    }
+}
+
+/// Drops the memo wherever image presence or container state changes under our control,
+/// so the next turn re-walks instead of confirming a pick that may no longer hold.
+pub(crate) fn forget_settled_runtime() {
+    if let Ok(mut m) = settled_runtime_memo().lock() {
+        *m = None;
+    }
 }
 
 /// Every installed runtime in preference order, for operations that must act on ALL
@@ -613,6 +651,9 @@ async fn run_build(bin: &Path, build_args: &[String]) -> AppResult<()> {
             "Building the agent image failed:\n{tail}"
         )));
     }
+    // A finished build changes which engine holds an image, so the settled pick a
+    // turn would confirm is no longer trustworthy.
+    forget_settled_runtime();
     Ok(())
 }
 
@@ -988,6 +1029,9 @@ pub async fn agent_sandbox_cleanup(app: AppHandle, session_id: String) -> AppRes
     for (bin, _) in runtime_candidates().await {
         let _ = run_capture(&bin, &["rm", "-f", &name], DETECT_TIMEOUT).await;
     }
+    // Container state just changed under us; drop the settled pick so the next turn
+    // re-walks rather than confirming a stale one.
+    forget_settled_runtime();
     Ok(())
 }
 
@@ -1662,6 +1706,27 @@ mod tests {
             at,
             CANDIDATE_TTL
         ));
+    }
+
+    #[test]
+    fn settled_runtime_memo_is_read_until_invalidated_or_expired() {
+        remember_settled_runtime(Path::new("pm"), "podman");
+        assert_eq!(
+            settled_runtime(),
+            Some((PathBuf::from("pm"), "podman".to_string()))
+        );
+        forget_settled_runtime();
+        assert_eq!(settled_runtime(), None);
+        // An entry older than the TTL reads as absent, so a stopped preferred engine is
+        // re-probed on the next window rather than the fallback pick riding forever.
+        let old = Instant::now()
+            .checked_sub(CANDIDATE_TTL)
+            .expect("host uptime exceeds the TTL, so the expiry arm must run");
+        if let Ok(mut m) = settled_runtime_memo().lock() {
+            *m = Some((old, (PathBuf::from("pm"), "podman".to_string())));
+        }
+        assert_eq!(settled_runtime(), None);
+        forget_settled_runtime();
     }
 
     #[test]

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -57,9 +57,12 @@ pub(crate) async fn gh_origin_slug(repo_path: &str) -> AppResult<String> {
 /// `upstream` on a non-fork clone reads clearly. `git_remote_url`'s TTL cache is
 /// keyed by (repo, name), so each lens caches independently — no extra work here.
 ///
-/// This is also where the slug is grammar-checked ([`valid_github_slug`]): every
-/// `gh` spawn resolves its slug here or through [`gh_origin_slug`], so the 100+
-/// `repos/{slug}/…` endpoint sites inherit the guard and none re-check it.
+/// This is also where the slug is grammar-checked ([`valid_github_slug`]): slugs for
+/// the checked-out repository resolve here or through [`gh_origin_slug`], so those
+/// `repos/{slug}/…` sites inherit the guard and none re-check it. Slug-shaped values
+/// from elsewhere sit outside it — the fork/star paths in `forge/github.rs` validate
+/// their own owner/name pair, while that file's viewer-login probe and readiness poll,
+/// plus the cross-repo branch delete in `pr.rs`, interpolate API-produced values.
 pub(crate) async fn gh_lens_slug(repo_path: &str, lens: Option<&str>) -> AppResult<String> {
     let remote = lens_remote(lens)?;
     let url =

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -56,15 +56,35 @@ pub(crate) async fn gh_origin_slug(repo_path: &str) -> AppResult<String> {
 /// scp-style URLs). The error NAMES the remote it failed on so a missing
 /// `upstream` on a non-fork clone reads clearly. `git_remote_url`'s TTL cache is
 /// keyed by (repo, name), so each lens caches independently — no extra work here.
+///
+/// This is also where the slug is grammar-checked ([`valid_github_slug`]): every
+/// `gh` spawn resolves its slug here or through [`gh_origin_slug`], so the 100+
+/// `repos/{slug}/…` endpoint sites inherit the guard and none re-check it.
 pub(crate) async fn gh_lens_slug(repo_path: &str, lens: Option<&str>) -> AppResult<String> {
     let remote = lens_remote(lens)?;
     let url =
         crate::git::remote::git_remote_url(repo_path.to_string(), remote.to_string()).await?;
-    crate::forge::remote_path(&url).ok_or_else(|| {
+    let slug = crate::forge::remote_path(&url).ok_or_else(|| {
         AppError::Gh(format!(
             "could not determine the GitHub repository from the {remote} remote"
         ))
-    })
+    })?;
+    if !valid_github_slug(&slug) {
+        return Err(AppError::Gh(format!(
+            "the {remote} remote's repository path {slug:?} isn't a valid GitHub owner/repo slug"
+        )));
+    }
+    Ok(slug)
+}
+
+/// Whether a slug is safe to interpolate into a `gh api` endpoint and to pass as
+/// `gh -R <slug>` argv: gh expands `{…}` in an endpoint and splits it on `?`/`#`
+/// (query/fragment), a leading `-` reads as a flag, and `.`/`..` traverse the path.
+fn valid_github_slug(slug: &str) -> bool {
+    let Some((owner, repo)) = slug.split_once('/') else {
+        return false;
+    };
+    crate::forge::validate_owner(owner).is_ok() && crate::forge::validate_repo_name(repo).is_ok()
 }
 
 /// Validate a lens value and map it to the git remote name it resolves. Pure —
@@ -89,7 +109,7 @@ pub(crate) fn fork_owner_of(slug: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{fork_owner_of, lens_remote};
+    use super::{fork_owner_of, lens_remote, valid_github_slug};
 
     #[test]
     fn lens_remote_accepts_none_origin_upstream() {
@@ -116,5 +136,44 @@ mod tests {
         // A malformed slug with no slash yields the whole string (gh then errors).
         assert_eq!(fork_owner_of("nowhere"), "nowhere");
         assert_eq!(fork_owner_of(""), "");
+    }
+
+    #[test]
+    fn valid_github_slug_accepts_real_slugs() {
+        for slug in [
+            "theBGuy/GitDesktop",
+            "octo-cat/hello.world_2",
+            "a1/b2",
+            "user/repo-name.js",
+        ] {
+            assert!(valid_github_slug(slug), "{slug:?} should be accepted");
+        }
+    }
+
+    #[test]
+    fn valid_github_slug_refuses_unaddressable_slugs() {
+        for slug in [
+            // Endpoint-retargeting characters: gh expands `{…}` and splits on `?`/`#`.
+            "own{er}/repo",
+            "owner/rep}o",
+            "owner/re?po",
+            "owner/re#po",
+            "owner/re po",
+            "a/b%7D",
+            // Shape: exactly one slash, both segments present.
+            "a/b/c",
+            "a",
+            "",
+            "/repo",
+            "owner/",
+            // A leading `-` reads as a flag in `gh -R <slug>` argv.
+            "-x/y",
+            "x/-y",
+            // Dot segments traverse the endpoint path.
+            "./x",
+            "x/..",
+        ] {
+            assert!(!valid_github_slug(slug), "{slug:?} should be refused");
+        }
     }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -1774,6 +1774,31 @@ pub async fn gh_pr_unminimize_comment(repo_path: String, comment_id: String) -> 
     Ok(())
 }
 
+/// Discards an unsubmitted (PENDING) review by its GraphQL node id — the same id
+/// [`RawReview::id`] already carries — so no repo slug or lens is involved and this
+/// works through any remote. GitHub only ever returns a PENDING review to its own
+/// author, so the caller can only reach (and delete) its own.
+#[tauri::command]
+pub async fn gh_pr_discard_pending_review(repo_path: String, review_id: String) -> AppResult<()> {
+    if review_id.trim().is_empty() {
+        return Err(AppError::InvalidArgument("a review id is required".into()));
+    }
+    run_gh(
+        Some(&repo_path),
+        &[
+            "api",
+            "graphql",
+            "-f",
+            "query=mutation($id:ID!){deletePullRequestReview(input:{pullRequestReviewId:$id}){clientMutationId}}",
+            "-f",
+            &format!("id={review_id}"),
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Checks out a PR's branch locally (handles fork-sourced PRs too).
 #[tauri::command]
 pub async fn gh_pr_checkout(
@@ -2987,8 +3012,11 @@ struct RawReview {
     state: String,
     #[serde(default)]
     body: String,
+    /// A PENDING review has no submit time; gh ≥2.94 spells that as literal JSON
+    /// `null` and `#[serde(default)]` only fills an ABSENT key, so an explicit
+    /// `null` needs `Option` or the whole `gh pr view` document fails to parse.
     #[serde(default)]
-    submitted_at: String,
+    submitted_at: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -3067,10 +3095,10 @@ fn parse_actions_run_job(url: &str) -> (Option<String>, Option<String>) {
     (Some(run_id), job_id)
 }
 
-/// Whether a timestamp is a real time. `gh` serializes a null GraphQL timestamp as
-/// Go's zero value (`"0001-01-01T00:00:00Z"`), so a still-running check "has" a
-/// `completedAt` and a PENDING review "has" a `submittedAt` unless that sentinel is
-/// dropped along with "".
+/// Whether a timestamp is a real time. gh ≥2.94 emits a null GraphQL timestamp as
+/// literal JSON `null` (the deserializers take `Option` for those fields); older gh
+/// spelled it as Go's zero value (`"0001-01-01T00:00:00Z"`), so a still-running check
+/// "has" a `completedAt` unless that sentinel is dropped along with "".
 fn real_check_time(s: &str) -> bool {
     !s.is_empty() && !s.starts_with("0001-01-01")
 }
@@ -3714,7 +3742,7 @@ pub async fn gh_pr_view(
                     author_avatar_url: String::new(),
                     state: r.state,
                     body: r.body,
-                    date: real_time_or_empty(r.submitted_at),
+                    date: real_time_or_empty(r.submitted_at.unwrap_or_default()),
                     id: r.id,
                     url: String::new(),
                     viewer_did_author: false,
@@ -3733,7 +3761,7 @@ pub async fn gh_pr_view(
                 author_avatar_url: String::new(),
                 state: r.state,
                 body: r.body,
-                date: real_time_or_empty(r.submitted_at),
+                date: real_time_or_empty(r.submitted_at.unwrap_or_default()),
                 id: r.id,
                 url: String::new(),
                 viewer_did_author: false,
@@ -5933,7 +5961,8 @@ mod tests {
     use super::{
         apply_stack_join, classify_gh_merge_refusal, classify_merge_async,
         external_items_from_thread_nodes,
-        flatten_slurped_pages, fork_head_identity, gh_api_error_message, host_from_url,
+        flatten_slurped_pages, fork_head_identity, gh_api_error_message,
+        gh_pr_discard_pending_review, host_from_url,
         is_diff_too_large, is_object_id, map_timeline_node, parse_actions_run_job,
         parse_auth_accounts, parse_pr_url_repo, parse_publish_owners, pr_edit_args, pr_poll_query,
         pull_stack_ref,
@@ -5950,7 +5979,7 @@ mod tests {
         ForgeTimelineEventOut,
         batch_check_present, build_divergence_compare_path, oid_outside_origin_graph,
         select_fork_pr_match, validate_branch,
-        ForkPrMatch, RawDivergenceRefs, RawForkPr, RawLogin, RawPr,
+        ForkPrMatch, RawDivergenceRefs, RawForkPr, RawLogin, RawPr, RawReview,
     };
     use crate::error::AppError;
     use crate::git::runner::{run_git, DEFAULT_TIMEOUT};
@@ -6876,6 +6905,16 @@ mod tests {
         assert_eq!(pick(vec![other_name, m(3, "contrib", 2)]), None);
     }
 
+    #[tokio::test]
+    async fn discard_pending_review_rejects_an_empty_id_before_spawning_gh() {
+        // The guard fires before any `gh` invocation, so a nonexistent repo path is
+        // enough to prove nothing was spawned.
+        for id in ["", "   "] {
+            let r = gh_pr_discard_pending_review("C:/nonexistent".into(), id.into()).await;
+            assert!(matches!(r, Err(AppError::InvalidArgument(_))));
+        }
+    }
+
     /// The anti-spoofing gate, against a real repo (temp_dir, git on PATH): a fork
     /// PR head that origin already reaches must never anchor a match, because forks
     /// share an object network and a crafted PR could otherwise claim unrelated
@@ -7636,6 +7675,57 @@ github.acme.com
         }))
         .expect("real submitted_at must deserialize");
         assert_eq!(rest_review_to_out(r2).date, "2026-07-18T12:34:56Z");
+    }
+
+    #[test]
+    fn graphql_review_null_submitted_at_deserializes_to_empty_date() {
+        // gh ≥2.94 spells a PENDING review's submit time as literal JSON null; a
+        // plain String field would fail the whole `gh pr view` document, so the PR
+        // wouldn't load at all. Mirrors the reviews arm's mapping expression.
+        let mapped = |r: RawReview| real_time_or_empty(r.submitted_at.unwrap_or_default());
+
+        let pending: RawReview = serde_json::from_value(serde_json::json!({
+            "id": "PRR_1",
+            "author": {"login": "alice"},
+            "state": "PENDING",
+            "body": "",
+            "submittedAt": null,
+        }))
+        .expect("null submittedAt must deserialize");
+        assert_eq!(pending.submitted_at, None);
+        assert_eq!(mapped(pending), "");
+
+        // An absent key is the case `#[serde(default)]` already covered.
+        let absent: RawReview = serde_json::from_value(serde_json::json!({
+            "id": "PRR_2",
+            "author": {"login": "bob"},
+            "state": "PENDING",
+            "body": "",
+        }))
+        .expect("absent submittedAt must deserialize");
+        assert_eq!(absent.submitted_at, None);
+        assert_eq!(mapped(absent), "");
+
+        // Older gh spelled the same null as Go's zero value; it still clears.
+        let sentinel: RawReview = serde_json::from_value(serde_json::json!({
+            "id": "PRR_3",
+            "state": "PENDING",
+            "submittedAt": "0001-01-01T00:00:00Z",
+        }))
+        .expect("Go-zero submittedAt must deserialize");
+        assert_eq!(sentinel.submitted_at.as_deref(), Some("0001-01-01T00:00:00Z"));
+        assert_eq!(mapped(sentinel), "");
+
+        // A submitted review's real timestamp passes straight through.
+        let submitted: RawReview = serde_json::from_value(serde_json::json!({
+            "id": "PRR_4",
+            "author": {"login": "carol"},
+            "state": "APPROVED",
+            "body": "lgtm",
+            "submittedAt": "2026-07-18T12:34:56Z",
+        }))
+        .expect("real submittedAt must deserialize");
+        assert_eq!(mapped(submitted), "2026-07-18T12:34:56Z");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -517,6 +517,7 @@ pub fn run() {
             github::pr::gh_list_repos,
             github::pr::gh_pr_minimize_comment,
             github::pr::gh_pr_unminimize_comment,
+            github::pr::gh_pr_discard_pending_review,
             github::pr::gh_pr_update_branch,
             github::pr::gh_pr_base_divergence,
             github::pr::gh_pr_checkout,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1181,16 +1181,17 @@ disabled, and names what it's waiting on — *available once GitDesktop connects
 (or Bitbucket) — so you can see the option exists and what makes it work.
 **Request changes** requires a summary. Submit posts all your pending drafts as one batch
 review (it works with no drafts too, for a plain verdict + summary). **Submit review…** and
-**Discard pending review** (both act on this local draft) are also available from the
-command palette ({{kbd:command-palette}}).
+**Discard pending review** (the app's own review flow, not the unfinished GitHub review
+below) are also available from the command palette ({{kbd:command-palette}}).
 
 An unfinished review of yours **on GitHub** (started on github.com or by another tool,
 never submitted) is different: the pull request shows a notice at the top, *You have an
 unfinished review on this pull request*, with **Finish on GitHub**, which opens the PR
 page where the draft can be submitted, and **Discard on GitHub…**, which permanently
 deletes the unfinished review and its draft comments after a confirm. Its draft line
-comments stay out of the app's threads until the review is submitted. Both actions are
-palette-only: **Finish review on GitHub** and **Discard review on GitHub**.
+comments stay out of the app's threads until the review is submitted. Both are
+palette-only by default (bind a key in Settings): **Finish review on GitHub** and
+**Discard review on GitHub**.
 
 ## The Commits tab
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1181,8 +1181,16 @@ disabled, and names what it's waiting on — *available once GitDesktop connects
 (or Bitbucket) — so you can see the option exists and what makes it work.
 **Request changes** requires a summary. Submit posts all your pending drafts as one batch
 review (it works with no drafts too, for a plain verdict + summary). **Submit review…** and
-**Discard pending review** are also available from the command palette
-({{kbd:command-palette}}).
+**Discard pending review** (both act on this local draft) are also available from the
+command palette ({{kbd:command-palette}}).
+
+An unfinished review of yours **on GitHub** (started on github.com or by another tool,
+never submitted) is different: the pull request shows a notice at the top, *You have an
+unfinished review on this pull request*, with **Finish on GitHub**, which opens the PR
+page where the draft can be submitted, and **Discard on GitHub…**, which permanently
+deletes the unfinished review and its draft comments after a confirm. Its draft line
+comments stay out of the app's threads until the review is submitted. Both actions are
+palette-only: **Finish review on GitHub** and **Discard review on GitHub**.
 
 ## The Commits tab
 

--- a/src/features/pulls/PendingReviewStrip.tsx
+++ b/src/features/pulls/PendingReviewStrip.tsx
@@ -1,0 +1,118 @@
+import { ArrowSquareOutIcon, NotePencilIcon } from "@phosphor-icons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useDiscardPendingReview } from "@/lib/git/queries";
+import type { PrThreadOut, RemoteLens } from "@/lib/git/types";
+import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { useConfirm } from "@/lib/stores/confirm";
+import { toastError } from "@/lib/toast";
+
+/**
+ * The notice for a review the viewer started on the forge and never submitted, in the
+ * slot and vocabulary of the mergeability banner above it. Renders nothing without
+ * one, which is also why nothing here is provider-gated: only GitHub models reviews at
+ * all, so a GitLab/Bitbucket pull request supplies none and the strip stays absent.
+ *
+ * Both actions name the forge, because both act on the review that lives THERE — the
+ * app's own on-disk draft comments have their own bar and their own discard.
+ */
+export function PendingReviewStrip({
+  repoPath,
+  lens,
+  number,
+  review,
+  prUrl,
+  remoteLabel,
+  stale,
+  selected,
+}: {
+  repoPath: string;
+  lens: RemoteLens;
+  number: number;
+  /** The viewer's unfinished review; absent when there is none. */
+  review: PrThreadOut | undefined;
+  /** The pull request's page on the forge, where the review can be submitted. */
+  prUrl: string;
+  /** The detected remote's name, for the action labels. */
+  remoteLabel: string;
+  /** The view is showing the PREVIOUS pull request's details while the switch lands.
+   *  Everything here addresses `number`, which is already the new one, so the strip
+   *  goes quiet rather than acting on the wrong pull request. */
+  stale: boolean;
+  /** This view owns the current selection — a lagging still-mounted view must not
+   *  answer the palette for a pull request the user has navigated away from. */
+  selected: boolean;
+}) {
+  const discard = useDiscardPendingReview(repoPath, lens);
+  const reviewId = review?.id;
+  // Held by both the buttons and the palette entries, so a keyboard route can never
+  // do what the disabled control refuses.
+  const ready = reviewId !== undefined && !stale && !discard.isPending;
+
+  function finishReview() {
+    openUrl(prUrl);
+  }
+
+  async function discardReview() {
+    if (reviewId === undefined) return;
+    const ok = await useConfirm.getState().ask({
+      title: `Discard your review on ${remoteLabel}?`,
+      body: "Your unfinished review and any draft comments in it are permanently deleted on GitHub.",
+      confirmLabel: `Discard on ${remoteLabel}`,
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
+    // The optimistic patch drops the review — and this strip with it — before the
+    // call settles, so the outcome rides the awaited continuation; per-call mutate
+    // callbacks would go with the unmounted observer.
+    try {
+      await discard.mutateAsync({ number, reviewId });
+      toast.success("Pending review discarded");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  useHotkeyAction("finish-review-on-github", finishReview, ready && selected);
+  useHotkeyAction(
+    "discard-review-on-github",
+    () => void discardReview(),
+    ready && selected,
+  );
+
+  if (review === undefined || stale) return null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b px-3 py-1.5 text-xs">
+      <span className="flex min-w-0 items-center gap-1.5 text-info">
+        {/* Decorative — the sentence carries the meaning, not the icon or the tone. */}
+        <NotePencilIcon aria-hidden className="size-3.5 shrink-0" />
+        <span className="min-w-0">
+          You have an unfinished review on this pull request.
+        </span>
+      </span>
+      <div className="flex items-center gap-1.5">
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={discard.isPending}
+          onClick={() => void discardReview()}
+        >
+          {`Discard on ${remoteLabel}…`}
+        </Button>
+        <Button
+          variant="outline"
+          size="xs"
+          disabled={discard.isPending}
+          onClick={finishReview}
+          title={`Open this pull request on ${remoteLabel} to submit or edit your review`}
+          className="cursor-pointer"
+        >
+          <ArrowSquareOutIcon data-icon="inline-start" />
+          {`Finish on ${remoteLabel}`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/pulls/PendingReviewStrip.tsx
+++ b/src/features/pulls/PendingReviewStrip.tsx
@@ -34,7 +34,7 @@ export function PendingReviewStrip({
   review: PrThreadOut | undefined;
   /** The pull request's page on the forge, where the review can be submitted. */
   prUrl: string;
-  /** The detected remote's name, for the action labels. */
+  /** The detected provider's label ("GitHub"), for the action labels. */
   remoteLabel: string;
   /** The view is showing the PREVIOUS pull request's details while the switch lands.
    *  Everything here addresses `number`, which is already the new one, so the strip

--- a/src/features/pulls/PendingReviewStrip.tsx
+++ b/src/features/pulls/PendingReviewStrip.tsx
@@ -47,15 +47,17 @@ export function PendingReviewStrip({
   const discard = useDiscardPendingReview(repoPath, lens);
   const reviewId = review?.id;
   // Held by both the buttons and the palette entries, so a keyboard route can never
-  // do what the disabled control refuses.
-  const ready = reviewId !== undefined && !stale && !discard.isPending;
+  // do what the disabled control refuses. An absent id is spelled "" here, the way
+  // the backend spells a review whose source supplied none.
+  const ready = !!reviewId && !stale && !discard.isPending;
 
   function finishReview() {
+    if (!ready) return;
     openUrl(prUrl);
   }
 
   async function discardReview() {
-    if (reviewId === undefined) return;
+    if (!ready) return;
     const ok = await useConfirm.getState().ask({
       title: `Discard your review on ${remoteLabel}?`,
       body: "Your unfinished review and any draft comments in it are permanently deleted on GitHub.",
@@ -74,14 +76,26 @@ export function PendingReviewStrip({
     }
   }
 
-  useHotkeyAction("finish-review-on-github", finishReview, ready && selected);
+  // The dispatch route re-checks `selected` at invoke: `enabled` de-registers one
+  // commit late and the dispatcher runs the LATEST closure, so a keydown in that
+  // window would otherwise act on a pull request the user has already left. A click
+  // can't land that way — its closure is all one PR's — so the buttons don't consult it.
+  useHotkeyAction(
+    "finish-review-on-github",
+    () => {
+      if (selected) finishReview();
+    },
+    ready && selected,
+  );
   useHotkeyAction(
     "discard-review-on-github",
-    () => void discardReview(),
+    () => {
+      if (selected) void discardReview();
+    },
     ready && selected,
   );
 
-  if (review === undefined || stale) return null;
+  if (!review?.id || stale) return null;
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b px-3 py-1.5 text-xs">

--- a/src/features/pulls/PendingReviewStrip.tsx
+++ b/src/features/pulls/PendingReviewStrip.tsx
@@ -110,6 +110,7 @@ export function PendingReviewStrip({
         <Button
           variant="ghost"
           size="xs"
+          className="text-destructive"
           disabled={discard.isPending}
           onClick={() => void discardReview()}
         >

--- a/src/features/pulls/PendingReviewStrip.tsx
+++ b/src/features/pulls/PendingReviewStrip.tsx
@@ -107,7 +107,6 @@ export function PendingReviewStrip({
           disabled={discard.isPending}
           onClick={finishReview}
           title={`Open this pull request on ${remoteLabel} to submit or edit your review`}
-          className="cursor-pointer"
         >
           <ArrowSquareOutIcon data-icon="inline-start" />
           {`Finish on ${remoteLabel}`}

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -35,8 +35,13 @@ import {
 
 /** Which reviews render, and which line-comment threads each of them claims. */
 export interface PrThreadClaims {
-  /** Reviews worth a row: a visible body, or a state to report. */
+  /** Reviews worth a row: a visible body, or a state to report — never the viewer's
+   *  own PENDING review, which the notice strip carries instead. */
   renderedReviews: PrThreadOut[];
+  /** The viewer's own unfinished reviews, which the notice strip owns instead of the
+   *  feed. GitHub returns a PENDING review only to its author and allows one at a
+   *  time; the array shape keeps the derivation total. */
+  pendingReviews: PrThreadOut[];
   /** Threads grouped by the review that owns them — one pass, reused for the
    *  claimed-id set and each review's inline slice. */
   threadsByReview: Map<string, ReviewThreadOut[]>;
@@ -66,10 +71,25 @@ export function usePrThreadClaims(
     // `reviewId`; always "" on GitLab/Bitbucket, which don't model reviews).
     // Claimed threads render inline under their review; the rest fall to the
     // residual block.
-    const renderedReviews = (reviews ?? []).filter(
-      (r) => hasVisibleBody(r.body) || r.state,
+    const all = reviews ?? [];
+    // A PENDING review is the viewer's own unsubmitted draft — dateless, so a feed row
+    // would sort ahead of everything. Excluded on STATE, not on body: a started review
+    // can already carry a draft summary. Its line comments come back from the threads
+    // read as well, and they stay drafts on GitHub until the review is finished or
+    // discarded, so rendering them as ordinary threads would offer Reply and Resolve
+    // on comments nobody else can see. The notice strip names the review instead.
+    const pendingReviews = all.filter((r) => r.state === "PENDING");
+    const renderedReviews = all.filter(
+      (r) => r.state !== "PENDING" && (hasVisibleBody(r.body) || r.state),
     );
-    const threads = reviewThreads ?? [];
+    // Non-empty ids only: GitLab/Bitbucket threads carry `reviewId: ""`, and an
+    // ""-member here would swallow every one of them.
+    const pendingIds = new Set(
+      pendingReviews.map((r) => r.id).filter((id) => id !== ""),
+    );
+    const threads = (reviewThreads ?? []).filter(
+      (t) => !pendingIds.has(t.reviewId),
+    );
     const threadsByReview = new Map<string, ReviewThreadOut[]>();
     // The thread a wrapper review wraps: the FIRST thread holding a comment whose
     // `reviewId` is that review's — a map rather than a per-row scan over every
@@ -113,6 +133,7 @@ export function usePrThreadClaims(
     const residualThreads = threads.filter((t) => !claimedThreadIds.has(t.id));
     return {
       renderedReviews,
+      pendingReviews,
       threadsByReview,
       wrapperReviewIds,
       wrappedThreadFor,

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -17,6 +17,7 @@ import type {
   PrThreadOut,
   ReviewThreadOut,
 } from "@/lib/git/types";
+import { dropDraftsByReviewIds } from "@/lib/pulls/pending-review-threads";
 import { parseableDate } from "@/lib/time";
 import {
   coalesceCommitRuns,
@@ -84,30 +85,17 @@ export function usePrThreadClaims(
     const all = reviews ?? [];
     // A PENDING review is the viewer's own unsubmitted draft — dateless, so a feed row
     // would sort ahead of everything. Excluded on STATE, not on body: a started review
-    // can already carry a draft summary. Its line comments come back from the threads
-    // read as well, and they stay drafts on GitHub until the review is finished or
-    // discarded, so rendering them as ordinary threads would offer Reply and Resolve
-    // on comments nobody else can see. The notice strip names the review instead.
-    // Comments are filtered as well as whole threads: a thread carries only its FIRST
-    // comment's review id, so a draft REPLY to an already-submitted thread would ride
-    // through the thread-level test.
+    // can already carry a draft summary. The notice strip names the review instead,
+    // and `dropDraftsByReviewIds` takes its line comments out of the threads read.
     const pendingReviews = all.filter((r) => r.state === "PENDING");
     const renderedReviews = all.filter(
       (r) => r.state !== "PENDING" && (hasVisibleBody(r.body) || r.state),
     );
-    // Non-empty ids only: GitLab/Bitbucket threads carry `reviewId: ""`, and an
-    // ""-member here would swallow every one of them.
+    // Non-empty ids only — see `dropDraftsByReviewIds` on why an "" member is unsafe.
     const pendingIds = new Set(
       pendingReviews.map((r) => r.id).filter((id) => id !== ""),
     );
-    const threads = (reviewThreads ?? []).flatMap((t) => {
-      if (pendingIds.has(t.reviewId)) return [];
-      const comments = t.comments.filter((c) => !pendingIds.has(c.reviewId));
-      if (comments.length === 0) return [];
-      // Identity preserved when nothing was dropped — the thread objects key and
-      // memoize the rendered rows.
-      return [comments.length === t.comments.length ? t : { ...t, comments }];
-    });
+    const threads = dropDraftsByReviewIds(reviewThreads ?? [], pendingIds);
     const threadsByReview = new Map<string, ReviewThreadOut[]>();
     // The thread a wrapper review wraps: the FIRST thread holding a comment whose
     // `reviewId` is that review's — a map rather than a per-row scan over every

--- a/src/features/pulls/PrActivityFeed.tsx
+++ b/src/features/pulls/PrActivityFeed.tsx
@@ -54,6 +54,16 @@ export interface PrThreadClaims {
   claimedThreadIds: Set<string>;
   /** Threads no review claimed — the residual block under the feed. */
   residualThreads: ReviewThreadOut[];
+  /** Every thread that survives the pending-draft filter — the ONE list both the
+   *  Conversation feed and the Files pane's line anchors read, so the viewer's
+   *  unsubmitted drafts can't be hidden on one tab and posted-looking on the other.
+   *  `undefined` (not `[]`) while the read hasn't landed, so a consumer can still
+   *  tell loading from empty. */
+  visibleThreads: ReviewThreadOut[] | undefined;
+  /** {@link visibleThreads}' length, 0 while it's still loading — what the feed can
+   *  actually render, claimed and residual together. The empty state reads this
+   *  rather than the raw query length, which still counts drafts nothing renders. */
+  visibleThreadCount: number;
 }
 
 /**
@@ -78,6 +88,9 @@ export function usePrThreadClaims(
     // read as well, and they stay drafts on GitHub until the review is finished or
     // discarded, so rendering them as ordinary threads would offer Reply and Resolve
     // on comments nobody else can see. The notice strip names the review instead.
+    // Comments are filtered as well as whole threads: a thread carries only its FIRST
+    // comment's review id, so a draft REPLY to an already-submitted thread would ride
+    // through the thread-level test.
     const pendingReviews = all.filter((r) => r.state === "PENDING");
     const renderedReviews = all.filter(
       (r) => r.state !== "PENDING" && (hasVisibleBody(r.body) || r.state),
@@ -87,9 +100,14 @@ export function usePrThreadClaims(
     const pendingIds = new Set(
       pendingReviews.map((r) => r.id).filter((id) => id !== ""),
     );
-    const threads = (reviewThreads ?? []).filter(
-      (t) => !pendingIds.has(t.reviewId),
-    );
+    const threads = (reviewThreads ?? []).flatMap((t) => {
+      if (pendingIds.has(t.reviewId)) return [];
+      const comments = t.comments.filter((c) => !pendingIds.has(c.reviewId));
+      if (comments.length === 0) return [];
+      // Identity preserved when nothing was dropped — the thread objects key and
+      // memoize the rendered rows.
+      return [comments.length === t.comments.length ? t : { ...t, comments }];
+    });
     const threadsByReview = new Map<string, ReviewThreadOut[]>();
     // The thread a wrapper review wraps: the FIRST thread holding a comment whose
     // `reviewId` is that review's — a map rather than a per-row scan over every
@@ -139,6 +157,10 @@ export function usePrThreadClaims(
       wrappedThreadFor,
       claimedThreadIds,
       residualThreads,
+      // The `?? []` above is an internal convenience; the loading arm is preserved
+      // here rather than reported as an empty result.
+      visibleThreads: reviewThreads === undefined ? undefined : threads,
+      visibleThreadCount: threads.length,
     };
   }, [reviews, reviewThreads]);
 }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -185,6 +185,7 @@ import { cn } from "@/lib/utils";
 import { ChecksRollup } from "./ChecksRollup";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { PendingReviewBar } from "./PendingReviewBar";
+import { PendingReviewStrip } from "./PendingReviewStrip";
 import { PrActivityFeed, usePrThreadClaims } from "./PrActivityFeed";
 import { PrCommitDetail } from "./PrCommitDetail";
 import {
@@ -2705,6 +2706,20 @@ export function RemotePrView({
         retryBusy={mergeability.isFetching}
       />
 
+      {/* Same slot as the banner above, and shown whatever section is active: an
+          unfinished review is PR state, and the feed no longer carries a row for it.
+          GitHub allows one per viewer — the first is the only one. */}
+      <PendingReviewStrip
+        repoPath={repoPath}
+        lens={lens}
+        number={number}
+        review={threadClaims.pendingReviews[0]}
+        prUrl={pr.url}
+        remoteLabel={remoteLabel}
+        stale={detailsStale}
+        selected={isSelectedPr}
+      />
+
       {aiEnabled && canComment && section === "review" && (
         <PrReviewPanel
           prKind="remote"
@@ -2947,7 +2962,10 @@ export function RemotePrView({
                 revealThreadId={revealThreadId}
                 onRevealed={() => setRevealThreadId(null)}
               />
-              {pr.reviews.length === 0 &&
+              {/* What the FEED holds, not what the payload does: the viewer's own
+                  pending review is carried by the notice strip, so counting it here
+                  would silence this line over an empty feed. */}
+              {threadClaims.renderedReviews.length === 0 &&
                 pr.comments.length === 0 &&
                 pr.commits.length === 0 &&
                 !timeline.data?.length &&

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2963,13 +2963,14 @@ export function RemotePrView({
                 onRevealed={() => setRevealThreadId(null)}
               />
               {/* What the FEED holds, not what the payload does: the viewer's own
-                  pending review is carried by the notice strip, so counting it here
-                  would silence this line over an empty feed. */}
+                  pending review and its draft line comments are carried by the notice
+                  strip, so counting either here would silence this line over an empty
+                  feed. */}
               {threadClaims.renderedReviews.length === 0 &&
                 pr.comments.length === 0 &&
                 pr.commits.length === 0 &&
                 !timeline.data?.length &&
-                !reviewThreads.data?.length && (
+                threadClaims.visibleThreadCount === 0 && (
                   <p className="text-xs text-muted-foreground">
                     No activity yet.
                   </p>
@@ -3177,10 +3178,13 @@ export function RemotePrView({
             fileDiff={fileDiff}
             isPending={prDiff.isPending}
             isError={prDiff.isError}
-            // The same threads + handlers/gates the Conversation block uses —
-            // reuse the top-level read/mutations, don't re-fetch. Quoting from a
-            // diff card feeds the view-level composer (persists to Conversation).
-            threads={reviewThreads.data}
+            // The same threads + handlers/gates the Conversation block uses — one
+            // filtered list off the top-level read, not a second fetch, so an
+            // unsubmitted GitHub review's drafts stay out of BOTH tabs rather than
+            // anchoring here as ordinary Reply/Resolve threads. The app's own drafts
+            // arrive separately below, badged. Quoting from a diff card feeds the
+            // view-level composer (persists to Conversation).
+            threads={threadClaims.visibleThreads}
             drafts={drafts.data}
             repoPath={repoPath}
             lens={lens}

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -550,6 +550,9 @@ function AllowedHostsField({
    *  field stays mounted, and allow-list writes from elsewhere; the input axis
    *  rides the typing and Escape clears below. */
   const hostsSig = JSON.stringify(hosts);
+  // Set during render of the component that owns the state: React's derived-state
+  // reset, re-rendered before commit with no cross-component warning. An effect
+  // would commit a stale warning for a frame first.
   if (warn && warn.sig !== hostsSig) setWarn(null);
   const visibleWarn = warn && warn.sig === hostsSig ? warn.text : null;
 

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -543,23 +543,30 @@ function AllowedHostsField({
   onChange: (next: string[]) => void;
 }) {
   const [draft, setDraft] = useState("");
-  const [warn, setWarn] = useState<string | null>(null);
+  const [warn, setWarn] = useState<{ text: string; sig: string } | null>(null);
+  /** A warning is valid on two axes. The hosts-draft axis rides this signature —
+   *  a mismatch retires the warning outright, so restoring the hosts can't
+   *  resurrect it — covering the footer's Discard, which form.reset()s while this
+   *  field stays mounted, and allow-list writes from elsewhere; the input axis
+   *  rides the typing and Escape clears below. */
+  const hostsSig = JSON.stringify(hosts);
+  if (warn && warn.sig !== hostsSig) setWarn(null);
+  const visibleWarn = warn && warn.sig === hostsSig ? warn.text : null;
 
   function add() {
     const host = normalizeHost(draft);
     if (!host) {
-      setWarn("Enter a host like 192.168.1.50:11434");
+      setWarn({ text: "Enter a host like 192.168.1.50:11434", sig: hostsSig });
       return;
     }
     // isHostAllowed also covers built-in/local hosts and a port already covered
     // by a no-port entry, so this blocks adding a redundant or always-allowed one.
     if (isHostAllowed(`http://${host}`, hosts)) {
-      setWarn(`${host} is already allowed`);
+      setWarn({ text: `${host} is already allowed`, sig: hostsSig });
       return;
     }
     onChange([...hosts, host]);
     setDraft("");
-    setWarn(null);
   }
 
   return (
@@ -594,7 +601,7 @@ function AllowedHostsField({
               }
             }}
           />
-          {warn && <p className="text-xs text-warning">{warn}</p>}
+          {visibleWarn && <p className="text-xs text-warning">{visibleWarn}</p>}
         </div>
         <Button
           type="button"

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -92,6 +92,9 @@ export const KeyboardSection = withForm({
      *  knowing to clear them; the refusal note is advisory (an attempted key, not
      *  the draft), and retiring it early is the safe direction. */
     const draftSig = JSON.stringify(overrides);
+    // Set during render of the component that owns the state: React's derived-state
+    // reset, re-rendered before commit. An effect would commit — and announce — the
+    // stale note for a frame first.
     if (note && note.sig !== draftSig) setNote(null);
     const visibleNote = note && note.sig === draftSig ? note.text : null;
     // View state only: the filter never touches the form, so it can't dirty

--- a/src/features/settings/KeyboardSection.tsx
+++ b/src/features/settings/KeyboardSection.tsx
@@ -79,7 +79,21 @@ export const KeyboardSection = withForm({
   render: function KeyboardSectionRender({ form }) {
     const overrides = useSelector(form.store, (s) => s.values.hotkeys);
     const [recordingId, setRecordingId] = useState<string | null>(null);
-    const [note, setNote] = useState<string | null>(null);
+    const [note, setNote] = useState<{
+      text: string;
+      /** The overrides-draft signature this note was posted under. */
+      sig: string;
+    } | null>(null);
+    /** Signature over the overrides draft a note was posted under. A mismatch
+     *  retires the note outright, so a draft that later returns to that signature
+     *  can't resurrect a dismissed message. Steal and consequence notes describe
+     *  the draft, so any route changing it — including the footer's Discard, which
+     *  form.reset()s while this section stays mounted — retires them without
+     *  knowing to clear them; the refusal note is advisory (an attempted key, not
+     *  the draft), and retiring it early is the safe direction. */
+    const draftSig = JSON.stringify(overrides);
+    if (note && note.sig !== draftSig) setNote(null);
+    const visibleNote = note && note.sig === draftSig ? note.text : null;
     // View state only: the filter never touches the form, so it can't dirty
     // the Save/Discard bar or survive into saved settings.
     const [filter, setFilter] = useState("");
@@ -95,9 +109,14 @@ export const KeyboardSection = withForm({
       return ACTIONS.find((a) => a.id === id)?.defaultBinding ?? null;
     };
 
-    /** Assigns or clears a binding, returning true when it posted the steal
-     *  message — that note outranks any softer one the caller would add. */
-    function setBinding(id: string, binding: string | null): boolean {
+    /** Assigns or clears a binding. Reports whether it posted the steal message
+     *  — that note outranks any softer one the caller would add — along with the
+     *  signature of the draft it just wrote, so the caller's own note rides the
+     *  same one. */
+    function setBinding(
+      id: string,
+      binding: string | null,
+    ): { stole: boolean; sig: string } {
       const next = { ...overrides };
       let stolenFrom: string | null = null;
       if (binding) {
@@ -115,12 +134,13 @@ export const KeyboardSection = withForm({
       if (binding === def) delete next[id];
       else next[id] = binding;
       form.setFieldValue("hotkeys", next);
+      const sig = JSON.stringify(next);
       const stealNote =
         stolenFrom && binding
           ? `${formatBinding(binding)} was taken from "${stolenFrom}", which is now unbound.`
           : null;
-      setNote(stealNote);
-      return stealNote !== null;
+      setNote(stealNote ? { text: stealNote, sig } : null);
+      return { stole: stealNote !== null, sig };
     }
 
     // While recording, capture every keypress before the app's own hotkey
@@ -147,14 +167,15 @@ export const KeyboardSection = withForm({
       const binding = eventToBinding(e);
       if (!binding) return; // bare modifier — keep waiting
       if (!isBindableCombo(binding)) {
-        setNote(refusalNote(binding));
+        setNote({ text: refusalNote(binding), sig: draftSig });
         return;
       }
       // The assignment always stands; a modifier-less binding only earns a note
       // about where it stays quiet, and never over the steal message. (Chords
       // are exempt: the quiet zones named by the note don't apply to them.)
-      if (!setBinding(id, binding) && !hasModifier(binding)) {
-        setNote(consequenceNote(binding));
+      const { stole, sig } = setBinding(id, binding);
+      if (!stole && !hasModifier(binding)) {
+        setNote({ text: consequenceNote(binding), sig });
       }
       setRecordingId(null);
     });
@@ -220,14 +241,16 @@ export const KeyboardSection = withForm({
             unbinds. Unbound actions stay available in the command palette.
             Changes apply when you save.
           </p>
-          {note && <p className="mt-1 text-xs text-warning">{note}</p>}
+          {visibleNote && (
+            <p className="mt-1 text-xs text-warning">{visibleNote}</p>
+          )}
           {/* Announce recording state + notes to screen readers. */}
           <span role="status" aria-live="assertive" className="sr-only">
             {recordingId
               ? `Recording shortcut for ${
                   ACTIONS.find((a) => a.id === recordingId)?.label ?? "action"
                 }. Press the new combination, or Escape to cancel.`
-              : (note ?? "")}
+              : (visibleNote ?? "")}
           </span>
         </div>
         <div className="flex gap-2">
@@ -261,10 +284,7 @@ export const KeyboardSection = withForm({
             variant="outline"
             size="sm"
             disabled={overrideCount === 0}
-            onClick={() => {
-              form.setFieldValue("hotkeys", {});
-              setNote(null);
-            }}
+            onClick={() => form.setFieldValue("hotkeys", {})}
           >
             Reset all to defaults
           </Button>
@@ -327,7 +347,6 @@ export const KeyboardSection = withForm({
                         const next = { ...overrides };
                         delete next[action.id];
                         form.setFieldValue("hotkeys", next);
-                        setNote(null);
                       }}
                     >
                       <ArrowCounterClockwiseIcon />

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2681,6 +2681,10 @@ export const ghPrMinimizeComment = (
 export const ghPrUnminimizeComment = (repoPath: string, commentId: string) =>
   invoke<void>("gh_pr_unminimize_comment", { repoPath, commentId });
 
+/** Discards an unsubmitted (PENDING) review by its node id; only its author sees one. */
+export const discardPendingReview = (repoPath: string, reviewId: string) =>
+  invoke<void>("gh_pr_discard_pending_review", { repoPath, reviewId });
+
 /** Outcome of an ACCEPTED forge merge (a failure rejects the invoke instead).
  *  `queued` means the forge took the merge but hasn't completed it — the PR is
  *  NOT merged yet. `cleanupWarning` carries the human-readable detail either

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -2682,7 +2682,7 @@ export const ghPrUnminimizeComment = (repoPath: string, commentId: string) =>
   invoke<void>("gh_pr_unminimize_comment", { repoPath, commentId });
 
 /** Discards an unsubmitted (PENDING) review by its node id; only its author sees one. */
-export const discardPendingReview = (repoPath: string, reviewId: string) =>
+export const ghPrDiscardPendingReview = (repoPath: string, reviewId: string) =>
   invoke<void>("gh_pr_discard_pending_review", { repoPath, reviewId });
 
 /** Outcome of an ACCEPTED forge merge (a failure rejects the invoke instead).

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4790,11 +4790,30 @@ export function useUnrequestChangesPr(repo: string) {
   );
 }
 
+/** Drops one review's unsubmitted line comments from a threads list: whole threads it
+ *  opened, plus its draft replies inside threads someone else opened (a thread carries
+ *  only its FIRST comment's review id). Mirrors `usePrThreadClaims`' pending-draft
+ *  filter, so the optimistic window shows what the reconciling refetch will. */
+function dropReviewDrafts(
+  threads: ReviewThreadOut[],
+  reviewId: string,
+): ReviewThreadOut[] {
+  return threads.flatMap((t) => {
+    if (t.reviewId === reviewId) return [];
+    const comments = t.comments.filter((c) => c.reviewId !== reviewId);
+    if (comments.length === 0) return [];
+    return [comments.length === t.comments.length ? t : { ...t, comments }];
+  });
+}
+
 /** Delete the viewer's unfinished (PENDING) review, dropping it from the cached PR
- *  details optimistically so the notice strip goes at once. Field-scoped rollback:
- *  only the reviews list is captured, so a failed discard doesn't revert a concurrent
- *  assignee/reviewer-set sharing this PR key. GitHub-only — no other provider models
- *  a pending review. */
+ *  details optimistically so the notice strip goes at once. The review-threads cache
+ *  is patched in the same breath: the feed hides that review's drafts by matching them
+ *  against the PENDING review, so dropping only the review would flash the drafts in as
+ *  ordinary comments until the settle refetch lands. Rollback is field-scoped on the
+ *  details key (only `reviews`, so a concurrent assignee-set survives); the threads key
+ *  holds nothing else, so it restores whole. GitHub-only — no other provider models a
+ *  pending review. */
 export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -4802,23 +4821,39 @@ export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
       api.discardPendingReview(repo, args.reviewId),
     onMutate: async (args) => {
       const key = ["repo", repo, "pr", lens, args.number] as const;
-      await queryClient.cancelQueries({ queryKey: key });
+      const threadsKey = prReviewThreadsKey(repo, args.number, lens);
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: key }),
+        queryClient.cancelQueries({ queryKey: threadsKey }),
+      ]);
       const prev = queryClient.getQueryData<PrDetails>(key);
+      const prevThreads =
+        queryClient.getQueryData<ReviewThreadOut[]>(threadsKey);
       queryClient.setQueryData<PrDetails>(key, (d) =>
         d
           ? { ...d, reviews: d.reviews.filter((r) => r.id !== args.reviewId) }
           : d,
       );
-      return { key, prevReviews: prev?.reviews };
+      queryClient.setQueryData<ReviewThreadOut[]>(threadsKey, (list) =>
+        list ? dropReviewDrafts(list, args.reviewId) : list,
+      );
+      return { key, threadsKey, prevReviews: prev?.reviews, prevThreads };
     },
     onError: (_e, _args, ctx) => {
-      const prevReviews = ctx?.prevReviews;
-      const key = ctx?.key;
-      if (prevReviews === undefined || key === undefined) return;
-      queryClient.setQueryData<PrDetails>(key, (cur) =>
-        cur ? { ...cur, reviews: prevReviews } : cur,
-      );
+      if (ctx === undefined) return;
+      // Locals, not `ctx.x`: a property read doesn't stay narrowed inside the
+      // updater closure below.
+      const { key, threadsKey, prevReviews, prevThreads } = ctx;
+      if (prevReviews !== undefined) {
+        queryClient.setQueryData<PrDetails>(key, (cur) =>
+          cur ? { ...cur, reviews: prevReviews } : cur,
+        );
+      }
+      if (prevThreads !== undefined) {
+        queryClient.setQueryData(threadsKey, prevThreads);
+      }
     },
+    // Prefix-matches the threads key too, so one invalidate reconciles both.
     onSettled: (_d, _e, args) =>
       queryClient.invalidateQueries({
         queryKey: ["repo", repo, "pr", lens, args.number],

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4805,6 +4805,9 @@ export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
     mutationFn: (args: { number: number; reviewId: string }) =>
       api.ghPrDiscardPendingReview(repo, args.reviewId),
     onMutate: async (args) => {
+      // An "" id would hand dropDraftsByReviewIds a set member its contract bans;
+      // skipping the patch keeps the caches whole while the backend rejects the call.
+      if (!args.reviewId) return;
       const key = ["repo", repo, "pr", lens, args.number] as const;
       const threadsKey = prReviewThreadsKey(repo, args.number, lens);
       await Promise.all([

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ignoreLines, REPLACEMENT_CHAR } from "@/lib/ai/ignore";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
+import { dropDraftsByReviewIds } from "@/lib/pulls/pending-review-threads";
 import { reloadReviewNotes } from "@/lib/review-notes/store";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
@@ -4790,22 +4791,6 @@ export function useUnrequestChangesPr(repo: string) {
   );
 }
 
-/** Drops one review's unsubmitted line comments from a threads list: whole threads it
- *  opened, plus its draft replies inside threads someone else opened (a thread carries
- *  only its FIRST comment's review id). Mirrors `usePrThreadClaims`' pending-draft
- *  filter, so the optimistic window shows what the reconciling refetch will. */
-function dropReviewDrafts(
-  threads: ReviewThreadOut[],
-  reviewId: string,
-): ReviewThreadOut[] {
-  return threads.flatMap((t) => {
-    if (t.reviewId === reviewId) return [];
-    const comments = t.comments.filter((c) => c.reviewId !== reviewId);
-    if (comments.length === 0) return [];
-    return [comments.length === t.comments.length ? t : { ...t, comments }];
-  });
-}
-
 /** Delete the viewer's unfinished (PENDING) review, dropping it from the cached PR
  *  details optimistically so the notice strip goes at once. The review-threads cache
  *  is patched in the same breath: the feed hides that review's drafts by matching them
@@ -4818,7 +4803,7 @@ export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: { number: number; reviewId: string }) =>
-      api.discardPendingReview(repo, args.reviewId),
+      api.ghPrDiscardPendingReview(repo, args.reviewId),
     onMutate: async (args) => {
       const key = ["repo", repo, "pr", lens, args.number] as const;
       const threadsKey = prReviewThreadsKey(repo, args.number, lens);
@@ -4835,7 +4820,7 @@ export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
           : d,
       );
       queryClient.setQueryData<ReviewThreadOut[]>(threadsKey, (list) =>
-        list ? dropReviewDrafts(list, args.reviewId) : list,
+        list ? dropDraftsByReviewIds(list, new Set([args.reviewId])) : list,
       );
       return { key, threadsKey, prevReviews: prev?.reviews, prevThreads };
     },

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -4790,6 +4790,42 @@ export function useUnrequestChangesPr(repo: string) {
   );
 }
 
+/** Delete the viewer's unfinished (PENDING) review, dropping it from the cached PR
+ *  details optimistically so the notice strip goes at once. Field-scoped rollback:
+ *  only the reviews list is captured, so a failed discard doesn't revert a concurrent
+ *  assignee/reviewer-set sharing this PR key. GitHub-only — no other provider models
+ *  a pending review. */
+export function useDiscardPendingReview(repo: string, lens: RemoteLens) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { number: number; reviewId: string }) =>
+      api.discardPendingReview(repo, args.reviewId),
+    onMutate: async (args) => {
+      const key = ["repo", repo, "pr", lens, args.number] as const;
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<PrDetails>(key);
+      queryClient.setQueryData<PrDetails>(key, (d) =>
+        d
+          ? { ...d, reviews: d.reviews.filter((r) => r.id !== args.reviewId) }
+          : d,
+      );
+      return { key, prevReviews: prev?.reviews };
+    },
+    onError: (_e, _args, ctx) => {
+      const prevReviews = ctx?.prevReviews;
+      const key = ctx?.key;
+      if (prevReviews === undefined || key === undefined) return;
+      queryClient.setQueryData<PrDetails>(key, (cur) =>
+        cur ? { ...cur, reviews: prevReviews } : cur,
+      );
+    },
+    onSettled: (_d, _e, args) =>
+      queryClient.invalidateQueries({
+        queryKey: ["repo", repo, "pr", lens, args.number],
+      }),
+  });
+}
+
 /** Toggle a PR/MR's draft state both ways on all three providers. `lens` threads the
  *  fork identity through to the GitHub arm. Optimistically patches `isDraft` with
  *  field-scoped rollback so the badge flips instantly; the repo-wide invalidate on

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -790,6 +790,22 @@ export const ACTIONS = [
     category: "Pull requests",
     defaultBinding: null,
   },
+  // The forge-side twin of the pair above: those act on the LOCAL draft comments this
+  // app stores, these on a review already started on GitHub. Labels name the provider
+  // literally because a registry label is a static string, while the strip's own
+  // buttons template the detected remote's name.
+  {
+    id: "finish-review-on-github",
+    label: "Finish review on GitHub",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
+  {
+    id: "discard-review-on-github",
+    label: "Discard review on GitHub",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
   {
     id: "pr-stack-next",
     label: "Next pull request in stack",

--- a/src/lib/pulls/pending-review-threads.ts
+++ b/src/lib/pulls/pending-review-threads.ts
@@ -1,0 +1,28 @@
+import type { ReviewThreadOut } from "@/lib/git/types";
+
+/**
+ * Drops the line comments belonging to unsubmitted (PENDING) reviews from a threads
+ * list — whole threads one of those reviews opened, plus its draft replies inside
+ * threads somebody else opened.
+ *
+ * Both halves are needed: a thread carries only its FIRST comment's review id, so a
+ * draft REPLY on an already-submitted thread rides through the thread-level test.
+ * They come back from the threads read but stay drafts on the forge until the review
+ * is finished or discarded, so rendering them as ordinary threads would offer Reply
+ * and Resolve on comments nobody else can see. `ids` must hold no `""` — GitLab and
+ * Bitbucket threads carry `reviewId: ""`, and an empty member would swallow all of them.
+ *
+ * Thread identity is preserved wherever nothing was dropped, so unaffected rows keep
+ * the object reference their rendered cards key and memoize on.
+ */
+export function dropDraftsByReviewIds(
+  threads: ReviewThreadOut[],
+  ids: ReadonlySet<string>,
+): ReviewThreadOut[] {
+  return threads.flatMap((t) => {
+    if (ids.has(t.reviewId)) return [];
+    const comments = t.comments.filter((c) => !ids.has(c.reviewId));
+    if (comments.length === 0) return [];
+    return [comments.length === t.comments.length ? t : { ...t, comments }];
+  });
+}


### PR DESCRIPTION
A review started on github.com (or by another tool) and never submitted was invisible in the app — worse, since gh 2.94 spells a PENDING review's `submittedAt` as literal JSON `null`, the whole `gh pr view` document failed to deserialize and such a pull request wouldn't load at all. This adds a notice at the top of the pull request offering **Finish on GitHub** and **Discard on GitHub**, fixes the parse failure underneath it, and carries the adjacent fixes found while building it (endpoint-slug validation, agent/container probe caching, and Settings notices outliving a Discard).

### Unfinished-review notice

- Adds `src/features/pulls/PendingReviewStrip.tsx`: renders in the mergeability-banner slot, opens `pr.url` via `openUrl` for **Finish on GitHub**, and routes **Discard on GitHub…** through `useConfirm` with a destructive confirm. It renders nothing without a pending review or while `stale`, and its hotkey handlers are gated on `ready && selected` so a lagging view can't answer the palette for a pull request the user left.
- `src/features/pulls/PrActivityFeed.tsx`: `usePrThreadClaims` now returns `pendingReviews`, excludes PENDING from `renderedReviews` on state rather than body, and drops review threads whose `reviewId` belongs to a pending review — filtered on non-empty ids only, so GitLab/Bitbucket threads carrying `reviewId: ""` survive.
- `src/features/pulls/RemotePrView.tsx`: mounts `PendingReviewStrip` with `threadClaims.pendingReviews[0]` for every section, and switches the "no activity" condition from `pr.reviews.length` to `threadClaims.renderedReviews.length` so the strip's review no longer silences that line over an empty feed.
- `src/lib/git/queries.ts`: `useDiscardPendingReview` optimistically removes the review from the cached `PrDetails`, with field-scoped rollback limited to `reviews` and an `onSettled` invalidate. `src/lib/git/api.ts` adds the `discardPendingReview` invoke wrapper.
- `src-tauri/src/github/pr.rs`: new `gh_pr_discard_pending_review` command runs `deletePullRequestReview` against the review's GraphQL node id (no slug or lens, so it works through any remote) and rejects a blank id before spawning `gh`; registered in `src-tauri/src/lib.rs`.
- `src/lib/hotkeys/registry.ts`: adds the `finish-review-on-github` and `discard-review-on-github` actions (palette-only, no default bindings), documented as the forge-side twins of the existing local-draft pair.

### GitHub API robustness

- `RawReview::submitted_at` becomes `Option<String>` in `src-tauri/src/github/pr.rs`, with both mapping sites using `unwrap_or_default()`; `#[serde(default)]` only fills an absent key, so an explicit `null` previously failed the entire document. `real_check_time`'s doc comment is corrected for the new gh behavior, and `graphql_review_null_submitted_at_deserializes_to_empty_date` covers null, absent, Go-zero, and real timestamps.
- `src-tauri/src/github/mod.rs`: `gh_lens_slug` grammar-checks the slug through a new `valid_github_slug` (delegating to `forge::validate_owner` / `validate_repo_name`), refusing `{`/`}`/`?`/`#`, a leading `-`, dot segments, and malformed shapes. Every `gh` spawn resolves its slug here, so the `repos/{slug}/…` endpoint sites inherit the guard; both accept and refuse cases are covered by tests.

### Agent CLI and container-engine probing

- `src-tauri/src/agent.rs`: adds a per-`AgentKind` resolution cache (`RESOLVE_SLOTS`, `resolve_cache`, `cached_resolve`, `AgentKind::slot`) held for `CANDIDATE_TTL`, plus per-slot single-flight `tokio::sync::Mutex` gates so racing callers spend one login-shell spawn instead of N. A `bin_path` override bypasses the cache in both directions so a Settings edit takes effect immediately. Tests pin the distinct-slot invariant and the cache-serves/override-bypasses behavior.
- `src-tauri/src/agent_sandbox.rs`: adds the `settled_runtime` / `remember_settled_runtime` / `forget_settled_runtime` memo, stamped once and expiring with `CANDIDATE_TTL` so expiry is what re-prefers a recovered engine. `agent_session`'s container branch consults it before `preferred_runtime`, and only memoizes the fallback `RuntimePick::WithImage` outcome, keeping the happy path at exactly one `image inspect`. The memo is dropped in `run_build` and `agent_sandbox_cleanup`; `CANDIDATE_TTL` and `cache_entry_fresh` become `pub(crate)`.

### Settings notice lifetimes

- `src/features/settings/KeyboardSection.tsx`: `note` now carries the overrides-draft signature it was posted under and retires on mismatch; `setBinding` returns `{ stole, sig }` so the caller's consequence note rides the same draft. The imperative clears on "Reset all to defaults" and per-row revert are removed, and the `aria-live` region reads the visible note.
- `src/features/settings/AiProviderSection.tsx`: the allowed-hosts `warn` gets the same signature treatment, which covers the footer's Discard (it `form.reset()`s from outside the section, where no in-file clear reaches).
- `.claude/skills/gd-conventions/SKILL.md`: records the signature-carrying rule for stored notes that describe form-draft values.

### Documentation

- `src/features/help/content.ts`: the review section now separates the app's local pending drafts from an unfinished review on GitHub, describes both actions and the confirm, notes that its draft line comments stay out of the app's threads, and names the two palette-only actions.
- `site/src/data/capabilities.ts`: adds the unfinished-review notice under "Pull requests & review".
- Five `changelog.d/` fragments: `added-pending-review-strip`, `fixed-pending-review-pr-load`, `fixed-gh-endpoint-slug-guard`, `fixed-agent-resolution-probes`, and `fixed-settings-notices-discard`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests with unfinished GitHub reviews now show options to finish or discard them.
  - Added palette commands and confirmation flow for managing unfinished reviews.
  - Review drafts remain separate from submitted activity and file discussions.

- **Bug Fixes**
  - Pull requests with pending reviews now load normally.
  - GitHub repository paths are validated to prevent redirected requests.
  - Settings notices now follow the current draft and clear when changes are discarded.
  - Agent and container detection avoid unnecessary repeated checks.

- **Documentation**
  - Updated pull-request guidance and capability descriptions for unfinished reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->