### PR TITLE
fix(changes,branches,commit): await mutations so outcomes land

### DIFF
--- a/changelog.d/fixed-cleanup-rules-settling.md
+++ b/changelog.d/fixed-cleanup-rules-settling.md
@@ -1,3 +1,3 @@
-- Cleaning up branches and deleting a branch now wait for branch protection
-  rules to finish loading before any delete runs, so a protected branch can't
-  slip through while the rules are still being read.
+- Deleting local branches (singly or through bulk clean-up) and committing now
+  wait for branch protection rules to load first, so protection applies from the
+  moment a repository opens.

--- a/changelog.d/fixed-cleanup-rules-settling.md
+++ b/changelog.d/fixed-cleanup-rules-settling.md
@@ -1,0 +1,3 @@
+- Cleaning up branches now waits for branch protection rules to finish loading
+  before offering or running a bulk delete, so a protected branch stays out of
+  the batch.

--- a/changelog.d/fixed-cleanup-rules-settling.md
+++ b/changelog.d/fixed-cleanup-rules-settling.md
@@ -1,3 +1,3 @@
-- Cleaning up branches now waits for branch protection rules to finish loading
-  before offering or running a bulk delete, so a protected branch stays out of
-  the batch.
+- Cleaning up branches and deleting a branch now wait for branch protection
+  rules to finish loading before any delete runs, so a protected branch can't
+  slip through while the rules are still being read.

--- a/changelog.d/fixed-mutation-callbacks-tab-switch.md
+++ b/changelog.d/fixed-mutation-callbacks-tab-switch.md
@@ -1,0 +1,4 @@
+- Success and error toasts, confirm-dialog cleanup, selection resets, and
+  recovery prompts from branch, staging, stash, sync, conflict, and commit
+  actions now arrive reliably even if you switch tabs or close the dialog while
+  the operation is still running.

--- a/changelog.d/fixed-mutation-callbacks-tab-switch.md
+++ b/changelog.d/fixed-mutation-callbacks-tab-switch.md
@@ -1,4 +1,4 @@
 - Success and error toasts, confirm-dialog cleanup, selection resets, and
-  recovery prompts from branch, staging, stash, sync, conflict, and commit
-  actions now arrive reliably even if you switch tabs or close the dialog while
-  the operation is still running.
+  recovery prompts from branch, staging, stash, sync, conflict, repository-file,
+  and commit-box actions now arrive reliably even if you switch tabs or close
+  the dialog while the operation is still running.

--- a/changelog.d/fixed-reserved-name-stage-explain.md
+++ b/changelog.d/fixed-reserved-name-stage-explain.md
@@ -1,3 +1,4 @@
 - Files with Windows-reserved device names (`nul`, `con`, `com3`, and friends)
-  now say on the row and in the context menu why git can't stage them, and
-  "Stage all" stages the rest of your changes instead of failing outright.
+  now say on the row and in the context menu why git can't stage them, and both
+  "Stage all" and the Repository files dialog's Force-add stage everything else
+  instead of failing outright.

--- a/changelog.d/fixed-reserved-name-stage-explain.md
+++ b/changelog.d/fixed-reserved-name-stage-explain.md
@@ -1,0 +1,3 @@
+- Files with Windows-reserved device names (`nul`, `con`, `com3`, and friends)
+  now say on the row and in the context menu why git can't stage them, and
+  "Stage all" stages the rest of your changes instead of failing outright.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -314,6 +314,13 @@ const DIFF_STAT_PAIR_RE = new RegExp(
   "g",
 );
 
+// A local DEFINITION of the change-kind badge table — the `const KIND_BADGE`
+// binding, not a read of the shared one (an import names it without `const`).
+// Matched per line: nothing wraps between the keyword and the name. A table
+// under a different name is invisible here, so this holds the copy-paste route
+// the two duplicates actually took, not the whole class.
+const KIND_BADGE_DEF_RE = /\bconst\s+KIND_BADGE\b/;
+
 // `<Activity` as a JSX open tag. The lookahead is what separates it from the
 // app's own `<ActivityDock>`/`<ActivityBell>`/`<ActivityStrip>` components, and
 // comment stripping is what keeps the many prose mentions of `<Activity>` clean.
@@ -491,15 +498,19 @@ export const CHECKS = [
     // Scoped to the trees that are fully converted, so the check can only ever
     // see a NEW site: the settings dialog's own sections (which unmount on BOTH
     // dialog close and every rail section switch — the keyed crossfade), Explore,
-    // whose detail pane is keyed per repo, and Actions, whose run detail is keyed
-    // per run and whose dispatch dialog unmounts with the repo view. The wider app
-    // is a separate tier: pulls/ and repository/ still carry per-call callback
-    // sites in bulk, so scanning them would report a backlog rather than a
-    // regression. Each tree joins this check on the change that converts it.
+    // whose detail pane is keyed per repo, Actions, whose run detail is keyed per
+    // run and whose dispatch dialog unmounts with the repo view, and the
+    // repository + commit trees, whose panels ride <Activity>-hidden tabs and
+    // whose dialogs close mid-flight. The wider app is a separate tier: pulls/
+    // still carries per-call callback sites in bulk, so scanning it would report a
+    // backlog rather than a regression. Each tree joins this check on the change
+    // that converts it.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||
-      file.startsWith("src/features/actions/"),
+      file.startsWith("src/features/actions/") ||
+      file.startsWith("src/features/repository/") ||
+      file.startsWith("src/features/commit/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
     allowlist: [],
     message:
@@ -581,6 +592,15 @@ export const CHECKS = [
     allowlist: [],
     message:
       "`+added -deleted` counts render through DiffStat (src/components/diff-stat.tsx) — a hand-rolled pair drifts from the canonical spacing, minus glyph, and tabular digits one site at a time; a site the component genuinely can't express needs an allowlist entry with rationale",
+  },
+  {
+    name: "kind-badge-single-source",
+    // The shared module IS the table; everything else imports it.
+    appliesTo: (file) => file !== "src/lib/git/change-kind-badge.ts",
+    scan: perLine(KIND_BADGE_DEF_RE),
+    allowlist: [],
+    message:
+      "the change-kind letter, screen-reader label, and colour token come from KIND_BADGE in src/lib/git/change-kind-badge.ts — a second definition drifts one surface at a time, so the Changes list and the commit dialog's staged summary stop agreeing on the same file; import it rather than re-spelling the table",
   },
   {
     name: "lone-activity-boundary",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -52,6 +52,7 @@ const menuSuppression = scanner("context-menu-suppression");
 const loneActivity = scanner("lone-activity-boundary");
 const seedOnOpen = scanner("seed-effect-on-open");
 const diffStatPair = scanner("hand-rolled-diff-stat");
+const kindBadge = scanner("kind-badge-single-source");
 const nullFallback = scanner("null-suspense-fallback");
 const bareGroupLabel = scanner("bare-group-label");
 const unguardedDispatcher = scanner("unguarded-binding-dispatcher");
@@ -531,9 +532,12 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
     assert.equal(appliesTo(file), true, `should scan ${file}`);
   }
   for (const file of [
-    "src/features/pulls/LocalPrView.tsx",
     "src/features/repository/ChangesPanel.tsx",
+    "src/features/commit/CommitBox.tsx",
   ]) {
+    assert.equal(appliesTo(file), true, `should scan ${file}`);
+  }
+  for (const file of ["src/features/pulls/LocalPrView.tsx"]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
 });
@@ -699,6 +703,45 @@ test("hand-rolled-diff-stat exempts the component file and vendored ui only", ()
   assert.equal(appliesTo("src/components/diff-stat.tsx"), false);
   assert.equal(appliesTo("src/components/ui/badge.tsx"), false);
   assert.equal(appliesTo("src/features/repository/FileRow.tsx"), true);
+});
+
+test("kind-badge-single-source flags a re-declared table, exported or not", () => {
+  // The two duplicates' own shape: a typed Record the formatter splits after
+  // the `=`, so only the keyword-plus-name line has to match.
+  const local = [
+    "const KIND_BADGE: Record<",
+    "  ChangeKind,",
+    "  { letter: string; label: string; className: string }",
+    "> = {",
+    '  added: { letter: "A", label: "Added", className: "text-success" },',
+    "};",
+  ].join("\n");
+  assert.deepEqual(kindBadge(local), [1]);
+  assert.deepEqual(
+    kindBadge('export const KIND_BADGE = { added: { letter: "A" } };'),
+    [1],
+  );
+});
+
+test("kind-badge-single-source leaves imports and reads of the shared table alone", () => {
+  for (const source of [
+    'import { KIND_BADGE } from "@/lib/git/change-kind-badge";',
+    "const badge = KIND_BADGE[kind];",
+    // A differently-named table is outside this check's shape by design.
+    "const KIND_GLYPH = { added: PlusIcon };",
+    // The comment naming the banned shape is what comment stripping keeps clean.
+    "// a second `const KIND_BADGE` drifts from the shared table",
+  ])
+    assert.deepEqual(kindBadge(source), [], `should ignore ${source}`);
+});
+
+test("kind-badge-single-source exempts the shared module only", () => {
+  const { appliesTo } = CHECKS.find(
+    (c) => c.name === "kind-badge-single-source",
+  );
+  assert.equal(appliesTo("src/lib/git/change-kind-badge.ts"), false);
+  assert.equal(appliesTo("src/features/repository/FileRow.tsx"), true);
+  assert.equal(appliesTo("src/features/commit/CommitDialog.tsx"), true);
 });
 
 test("null-suspense-fallback flags the literal on one line or wrapped", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -528,10 +528,7 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
     "src/features/repo-settings/RulesetsSection.tsx",
     "src/features/explore/ExploreDetail.tsx",
     "src/features/actions/RunDetailView.tsx",
-  ]) {
-    assert.equal(appliesTo(file), true, `should scan ${file}`);
-  }
-  for (const file of [
+    // Joined when the repository/commit conversions landed:
     "src/features/repository/ChangesPanel.tsx",
     "src/features/commit/CommitBox.tsx",
   ]) {

--- a/src-tauri/src/fsops.rs
+++ b/src-tauri/src/fsops.rs
@@ -68,14 +68,16 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> AppResult<()> {
 }
 
 /// True when `name`'s stem (everything before the first dot) is a reserved DOS
-/// device name. Windows resolves such a name to the DEVICE at any position in a
-/// path, extension or not, so `nul.txt` is as unopenable as `nul`. Win32 also
+/// device name. Windows resolves such a FINAL path component to the DEVICE in
+/// whatever directory the file sits, extension or not, so `nul.txt` and
+/// `src/nul` are as unopenable as `nul` (callers pass `file_name()`). Win32 also
 /// strips trailing dots and SPACES off the final component, which makes `nul `
 /// the device too (measured); the first-dot split covers the dots, the trim
 /// covers the spaces. Only a single COM/LPT ordinal 1–9 is a device, written
 /// either as an ASCII digit or as a Latin-1 superscript (`com¹`, `com²`,
 /// `com³`); `com0`, `com10`, `com⁴` (U+2074, outside Latin-1) and `console` are
-/// ordinary names.
+/// ordinary names. Mirrored by `src/lib/git/reserved-device-name.ts` — a change
+/// here moves there in the same change.
 #[cfg_attr(not(windows), allow(dead_code))]
 fn is_reserved_device_name(name: &str) -> bool {
     let stem = name

--- a/src/features/commit/AmendForcePushDialog.tsx
+++ b/src/features/commit/AmendForcePushDialog.tsx
@@ -37,7 +37,9 @@ export function AmendForcePushDialog({
 
   function confirm() {
     if (dontShowAgain && settings.data) {
-      saveSettings.mutate({ ...settings.data, confirmAmendForcePush: false });
+      void saveSettings
+        .mutateAsync({ ...settings.data, confirmAmendForcePush: false })
+        .catch(() => undefined);
     }
     onConfirm();
   }

--- a/src/features/commit/CommitDialog.tsx
+++ b/src/features/commit/CommitDialog.tsx
@@ -15,8 +15,9 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { clipTitle } from "@/lib/clip-title";
+import { KIND_BADGE } from "@/lib/git/change-kind-badge";
 import { useWorkingLineStats } from "@/lib/git/queries";
-import type { ChangeKind, FileEntry } from "@/lib/git/types";
+import type { FileEntry } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings } from "@/lib/hotkeys/hotkeys";
 import { useGenerateChordHint } from "@/lib/hotkeys/useGenerateChord";
@@ -25,26 +26,6 @@ import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
 import { CoAuthorPicker } from "./CoAuthorPicker";
 import { useCommitSubmit } from "./useCommitSubmit";
-
-// The Changes panel's status letters and tokens, for the read-only staged
-// summary: the same file in both surfaces must read the same letter and colour.
-const KIND_BADGE: Record<
-  ChangeKind,
-  { letter: string; label: string; className: string }
-> = {
-  added: { letter: "A", label: "Added", className: "text-success" },
-  untracked: { letter: "U", label: "Untracked", className: "text-success" },
-  modified: { letter: "M", label: "Modified", className: "text-warning" },
-  typechange: { letter: "T", label: "Type changed", className: "text-warning" },
-  deleted: { letter: "D", label: "Deleted", className: "text-destructive" },
-  renamed: { letter: "R", label: "Renamed", className: "text-info" },
-  copied: { letter: "C", label: "Copied", className: "text-info" },
-  conflicted: {
-    letter: "!",
-    label: "Conflicted",
-    className: "text-destructive",
-  },
-};
 
 /**
  * The pop-out commit composer. Rendered exactly ONCE, hoisted in RepositoryView:

--- a/src/features/commit/useCommitSubmit.ts
+++ b/src/features/commit/useCommitSubmit.ts
@@ -124,7 +124,11 @@ export function useCommitSubmit(
     active && canGenerate && !generating,
   );
 
-  function doCommit() {
+  // Awaited rather than per-call callbacks: both hosts can go while the commit
+  // is in flight (the dialog closes itself, the inline box rides an
+  // <Activity>-hidden tab), and react-query drops per-call callbacks once the
+  // observer has no listeners.
+  async function doCommit() {
     const commitTitle = title.trim();
     // Trailers must be the final paragraph of the message.
     const fullBody = [body.trim(), coAuthorTrailers(coAuthors)]
@@ -142,46 +146,45 @@ export function useCommitSubmit(
     // Desktop feel) instead of snapping empty once the commit resolves. Also
     // flips canCommit false, which blocks an accidental double-submit.
     clearCommitDraft();
-    commit.mutate(
-      { title: commitTitle, body: fullBody || undefined, amend: wasAmending },
-      {
-        onSuccess: (result) => {
-          // First, so the pop-out closes the instant the commit lands rather
-          // than behind the reporting work below.
-          onCommitted?.();
-          if (!wasAmending) {
-            track({
-              name: "commit_created",
-              properties: {
-                file_count: fileCount,
-                has_ai_message: snapshot.aiGenerated,
-                has_co_authors: snapshot.coAuthors.length > 0,
-              },
-            });
-          }
-          toast.success(
-            `${wasAmending ? "Amended" : "Committed"} ${result.hash.slice(0, 7)}`,
-          );
-          // Amending rewrites an existing commit; only new commits fire
-          // on-commit automations.
-          if (!wasAmending) {
-            triggerAutomations({
-              kind: "commit",
-              repoPath,
-              hash: result.hash,
-              title: commitTitle,
-              branch: branchName ?? "",
-            });
-          }
-        },
-        onError: (e) => {
-          // The commit failed — put the message back so it isn't lost (restores
-          // amending mode too).
-          restoreCommitDraft({ ...snapshot, amendingHash }, draftKey);
-          toastError(e);
-        },
-      },
-    );
+    try {
+      const result = await commit.mutateAsync({
+        title: commitTitle,
+        body: fullBody || undefined,
+        amend: wasAmending,
+      });
+      // First, so the pop-out closes the instant the commit lands rather
+      // than behind the reporting work below.
+      onCommitted?.();
+      if (!wasAmending) {
+        track({
+          name: "commit_created",
+          properties: {
+            file_count: fileCount,
+            has_ai_message: snapshot.aiGenerated,
+            has_co_authors: snapshot.coAuthors.length > 0,
+          },
+        });
+      }
+      toast.success(
+        `${wasAmending ? "Amended" : "Committed"} ${result.hash.slice(0, 7)}`,
+      );
+      // Amending rewrites an existing commit; only new commits fire
+      // on-commit automations.
+      if (!wasAmending) {
+        triggerAutomations({
+          kind: "commit",
+          repoPath,
+          hash: result.hash,
+          title: commitTitle,
+          branch: branchName ?? "",
+        });
+      }
+    } catch (e) {
+      // The commit failed — put the message back so it isn't lost (restores
+      // amending mode too).
+      restoreCommitDraft({ ...snapshot, amendingHash }, draftKey);
+      toastError(e);
+    }
   }
 
   return {

--- a/src/features/commit/useCommitSubmit.ts
+++ b/src/features/commit/useCommitSubmit.ts
@@ -97,8 +97,9 @@ export function useCommitSubmit(
     !locked &&
     !rulesSettling;
   const canGenerate = aiEnabled && aiConfigured && stagedCount > 0;
-  // Why Commit is refused, most-blocking first: a branch rule nothing the user
-  // types can lift, then the missing title, then the empty stage.
+  // Why Commit is refused, most-blocking first: the still-unread rules, then a
+  // branch rule nothing the user types can lift, then the missing title, then
+  // the empty stage.
   const commitDisabledReason = ((): string | null => {
     switch (true) {
       case rulesSettling:

--- a/src/features/commit/useCommitSubmit.ts
+++ b/src/features/commit/useCommitSubmit.ts
@@ -3,7 +3,10 @@ import { toast } from "sonner";
 import { track } from "@/lib/analytics";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { requiresPullRequest } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import {
+  useEffectiveBranchRules,
+  useEffectiveBranchRulesSettling,
+} from "@/lib/branch-rules/queries";
 import { coAuthorTrailers } from "@/lib/git/co-authors";
 import { useCommit, useRepoStatus } from "@/lib/git/queries";
 import type { ChangeKind, FileEntry } from "@/lib/git/types";
@@ -60,6 +63,9 @@ export function useCommitSubmit(
   const aiEnabled = useAiEnabled();
   const aiConfigured = useAiConfigured();
   const rulesConfig = useEffectiveBranchRules(repoPath);
+  // While either rules scope is on its FIRST read the effective config stands in
+  // as empty, so `locked` is vacuously false — commit holds on this instead.
+  const rulesSettling = useEffectiveBranchRulesSettling(repoPath);
 
   const amending = amendingHash !== null;
   const branchName = status.data?.branch?.name ?? null;
@@ -88,12 +94,15 @@ export function useCommitSubmit(
     title.trim().length > 0 &&
     (stagedCount > 0 || amending) &&
     !commit.isPending &&
-    !locked;
+    !locked &&
+    !rulesSettling;
   const canGenerate = aiEnabled && aiConfigured && stagedCount > 0;
   // Why Commit is refused, most-blocking first: a branch rule nothing the user
   // types can lift, then the missing title, then the empty stage.
   const commitDisabledReason = ((): string | null => {
     switch (true) {
+      case rulesSettling:
+        return "Checking branch protection rules…";
       case locked:
         return "This branch requires changes via a pull request";
       case title.trim().length === 0:
@@ -129,6 +138,10 @@ export function useCommitSubmit(
   // <Activity>-hidden tab), and react-query drops per-call callbacks once the
   // observer has no listeners.
   async function doCommit() {
+    // Belt for a gate that flipped under an open surface: `canCommit` disables
+    // the button and hotkey, but the rules can settle to "locked" between the
+    // render that enabled them and the click.
+    if (rulesSettling || locked) return;
     const commitTitle = title.trim();
     // Trailers must be the final paragraph of the message.
     const fullBody = [body.trim(), coAuthorTrailers(coAuthors)]

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -444,8 +444,8 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
 > Discarding an **untracked** file moves it to the recycle bin, so it's recoverable —
 > it isn't deleted outright. The exception is a name Windows reserves for a device
 > (\`nul\`, \`con\`, \`com3\`): the recycle bin can't take one, so those are removed
-> permanently. Git can't stage such a file at all, so its **Stage** control explains
-> that rather than failing, and **Stage all** stages everything else.`,
+> permanently. On Windows git can't stage such a file at all, so its **Stage**
+> control explains that rather than failing, and **Stage all** stages everything else.`,
   },
   {
     id: "history",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -444,7 +444,8 @@ Write a **summary** (there's a 72-character budget indicator) and an optional
 > Discarding an **untracked** file moves it to the recycle bin, so it's recoverable —
 > it isn't deleted outright. The exception is a name Windows reserves for a device
 > (\`nul\`, \`con\`, \`com3\`): the recycle bin can't take one, so those are removed
-> permanently.`,
+> permanently. Git can't stage such a file at all, so its **Stage** control explains
+> that rather than failing, and **Stage all** stages everything else.`,
   },
   {
     id: "history",

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -31,7 +31,10 @@ import {
   isMergeMethodAllowed,
   requiresPullRequest,
 } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import {
+  useEffectiveBranchRules,
+  useEffectiveBranchRulesSettling,
+} from "@/lib/branch-rules/queries";
 import { clipTitle } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { isDirtyTreeRefusal } from "@/lib/error-summary";
@@ -219,6 +222,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const rulesConfig = useEffectiveBranchRules(repoPath);
+  // While either rules scope is on its first read the effective config stands in
+  // as empty, so every protection check reads not-blocked — the delete surfaces
+  // hold on this rather than acting on that stand-in.
+  const rulesSettling = useEffectiveBranchRulesSettling(repoPath);
   const amendingHash = useUiStore((s) => s.amendingHash);
   const openSettings = useUiStore((s) => s.openSettings);
   const aiEnabled = useAiEnabled();
@@ -699,27 +706,45 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   const onError = (e: unknown) => toastError(e);
 
-  function setArchived(name: string, archived: boolean) {
-    setBranchArchived.mutate(
-      { name, archived },
-      {
-        onSuccess: () =>
-          toast.success(archived ? `Archived ${name}` : `Unarchived ${name}`),
-        onError,
-      },
-    );
+  // Awaited, not per-call callbacks: react-query drops those when the observer
+  // loses its listeners — a hidden `<Activity>` tab or an unmounted host — and
+  // the outcome would never reach the user. Every mutation below follows suit.
+  async function setArchived(name: string, archived: boolean) {
+    try {
+      await setBranchArchived.mutateAsync({ name, archived });
+      toast.success(archived ? `Archived ${name}` : `Unarchived ${name}`);
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function doUnlockWorktree(path: string) {
+    try {
+      await unlockWorktree.mutateAsync(path);
+      toast.success("Worktree unlocked");
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Dispatch the actual checkout — remote-only targets track a specific remote,
-  // local targets use plain switch. Both share the guards in `switchTo`.
-  function runCheckout(
+  // local targets use plain switch. Both share the guards in `switchTo`. The
+  // failure handler stays per-CALLER: each one recovers differently.
+  async function runCheckout(
     target: { name: string; remote: string | null },
     opts?: { onError?: (e: unknown) => void },
   ) {
-    if (target.remote) {
-      checkoutRemote.mutate({ remote: target.remote, name: target.name }, opts);
-    } else {
-      checkout.mutate(target.name, opts);
+    try {
+      if (target.remote) {
+        await checkoutRemote.mutateAsync({
+          remote: target.remote,
+          name: target.name,
+        });
+      } else {
+        await checkout.mutateAsync(target.name);
+      }
+    } catch (e) {
+      opts?.onError?.(e);
     }
   }
 
@@ -743,14 +768,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       setSwitchTarget({ name, remote });
       return;
     }
-    runCheckout({ name, remote }, { onError });
+    void runCheckout({ name, remote }, { onError });
   }
 
   function bringAndSwitch() {
     if (!switchTarget) return;
     const target = switchTarget;
     setSwitchTarget(null);
-    runCheckout(target, {
+    void runCheckout(target, {
       onError: (e) => {
         // git refused to carry the changes over rather than failing outright —
         // re-open the choice with stashing pointed out, instead of a dead-end
@@ -775,7 +800,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const reapply = reapplyOnSwitch;
     setSwitchTarget(null);
     if (settings.data && settings.data.reapplyStashOnSwitch !== reapply) {
-      saveSettings.mutate({ ...settings.data, reapplyStashOnSwitch: reapply });
+      // Fire-and-forget, and deliberately silent: a preference that didn't
+      // persist must neither delay the switch nor report over its outcome.
+      void saveSettings
+        .mutateAsync({ ...settings.data, reapplyStashOnSwitch: reapply })
+        .catch(() => undefined);
     }
     try {
       const outcome = await switchAutostash.mutateAsync({
@@ -811,6 +840,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   async function doDelete() {
     if (!deleteTarget) return;
+    // The guard below reads not-blocked from the stand-in config while the rules
+    // are still loading, so it would pass vacuously — refuse instead of deleting
+    // a branch a settled rule protects.
+    if (rulesSettling) {
+      toast.error("Branch rules are still loading — try again in a moment");
+      setDeleteTarget(null);
+      return;
+    }
     // Belt-and-suspenders: the menu items are already disabled for protected
     // branches, but guard here too in case a rule changed under an open dialog.
     if (isDeletionBlocked(rulesConfig, deleteTarget)) {
@@ -863,6 +900,52 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
   }
 
+  async function doDeleteRemoteBranch() {
+    if (!remoteDeleteTarget) return;
+    const target = remoteDeleteTarget;
+    try {
+      await deleteRemoteBranch.mutateAsync(target);
+      toast.success(`Deleted ${target.name} on ${target.remote}`);
+    } catch (e) {
+      onError(e);
+    } finally {
+      setRemoteDeleteTarget(null);
+    }
+  }
+
+  async function doDiscardAll() {
+    try {
+      await discardAll.mutateAsync(undefined);
+      toast.success("All changes discarded");
+    } catch (e) {
+      onError(e);
+    } finally {
+      setDiscardAllOpen(false);
+    }
+  }
+
+  async function doStashAll() {
+    try {
+      await stashAll.mutateAsync(undefined);
+      toast.success("Changes stashed");
+    } catch (e) {
+      onError(e);
+    } finally {
+      setStashAllOpen(false);
+    }
+  }
+
+  async function doStashPop() {
+    try {
+      await stashPop.mutateAsync(undefined);
+      toast.success("Stash restored");
+    } catch (e) {
+      onError(e);
+    } finally {
+      setStashPopOpen(false);
+    }
+  }
+
   // The picker dialog seeds its own branch + options on open; the switcher only
   // flags which mode is active.
   function openPicker(mode: PickerMode) {
@@ -900,20 +983,20 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   // The dialog collects the branch + options; the switcher owns the mutations
   // (they feed `busy`) and dispatches them here after closing the picker.
-  function runPicker(
+  async function runPicker(
     mode: PickerMode,
     branch: string,
     options: MergeRunOptions,
   ) {
     setPickerMode(null);
     if (mode === "rebase") {
-      rebaseBranch.mutate(branch, {
-        onSuccess: () => toast.success(`Rebased onto ${branch}`),
-        onError: (e) => {
-          if (beginRebaseRecovery(e, branch)) return;
-          onError(e);
-        },
-      });
+      try {
+        await rebaseBranch.mutateAsync(branch);
+        toast.success(`Rebased onto ${branch}`);
+      } catch (e) {
+        if (beginRebaseRecovery(e, branch)) return;
+        onError(e);
+      }
     } else {
       const squash = mode === "squash";
       // Options apply to a regular merge only, not squash.
@@ -923,21 +1006,17 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       // only redo a merge that asked for nothing else — offering it for the
       // others would quietly drop the option the user chose.
       const plain = !squash && !noFf && strategy === "none";
-      mergeBranch.mutate(
-        { branch, squash, noFf, strategy },
-        {
-          onSuccess: () =>
-            toast.success(
-              squash
-                ? `Squashed ${branch} — changes are staged, review and commit`
-                : `Merged ${branch}`,
-            ),
-          onError: (e) => {
-            if (plain && beginMergeRecovery(e, branch)) return;
-            onError(e);
-          },
-        },
-      );
+      try {
+        await mergeBranch.mutateAsync({ branch, squash, noFf, strategy });
+        toast.success(
+          squash
+            ? `Squashed ${branch} — changes are staged, review and commit`
+            : `Merged ${branch}`,
+        );
+      } catch (e) {
+        if (plain && beginMergeRecovery(e, branch)) return;
+        onError(e);
+      }
     }
   }
 
@@ -960,7 +1039,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // Proactive rather than error-triggered: the dialog already knows the tree is
   // dirty, and git would refuse before touching anything, so offering the
   // compound up front beats a round-trip that can only fail.
-  function runRebaseOnto(newBase: string, oldBase: string) {
+  async function runRebaseOnto(newBase: string, oldBase: string) {
     setRebaseOntoOpen(false);
     const request = {
       operationLabel: "rebase",
@@ -974,19 +1053,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       recovery.begin(request);
       return;
     }
-    rebaseOnto.mutate(
-      { newBase, oldBase },
-      {
-        onSuccess: () => toast.success(`Rebased onto ${newBase}`),
-        // `hasTrackedChanges` is a query-state read that can trail the tree: a
-        // file saved between the check and the run still deserves the offer, so
-        // a dirty refusal routes back into the same recovery.
-        onError: (e) => {
-          if (recovery.handleError(e, request)) return;
-          onError(e);
-        },
-      },
-    );
+    try {
+      await rebaseOnto.mutateAsync({ newBase, oldBase });
+      toast.success(`Rebased onto ${newBase}`);
+    } catch (e) {
+      // `hasTrackedChanges` is a query-state read that can trail the tree: a
+      // file saved between the check and the run still deserves the offer, so
+      // a dirty refusal routes back into the same recovery.
+      if (recovery.handleError(e, request)) return;
+      onError(e);
+    }
   }
 
   // A branch update only touches the working tree when it merges in place, i.e.
@@ -1008,45 +1084,43 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // it (unless it's already current): fast-forwards when possible, otherwise
   // merges via a throwaway worktree so the working tree — and its watchers —
   // stay put. A conflicting merge aborts and reports rather than switching.
-  function doUpdateFromDefault(target: string) {
+  async function doUpdateFromDefault(target: string) {
     if (!defaultName || target === defaultName) return;
     const base = defaultName;
     setOpen(false);
-    updateBranchFrom.mutate(
-      { branch: target, base },
-      {
-        onSuccess: (status) =>
-          toast.success(
-            status === "up-to-date"
-              ? `${target} is already up to date with ${base}`
-              : `Updated ${target} from ${base}`,
-          ),
-        onError: (e) => {
-          if (!beginUpdateRecovery(e, target, base)) onError(e);
-        },
-      },
-    );
+    try {
+      const outcome = await updateBranchFrom.mutateAsync({
+        branch: target,
+        base,
+      });
+      toast.success(
+        outcome === "up-to-date"
+          ? `${target} is already up to date with ${base}`
+          : `Updated ${target} from ${base}`,
+      );
+    } catch (e) {
+      if (!beginUpdateRecovery(e, target, base)) onError(e);
+    }
   }
 
   // Pull `target`'s own upstream (e.g. `origin/master`) into it without checking
   // it out — the "just merged a PR, bring master current before I switch back"
   // flow. Merges in place when `target` is current, fast-forwards otherwise.
-  function doUpdateFromUpstream(target: string, base: string) {
+  async function doUpdateFromUpstream(target: string, base: string) {
     setOpen(false);
-    updateBranchFrom.mutate(
-      { branch: target, base },
-      {
-        onSuccess: (status) =>
-          toast.success(
-            status === "up-to-date"
-              ? `${target} is already up to date with ${base}`
-              : `Updated ${target} from ${base}`,
-          ),
-        onError: (e) => {
-          if (!beginUpdateRecovery(e, target, base)) onError(e);
-        },
-      },
-    );
+    try {
+      const outcome = await updateBranchFrom.mutateAsync({
+        branch: target,
+        base,
+      });
+      toast.success(
+        outcome === "up-to-date"
+          ? `${target} is already up to date with ${base}`
+          : `Updated ${target} from ${base}`,
+      );
+    } catch (e) {
+      if (!beginUpdateRecovery(e, target, base)) onError(e);
+    }
   }
 
   // The remedy for a branch whose upstream already carries its changes under
@@ -1074,26 +1148,33 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       confirmVariant: "destructive",
     });
     if (!ok) return;
-    const done = {
-      onSuccess: () => toast.success(`Reset ${branch.name} to ${base}`),
-      onError,
-    };
-    if (branch.isCurrent) {
-      // The confirmation above spans an await, and HEAD can move under it — an
-      // out-of-app `git switch`, or the app's own checkout. `reset --hard` names
-      // no branch, so a moved HEAD would rewrite whatever is checked out NOW to a
-      // tip measured for a branch the user is no longer on. The ref reads live;
-      // the captured name is the only branch the confirmation described. Says so
-      // rather than returning quietly: the user just confirmed a destructive
-      // action, and silence there reads as "it worked". Wording kept in step with
-      // the sync controls' twin.
-      if (currentNameRef.current !== branch.name) {
-        toast.info("HEAD moved while the dialog was open — nothing was reset.");
-        return;
+    try {
+      if (branch.isCurrent) {
+        // The confirmation above spans an await, and HEAD can move under it — an
+        // out-of-app `git switch`, or the app's own checkout. `reset --hard`
+        // names no branch, so a moved HEAD would rewrite whatever is checked out
+        // NOW to a tip measured for a branch the user is no longer on. The ref
+        // reads live; the captured name is the only branch the confirmation
+        // described. Says so rather than returning quietly: the user just
+        // confirmed a destructive action, and silence there reads as "it
+        // worked". Wording kept in step with the sync controls' twin.
+        if (currentNameRef.current !== branch.name) {
+          toast.info(
+            "HEAD moved while the dialog was open — nothing was reset.",
+          );
+          return;
+        }
+        await hardReset.mutateAsync(tip);
+      } else {
+        await resetToUpstream.mutateAsync({
+          branch: branch.name,
+          expectedTip: tip,
+        });
       }
-      hardReset.mutate(tip, done);
-    } else
-      resetToUpstream.mutate({ branch: branch.name, expectedTip: tip }, done);
+      toast.success(`Reset ${branch.name} to ${base}`);
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Push a branch's ref without checking it out — the outbound counterpart of
@@ -1103,7 +1184,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // the backend resolves to the branch's own upstream remote.
   function doPushBranch(branch: Branch, remote?: string) {
     setOpen(false);
-    if (branch.upstream && !branch.upstreamGone) runPushBranch(branch, remote);
+    if (branch.upstream && !branch.upstreamGone)
+      void runPushBranch(branch, remote);
     else void beginPublishBranch(branch, remote);
   }
 
@@ -1118,23 +1200,25 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     );
     setDetecting(false);
     if (match) setForkGuard({ match, branch, remote });
-    else runPushBranch(branch, remote);
+    else void runPushBranch(branch, remote);
   }
 
-  function runPushBranch(branch: Branch, remote?: string) {
+  async function runPushBranch(branch: Branch, remote?: string) {
     const publishing = !branch.upstream || branch.upstreamGone;
-    push.mutate(
-      { setUpstream: false, branch: branch.name, remote },
-      {
-        onSuccess: () =>
-          toast.success(
-            publishing
-              ? `Published ${branch.name} to ${remote ?? "origin"}`
-              : `Pushed ${branch.name} to ${branch.upstream}`,
-          ),
-        onError,
-      },
-    );
+    try {
+      await push.mutateAsync({
+        setUpstream: false,
+        branch: branch.name,
+        remote,
+      });
+      toast.success(
+        publishing
+          ? `Published ${branch.name} to ${remote ?? "origin"}`
+          : `Pushed ${branch.name} to ${branch.upstream}`,
+      );
+    } catch (e) {
+      onError(e);
+    }
   }
 
   const busy =
@@ -1256,7 +1340,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   });
   useHotkeyAction(
     "update-from-default",
-    () => currentName && doUpdateFromDefault(currentName),
+    () => {
+      if (currentName) void doUpdateFromDefault(currentName);
+    },
     Boolean(defaultName && defaultName !== currentName && !busy),
   );
   const defaultBranchRow = allBranches.find((b) => b.name === defaultName);
@@ -1291,7 +1377,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         return;
       }
     }
-    doUpdateFromUpstream(row.name, row.upstream);
+    void doUpdateFromUpstream(row.name, row.upstream);
   }
   useHotkeyAction(
     "update-default-from-upstream",
@@ -1727,7 +1813,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               {canUpdate && (
                 <ContextMenuItem
                   disabled={busy}
-                  onClick={() => doUpdateFromDefault(branch.name)}
+                  onClick={() => void doUpdateFromDefault(branch.name)}
                 >
                   Update from {defaultName}
                 </ContextMenuItem>
@@ -1774,7 +1860,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   return (
                     <ContextMenuItem
                       disabled={busy}
-                      onClick={() => doUpdateFromUpstream(branch.name, base)}
+                      onClick={() =>
+                        void doUpdateFromUpstream(branch.name, base)
+                      }
                     >
                       Update from {base}
                     </ContextMenuItem>
@@ -1833,7 +1921,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           </ContextMenuItem>
           <ContextMenuItem
             disabled={archiveBlockedReason !== null}
-            onClick={() => setArchived(branch.name, !branch.archived)}
+            onClick={() => void setArchived(branch.name, !branch.archived)}
           >
             {archiveBlockedReason === null
               ? archiveLabel
@@ -2194,11 +2282,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                                   // re-renders it.
                                   if (refuseWhileLeaving(w.path, isRemoving))
                                     return;
-                                  unlockWorktree.mutate(w.path, {
-                                    onSuccess: () =>
-                                      toast.success("Worktree unlocked"),
-                                    onError,
-                                  });
+                                  void doUnlockWorktree(w.path);
                                 }}
                               >
                                 {itemLabel("Unlock")}
@@ -2350,9 +2434,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     defaultName === currentName ||
                     busy
                   }
-                  onClick={() =>
-                    currentName && doUpdateFromDefault(currentName)
-                  }
+                  onClick={() => {
+                    if (currentName) void doUpdateFromDefault(currentName);
+                  }}
                 >
                   Update from {defaultName ?? "default branch"}
                 </MenuRow>
@@ -2435,6 +2519,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         defaultBranch={defaultName}
         currentBranch={currentName}
         isProtected={(name) => isDeletionBlocked(rulesConfig, name)}
+        // Until both rules scopes land, `isProtected` excludes nothing, so the
+        // dialog holds its list rather than offering a branch a rule refuses.
+        rulesSettling={rulesSettling}
         isInWorktree={(name) => worktreeByBranch.has(name)}
         // From the removal store, not the worktree read: `isInWorktree` still
         // matches a worktree git lists until its removal finishes, and that
@@ -2502,20 +2589,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         confirmLabel="Delete"
         confirmVariant="destructive"
         pending={deleteRemoteBranch.isPending}
-        onConfirm={() => {
-          if (!remoteDeleteTarget) return;
-          const target = remoteDeleteTarget;
-          deleteRemoteBranch.mutate(target, {
-            onSuccess: () => {
-              toast.success(`Deleted ${target.name} on ${target.remote}`);
-              setRemoteDeleteTarget(null);
-            },
-            onError: (e) => {
-              onError(e);
-              setRemoteDeleteTarget(null);
-            },
-          });
-        }}
+        onConfirm={doDeleteRemoteBranch}
       />
 
       <DeleteWorktreeDialog
@@ -2569,18 +2643,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         confirmLabel="Discard all"
         confirmVariant="destructive"
         pending={discardAll.isPending}
-        onConfirm={() =>
-          discardAll.mutate(undefined, {
-            onSuccess: () => {
-              toast.success("All changes discarded");
-              setDiscardAllOpen(false);
-            },
-            onError: (e) => {
-              onError(e);
-              setDiscardAllOpen(false);
-            },
-          })
-        }
+        onConfirm={doDiscardAll}
       />
 
       <ConfirmDialog
@@ -2592,18 +2655,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         }
         confirmLabel="Stash changes"
         pending={stashAll.isPending}
-        onConfirm={() =>
-          stashAll.mutate(undefined, {
-            onSuccess: () => {
-              toast.success("Changes stashed");
-              setStashAllOpen(false);
-            },
-            onError: (e) => {
-              onError(e);
-              setStashAllOpen(false);
-            },
-          })
-        }
+        onConfirm={doStashAll}
       />
 
       <ConfirmDialog
@@ -2613,18 +2665,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         body="Applies the most recent stash to your working tree and removes it from the stash list. If applying conflicts, the stash is kept."
         confirmLabel="Pop stash"
         pending={stashPop.isPending}
-        onConfirm={() =>
-          stashPop.mutate(undefined, {
-            onSuccess: () => {
-              toast.success("Stash restored");
-              setStashPopOpen(false);
-            },
-            onError: (e) => {
-              onError(e);
-              setStashPopOpen(false);
-            },
-          })
-        }
+        onConfirm={doStashPop}
       />
 
       <BranchMergePickerDialog
@@ -2655,7 +2696,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         onClose={() => setForkGuard(null)}
         onPublishAnyway={() => {
           setForkGuard(null);
-          if (forkGuard) runPushBranch(forkGuard.branch, forkGuard.remote);
+          if (forkGuard) void runPushBranch(forkGuard.branch, forkGuard.remote);
         }}
       />
 

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -16,6 +16,7 @@ import {
   globLiteralPath,
   literalPathspec,
 } from "@/lib/git/glob";
+import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { FileEntry } from "@/lib/git/types";
 import { isWindows } from "@/lib/hotkeys/binding";
 import {
@@ -63,6 +64,9 @@ export interface ChangesMenuActions {
   aiExcludeSelected: () => void;
 }
 
+/** A disabled menu item can't carry a tooltip, so the reason rides its label. */
+const RESERVED_HINT = " (Windows-reserved name)";
+
 /** "src/lib/x.ts" -> ["src/lib", "src"] (closest folder first). */
 function ancestorFolders(path: string): string[] {
   const folders: string[] = [];
@@ -87,6 +91,7 @@ export function ChangesContextMenuItems({
   repoPath,
   inSelection,
   selectionCount,
+  stageableSelectionCount,
   selectedTrackedCount,
   actions,
 }: {
@@ -95,6 +100,10 @@ export function ChangesContextMenuItems({
   /** Whether the right-clicked row is part of the active multi-selection. */
   inSelection: boolean;
   selectionCount: number;
+  /** Selected files staging can actually reach — the whole selection minus the
+   *  Windows-reserved device names `git add` refuses. Drives the Stage item's
+   *  count, and disables it at 0. */
+  stageableSelectionCount: number;
   selectedTrackedCount: number;
   actions: ChangesMenuActions;
 }) {
@@ -124,8 +133,13 @@ export function ChangesContextMenuItems({
     return (
       <>
         {!staged && (
-          <ContextMenuItem onClick={actions.stageSelected}>
-            Stage {selectionCount} files
+          <ContextMenuItem
+            disabled={stageableSelectionCount === 0}
+            onClick={actions.stageSelected}
+          >
+            {stageableSelectionCount === 0
+              ? `Stage files${RESERVED_HINT}`
+              : `Stage ${stageableSelectionCount} files`}
           </ContextMenuItem>
         )}
         {staged && (
@@ -168,6 +182,8 @@ export function ChangesContextMenuItems({
   // hold a metacharacter of its own (`a.ts[x]`), which would widen the match.
   const extensionPattern = extension && `*.${globLiteralPath(extension)}`;
   const isTracked = entry.unstaged !== "untracked" && entry.staged !== "added";
+  // Only staging reads the working-tree file, so only it hits the device.
+  const stageBlocked = !staged && reservedDeviceName(entry.path) !== null;
   const isConflicted =
     entry.unstaged === "conflicted" || entry.staged === "conflicted";
   return (
@@ -180,8 +196,12 @@ export function ChangesContextMenuItems({
           <ContextMenuSeparator />
         </>
       )}
-      <ContextMenuItem onClick={() => actions.toggle(entry, staged)}>
+      <ContextMenuItem
+        disabled={stageBlocked}
+        onClick={() => actions.toggle(entry, staged)}
+      >
         {staged ? "Unstage file" : "Stage file"}
+        {stageBlocked ? RESERVED_HINT : ""}
       </ContextMenuItem>
       {!staged && (
         <ContextMenuItem onClick={() => actions.discardFile(entry)}>

--- a/src/features/repository/ChangesContextMenu.tsx
+++ b/src/features/repository/ChangesContextMenu.tsx
@@ -130,6 +130,9 @@ export function ChangesContextMenuItems({
   }
   const { entry, staged } = target;
   if (inSelection && selectionCount > 1) {
+    // The stageable count can drop to 1 (or 0) inside a >1 selection when the
+    // rest are Windows-reserved names, so this label pluralizes off its own n.
+    const n = stageableSelectionCount;
     return (
       <>
         {!staged && (
@@ -137,9 +140,9 @@ export function ChangesContextMenuItems({
             disabled={stageableSelectionCount === 0}
             onClick={actions.stageSelected}
           >
-            {stageableSelectionCount === 0
-              ? `Stage files${RESERVED_HINT}`
-              : `Stage ${stageableSelectionCount} files`}
+            {n === 0
+              ? "Stage files (Windows-reserved names)"
+              : `Stage ${n} file${n === 1 ? "" : "s"}`}
           </ContextMenuItem>
         )}
         {staged && (

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -82,6 +82,13 @@ function canStage(entry: FileEntry): boolean {
   return reservedDeviceName(entry.path) === null;
 }
 
+/** The discard-copy predicate: recycle-bin refusal keys on the reserved NAME,
+ *  not on stageability — kept a sibling of `canStage` so the two rules can
+ *  diverge without silently changing the confirm copy. */
+function isReservedName(entry: FileEntry): boolean {
+  return reservedDeviceName(entry.path) !== null;
+}
+
 /** Appended to a multi-file discard confirm: the recycle bin refuses a reserved
  *  device name, so the backend removes those outright. */
 const RESERVED_DISCARD_NOTE =
@@ -788,17 +795,21 @@ export function ChangesPanel({
   // deleted outright; "all" discards the whole tree, not just what's on screen.
   const discardHasReserved = (
     shownDiscardScope?.kind === "all" ? entries : discardFiles
-  ).some((e) => e.unstaged === "untracked" && !canStage(e));
-  const discardBody =
-    shownDiscardScope?.kind === "all"
-      ? `All uncommitted changes are discarded: tracked files reset to the last commit, untracked files move to the recycle bin.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`
-      : discardOne
-        ? discardOne.unstaged === "untracked"
-          ? discardHasReserved
-            ? `${discardOne.path} is untracked. Its Windows-reserved name can't go to the recycle bin, so it will be deleted permanently.`
-            : `${discardOne.path} is untracked — it will be moved to the recycle bin.`
-          : `Unstaged changes to ${discardOne.path} will be restored to the last committed version. This cannot be undone.`
-        : `Changes to ${discardFiles.length} files will be discarded — tracked files are restored and untracked files moved to the recycle bin. This cannot be undone.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`;
+  ).some((e) => e.unstaged === "untracked" && isReservedName(e));
+  const discardBody = ((): string => {
+    switch (true) {
+      case shownDiscardScope?.kind === "all":
+        return `All uncommitted changes are discarded: tracked files reset to the last commit, untracked files move to the recycle bin.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`;
+      case discardOne !== null && discardOne.unstaged !== "untracked":
+        return `Unstaged changes to ${discardOne.path} will be restored to the last committed version. This cannot be undone.`;
+      case discardOne !== null && discardHasReserved:
+        return `${discardOne.path} is untracked. Its Windows-reserved name can't go to the recycle bin, so it will be deleted permanently.`;
+      case discardOne !== null:
+        return `${discardOne.path} is untracked — it will be moved to the recycle bin.`;
+      default:
+        return `Changes to ${discardFiles.length} files will be discarded — tracked files are restored and untracked files moved to the recycle bin. This cannot be undone.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`;
+    }
+  })();
 
   const stashFiles =
     shownStashScope?.kind === "files" ? shownStashScope.entries : [];

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -9,6 +9,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { type MouseEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -43,6 +44,7 @@ import {
   useUntrack,
   useWorkingLineStats,
 } from "@/lib/git/queries";
+import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
@@ -73,6 +75,17 @@ function unstagePaths(entry: FileEntry): string[] {
     literalPathspec,
   );
 }
+
+/** Windows resolves a reserved device name to the DEVICE, so `git add` reads it
+ *  and aborts the whole pathspec batch — every stage path filters these out. */
+function canStage(entry: FileEntry): boolean {
+  return reservedDeviceName(entry.path) === null;
+}
+
+/** Appended to a multi-file discard confirm: the recycle bin refuses a reserved
+ *  device name, so the backend removes those outright. */
+const RESERVED_DISCARD_NOTE =
+  ' Files with Windows-reserved names (like "nul") skip the recycle bin and are deleted permanently.';
 
 type FilterKind = "included" | "excluded" | "new" | "modified" | "deleted";
 
@@ -239,6 +252,9 @@ export function ChangesPanel({
     (e) => e.unstaged !== null && visible(e),
   );
   const stagedEntries = entries.filter((e) => e.staged !== null && visible(e));
+  // What "Stage all" can actually reach: the excluded rows stay listed, each
+  // wearing its own explanation, so skipping them needs no toast.
+  const stageableUnstaged = unstagedEntries.filter(canStage);
   const nothingMatches =
     entries.length > 0 &&
     stagedEntries.length === 0 &&
@@ -262,6 +278,7 @@ export function ChangesPanel({
   );
   const selectedEntries = entries.filter((e) => selectedPaths.has(e.path));
   const selectionCount = selectedEntries.length;
+  const stageableSelected = selectedEntries.filter(canStage);
   // Untracking only applies to files git already tracks (not fresh untracked
   // files or brand-new staged adds) — mirrors FileRow's per-file rule.
   const selectedTracked = selectedEntries.filter(
@@ -428,45 +445,56 @@ export function ChangesPanel({
 
   // Toggle one file's staged state — the row's +/- button and the single menu.
   function handleToggle(entry: FileEntry, staged: boolean) {
-    if (staged) unstage.mutate(unstagePaths(entry), { onError });
-    else stage.mutate([literalPathspec(entry.path)], { onError });
+    if (staged) {
+      void unstage.mutateAsync(unstagePaths(entry)).catch(onError);
+      return;
+    }
+    // Fire-time guard: the affordances are already disabled, but a hotkey or a
+    // later call site must not reach a `git add` that dies reading the device.
+    if (!canStage(entry)) return;
+    void stage.mutateAsync([literalPathspec(entry.path)]).catch(onError);
   }
 
   // Single-file ignore / untrack (the per-row menu); the bulk equivalents are
   // ignoreSelected / untrackSelected below.
-  function ignoreOne(pattern: string, label: string) {
-    appendIgnore.mutate([pattern], {
-      onSuccess: (added) =>
-        toast.success(
-          added === 0
-            ? `"${label}" is already in .gitignore`
-            : `Added "${label}" to .gitignore`,
-        ),
-      onError,
-    });
+  async function ignoreOne(pattern: string, label: string) {
+    try {
+      const added = await appendIgnore.mutateAsync([pattern]);
+      toast.success(
+        added === 0
+          ? `"${label}" is already in .gitignore`
+          : `Added "${label}" to .gitignore`,
+      );
+    } catch (e) {
+      onError(e);
+    }
   }
-  function aiExcludeOne(patterns: string[], label: string) {
-    appendAiIgnore.mutate(patterns, {
-      onSuccess: (added) =>
-        toast.success(
-          added === 0
-            ? `"${label}" is already in .gitdesktop/aiignore`
-            : `Added "${label}" to .gitdesktop/aiignore`,
-        ),
-      onError,
-    });
+  async function aiExcludeOne(patterns: string[], label: string) {
+    try {
+      const added = await appendAiIgnore.mutateAsync(patterns);
+      toast.success(
+        added === 0
+          ? `"${label}" is already in .gitdesktop/aiignore`
+          : `Added "${label}" to .gitdesktop/aiignore`,
+      );
+    } catch (e) {
+      onError(e);
+    }
   }
-  function untrackOne(pathspec: string, ignorePattern: string, label: string) {
-    untrack.mutate(
-      { pathspecs: [pathspec], ignorePatterns: [ignorePattern] },
-      {
-        onSuccess: () =>
-          toast.success(
-            `Untracked ${label} — kept on disk, added to .gitignore`,
-          ),
-        onError,
-      },
-    );
+  async function untrackOne(
+    pathspec: string,
+    ignorePattern: string,
+    label: string,
+  ) {
+    try {
+      await untrack.mutateAsync({
+        pathspecs: [pathspec],
+        ignorePatterns: [ignorePattern],
+      });
+      toast.success(`Untracked ${label} — kept on disk, added to .gitignore`);
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Right-click anywhere in the list: act on the row under the cursor, or fall
@@ -487,33 +515,40 @@ export function ChangesPanel({
   }
 
   function stageAll() {
-    stage.mutate(
-      unstagedEntries.map((e) => literalPathspec(e.path)),
-      { onError },
-    );
+    void stage
+      .mutateAsync(stageableUnstaged.map((e) => literalPathspec(e.path)))
+      .catch(onError);
   }
 
   function unstageAll() {
-    unstage.mutate(stagedEntries.flatMap(unstagePaths), { onError });
+    void unstage
+      .mutateAsync(stagedEntries.flatMap(unstagePaths))
+      .catch(onError);
   }
 
   // Bulk stage/unstage of the selection. Direction comes from the section the
   // row was right-clicked in; re-staging an already-staged path (or vice versa)
   // is a harmless git no-op, so every selected file ends up in that state.
-  function stageSelected() {
-    if (selectionCount === 0) return;
-    stage.mutate(
-      selectedEntries.map((e) => literalPathspec(e.path)),
-      { onError, onSuccess: () => setSelectedKeys(new Set()) },
-    );
+  async function stageSelected() {
+    if (stageableSelected.length === 0) return;
+    try {
+      await stage.mutateAsync(
+        stageableSelected.map((e) => literalPathspec(e.path)),
+      );
+      setSelectedKeys(new Set());
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function unstageSelected() {
+  async function unstageSelected() {
     if (selectionCount === 0) return;
-    unstage.mutate(selectedEntries.flatMap(unstagePaths), {
-      onError,
-      onSuccess: () => setSelectedKeys(new Set()),
-    });
+    try {
+      await unstage.mutateAsync(selectedEntries.flatMap(unstagePaths));
+      setSelectedKeys(new Set());
+    } catch (e) {
+      onError(e);
+    }
   }
 
   function requestDiscardSelected() {
@@ -528,23 +563,23 @@ export function ChangesPanel({
 
   // Bulk ignore: add a `/path` line per selected file (any kind). The Rust side
   // de-dupes and skips lines already present.
-  function ignoreSelected() {
+  async function ignoreSelected() {
     if (selectionCount === 0) return;
     const patterns = selectedEntries.map((e) => `/${globLiteralPath(e.path)}`);
-    appendIgnore.mutate(patterns, {
-      onSuccess: (added) => {
-        toast.success(ignoreToast(added, patterns.length, ".gitignore"));
-        setSelectedKeys(new Set());
-      },
-      onError,
-    });
+    try {
+      const added = await appendIgnore.mutateAsync(patterns);
+      toast.success(ignoreToast(added, patterns.length, ".gitignore"));
+      setSelectedKeys(new Set());
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Bulk AI-exclude: add a `/path` line per selected file — the leading slash
   // anchors each pattern to THIS file rather than every file with that name.
   // A path holding `\` contributes a second line, so the count below is LINES,
   // which is what the toast names. The Rust side skips lines already in EFFECT.
-  function aiExcludeSelected() {
+  async function aiExcludeSelected() {
     if (selectionCount === 0) return;
     // Deduped: a literal `weird\name.env` and a real `weird/name.env` both emit
     // the `/`-separated line, and the duplicate would read as a false partial
@@ -554,127 +589,118 @@ export function ChangesPanel({
         selectedEntries.flatMap((e) => aiExcludePatternLinesForPath(e.path)),
       ),
     ];
-    appendAiIgnore.mutate(patterns, {
-      onSuccess: (added) => {
-        toast.success(
-          ignoreToast(added, patterns.length, ".gitdesktop/aiignore"),
-        );
-        setSelectedKeys(new Set());
-      },
-      onError,
-    });
+    try {
+      const added = await appendAiIgnore.mutateAsync(patterns);
+      toast.success(
+        ignoreToast(added, patterns.length, ".gitdesktop/aiignore"),
+      );
+      setSelectedKeys(new Set());
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Bulk untrack: `git rm --cached` the tracked files in the selection (kept on
   // disk) + add their ignore lines, in one shot.
-  function untrackSelected() {
+  async function untrackSelected() {
     if (selectedTracked.length === 0) return;
-    untrack.mutate(
-      {
+    try {
+      await untrack.mutateAsync({
         pathspecs: selectedTracked.map((e) => literalPathspec(e.path)),
         ignorePatterns: selectedTracked.map(
           (e) => `/${globLiteralPath(e.path)}`,
         ),
-      },
-      {
-        onSuccess: () => {
-          toast.success(
-            `Untracked ${selectedTracked.length} files — kept on disk, added to .gitignore`,
-          );
-          setSelectedKeys(new Set());
-        },
-        onError,
-      },
-    );
+      });
+      toast.success(
+        `Untracked ${selectedTracked.length} files — kept on disk, added to .gitignore`,
+      );
+      setSelectedKeys(new Set());
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function confirmDiscard() {
+  async function confirmDiscard() {
     if (!discardScope) return;
     const finish = () => {
       setDiscardScope(null);
       setSelectedKeys(new Set());
     };
     if (discardScope.kind === "all") {
-      discardAll.mutate(undefined, {
-        onSuccess: () => {
-          toast.success("All changes discarded");
-          finish();
-        },
-        onError: (e) => {
-          onError(e);
-          finish();
-        },
-      });
+      try {
+        await discardAll.mutateAsync(undefined);
+        toast.success("All changes discarded");
+        finish();
+      } catch (e) {
+        onError(e);
+        finish();
+      }
       return;
     }
     const targets = discardScope.entries.map((e) => ({
       path: e.path,
       untracked: e.unstaged === "untracked",
     }));
-    discardPaths.mutate(targets, {
-      onSuccess: () => {
-        toast.success(
-          targets.length === 1
-            ? `Discarded changes to ${targets[0].path}`
-            : `Discarded changes to ${targets.length} files`,
-        );
-        finish();
-      },
-      onError: (e) => {
-        onError(e);
-        finish();
-      },
-    });
+    try {
+      await discardPaths.mutateAsync(targets);
+      toast.success(
+        targets.length === 1
+          ? `Discarded changes to ${targets[0].path}`
+          : `Discarded changes to ${targets.length} files`,
+      );
+      finish();
+    } catch (e) {
+      onError(e);
+      finish();
+    }
   }
 
-  function confirmStash() {
+  async function confirmStash() {
     if (!stashScope) return;
     const finish = () => {
       setStashScope(null);
       setSelectedKeys(new Set());
     };
     if (stashScope.kind === "all") {
-      stashAll.mutate(undefined, {
-        onSuccess: () => {
-          toast.success("Changes stashed");
-          finish();
-        },
-        onError: (e) => {
-          onError(e);
-          finish();
-        },
-      });
+      try {
+        await stashAll.mutateAsync(undefined);
+        toast.success("Changes stashed");
+        finish();
+      } catch (e) {
+        onError(e);
+        finish();
+      }
       return;
     }
     const targets = stashScope.entries.map((e) => e.path);
-    // Literal pathspecs so a `[slug]`-style path can't sweep a sibling's work
-    // into the stash; `targets` stays raw for the toast below.
-    stashPaths.mutate(targets.map(literalPathspec), {
+    try {
+      // Literal pathspecs so a `[slug]`-style path can't sweep a sibling's work
+      // into the stash; `targets` stays raw for the toast below.
+      const matched = await stashPaths.mutateAsync(
+        targets.map(literalPathspec),
+      );
       // `matched` is false when the paths matched nothing, so no stash exists to
       // report — the selection no longer had changes when git ran.
-      onSuccess: (matched) => {
-        if (matched) {
-          toast.success(
-            targets.length === 1
-              ? `Stashed ${targets[0]}`
-              : `Stashed ${targets.length} files`,
-          );
-        } else {
-          toast.info("Nothing to stash");
-        }
-        finish();
-      },
-      onError: (e) => {
-        onError(e);
-        finish();
-      },
-    });
+      if (matched) {
+        toast.success(
+          targets.length === 1
+            ? `Stashed ${targets[0]}`
+            : `Stashed ${targets.length} files`,
+        );
+      } else {
+        toast.info("Nothing to stash");
+      }
+      finish();
+    } catch (e) {
+      onError(e);
+      finish();
+    }
   }
 
   useHotkeyAction(
     "stage-all",
     stageAll,
-    !mutating && unstagedEntries.length > 0,
+    !mutating && stageableUnstaged.length > 0,
   );
   useHotkeyAction(
     "unstage-all",
@@ -683,12 +709,12 @@ export function ChangesPanel({
   );
   useHotkeyAction(
     "stage-selected-files",
-    stageSelected,
-    !mutating && selectedEntries.some((e) => e.unstaged !== null),
+    () => void stageSelected(),
+    !mutating && stageableSelected.some((e) => e.unstaged !== null),
   );
   useHotkeyAction(
     "unstage-selected-files",
-    unstageSelected,
+    () => void unstageSelected(),
     !mutating && selectedEntries.some((e) => e.staged !== null),
   );
   useHotkeyAction(
@@ -758,14 +784,21 @@ export function ChangesPanel({
       : discardOne
         ? "Discard changes?"
         : `Discard ${discardFiles.length} changes?`;
+  // Only untracked entries reach the recycle bin, so only they can be the ones
+  // deleted outright; "all" discards the whole tree, not just what's on screen.
+  const discardHasReserved = (
+    shownDiscardScope?.kind === "all" ? entries : discardFiles
+  ).some((e) => e.unstaged === "untracked" && !canStage(e));
   const discardBody =
     shownDiscardScope?.kind === "all"
-      ? "All uncommitted changes are discarded: tracked files reset to the last commit, untracked files move to the recycle bin."
+      ? `All uncommitted changes are discarded: tracked files reset to the last commit, untracked files move to the recycle bin.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`
       : discardOne
         ? discardOne.unstaged === "untracked"
-          ? `${discardOne.path} is untracked — it will be moved to the recycle bin.`
+          ? discardHasReserved
+            ? `${discardOne.path} is untracked. Its Windows-reserved name can't go to the recycle bin, so it will be deleted permanently.`
+            : `${discardOne.path} is untracked — it will be moved to the recycle bin.`
           : `Unstaged changes to ${discardOne.path} will be restored to the last committed version. This cannot be undone.`
-        : `Changes to ${discardFiles.length} files will be discarded — tracked files are restored and untracked files moved to the recycle bin. This cannot be undone.`;
+        : `Changes to ${discardFiles.length} files will be discarded — tracked files are restored and untracked files moved to the recycle bin. This cannot be undone.${discardHasReserved ? RESERVED_DISCARD_NOTE : ""}`;
 
   const stashFiles =
     shownStashScope?.kind === "files" ? shownStashScope.entries : [];
@@ -883,13 +916,15 @@ export function ChangesPanel({
                 </span>
                 <button
                   type="button"
-                  onClick={() =>
-                    settings.data &&
-                    saveSettings.mutate({
-                      ...settings.data,
-                      showSelectionHint: false,
-                    })
-                  }
+                  onClick={() => {
+                    if (!settings.data) return;
+                    void saveSettings
+                      .mutateAsync({
+                        ...settings.data,
+                        showSelectionHint: false,
+                      })
+                      .catch(() => undefined);
+                  }}
                   className="shrink-0 font-medium whitespace-nowrap underline underline-offset-2 hover:no-underline"
                 >
                   Don't show again
@@ -965,11 +1000,21 @@ export function ChangesPanel({
                                 ? `Staged (${row.count})`
                                 : `Changes (${row.count})`}
                             </h3>
-                            <Button
+                            <DisabledReasonButton
                               variant="ghost"
                               size="xs"
                               className="text-muted-foreground"
-                              disabled={mutating}
+                              disabled={
+                                mutating ||
+                                (row.section === "unstaged" &&
+                                  stageableUnstaged.length === 0)
+                              }
+                              reason={
+                                row.section === "unstaged" &&
+                                stageableUnstaged.length === 0
+                                  ? "Git can't stage Windows-reserved device names, and every file here has one"
+                                  : null
+                              }
                               onClick={
                                 row.section === "staged" ? unstageAll : stageAll
                               }
@@ -977,7 +1022,7 @@ export function ChangesPanel({
                               {row.section === "staged"
                                 ? "Unstage all"
                                 : "Stage all"}
-                            </Button>
+                            </DisabledReasonButton>
                           </div>
                         ) : (
                           <FileRow
@@ -1019,16 +1064,17 @@ export function ChangesPanel({
                     : false
                 }
                 selectionCount={selectionCount}
+                stageableSelectionCount={stageableSelected.length}
                 selectedTrackedCount={selectedTracked.length}
                 actions={{
                   discardAll: () => setDiscardScope({ kind: "all" }),
                   stashAll: () => setStashScope({ kind: "all" }),
-                  stageSelected,
-                  unstageSelected,
+                  stageSelected: () => void stageSelected(),
+                  unstageSelected: () => void unstageSelected(),
                   discardSelected: requestDiscardSelected,
                   stashSelected: requestStashSelected,
-                  ignoreSelected,
-                  untrackSelected,
+                  ignoreSelected: () => void ignoreSelected(),
+                  untrackSelected: () => void untrackSelected(),
                   toggle: handleToggle,
                   resolveWithAi: (path) => startResolveOne(path, repoPath),
                   discardFile: (entry) =>
@@ -1037,10 +1083,12 @@ export function ChangesPanel({
                     setStashScope({ kind: "files", entries: [entry] }),
                   viewHistory: setHistoryPath,
                   blame: setBlamePath,
-                  ignore: ignoreOne,
-                  untrack: untrackOne,
-                  aiExclude: aiExcludeOne,
-                  aiExcludeSelected,
+                  ignore: (pattern, label) => void ignoreOne(pattern, label),
+                  untrack: (pathspec, ignorePattern, label) =>
+                    void untrackOne(pathspec, ignorePattern, label),
+                  aiExclude: (patterns, label) =>
+                    void aiExcludeOne(patterns, label),
+                  aiExcludeSelected: () => void aiExcludeSelected(),
                 }}
               />
             </ContextMenuContent>
@@ -1101,7 +1149,7 @@ export function ChangesPanel({
         }
         confirmVariant="destructive"
         pending={discardPaths.isPending || discardAll.isPending}
-        onConfirm={confirmDiscard}
+        onConfirm={() => void confirmDiscard()}
       />
 
       <ConfirmDialog
@@ -1111,7 +1159,7 @@ export function ChangesPanel({
         body={stashBody}
         confirmLabel={shownStashScope?.kind === "all" ? "Stash all" : "Stash"}
         pending={stashPaths.isPending || stashAll.isPending}
-        onConfirm={confirmStash}
+        onConfirm={() => void confirmStash()}
       />
     </div>
   );

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -449,8 +449,8 @@ export function ChangesPanel({
       void unstage.mutateAsync(unstagePaths(entry)).catch(onError);
       return;
     }
-    // Fire-time guard: the affordances are already disabled, but a hotkey or a
-    // later call site must not reach a `git add` that dies reading the device.
+    // Fire-time guard: the affordances are already disabled, but a later call
+    // site must not reach a `git add` that dies reading the device.
     if (!canStage(entry)) return;
     void stage.mutateAsync([literalPathspec(entry.path)]).catch(onError);
   }

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -139,23 +139,24 @@ const EMPTY_MERGED_CLAUSE: Record<PrCheckState, string> = {
   unavailable: " and nothing is idle for ",
 };
 
-/** What the candidate list is waiting on, per outstanding read. The two settle
+/** What the candidate list is waiting on, per outstanding read. They settle
  *  independently, so the line names the one actually running rather than
  *  whichever came first. */
-const CHECKING_COPY: Record<"merged" | "worktrees", string> = {
+const CHECKING_COPY: Record<"merged" | "worktrees" | "rules", string> = {
   merged: "Checking which branches are merged…",
   worktrees: "Checking which branches are checked out in another worktree…",
+  rules: "Checking branch protection rules…",
 };
 
 /** The one-line status above the candidate list while a check it depends on
  *  runs. A parked check has no progress to report, so it names what it's waiting
  *  on rather than implying the read is underway — and only the pull-request half
- *  can park, since both git reads work on local objects. */
+ *  can park, since the other reads work on local data. */
 function CheckingLine({
   what,
   paused,
 }: {
-  what: "merged" | "worktrees";
+  what: "merged" | "worktrees" | "rules";
   paused: boolean;
 }) {
   return (
@@ -238,6 +239,7 @@ export function CleanupBranchesDialog({
   isInWorktree,
   isWorktreeRemoving,
   worktreeCheckState,
+  rulesSettling,
   prMergedByBranch,
   prCheckState,
   prCheckPaused,
@@ -267,6 +269,13 @@ export function CleanupBranchesDialog({
    *  neither paints nor pre-selects. (`useEffectiveBranchRulesSettling` carries
    *  the same contract for the branch rules behind `isProtected`.) */
   worktreeCheckState: WorktreeCheckState;
+  /** Whether {@link isProtected} has an answer yet — the branch-rules half of
+   *  that same contract, from `useEffectiveBranchRulesSettling`. While true the
+   *  effective rules stand in as empty, so the predicate excludes nothing and
+   *  the list neither paints nor pre-selects. A FAILED rules read is
+   *  deliberately not held on: it falls open inside that hook, since nothing
+   *  would ever arrive to lift the hold. */
+  rulesSettling: boolean;
   /** Branch name → the label of the merged pull request it maps to ("#123").
    *  Name-keyed and limited to the PRs the app has fetched, so it labels rows,
    *  never selects them. */
@@ -374,6 +383,11 @@ export function CleanupBranchesDialog({
   // candidate below is provisional — the list stays behind the skeleton and the
   // selection stays unseeded rather than offering a row the answer would remove.
   const checkingWorktrees = worktreeCheckState === "pending";
+  // Settling rules hold exactly as a pending worktree read does — `isProtected`
+  // excludes nothing until they land. Held in BOTH modes: rules settle within
+  // moments of opening the repo while this dialog opens later, and the mode can
+  // flip while it is open, so a delete-only hold buys nothing and can miss.
+  const holdingReads = checkingWorktrees || rulesSettling;
 
   // Re-check every candidate whenever the set itself changes — opening, switching
   // mode, adjusting the window, or divergence resolving to reveal merged branches.
@@ -401,11 +415,11 @@ export function CleanupBranchesDialog({
   useEffect(() => {
     if (running) return; // don't clobber a batch mid-flight
     // Nothing may be pre-selected off a stand-in exclusion: the seed re-runs
-    // once the worktree read lands and the excluded rows are really gone.
-    if (checkingWorktrees) return;
+    // once those reads land and the excluded rows are really gone.
+    if (holdingReads) return;
     setSelected(new Set(autoSelectKey ? autoSelectKey.split("\n") : []));
     setActiveName(null);
-  }, [autoSelectKey, running, checkingWorktrees]);
+  }, [autoSelectKey, running, holdingReads]);
 
   // First load: a merged signal still in flight and nothing has surfaced yet.
   // Age-based candidates already show instantly (branch data is cached), so this
@@ -421,7 +435,7 @@ export function CleanupBranchesDialog({
   // Which of the status region's lines are DRAWN — it announces more than it
   // shows: the check line stays sr-only on the empty first paint (the skeleton
   // is the visual signal there).
-  const stillChecking = checkingMerged || checkingWorktrees;
+  const stillChecking = checkingMerged || holdingReads;
   const showCheckLine =
     stillChecking && (pausedMergedCheck || candidates.length > 0);
   const showPrFailedLine = prCheckState === "failed" && candidates.length > 0;
@@ -429,10 +443,10 @@ export function CleanupBranchesDialog({
   // failed read leaves the exclusion vacuous, which the empty state's own copy
   // would otherwise assert as real.
   const worktreeCheckFailed = worktreeCheckState === "failed";
-  // A provisional list is no list: the skeleton covers the whole worktree wait,
+  // A provisional list is no list: the skeleton covers the whole exclusion wait,
   // not just the empty first paint the merged check gates.
   const showSkeleton =
-    checkingWorktrees || (checkingMerged && candidates.length === 0);
+    holdingReads || (checkingMerged && candidates.length === 0);
 
   const selectedCount = candidateNames.filter((n) => selected.has(n)).length;
   const allChecked =
@@ -490,6 +504,11 @@ export function CleanupBranchesDialog({
       try {
         if (mode === "archive") {
           await api.gitSetBranchArchived(repoPath, name, true);
+        } else if (isProtected(name)) {
+          // Re-checked with the rules as of batch start, not only when the list
+          // was built: a rule can change while the dialog sits open, and a
+          // protected branch belongs in the failure rows rather than deleted.
+          fails.set(name, "protected by a branch rule");
         } else {
           await api.gitDeleteBranch(repoPath, name);
         }
@@ -627,9 +646,9 @@ export function CleanupBranchesDialog({
 
           {/* Select-all header — a tri-state indicator (the vendored Checkbox
               has no indeterminate visual, and components/ui/ is off-limits).
-              Withheld while the list is provisional — it would count rows the
-              worktree read may still remove. */}
-          {candidates.length > 0 && !checkingWorktrees && (
+              Withheld while the list is provisional — it would count rows an
+              outstanding exclusion read may still remove. */}
+          {candidates.length > 0 && !holdingReads && (
             <button
               type="button"
               disabled={running}
@@ -684,7 +703,13 @@ export function CleanupBranchesDialog({
                   honestly repeat on every mode and window change. */}
               {stillChecking ? (
                 <CheckingLine
-                  what={checkingMerged ? "merged" : "worktrees"}
+                  what={
+                    checkingMerged
+                      ? "merged"
+                      : checkingWorktrees
+                        ? "worktrees"
+                        : "rules"
+                  }
                   paused={pausedMergedCheck}
                 />
               ) : (
@@ -718,10 +743,11 @@ export function CleanupBranchesDialog({
 
             {/* List / skeleton / empty */}
             {showSkeleton ? (
-              // A running local worktree read is real activity, so it earns the
-              // skeleton even while the pull-request fetch sits parked.
+              // A running local read (worktrees, branch rules) is real activity,
+              // so it earns the skeleton even while the pull-request fetch sits
+              // parked.
               <CheckingPlaceholder
-                paused={pausedMergedCheck && !checkingWorktrees}
+                paused={pausedMergedCheck && !holdingReads}
               />
             ) : candidates.length === 0 ? (
               <p className="py-6 text-center text-xs text-muted-foreground">
@@ -802,7 +828,7 @@ export function CleanupBranchesDialog({
             <Button
               type="button"
               variant={mode === "delete" ? "destructive" : "default"}
-              disabled={selectedCount === 0 || running || checkingWorktrees}
+              disabled={selectedCount === 0 || running || holdingReads}
               onClick={onPrimary}
             >
               {primaryLabel}

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -703,16 +703,33 @@ export function CleanupBranchesDialog({
                   nothing about the check — what a `role="status"` region can
                   honestly repeat on every mode and window change. */}
               {stillChecking ? (
-                <CheckingLine
-                  what={
-                    checkingMerged
-                      ? "merged"
-                      : checkingWorktrees
-                        ? "worktrees"
-                        : "rules"
-                  }
-                  paused={pausedMergedCheck}
-                />
+                (() => {
+                  // A RUNNING local read outranks the parked merged fetch — the
+                  // line names the one actually running, and the waiting copy
+                  // shows only when the parked check is the sole outstanding one.
+                  const what = ((): "merged" | "worktrees" | "rules" => {
+                    switch (true) {
+                      case checkingMerged && !pausedMergedCheck:
+                        return "merged";
+                      case checkingWorktrees:
+                        return "worktrees";
+                      case rulesSettling:
+                        return "rules";
+                      default:
+                        return "merged";
+                    }
+                  })();
+                  return (
+                    <CheckingLine
+                      what={what}
+                      paused={
+                        pausedMergedCheck &&
+                        !checkingWorktrees &&
+                        !rulesSettling
+                      }
+                    />
+                  );
+                })()
               ) : (
                 <p className="sr-only">
                   {candidates.length === 0

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -505,9 +505,10 @@ export function CleanupBranchesDialog({
         if (mode === "archive") {
           await api.gitSetBranchArchived(repoPath, name, true);
         } else if (isProtected(name)) {
-          // Re-checked with the rules as of batch start, not only when the list
-          // was built: a rule can change while the dialog sits open, and a
-          // protected branch belongs in the failure rows rather than deleted.
+          // Defensive: `candidates` already excludes protected names in delete
+          // mode off this same predicate, so this arm is unreachable today — it
+          // exists so a future change to that filter can't silently reopen
+          // bulk-deleting a protected branch; failure rows beat silent success.
           fails.set(name, "protected by a branch rule");
         } else {
           await api.gitDeleteBranch(repoPath, name);

--- a/src/features/repository/ConflictBanner.tsx
+++ b/src/features/repository/ConflictBanner.tsx
@@ -109,6 +109,41 @@ export function ConflictBanner({
   // the commit via the Changes tab, then continues.
   const editPaused = Boolean(opState.data?.editPaused) && conflictedCount === 0;
 
+  // Awaited rather than per-call callbacks: this banner unmounts the moment the
+  // op ends (and rides an <Activity>-hidden tab), and react-query drops per-call
+  // callbacks once the observer has no listeners. The op travels as an argument
+  // because `op` is nullable at component scope.
+  async function doContinue(target: RepoOp) {
+    try {
+      const recorded = await continueOp.mutateAsync(target);
+      // Only a resolution that emptied the pick reaches this: a commit whose
+      // changes the destination already had never conflicts, so it is skipped
+      // inside the pick itself and never pauses here. The flag speaks for that
+      // one pick — a longer sequence may still have applied its remaining
+      // commits.
+      if (!recorded) {
+        toast.info("Commit skipped — your resolution left nothing to commit.");
+        return;
+      }
+      toast.success(
+        target === "merge" ? "Merge completed" : `${opVerb} continued`,
+      );
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function doAbort(target: RepoOp) {
+    try {
+      await abortOp.mutateAsync(target);
+      setConfirmAbort(false);
+      toast.success(`Aborted the ${target}`);
+    } catch (e) {
+      setConfirmAbort(false);
+      onError(e);
+    }
+  }
+
   return (
     // One calm status line — the per-file resolution actions live in the diff
     // pane's conflict view, so this just carries merge state + Continue/Abort
@@ -161,29 +196,7 @@ export function ConflictBanner({
               reason={
                 conflictedCount > 0 ? "Resolve every conflict first" : undefined
               }
-              onClick={() =>
-                continueOp.mutate(op, {
-                  onSuccess: (recorded) => {
-                    // Only a resolution that emptied the pick reaches this: a commit
-                    // whose changes the destination already had never conflicts, so
-                    // it is skipped inside the pick itself and never pauses here.
-                    // The flag speaks for that one pick — a longer sequence may
-                    // still have applied its remaining commits.
-                    if (!recorded) {
-                      toast.info(
-                        "Commit skipped — your resolution left nothing to commit.",
-                      );
-                      return;
-                    }
-                    toast.success(
-                      op === "merge"
-                        ? "Merge completed"
-                        : `${opVerb} continued`,
-                    );
-                  },
-                  onError,
-                })
-              }
+              onClick={() => void doContinue(op)}
             >
               {continueOp.isPending && <Spinner data-icon="inline-start" />}
               {OP_LABELS[op].cont}
@@ -211,18 +224,7 @@ export function ConflictBanner({
                   <Button
                     variant="destructive"
                     disabled={abortOp.isPending}
-                    onClick={() =>
-                      abortOp.mutate(op, {
-                        onSuccess: () => {
-                          setConfirmAbort(false);
-                          toast.success(`Aborted the ${op}`);
-                        },
-                        onError: (e) => {
-                          setConfirmAbort(false);
-                          onError(e);
-                        },
-                      })
-                    }
+                    onClick={() => void doAbort(op)}
                   >
                     {abortOp.isPending && <Spinner data-icon="inline-start" />}
                     Abort {op}

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -323,20 +323,17 @@ export function ConflictFileView({
     open.catch(toastError);
   }
 
-  function acceptRegion(index: number, choice: ConflictChoice) {
+  async function acceptRegion(index: number, choice: ConflictChoice) {
     if (!segments) return;
     const content = resolveBlock(segments, index, choice);
     // Stage once the last marker is gone — same end state as the AI flow.
     const stage = !hasConflictMarkers(content);
-    resolve.mutate(
-      { path, content, stage },
-      {
-        onSuccess: () => {
-          if (stage) toast.success(`Resolved ${baseName(path)}`);
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await resolve.mutateAsync({ path, content, stage });
+      if (stage) toast.success(`Resolved ${baseName(path)}`);
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   async function acceptAll(side: "ours" | "theirs") {
@@ -364,16 +361,14 @@ export function ConflictFileView({
       confirmVariant: "destructive",
     });
     if (!ok) return;
-    checkoutSide.mutate(
-      { path, side },
-      {
-        onSuccess: () =>
-          toast.success(
-            `Resolved ${baseName(path)} — took ${side === "ours" ? "current" : "incoming"}`,
-          ),
-        onError: toastError,
-      },
-    );
+    try {
+      await checkoutSide.mutateAsync({ path, side });
+      toast.success(
+        `Resolved ${baseName(path)} — took ${side === "ours" ? "current" : "incoming"}`,
+      );
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   // Which fallback state is on screen, and so whether Mark resolved is offered.

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -1,27 +1,11 @@
 import { MinusIcon, PlusIcon } from "@phosphor-icons/react";
 import { memo } from "react";
 import { DiffStat } from "@/components/diff-stat";
-import { Button } from "@/components/ui/button";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { KIND_BADGE } from "@/lib/git/change-kind-badge";
+import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { ChangeKind, DiffStatEntry, FileEntry } from "@/lib/git/types";
 import { cn } from "@/lib/utils";
-
-const KIND_BADGE: Record<
-  ChangeKind,
-  { letter: string; label: string; className: string }
-> = {
-  added: { letter: "A", label: "Added", className: "text-success" },
-  untracked: { letter: "U", label: "Untracked", className: "text-success" },
-  modified: { letter: "M", label: "Modified", className: "text-warning" },
-  typechange: { letter: "T", label: "Type changed", className: "text-warning" },
-  deleted: { letter: "D", label: "Deleted", className: "text-destructive" },
-  renamed: { letter: "R", label: "Renamed", className: "text-info" },
-  copied: { letter: "C", label: "Copied", className: "text-info" },
-  conflicted: {
-    letter: "!",
-    label: "Conflicted",
-    className: "text-destructive",
-  },
-};
 
 /**
  * A single changed-file row. Deliberately light: it carries no context menu or
@@ -63,6 +47,9 @@ export const FileRow = memo(function FileRow({
   const label = entry.origPath
     ? `${entry.origPath} → ${entry.path}`
     : entry.path;
+  // Staging is the only direction that reads the working-tree file, so only it
+  // hits the device; unstaging works on such a path as on any other.
+  const reservedName = staged ? null : reservedDeviceName(entry.path);
 
   return (
     <div
@@ -113,7 +100,7 @@ export const FileRow = memo(function FileRow({
           className="text-[11px]"
         />
       ) : null}
-      <Button
+      <DisabledReasonButton
         variant="ghost"
         size="icon-xs"
         className={cn(
@@ -124,14 +111,18 @@ export const FileRow = memo(function FileRow({
           (active || selected) && "opacity-100",
         )}
         aria-label={staged ? `Unstage ${entry.path}` : `Stage ${entry.path}`}
-        disabled={disabled}
+        disabled={disabled || reservedName !== null}
+        reason={
+          reservedName &&
+          `"${reservedName}" is a Windows-reserved device name — git can't stage it`
+        }
         onClick={(e) => {
           e.stopPropagation();
           onToggle(entry, staged);
         }}
       >
         {staged ? <MinusIcon /> : <PlusIcon />}
-      </Button>
+      </DisabledReasonButton>
     </div>
   );
 });

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -114,7 +114,7 @@ export const FileRow = memo(function FileRow({
         disabled={disabled || reservedName !== null}
         reason={
           reservedName &&
-          `"${reservedName}" is a Windows-reserved device name — git can't stage it`
+          `"${reservedName}" resolves to a Windows device name — git can't stage it`
         }
         onClick={(e) => {
           e.stopPropagation();

--- a/src/features/repository/ForkPrPublishGuard.tsx
+++ b/src/features/repository/ForkPrPublishGuard.tsx
@@ -84,16 +84,18 @@ export function ForkPrPublishGuard({
       return;
     }
     setEnsuring(false);
-    push.mutate(
-      { setUpstream: false, branch, remote, remoteBranch: match.headRefName },
-      {
-        onSuccess: () => {
-          toast.success(`Pushed ${commits} to ${slug}:${match.headRefName}.`);
-          onClose();
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await push.mutateAsync({
+        setUpstream: false,
+        branch,
+        remote,
+        remoteBranch: match.headRefName,
+      });
+      toast.success(`Pushed ${commits} to ${slug}:${match.headRefName}.`);
+      onClose();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   return (

--- a/src/features/repository/OpRecoveryBanner.tsx
+++ b/src/features/repository/OpRecoveryBanner.tsx
@@ -71,9 +71,7 @@ export function OpRecoveryBanner({ repoPath }: { repoPath: string }) {
           size="icon-xs"
           aria-label="Dismiss"
           disabled={dismiss.isPending}
-          onClick={() =>
-            dismiss.mutate(op.id, { onError: (e) => toastError(e) })
-          }
+          onClick={() => void dismiss.mutateAsync(op.id).catch(toastError)}
         >
           {dismiss.isPending ? <Spinner /> : <XIcon />}
         </Button>

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -166,7 +166,7 @@ export function RepoList({
   // NEXT open groups (and labels its context menu) synchronously. Fires once
   // whenever a record's stored value is stale; the helper no-ops when nothing
   // changed, so its settings refetch doesn't loop.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mutate() is stable; rerun only on resolved owners / records
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mutateAsync() is stable; rerun only on resolved owners / records
   useEffect(() => {
     const resolved = owners.data;
     if (!resolved?.length) return;
@@ -178,7 +178,7 @@ export function RepoList({
         (o.provider || undefined) !== r?.provider
       );
     });
-    if (stale) persistOwners.mutate(resolved);
+    if (stale) void persistOwners.mutateAsync(resolved).catch(() => undefined);
   }, [owners.data, recents]);
 
   // Backfill visibility + fork provenance for rows whose provider resolves but

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -444,56 +444,47 @@ export function RepositoryFilesDialog({
     });
   }
 
-  function runUntrack(paths: string[]) {
-    untrack.mutate(
-      {
+  async function runUntrack(paths: string[]) {
+    try {
+      await untrack.mutateAsync({
         pathspecs: paths.map(literalPathspec),
         ignorePatterns: paths.map(ignorePattern),
-      },
-      {
-        onSuccess: () => {
-          toast.success(
-            `Untracked ${paths.length} file${paths.length === 1 ? "" : "s"} — kept on disk, added to .gitignore`,
-          );
-          setSelected(new Set());
-          setPending(null);
-        },
-        onError: (e) => {
-          onError(e);
-          setPending(null);
-        },
-      },
-    );
+      });
+      toast.success(
+        `Untracked ${paths.length} file${paths.length === 1 ? "" : "s"} — kept on disk, added to .gitignore`,
+      );
+      setSelected(new Set());
+      setPending(null);
+    } catch (e) {
+      onError(e);
+      setPending(null);
+    }
   }
 
-  function runForceAdd(paths: string[]) {
-    forceAdd.mutate(paths.map(literalPathspec), {
-      onSuccess: () => {
-        toast.success(`Force-added ${paths.length} items`);
-        setSelected(new Set());
-        setPending(null);
-      },
-      onError: (e) => {
-        onError(e);
-        setPending(null);
-      },
-    });
+  async function runForceAdd(paths: string[]) {
+    try {
+      await forceAdd.mutateAsync(paths.map(literalPathspec));
+      toast.success(`Force-added ${paths.length} items`);
+      setSelected(new Set());
+      setPending(null);
+    } catch (e) {
+      onError(e);
+      setPending(null);
+    }
   }
 
-  function runRemoveRules(rules: { source: string; pattern: string }[]) {
-    unignore.mutate(rules, {
-      onSuccess: () => {
-        toast.success(
-          `Removed ${rules.length} rule${rules.length === 1 ? "" : "s"} from .gitignore`,
-        );
-        setSelected(new Set());
-        setPending(null);
-      },
-      onError: (e) => {
-        onError(e);
-        setPending(null);
-      },
-    });
+  async function runRemoveRules(rules: { source: string; pattern: string }[]) {
+    try {
+      await unignore.mutateAsync(rules);
+      toast.success(
+        `Removed ${rules.length} rule${rules.length === 1 ? "" : "s"} from .gitignore`,
+      );
+      setSelected(new Set());
+      setPending(null);
+    } catch (e) {
+      onError(e);
+      setPending(null);
+    }
   }
 
   // Bulk AI-exclude from the tracked list — the add path for files with nothing

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -472,6 +472,10 @@ export function RepositoryFilesDialog({
     // Defensive — the offer path already filters. Kept so a future caller can't
     // reopen the device read that aborts the whole pathspec batch.
     const stageable = paths.filter((p) => reservedDeviceName(p) === null);
+    if (stageable.length === 0) {
+      setPending(null);
+      return;
+    }
     try {
       await forceAdd.mutateAsync(stageable.map(literalPathspec));
       toast.success(
@@ -979,13 +983,13 @@ export function RepositoryFilesDialog({
             <Button
               disabled={busy}
               onClick={() => {
-                if (pending?.kind === "untrack") runUntrack(pending.paths);
+                if (pending?.kind === "untrack") void runUntrack(pending.paths);
                 else if (pending?.kind === "forceAdd")
-                  runForceAdd(pending.paths);
+                  void runForceAdd(pending.paths);
                 else if (pending?.kind === "removeRule")
-                  runRemoveRules(pending.rules);
+                  void runRemoveRules(pending.rules);
                 else if (pending?.kind === "removeAiRule")
-                  runRemoveAiRules(pending.rules);
+                  void runRemoveAiRules(pending.rules);
               }}
             >
               {shownPending && PENDING_COPY[shownPending.kind].confirm}

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -39,6 +39,7 @@ import {
   useUnignoreRules,
   useUntrack,
 } from "@/lib/git/queries";
+import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { AiIgnoreVerdict, IgnoredFile } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
@@ -357,6 +358,12 @@ export function RepositoryFilesDialog({
   // filter clears), so you never touch something you can't see.
   const selectedPaths = filtered.filter((p) => selected.has(p));
   const count = selectedPaths.length;
+  // Windows resolves a reserved device name to the DEVICE, so `git add --force`
+  // reads it and aborts the whole pathspec batch — force-add offers, counts and
+  // runs on this subset alone. The other bulk actions never read the file.
+  const stageableSelected = selectedPaths.filter(
+    (p) => reservedDeviceName(p) === null,
+  );
 
   function toggle(path: string) {
     setSelected((prev) => {
@@ -462,9 +469,14 @@ export function RepositoryFilesDialog({
   }
 
   async function runForceAdd(paths: string[]) {
+    // Defensive — the offer path already filters. Kept so a future caller can't
+    // reopen the device read that aborts the whole pathspec batch.
+    const stageable = paths.filter((p) => reservedDeviceName(p) === null);
     try {
-      await forceAdd.mutateAsync(paths.map(literalPathspec));
-      toast.success(`Force-added ${paths.length} items`);
+      await forceAdd.mutateAsync(stageable.map(literalPathspec));
+      toast.success(
+        `Force-added ${stageable.length} ${stageable.length === 1 ? "item" : "items"}`,
+      );
       setSelected(new Set());
       setPending(null);
     } catch (e) {
@@ -830,15 +842,25 @@ export function RepositoryFilesDialog({
               )}
               {tab === "ignored" && (
                 <>
-                  <Button
+                  <DisabledReasonButton
                     size="sm"
-                    disabled={busy}
+                    disabled={busy || stageableSelected.length === 0}
+                    reason={
+                      stageableSelected.length === 0
+                        ? "Git can't stage Windows-reserved device names, and every selected file has one"
+                        : null
+                    }
                     onClick={() =>
-                      setPending({ kind: "forceAdd", paths: selectedPaths })
+                      setPending({
+                        kind: "forceAdd",
+                        paths: stageableSelected,
+                      })
                     }
                   >
-                    Force-add {count}
-                  </Button>
+                    {stageableSelected.length === 0
+                      ? "Force-add"
+                      : `Force-add ${stageableSelected.length}`}
+                  </DisabledReasonButton>
                   <Button
                     variant="outline"
                     size="sm"

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -522,23 +522,24 @@ export function RepositoryView() {
     // two. A failed write restores the previous value synchronously, so the
     // hand-off can ride the rollback's own commit.
     queryClient.setQueryData(settingsKeys.settings, updated);
-    saveSettings.mutate(updated, {
-      onError: () => {
-        // Only roll back if this call's change is still the latest: otherwise a
-        // late-failing earlier write would stomp a newer successful one (two
-        // fast presses where the first write rejects after the second lands).
-        const latest = queryClient.getQueryData<AppSettings>(
-          settingsKeys.settings,
-        );
-        if (latest?.sidebarCollapsed !== next) return;
-        if (
-          handoffRef.current ||
-          sidebarRef.current?.contains(document.activeElement)
-        ) {
-          refocusToggleRef.current = !next;
-        }
-        queryClient.setQueryData(settingsKeys.settings, current);
-      },
+    // Awaited in a detached chain rather than a per-call onError: react-query
+    // drops per-call callbacks once the observer has no listeners, and this
+    // writer must keep reporting `changed` synchronously to its callers.
+    void saveSettings.mutateAsync(updated).catch(() => {
+      // Only roll back if this call's change is still the latest: otherwise a
+      // late-failing earlier write would stomp a newer successful one (two
+      // fast presses where the first write rejects after the second lands).
+      const latest = queryClient.getQueryData<AppSettings>(
+        settingsKeys.settings,
+      );
+      if (latest?.sidebarCollapsed !== next) return;
+      if (
+        handoffRef.current ||
+        sidebarRef.current?.contains(document.activeElement)
+      ) {
+        refocusToggleRef.current = !next;
+      }
+      queryClient.setQueryData(settingsKeys.settings, current);
     });
     return true;
   }

--- a/src/features/repository/SyncControls.tsx
+++ b/src/features/repository/SyncControls.tsx
@@ -183,11 +183,13 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // One entry point for every fetch — manual (button/hotkey) and automatic —
   // so a successful fetch always records its freshness. Auto-fetches stay quiet
   // (a failed background fetch just retries next tick).
-  function doFetch(silent: boolean) {
-    fetchRemote.mutate(undefined, {
-      onSuccess: () => markFetched(repoPath),
-      onError: silent ? undefined : onError,
-    });
+  async function doFetch(silent: boolean) {
+    try {
+      await fetchRemote.mutateAsync(undefined);
+      markFetched(repoPath);
+    } catch (e) {
+      if (!silent) onError(e);
+    }
   }
 
   // Opt-out periodic background fetch (Settings → General). Shares the fetch
@@ -198,7 +200,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     intervalMs: Number(settings.data?.autoFetchInterval ?? "10") * 60_000,
     hasOrigin,
     busy,
-    fetch: () => doFetch(true),
+    fetch: () => void doFetch(true),
   });
 
   // The Fetch tooltip is a plain attribute string, so the shared clock has to be
@@ -324,58 +326,56 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // dirty-tree recovery only ever sees refusals from the run itself. Every other
   // error keeps its normal toast. Both are triggered by the refusal, never
   // pre-flighted.
-  function doPull(mode: PullMode) {
+  async function doPull(mode: PullMode) {
     const plain = pullSuccessMessage(mode);
-    pull.mutate(mode, {
-      onSuccess: () => {
-        if (plain) toast.success(plain);
-      },
-      onError: (e) => {
-        if (pullDropGuard.handleError(e)) return;
-        const taken = recovery.handleError(e, {
-          operationLabel: "pull",
-          reappliedMessage: "Pulled and reapplied your changes.",
-          // ff-only has no ordinary success toast, but a recovery the user ran
-          // deliberately still has to confirm itself.
-          plainMessage: plain ?? "Pulled.",
-          run: { op: "pull", mode },
-          // The retried pull re-runs the fork-point guard before it stashes, so
-          // a rebase pull can raise the decision here too.
-          onUnhandledError: pullDropGuard.handleRecoveryError,
-        });
-        if (!taken) onError(e);
-      },
-    });
+    try {
+      await pull.mutateAsync(mode);
+      if (plain) toast.success(plain);
+    } catch (e) {
+      if (pullDropGuard.handleError(e)) return;
+      const taken = recovery.handleError(e, {
+        operationLabel: "pull",
+        reappliedMessage: "Pulled and reapplied your changes.",
+        // ff-only has no ordinary success toast, but a recovery the user ran
+        // deliberately still has to confirm itself.
+        plainMessage: plain ?? "Pulled.",
+        run: { op: "pull", mode },
+        // The retried pull re-runs the fork-point guard before it stashes, so
+        // a rebase pull can raise the decision here too.
+        onUnhandledError: pullDropGuard.handleRecoveryError,
+      });
+      if (!taken) onError(e);
+    }
   }
 
   // Sync the current branch with the fork's upstream: fetch upstream, resolve
   // its default branch, then fast-forward or merge. Honest terminal toast per
   // outcome; a conflicting merge rejects and the conflict banner takes over
   // (its error still toasts). No auto-push — Push lights up on its own.
-  function doUpdateFromUpstream() {
-    updateUpstream.mutate(undefined, {
-      onSuccess: (outcome) => {
-        const ref = `upstream/${outcome.branch}`;
-        if (outcome.kind === "up-to-date") {
-          toast.success(`Already up to date with ${ref}.`);
-        } else if (outcome.kind === "fast-forwarded") {
-          toast.success(`Fast-forwarded to ${ref}.`);
-        } else if (outcome.kind === "dirty-blocked") {
-          // The merge was refused, not attempted-and-broken: recover from the
-          // already-resolved ref, so confirming costs no second fetch.
-          recovery.begin({
-            operationLabel: "update",
-            detail: ref,
-            reappliedMessage: `Updated from ${ref} and reapplied your changes.`,
-            plainMessage: `Merged ${ref} into your branch.`,
-            run: { op: "merge", ref: outcome.ref },
-          });
-        } else {
-          toast.success(`Merged ${ref} into your branch.`);
-        }
-      },
-      onError,
-    });
+  async function doUpdateFromUpstream() {
+    try {
+      const outcome = await updateUpstream.mutateAsync(undefined);
+      const ref = `upstream/${outcome.branch}`;
+      if (outcome.kind === "up-to-date") {
+        toast.success(`Already up to date with ${ref}.`);
+      } else if (outcome.kind === "fast-forwarded") {
+        toast.success(`Fast-forwarded to ${ref}.`);
+      } else if (outcome.kind === "dirty-blocked") {
+        // The merge was refused, not attempted-and-broken: recover from the
+        // already-resolved ref, so confirming costs no second fetch.
+        recovery.begin({
+          operationLabel: "update",
+          detail: ref,
+          reappliedMessage: `Updated from ${ref} and reapplied your changes.`,
+          plainMessage: `Merged ${ref} into your branch.`,
+          run: { op: "merge", ref: outcome.ref },
+        });
+      } else {
+        toast.success(`Merged ${ref} into your branch.`);
+      }
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // The remedy when the upstream already carries this branch's commits under
@@ -409,31 +409,31 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
       toast.info("HEAD moved while the dialog was open — nothing was reset.");
       return;
     }
-    hardReset.mutate(tip, {
-      onSuccess: () => toast.success(`Reset ${branch} to ${upstream}`),
-      onError,
-    });
+    try {
+      await hardReset.mutateAsync(tip);
+      toast.success(`Reset ${branch} to ${upstream}`);
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function doPush(force: boolean) {
-    push.mutate(
-      { setUpstream: !hasUpstream, force },
-      {
-        onSuccess: (guard) => {
-          // Only a force push has a guarantee to report, and only the two
-          // degraded values say more than the plain confirmation does.
-          if (force)
-            toast.success("Force pushed", {
-              description: FORCE_PUSH_DEGRADED[guard],
-            });
-          setForceConfirmOpen(false);
-        },
-        onError: (e) => {
-          onError(e);
-          setForceConfirmOpen(false);
-        },
-      },
-    );
+  async function doPush(force: boolean) {
+    try {
+      const guard = await push.mutateAsync({
+        setUpstream: !hasUpstream,
+        force,
+      });
+      // Only a force push has a guarantee to report, and only the two
+      // degraded values say more than the plain confirmation does.
+      if (force)
+        toast.success("Force pushed", {
+          description: FORCE_PUSH_DEGRADED[guard],
+        });
+      setForceConfirmOpen(false);
+    } catch (e) {
+      onError(e);
+      setForceConfirmOpen(false);
+    }
   }
 
   // Publishing an untracked branch that is really a local copy of a fork PR's
@@ -445,7 +445,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   async function beginPush(force: boolean) {
     const branch = head?.name;
     if (force || hasUpstream || !branch) {
-      doPush(force);
+      void doPush(force);
       return;
     }
     setDetecting(true);
@@ -458,18 +458,18 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
     // fast-forward of the wrong work, so the moment has passed — just publish.
     if (match && headNameRef.current === branch)
       setForkGuard({ match, branch });
-    else doPush(false);
+    else void doPush(false);
   }
 
   // Hotkeys mirror the buttons' disabled states exactly.
-  useHotkeyAction("fetch", () => doFetch(false), !noOrigin && !busy);
+  useHotkeyAction("fetch", () => void doFetch(false), !noOrigin && !busy);
   // Pull needs no explicit `!detached` term: `hasUpstream` is already false on a
   // detached HEAD (the backend leaves `head.upstream` null, mirroring git's "no
   // upstream for a detached HEAD"), so this hotkey and the Pull button below are
   // disabled there for free — unlike Push, which has no upstream precondition.
   useHotkeyAction(
     "pull",
-    () => doPull("ffOnly"),
+    () => void doPull("ffOnly"),
     !noOrigin && !busy && hasUpstream && !diverged,
   );
   useHotkeyAction(
@@ -485,7 +485,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
   // to sync from or nowhere to merge into.
   useHotkeyAction(
     "update-from-upstream",
-    doUpdateFromUpstream,
+    () => void doUpdateFromUpstream(),
     canUpdateUpstream && !busy,
   );
 
@@ -525,7 +525,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           // sm size is px-2.5 and the leading-icon rule already pulls the left
           // side to pl-1.5, so without this the icon sits 4px off-center.
           className="focus-visible:relative focus-visible:z-10 max-md:pr-1.5"
-          onClick={() => doFetch(false)}
+          onClick={() => void doFetch(false)}
         >
           {fetchRemote.isPending ? (
             <Spinner data-icon="inline-start" />
@@ -547,7 +547,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
           aria-label={pullDescription ?? "Pull"}
           aria-keyshortcuts={pullKeyshortcuts}
           className="border-l-0 focus-visible:relative focus-visible:z-10 max-md:pr-1.5"
-          onClick={() => doPull("ffOnly")}
+          onClick={() => void doPull("ffOnly")}
         >
           {/* Covers the recovery compounds too: with the preference on they
               run with no dialog open to show progress. */}
@@ -587,7 +587,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             <DropdownMenuContent align="end" className="min-w-48">
               {hasUpstream && (
                 <>
-                  <DropdownMenuItem onClick={() => doPull("rebase")}>
+                  <DropdownMenuItem onClick={() => void doPull("rebase")}>
                     Pull with rebase
                   </DropdownMenuItem>
                   {/* Disabled with the reason IN the label: a disabled menu item
@@ -596,7 +596,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
                   <DropdownMenuItem
                     disabled={mixedRewrite}
                     title={mixedRewrite ? mergeDuplicatesReason : undefined}
-                    onClick={() => doPull("merge")}
+                    onClick={() => void doPull("merge")}
                   >
                     {mixedRewrite
                       ? `Pull with merge (${head?.upstream} already carries these changes under different ids)`
@@ -617,7 +617,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
                 <>
                   {hasUpstream && <DropdownMenuSeparator />}
                   {/* Base UI menu items fire on onClick, NOT onSelect. */}
-                  <DropdownMenuItem onClick={doUpdateFromUpstream}>
+                  <DropdownMenuItem onClick={() => void doUpdateFromUpstream()}>
                     Update from upstream
                   </DropdownMenuItem>
                 </>
@@ -711,7 +711,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
             <Button
               variant="destructive"
               disabled={push.isPending}
-              onClick={() => doPush(true)}
+              onClick={() => void doPush(true)}
             >
               {push.isPending && <Spinner data-icon="inline-start" />}
               Force push
@@ -727,7 +727,7 @@ export function SyncControls({ repoPath }: { repoPath: string }) {
         onClose={() => setForkGuard(null)}
         onPublishAnyway={() => {
           setForkGuard(null);
-          doPush(false);
+          void doPush(false);
         }}
       />
 

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -128,7 +128,8 @@ export function useOpenRepoByPath() {
               },
               cancel: {
                 label: "Remove",
-                onClick: () => removeRecent.mutate(path),
+                onClick: () =>
+                  void removeRecent.mutateAsync(path).catch(() => undefined),
               },
             });
           }

--- a/src/features/repository/useStashReapplyRecovery.tsx
+++ b/src/features/repository/useStashReapplyRecovery.tsx
@@ -223,7 +223,9 @@ export function useStashReapplyRecovery(repoPath: string) {
     // Write only on change (AmendForcePush precedent) — the prompt never shows
     // while the preference is already on.
     if (always && settings.data && !settings.data.autoStashOnPull) {
-      saveSettings.mutate({ ...settings.data, autoStashOnPull: true });
+      void saveSettings
+        .mutateAsync({ ...settings.data, autoStashOnPull: true })
+        .catch(() => undefined);
     }
     void runRecovery(request);
   }

--- a/src/lib/git/change-kind-badge.ts
+++ b/src/lib/git/change-kind-badge.ts
@@ -1,0 +1,22 @@
+import type { ChangeKind } from "./types";
+
+/** The status letter, screen-reader label, and colour token per change kind.
+ *  Shared so the Changes list and the commit dialog's staged summary read the
+ *  same letter and colour for the same file. */
+export const KIND_BADGE: Record<
+  ChangeKind,
+  { letter: string; label: string; className: string }
+> = {
+  added: { letter: "A", label: "Added", className: "text-success" },
+  untracked: { letter: "U", label: "Untracked", className: "text-success" },
+  modified: { letter: "M", label: "Modified", className: "text-warning" },
+  typechange: { letter: "T", label: "Type changed", className: "text-warning" },
+  deleted: { letter: "D", label: "Deleted", className: "text-destructive" },
+  renamed: { letter: "R", label: "Renamed", className: "text-info" },
+  copied: { letter: "C", label: "Copied", className: "text-info" },
+  conflicted: {
+    letter: "!",
+    label: "Conflicted",
+    className: "text-destructive",
+  },
+};

--- a/src/lib/git/reserved-device-name.ts
+++ b/src/lib/git/reserved-device-name.ts
@@ -1,0 +1,26 @@
+import { isWindows } from "@/lib/hotkeys/binding";
+
+/** Reserved DOS device stems. A frontend copy of the backend's
+ *  `is_reserved_device_name` (src-tauri/src/fsops.rs) — the two must not drift.
+ *  Only a single COM/LPT ordinal 1–9 is a device, as an ASCII digit or a
+ *  Latin-1 superscript; without the `u` flag `i` folds ASCII alone, matching the
+ *  Rust side's `to_ascii_uppercase`. */
+const RESERVED_STEM = /^(?:con|prn|aux|nul|(?:com|lpt)[1-9¹²³])$/i;
+
+/**
+ * The final segment of `path` when Windows resolves it to a device rather than
+ * a file, else null. `git add` reads the device and dies, so such a file can
+ * never be staged — callers explain rather than offer the action.
+ *
+ * `path` is a repo-relative git path ("/"-separated); only its last segment
+ * decides. Always null off Windows, where these are ordinary stageable files.
+ */
+export function reservedDeviceName(path: string): string | null {
+  if (!isWindows) return null;
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  // Win32 strips trailing dots and spaces off a final component, so `nul.txt`
+  // and `nul ` are the device too: the stem is everything before the first dot,
+  // trailing spaces trimmed.
+  const stem = name.split(".")[0].replace(/ +$/, "");
+  return RESERVED_STEM.test(stem) ? name : null;
+}


### PR DESCRIPTION
React Query drops per-call `mutate` callbacks once a mutation's observer loses its listeners — which happens routinely here, because the Changes/Branches panels ride `<Activity>`-hidden tabs and several dialogs close themselves mid-flight. This converts the repository and commit trees to awaited `mutateAsync` so success toasts, error recovery, dialog cleanup, and selection resets always arrive, and adds two smaller correctness fixes that surfaced in the same trees.

### Awaited mutations across the repository and commit trees

- Rewrites the callback-style mutations in `src/features/repository/BranchSwitcher.tsx` as awaited helpers (`setArchived`, `doUnlockWorktree`, `runCheckout`, `doDeleteRemoteBranch`, `doDiscardAll`), keeping the per-caller `onError` seam on `runCheckout` because each caller recovers differently.
- Converts the staging and ignore paths in `src/features/repository/ChangesPanel.tsx` (`handleToggle`, `ignoreOne`, `aiExcludeOne`, `untrackOne`, `stageAll`) and the bulk actions in `src/features/repository/RepositoryFilesDialog.tsx` (`runUntrack`, `runForceAdd`, `runRemoveRules`), so the "kept on disk" / "already in .gitignore" toasts and the `setSelected` / `setPending` resets can't be dropped.
- Converts `src/features/repository/SyncControls.tsx` (`doFetch`, `doPull`, `doUpdateFromUpstream`, the hard-reset path), preserving the `pullDropGuard` / `recovery.handleError` ordering that decides between a recovery prompt and a plain toast.
- Extracts `doContinue` / `doAbort` in `src/features/repository/ConflictBanner.tsx` — the banner unmounts the instant the op ends — and awaits `resolve` / `checkoutSide` in `src/features/repository/ConflictFileView.tsx`.
- Makes `doCommit` in `src/features/commit/useCommitSubmit.ts` async: the success path still closes the pop-out first, tracks `commit_created`, toasts the short hash, and fires on-commit automations; the catch path restores the draft via `restoreCommitDraft` before toasting.
- Smaller detached conversions where the outcome is deliberately silent or single-purpose: `ForkPrPublishGuard.tsx`, `OpRecoveryBanner.tsx`, `RepoList.tsx`, `useOpenRepoByPath.ts`, `useStashReapplyRecovery.tsx`, `commit/AmendForcePushDialog.tsx`, and the sidebar-collapse writer in `RepositoryView.tsx`, whose optimistic rollback now rides a detached `.catch()` so the function keeps returning `changed` synchronously.

### Windows-reserved device names can't be staged

- Adds `src/lib/git/reserved-device-name.ts`, a frontend mirror of the backend's `is_reserved_device_name` (`src-tauri/src/fsops.rs`), handling the trailing-dot/space stem rule and the Latin-1 superscript COM/LPT ordinals, and returning null off Windows.
- `src/features/repository/FileRow.tsx` swaps its stage button for `DisabledReasonButton` and names the reason on the row; `ChangesContextMenu.tsx` disables the Stage item and appends a "(Windows-reserved name)" hint, counting only reachable files via the new `stageableSelectionCount` prop.
- `ChangesPanel.tsx` gains `canStage` and filters both "Stage all" (`stageableUnstaged`) and the selection stage path, plus a fire-time guard in `handleToggle` so a hotkey can't reach a `git add` that dies on the device; the multi-file discard confirm gains `RESERVED_DISCARD_NOTE`.

### Branch rules must settle before a delete

- `BranchSwitcher.tsx` reads `useEffectiveBranchRulesSettling` and refuses `doDelete` while the effective rules are still standing in as empty, rather than passing the protection guard vacuously.
- `CleanupBranchesDialog.tsx` takes a `rulesSettling` prop and folds it into a single `holdingReads` flag that gates the skeleton, the selection seed, and the checking line (new `rules` entry in `CHECKING_COPY`); the batch runner also re-checks `isProtected` at batch start so a rule that changed while the dialog sat open lands in the failure rows.

### Shared badge table and guardrails

- Extracts the duplicated status-letter table into `src/lib/git/change-kind-badge.ts` and imports it in `FileRow.tsx` and `commit/CommitDialog.tsx`, so the Changes list and the staged summary can't drift apart.
- `scripts/check-banned-patterns.mjs` extends `bare-mutate-in-converted-trees` to `src/features/repository/` and `src/features/commit/` now that both trees are converted, and adds a `kind-badge-single-source` check that flags any second `const KIND_BADGE` definition; `scripts/checks.test.mjs` covers both, including that imports and reads of the shared table stay clean.

### Docs

- Updates the discard/staging note in `src/features/help/content.ts` to explain that the Stage control says why a reserved name can't be staged and that "Stage all" stages everything else.
- Adds three fragments: `changelog.d/fixed-mutation-callbacks-tab-switch.md`, `changelog.d/fixed-cleanup-rules-settling.md`, and `changelog.d/fixed-reserved-name-stage-explain.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Commits and branch cleanup now wait for protection rules to finish loading.
  - Improved operation feedback and cleanup when switching tabs or closing dialogs.
  - Windows-reserved filenames now explain why they cannot be staged.
  - “Stage all” and multi-file staging continue with eligible files instead of failing entirely.
  - Improved error handling and recovery across commit, sync, stash, conflict, and branch operations.

- **Documentation**
  - Added in-app guidance for handling Windows-reserved filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->