### PR TITLE
fix(pulls,issues,a11y): await PR writes, announce picker reasons

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -137,12 +137,14 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   fails on a new pair.
 - Disabled actions explain why via `DisabledReasonButton`
   (`src/components/disabled-reason-button.tsx`) — reason as tooltip + AT
-  announcement; menu/popover trigger sites keep the reason on a titled span
-  wrapper (its doc comment shows the idiom — a bare `title` on a disabled
-  element never shows). A disabled submit may instead explain via the field's
-  `warning` hint. Raw-`<button>` sites the vendored Button can't size (reaction
-  chips, the discussion upvote chip) take the SAME contract from the shared
-  `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
+  announcement; menu/popover trigger sites take the render arm with `disabled`
+  on the BUTTON, never the Trigger — a disabled Trigger leaves the tab order,
+  so its reason would reach hover only. The exact composition to copy is
+  `<Trigger render={<DisabledReasonButton disabled reason/>}>`; the full
+  contract sits in the primitive's doc comment. A disabled submit may instead
+  explain via the field's `warning` hint. Raw-`<button>` sites the vendored
+  Button can't size (reaction chips, the discussion upvote chip) take the SAME
+  contract from the shared `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
   (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
 - A conversation surface's own actions sit before the submit button via
   `CommentComposer`'s `leadingActions` slot when submit is the row's last

--- a/changelog.d/fixed-branch-picker-clip.md
+++ b/changelog.d/fixed-branch-picker-clip.md
@@ -1,0 +1,3 @@
+- Long branch names in the pull-request base and merge pickers now truncate
+  with an ellipsis and show the full name on hover — the options list still
+  widens to fit long names before trimming the rest.

--- a/changelog.d/fixed-branch-picker-clip.md
+++ b/changelog.d/fixed-branch-picker-clip.md
@@ -1,3 +1,4 @@
-- Long branch names in the pull-request base and merge pickers now truncate
-  with an ellipsis and show the full name on hover — the options list still
-  widens to fit long names before trimming the rest.
+- Long values in the app's dropdown pickers, branch names in the pull-request
+  base and merge pickers most of all, now truncate with an ellipsis and show
+  the full value on hover (the options list still widens to fit long entries
+  before trimming the rest).

--- a/changelog.d/fixed-dialog-group-captions.md
+++ b/changelog.d/fixed-dialog-group-captions.md
@@ -1,0 +1,3 @@
+- Screen readers now announce the "Linked issues", "Release notes", "Target",
+  and "Script" captions in the PR, release, and task dialogs — each names its
+  group of controls instead of reading as anonymous text.

--- a/changelog.d/fixed-dialog-group-captions.md
+++ b/changelog.d/fixed-dialog-group-captions.md
@@ -1,3 +1,3 @@
 - Screen readers now announce the "Linked issues", "Release notes", "Target",
   and "Script" captions across the pull-request, release, and task surfaces:
-  each names its group of controls instead of reading as anonymous text.
+  each names the group of controls it sits above.

--- a/changelog.d/fixed-dialog-group-captions.md
+++ b/changelog.d/fixed-dialog-group-captions.md
@@ -1,3 +1,3 @@
 - Screen readers now announce the "Linked issues", "Release notes", "Target",
-  and "Script" captions in the PR, release, and task dialogs — each names its
-  group of controls instead of reading as anonymous text.
+  and "Script" captions across the pull-request, release, and task surfaces:
+  each names its group of controls instead of reading as anonymous text.

--- a/changelog.d/fixed-picker-disabled-reasons.md
+++ b/changelog.d/fixed-picker-disabled-reasons.md
@@ -1,4 +1,4 @@
 - The Reviewers, Assignees, Labels, Milestone, and Type pickers, plus the
   sub-issue and relationship menus, now explain why they're unavailable to
-  keyboard and screen-reader users too — the disabled trigger stays focusable,
+  keyboard and screen-reader users too: the disabled trigger stays focusable,
   announces its reason, and shows it on hover.

--- a/changelog.d/fixed-picker-disabled-reasons.md
+++ b/changelog.d/fixed-picker-disabled-reasons.md
@@ -1,0 +1,4 @@
+- The Reviewers, Assignees, Labels, Milestone, and Type pickers, plus the
+  sub-issue and relationship menus, now explain why they're unavailable to
+  keyboard and screen-reader users too — the disabled trigger stays focusable,
+  announces its reason, and shows it on hover.

--- a/changelog.d/fixed-pr-action-continuations.md
+++ b/changelog.d/fixed-pr-action-continuations.md
@@ -1,3 +1,3 @@
 - Pull-request actions now finish reliably when you switch tabs while they're
-  in flight — confirm dialogs close, results are announced, and failed writes
+  in flight: confirm dialogs close, results are announced, and failed writes
   roll back and report.

--- a/changelog.d/fixed-pr-action-continuations.md
+++ b/changelog.d/fixed-pr-action-continuations.md
@@ -1,0 +1,3 @@
+- Pull-request actions now finish reliably when you switch tabs while they're
+  in flight — confirm dialogs close, results are announced, and failed writes
+  roll back and report.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -247,11 +247,12 @@ const SELECT_ITEM_BLOCK_TRUNCATE_RE = new RegExp(
 // The flex sibling of that dead span: a `min-w-0 flex-1 truncate` child, equally
 // inert unless the item ALSO carries a first-child shrink override — a pairing no
 // static pattern can see, so a legal site takes an allowlist entry. The window
-// doubles PAIR_GAP for headroom: that override plus the item's own props already
-// put the one live site 150 normalized chars from its tag, and a site drifting
-// past 160 would turn its allowlist entry stale rather than report. Reach stays
-// bounded by the tempered `(?!</SelectItem\b)` step, which holds only while no
-// SelectItem in src/ is self-closing (grep-verified: 67 tags, 67 closers).
+// doubles PAIR_GAP for headroom, which 160 alone would not give: the override
+// plus the item's own props already put the one live site 150 normalized chars
+// from its tag, and a site drifting past a bare-PAIR_GAP window would turn its
+// allowlist entry stale rather than report. Reach stays bounded by the tempered
+// `(?!</SelectItem\b)` step, which holds only while no SelectItem in src/ is
+// self-closing (grep-verified: 67 tags, 67 closers).
 const SELECT_ITEM_FLEX_TRUNCATE_RE = new RegExp(
   `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP * 2}}?` +
     `\\bmin-w-0 flex-1 truncate\\b`,
@@ -476,9 +477,11 @@ export const CHECKS = [
       perFile(SELECT_ITEM_FLEX_TRUNCATE_RE),
     ]),
     allowlist: [
-      // SelectControl's rich rows: the item-level first-child override lets the
-      // ItemText wrapper (a div under Base UI 1.7.0) shrink, which is what keeps
-      // the label's truncate live — a pairing the pattern cannot see.
+      // SelectControl's rich rows trip two arms, both false positives: the
+      // item-level first-child override lets the ItemText wrapper (a div under
+      // Base UI 1.7.0) shrink, which is what keeps the label's truncate live,
+      // and the clipTitle handler rides that same non-self-bounding label span —
+      // pairings the patterns cannot see.
       "src/components/form/fields.tsx",
     ],
     message:
@@ -513,9 +516,10 @@ export const CHECKS = [
     // whose detail pane is keyed per repo, Actions, whose run detail is keyed per
     // run and whose dispatch dialog unmounts with the repo view, and pulls, whose
     // surfaces go through an `<Activity>` tab hide on every repo-tab switch. The
-    // wider app is a separate tier: repository/ still carries per-call callback
-    // sites in bulk, so scanning it would report a backlog rather than a
-    // regression. Each tree joins this check on the change that converts it.
+    // wider app is a separate tier — repository/, issues/, and the smaller trees
+    // still carry per-call callback sites in bulk, so scanning them would report
+    // a backlog rather than a regression. Each tree joins this check on the
+    // change that converts it.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -291,6 +291,37 @@ const DESTRUCTURED_MUTATE_RE = /\bconst\s*\{[^}]*\bmutate\b[^}]*\}\s*=/g;
 const CONTEXT_MENU_SUPPRESS_RE =
   /\bset[A-Z]\w*\(\s*null\s*\)[^}]{0,160}?\.preventDefault\s*\(\s*\)/g;
 
+// The superseded disabled-trigger idiom: a reason exposed as `title` on a
+// wrapper around a popover/menu trigger whose control is natively disabled —
+// hover-only, because a disabled trigger leaves the tab order entirely, so
+// keyboard and assistive tech reach neither the control nor its reason.
+// Anchoring on the titled WRAPPER rather than on where `disabled` sits is what
+// lets one pattern cover both spellings the class shipped in (`disabled` on the
+// trigger, and `disabled` inside a plain `<Button/>` render element), and it is
+// what excludes the legitimate neighbours structurally instead of by name: a
+// titled span around a disabled Input or Switch carries no trigger tag, and a
+// menu SUB-trigger keeps its reason in its own label (a disabled item has no
+// room for a tooltip), so neither is ever wrapped in one. Sub/Submenu triggers
+// are excluded by name as well, pinning that idiom rather than resting on the
+// absence of a wrapper. Discriminating on a `Reason`-suffixed value instead
+// would miss the live sites whose hint is a bare conditional string rather than
+// a named reason (the discussions category menu, the branch trigger).
+// The tempered `(?!</)` steps hold the match inside one unclosed element chain,
+// so a titled span that already closed cannot pair with a later sibling's
+// trigger; the `DisabledReasonButton` step makes the FIXED composition
+// unmatchable even where a wrapper survives to carry layout classes. Both
+// windows are PAIR_GAP with ~1.4x headroom: across the live sites the widest
+// title→trigger run measures 113 normalized chars, the widest trigger→disabled
+// 84. Accepted evasions, all zero-instance today: a hint delivered by something
+// other than `title`, a wrapper that is a component rather than a tag, and a
+// `disabled` computed too far from the tag.
+const TITLED_TRIGGER_DISABLED_RE = new RegExp(
+  `title\\s*=(?:(?!</|DisabledReasonButton)[\\s\\S]){0,${PAIR_GAP}}?` +
+    `<(?![A-Za-z][\\w.]*Sub(?:menu)?Trigger\\b)[A-Za-z][\\w.]*Trigger\\b` +
+    `(?:(?!</|DisabledReasonButton)[\\s\\S]){0,${PAIR_GAP}}?\\bdisabled\\s*=`,
+  "g",
+);
+
 // Vendored shadcn/Base UI primitives are off-limits to edit (CLAUDE.md), so a
 // hit inside them could only ever be silenced by an allowlist entry, never
 // fixed. Their CALL SITES — the app code that composes them — stay scanned.
@@ -691,6 +722,35 @@ export const CHECKS = [
     ],
     message:
       "a path that matches eventToBinding(e) against a user binding and preventDefaults it must apply the same clause the global listener does — isEditableTarget, isTypeaheadTarget, and isTypeaheadKey (src/lib/hotkeys/binding.ts) — or a single-key binding steals keystrokes from text fields or typeahead lists, and named keys stop reaching the surfaces that should still get them; any subset leaves the case the missing predicate covers, and a file that dispatches no rebindable binding needs an allowlist entry with rationale",
+  },
+  {
+    name: "titled-disabled-trigger",
+    appliesTo: notVendoredUi,
+    scan: perFile(TITLED_TRIGGER_DISABLED_RE),
+    // DEFERRED, not exempt: every entry is a residual site of the class the
+    // pickers were converted out of, held back because each needs its own live
+    // keyboard pass. The gate blocks NEW sites; these come off the list as they
+    // convert, and the stale-entry rule turns each conversion into a required
+    // edit here.
+    allowlist: [
+      // The projects picker — the direct twin of the converted labels picker.
+      "src/features/conversations/ProjectsPopover.tsx",
+      // Category menu; its hint is a bare sign-in string rather than a reason
+      // prop, so the conversion has to introduce the reason first.
+      "src/features/discussions/DiscussionsPanel.tsx",
+      // Two menus (close options, more actions) whose `disabled` sits inside the
+      // render Button rather than on the trigger.
+      "src/features/issues/RemoteIssueView.tsx",
+      // Merge menus: the wrapper is what refuses the click a disabled Button
+      // drops, so converting them wants the live merge-gate pass.
+      "src/features/pulls/LocalPrView.tsx",
+      "src/features/pulls/RemotePrView.tsx",
+      // The branch trigger's wrapper also owns the header shrink cascade, so a
+      // conversion has to move those classes to wrapperClassName.
+      "src/features/repository/BranchSwitcher.tsx",
+    ],
+    message:
+      "a menu/popover trigger that carries its disabled reason on a titled wrapper is hover-only — a natively disabled trigger leaves the tab order, so keyboard and screen-reader users reach neither the control nor the reason; compose `<Trigger render={<DisabledReasonButton disabled reason/>}>` instead (src/components/disabled-reason-button.tsx), which holds the reason on a focusable aria-disabled button whose own useButton swallows activation; a site that genuinely cannot take the primitive needs an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -244,6 +244,19 @@ const SELECT_ITEM_BLOCK_TRUNCATE_RE = new RegExp(
   `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP}}?\\bblock truncate\\b`,
   "g",
 );
+// The flex sibling of that dead span: a `min-w-0 flex-1 truncate` child, equally
+// inert unless the item ALSO carries a first-child shrink override — a pairing no
+// static pattern can see, so a legal site takes an allowlist entry. The window
+// doubles PAIR_GAP for headroom: that override plus the item's own props already
+// put the one live site 150 normalized chars from its tag, and a site drifting
+// past 160 would turn its allowlist entry stale rather than report. Reach stays
+// bounded by the tempered `(?!</SelectItem\b)` step, which holds only while no
+// SelectItem in src/ is self-closing (grep-verified: 67 tags, 67 closers).
+const SELECT_ITEM_FLEX_TRUNCATE_RE = new RegExp(
+  `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP * 2}}?` +
+    `\\bmin-w-0 flex-1 truncate\\b`,
+  "g",
+);
 
 // A `.mutate(` call in any spelling — the token, not the callbacks object it
 // may carry. Matching the object instead would have to recognize every way one
@@ -460,10 +473,16 @@ export const CHECKS = [
     scan: anyOf([
       perFile(SELECT_ITEM_CLIP_TITLE_RE),
       perFile(SELECT_ITEM_BLOCK_TRUNCATE_RE),
+      perFile(SELECT_ITEM_FLEX_TRUNCATE_RE),
     ]),
-    allowlist: [],
+    allowlist: [
+      // SelectControl's rich rows: the item-level first-child override lets the
+      // ItemText wrapper (a div under Base UI 1.7.0) shrink, which is what keeps
+      // the label's truncate live — a pairing the pattern cannot see.
+      "src/components/form/fields.tsx",
+    ],
     message:
-      "Select popup rows route their clip affordance through SelectClipText (src/components/select-clip-text.tsx) — an item-level clipTitle handler is dead once the row span self-bounds, and a bare `block truncate` child never engages under the shrink-refusing ItemText; if the pairing is a false positive (a self-bounded clip span inside a rich row — its own max-w keeps the handler live), add an allowlist entry with rationale",
+      "Select popup rows route their clip affordance through SelectClipText (src/components/select-clip-text.tsx) — an item-level clipTitle handler is dead once the row span self-bounds, and a bare `block truncate` or `min-w-0 flex-1 truncate` child never engages under the shrink-refusing ItemText; if the pairing is a false positive (a self-bounded clip span inside a rich row, or a row whose item overrides ItemText's shrink refusal), add an allowlist entry with rationale",
   },
   {
     name: "setQueryData-noop",
@@ -491,19 +510,40 @@ export const CHECKS = [
     // Scoped to the trees that are fully converted, so the check can only ever
     // see a NEW site: the settings dialog's own sections (which unmount on BOTH
     // dialog close and every rail section switch — the keyed crossfade), Explore,
-    // whose detail pane is keyed per repo, and Actions, whose run detail is keyed
-    // per run and whose dispatch dialog unmounts with the repo view. The wider app
-    // is a separate tier: pulls/ and repository/ still carry per-call callback
-    // sites in bulk, so scanning them would report a backlog rather than a
+    // whose detail pane is keyed per repo, Actions, whose run detail is keyed per
+    // run and whose dispatch dialog unmounts with the repo view, and pulls, whose
+    // surfaces go through an `<Activity>` tab hide on every repo-tab switch. The
+    // wider app is a separate tier: repository/ still carries per-call callback
+    // sites in bulk, so scanning it would report a backlog rather than a
     // regression. Each tree joins this check on the change that converts it.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||
-      file.startsWith("src/features/actions/"),
+      file.startsWith("src/features/actions/") ||
+      file.startsWith("src/features/pulls/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
-    allowlist: [],
+    // Every pulls entry is a call carrying NO per-call callbacks object, so
+    // there is nothing an unmount can drop; the token match is the ratchet, and
+    // an exemption is an entry here rather than a hole in the pattern.
+    allowlist: [
+      // Archive/unarchive, single-arg `update.mutate(vars)` — the deselect it
+      // pairs with is synchronous.
+      "src/features/pulls/LocalPrContextMenu.tsx",
+      // The local-conversation write-through and the approve toggle, both
+      // single-arg `update.mutate(vars)`.
+      "src/features/pulls/LocalPrView.tsx",
+      // The palette's archive action, single-arg `updateLocalPr.mutate(vars)`.
+      "src/features/pulls/PullRequestsPanel.tsx",
+      // GitLab time tracking's set-estimate and add-spent, both single-arg.
+      "src/features/pulls/RemotePrViewParts.tsx",
+      // Deleting one stored review, single-arg `del.mutate(id)`.
+      "src/features/pulls/ReviewHistory.tsx",
+      // Reconciles merged/deleted heads from an effect: the destructured
+      // `mutate` is called single-arg on both arms.
+      "src/features/pulls/useReconcileLocalPrs.ts",
+    ],
     message:
-      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
+      "react-query gates per-call mutation callbacks on the observer still having listeners, so a dialog close, a rail section switch, an <Activity> tab hide, or a keyed pane remount mid-flight drops the toast, teardown, and navigation that lived in them — every mutation here awaits mutateAsync and puts its outcome in the continuation, so a bare .mutate( (or a `const { mutate }` destructure that reaches one) needs an allowlist entry with rationale",
   },
   {
     name: "context-menu-suppression",
@@ -606,18 +646,9 @@ export const CHECKS = [
     name: "bare-group-label",
     appliesTo: notVendoredUi,
     scan: perFile(UNASSOCIATED_LABEL_RE),
-    // Keyed per FILE, not per site, for both kinds of entry below: a coarser key
-    // means an unrelated edit to one of these files can't turn the entry stale
-    // mid-flight. The gate blocks NEW unassociated captions; the deferred group
-    // is not a to-do list.
+    // Keyed per FILE, not per site: a coarser key means an unrelated edit to one
+    // of these files can't turn the entry stale mid-flight.
     allowlist: [
-      // Deferred captions — same class, converted in their own change.
-      // Two "Linked issues" captions over the linked-issue chip rows.
-      "src/features/pulls/LinkedIssuesField.tsx",
-      // "Target" over the tag/commitish picker, "Release notes" over the editor.
-      "src/features/tags/CreateReleaseDialog.tsx",
-      // "Script" over the interpreter + path row.
-      "src/features/scripts/TaskDialog.tsx",
       // WRAPPING labels around a `<Checkbox>`, associated at RUNTIME: Base UI's
       // Root renders a `<span role="checkbox">` and routes a caller `id` to its
       // aria-hidden proxy input, so an `htmlFor` could not reach the interactive

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -280,6 +280,51 @@ test("select-item-clip-title exempts vendored ui only", () => {
   assert.equal(appliesTo("src/features/history/HistoryDialogs.tsx"), true);
 });
 
+test("select-item-clip-title flags the flex clip span across the override", () => {
+  // The flex spelling of the dead span: `flex-1` alone never wins against
+  // ItemText's nowrap intrinsic floor, so the truncate cannot engage.
+  const bare = [
+    "<SelectItem key={b} value={b}>",
+    '  <span className="min-w-0 flex-1 truncate">{b}</span>',
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(bare), [1]);
+  // SelectControl's real row, minus its clipTitleFromText prop so only this arm
+  // can fire: the item-level override that revives the truncate sits between the
+  // tag and the child, which is why the window doubles PAIR_GAP — the live site
+  // measures 150 normalized chars, and a site drifting past 160 would go missed
+  // with its allowlist entry reading stale.
+  const overridden = [
+    "<SelectItem",
+    "  key={optionValue}",
+    "  value={optionValue}",
+    "  disabled={disabledItems?.has(optionValue)}",
+    '  className="*:first:min-w-0 *:first:shrink"',
+    ">",
+    '  <span className="min-w-0 flex-1 truncate">{display}</span>',
+    "</SelectItem>",
+  ].join("\n");
+  assert.deepEqual(selectItemClipTitle(overridden), [1]);
+});
+
+test("select-item-clip-title allowlists the flex spelling per file", () => {
+  const check = CHECKS.find((c) => c.name === "select-item-clip-title");
+  const row = [
+    "<SelectItem key={v} value={v}>",
+    '  <span className="min-w-0 flex-1 truncate">{d}</span>',
+    "</SelectItem>",
+  ].join("\n");
+  const files = [
+    "src/components/form/fields.tsx",
+    "src/features/pulls/SomeNewPicker.tsx",
+  ];
+  const views = new Map(files.map((f) => [f, view(row)]));
+  // The shared control's entry suppresses only its own file; the same markup in
+  // a fresh picker (which carries no override) still reports.
+  const { violations } = runCheck(check, files, views);
+  assert.deepEqual(violations, ["src/features/pulls/SomeNewPicker.tsx:1"]);
+});
+
 test("setQueryData-noop catches a call wrapped across lines", () => {
   const source = [
     "queryClient.setQueryData(",
@@ -527,13 +572,12 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
     "src/features/repo-settings/RulesetsSection.tsx",
     "src/features/explore/ExploreDetail.tsx",
     "src/features/actions/RunDetailView.tsx",
+    "src/features/pulls/RemotePrView.tsx",
+    "src/features/pulls/useReconcileLocalPrs.ts",
   ]) {
     assert.equal(appliesTo(file), true, `should scan ${file}`);
   }
-  for (const file of [
-    "src/features/pulls/LocalPrView.tsx",
-    "src/features/repository/ChangesPanel.tsx",
-  ]) {
+  for (const file of ["src/features/repository/ChangesPanel.tsx"]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
 });
@@ -808,21 +852,15 @@ test("bare-group-label allowlists whole files, and exempts vendored ui", () => {
     check.appliesTo("src/features/repo-settings/PagesSection.tsx"),
     true,
   );
-  // Both kinds of entry are keyed per file: a deferred file's two captions are
-  // suppressed by its single entry, a WRAPPING label (implicit association, which
-  // neither htmlFor nor id can express) is suppressed by its own, and an unlisted
-  // file still reports.
+  // Entries are keyed per file: a WRAPPING label (implicit association, which
+  // neither htmlFor nor id can express) is suppressed by its file's entry, and an
+  // unlisted file still reports.
   const files = [
-    "src/features/pulls/LinkedIssuesField.tsx",
     "src/features/repo-settings/GitLabVariablesSection.tsx",
     "src/features/repo-settings/GitLabWebhooksSection.tsx",
     "src/features/repo-settings/PagesSection.tsx",
   ];
   const views = new Map([
-    [
-      "src/features/pulls/LinkedIssuesField.tsx",
-      view("<Label>Linked issues</Label>\n<Label>Linked issues</Label>"),
-    ],
     [
       "src/features/repo-settings/GitLabVariablesSection.tsx",
       view(

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -55,6 +55,7 @@ const diffStatPair = scanner("hand-rolled-diff-stat");
 const nullFallback = scanner("null-suspense-fallback");
 const bareGroupLabel = scanner("bare-group-label");
 const unguardedDispatcher = scanner("unguarded-binding-dispatcher");
+const titledDisabledTrigger = scanner("titled-disabled-trigger");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -305,6 +306,12 @@ test("select-item-clip-title flags the flex clip span across the override", () =
     "</SelectItem>",
   ].join("\n");
   assert.deepEqual(selectItemClipTitle(overridden), [1]);
+  // The arm's bound: the same utility trio is ordinary flex layout anywhere
+  // else, so only the SelectItem anchor makes it the dead span.
+  assert.deepEqual(
+    selectItemClipTitle('<div className="min-w-0 flex-1 truncate">{d}</div>'),
+    [],
+  );
 });
 
 test("select-item-clip-title allowlists the flex spelling per file", () => {
@@ -994,6 +1001,138 @@ test("unguarded-binding-dispatcher allowlists the non-rebindable dispatchers", (
   // The recorder is exempt by contract; a NEW file with the same shape is not.
   assert.deepEqual(runCheck(check, files, views).violations, [
     "src/features/pulls/SomeNewView.tsx:1",
+  ]);
+});
+
+test("titled-disabled-trigger flags both spellings of the hover-only reason", () => {
+  // `disabled` on the trigger — the shape the pickers shipped in.
+  const onTrigger = [
+    "<span",
+    "  title={disabledReason}",
+    '  className={disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"}',
+    ">",
+    "  <Popover.Trigger",
+    "    disabled={!!disabledReason}",
+    '    render={<Button variant="ghost" size="xs" aria-label="Edit labels" />}',
+    "  >",
+    "    Labels",
+    "  </Popover.Trigger>",
+    "</span>",
+  ].join("\n");
+  // Line 2, not 1: the match starts at the `title`, so a hit points at the
+  // reason carrier rather than at the wrapper's opening tag.
+  assert.deepEqual(titledDisabledTrigger(onTrigger), [2]);
+  // Same class, `disabled` inside the render element instead — the reason is
+  // hover-only either way, which is why the pattern anchors on the wrapper.
+  const inRender = [
+    '<span title={staleReason} className="inline-flex">',
+    "  <DropdownMenuTrigger",
+    "    render={",
+    '      <Button variant="outline" size="xs" disabled={detailsStale} />',
+    "    }",
+    "  >",
+    "    <DotsThreeIcon />",
+    "  </DropdownMenuTrigger>",
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(inRender), [1]);
+});
+
+test("titled-disabled-trigger leaves the primitive and the non-trigger wrappers alone", () => {
+  // The fixed composition: no wrapper of its own, and the primitive's name in
+  // the window blocks the match even if one survived for layout.
+  const converted = [
+    "<Popover.Trigger",
+    "  render={",
+    "    <DisabledReasonButton",
+    '      variant="ghost"',
+    '      aria-label="Edit labels"',
+    "      disabled={!!disabledReason}",
+    "      reason={disabledReason}",
+    "    />",
+    "  }",
+    ">",
+    "  Labels",
+    "</Popover.Trigger>",
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(converted), []);
+  const survivingWrapper = [
+    '<span title={disabledReason} className="inline-flex">',
+    "  <Popover.Trigger",
+    "    render={<DisabledReasonButton disabled={!!disabledReason} reason={disabledReason} />}",
+    "  >",
+    "    Labels",
+    "  </Popover.Trigger>",
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(survivingWrapper), []);
+  // A titled wrapper around a disabled NON-trigger control is the sanctioned
+  // idiom for inputs the primitive can't wrap — no trigger tag, no match.
+  for (const control of [
+    '  <Input id="issue-due-date" type="date" disabled={blocked} />',
+    '  <Switch id="issue-confidential" disabled={!!disabledReason} />',
+  ]) {
+    const wrapped = [
+      '<span title={disabledReason} className="inline-flex">',
+      control,
+      "</span>",
+    ].join("\n");
+    assert.deepEqual(titledDisabledTrigger(wrapped), []);
+  }
+  // A menu SUB-trigger carries its reason in its own label (a disabled item has
+  // no room for a tooltip), so it is excluded by name as well as by structure —
+  // this fixture puts a titled wrapper around one to prove the name arm.
+  const subTrigger = [
+    '<span title={disabledReason} className="inline-flex">',
+    "  <DropdownMenuSubTrigger",
+    "    disabled={!!disabledReason}",
+    '    className="data-disabled:opacity-50"',
+    "  >",
+    "    Hide…{disabledSuffix}",
+    "  </DropdownMenuSubTrigger>",
+    "</span>",
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(subTrigger), []);
+  // Triggers that take `disabled` with no reason contract at all: nothing titles
+  // them, so the wrapper anchor keeps them out without naming them.
+  const plain = [
+    '<TabsTrigger value="files" disabled={!hasFiles}>Files</TabsTrigger>',
+    '<ContextMenuTrigger disabled={locked} render={<button type="button" />} />',
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(plain), []);
+  // Tempering stops the scan where an element closes: a titled span that already
+  // finished cannot pair with a later sibling's disabled trigger.
+  const stacked = [
+    '<span title={hint} className="inline-flex">',
+    "  <Badge>{count}</Badge>",
+    "</span>",
+    "<DropdownMenuTrigger disabled={busy} render={<Button />}>",
+    "  Menu",
+    "</DropdownMenuTrigger>",
+  ].join("\n");
+  assert.deepEqual(titledDisabledTrigger(stacked), []);
+});
+
+test("titled-disabled-trigger allowlists the residual sites per file", () => {
+  const check = CHECKS.find((c) => c.name === "titled-disabled-trigger");
+  const row = [
+    '<span title={heldReason} className="inline-flex">',
+    "  <Popover.Trigger",
+    "    disabled={!!heldReason}",
+    '    render={<Button variant="ghost" size="xs" />}',
+    "  >",
+    "    Projects",
+    "  </Popover.Trigger>",
+    "</span>",
+  ].join("\n");
+  const files = [
+    "src/features/conversations/ProjectsPopover.tsx",
+    "src/features/issues/SomeNewPicker.tsx",
+  ];
+  const views = new Map(files.map((f) => [f, view(row)]));
+  // A deferred residual stays quiet; the same markup in a fresh picker reports.
+  assert.deepEqual(runCheck(check, files, views).violations, [
+    "src/features/issues/SomeNewPicker.tsx:1",
   ]);
 });
 

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -1,5 +1,6 @@
 import { type ComponentProps, type ReactNode, useEffect, useId } from "react";
 import { MarkdownEditor } from "@/components/markdown-editor";
+import { SelectClipText } from "@/components/select-clip-text";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -12,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type { MentionSource } from "@/features/conversations/useMentionCandidates";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { useFieldContext } from "@/lib/form-context";
 
 /**
@@ -259,7 +261,7 @@ export function SelectControl({
         disabled={disabled}
       >
         <SelectTrigger id={id} className="w-full">
-          <SelectValue />
+          <SelectValue onMouseEnter={clipTitleFromText} />
         </SelectTrigger>
         <SelectContent
           {...(sizeToContent
@@ -277,8 +279,20 @@ export function SelectControl({
                 key={optionValue}
                 value={optionValue}
                 disabled={disabledItems?.has(optionValue)}
+                // The vendored ItemText wrapper is `flex-1 shrink-0` and its
+                // intrinsic floor grows with its nowrap content, so a `truncate`
+                // child never clips; letting the item's first child shrink is
+                // what ellipsizes the label while the popup still sizes to its
+                // widest option. Tag-agnostic on purpose: the element type is
+                // Base UI's to change, only the first-child position is ours.
+                className="*:first:min-w-0 *:first:shrink"
               >
-                <span className="min-w-0 flex-1 truncate">{display}</span>
+                <span
+                  className="min-w-0 flex-1 truncate"
+                  onMouseEnter={clipTitleFromText}
+                >
+                  {display}
+                </span>
                 {annotations?.[optionValue]}
               </SelectItem>
             ) : (
@@ -287,7 +301,7 @@ export function SelectControl({
                 value={optionValue}
                 disabled={disabledItems?.has(optionValue)}
               >
-                {display}
+                <SelectClipText>{display}</SelectClipText>
               </SelectItem>
             ),
           )}

--- a/src/components/form/labeled-group.tsx
+++ b/src/components/form/labeled-group.tsx
@@ -28,7 +28,9 @@ export function LabeledGroup({
       className={cn("space-y-2", className)}
     >
       {actions ? (
-        <div className="flex items-center justify-between">
+        // `gap-2` is a collision floor under justify-between: invisible until a
+        // narrow host would butt the caption against the actions.
+        <div className="flex items-center justify-between gap-2">
           {caption}
           {actions}
         </div>

--- a/src/features/conversations/LabelsPopover.tsx
+++ b/src/features/conversations/LabelsPopover.tsx
@@ -1,9 +1,9 @@
 import { Popover } from "@base-ui/react/popover";
 import { TagIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
 import { useEditPrLabels, useRepoLabels } from "@/lib/git/queries";
@@ -94,30 +94,29 @@ export function LabelsPopover({
     }
   }
 
-  // Trigger first, so it never shifts as chips come and go. A natively disabled
-  // button swallows `title`, so the reason rides a wrapping span.
+  // Trigger first, so it never shifts as chips come and go.
   const trigger = (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <span
-        title={disabledReason}
-        className={
-          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+      <Popover.Trigger
+        render={
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit labels"
+            disabled={!!disabledReason}
+            reason={disabledReason}
+          />
         }
       >
-        <Popover.Trigger
-          disabled={!!disabledReason}
-          render={<Button variant="ghost" size="xs" aria-label="Edit labels" />}
-        >
-          {/* size-3 explicitly: the Button's own icon rule skips a sized
-              element, and a 16px swap would widen the label column mid-write. */}
-          {editLabels.isPending ? (
-            <Spinner className="size-3" data-icon="inline-start" />
-          ) : (
-            <TagIcon data-icon="inline-start" />
-          )}
-          Labels
-        </Popover.Trigger>
-      </span>
+        {/* size-3 explicitly: the Button's own icon rule skips a sized
+            element, and a 16px swap would widen the label column mid-write. */}
+        {editLabels.isPending ? (
+          <Spinner className="size-3" data-icon="inline-start" />
+        ) : (
+          <TagIcon data-icon="inline-start" />
+        )}
+        Labels
+      </Popover.Trigger>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner
           align="start"

--- a/src/features/issues/IssueMetaPickers.tsx
+++ b/src/features/issues/IssueMetaPickers.tsx
@@ -6,10 +6,10 @@ import {
   UserPlusIcon,
 } from "@phosphor-icons/react";
 import { type ComponentProps, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { MetaValueCell, UserChip } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -141,24 +141,20 @@ export function AssigneesPopover({
 
   const trigger = (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      {/* A natively disabled button swallows `title`, so the reason rides a
-          wrapping span. */}
-      <span
-        title={disabledReason}
-        className={
-          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+      <Popover.Trigger
+        render={
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit assignees"
+            disabled={!!disabledReason}
+            reason={disabledReason}
+          />
         }
       >
-        <Popover.Trigger
-          disabled={!!disabledReason}
-          render={
-            <Button variant="ghost" size="xs" aria-label="Edit assignees" />
-          }
-        >
-          <UserPlusIcon data-icon="inline-start" />
-          Assignees
-        </Popover.Trigger>
-      </span>
+        <UserPlusIcon data-icon="inline-start" />
+        Assignees
+      </Popover.Trigger>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner
           align="start"
@@ -252,25 +248,21 @@ export function MilestoneMenu({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <DropdownMenu>
-        {/* A natively disabled button swallows `title`, so the reason rides a
-            wrapping span. */}
-        <span
-          title={disabledReason}
-          className={
-            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        <DropdownMenuTrigger
+          render={
+            <DisabledReasonButton
+              variant="ghost"
+              size="xs"
+              aria-label="Set milestone"
+              disabled={!!disabledReason}
+              reason={disabledReason}
+            />
           }
         >
-          <DropdownMenuTrigger
-            disabled={!!disabledReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Set milestone" />
-            }
-          >
-            <FlagIcon data-icon="inline-start" />
-            {display}
-            <CaretDownIcon data-icon="inline-end" />
-          </DropdownMenuTrigger>
-        </span>
+          <FlagIcon data-icon="inline-start" />
+          {display}
+          <CaretDownIcon data-icon="inline-end" />
+        </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem
             onClick={() => onChange(null, null)}
@@ -333,29 +325,25 @@ export function IssueTypeMenu({
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <DropdownMenu>
-        {/* A natively disabled button swallows `title`, so the reason rides a
-            wrapping span. */}
-        <span
-          title={disabledReason}
-          className={
-            disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+        <DropdownMenuTrigger
+          render={
+            <DisabledReasonButton
+              variant="ghost"
+              size="xs"
+              aria-label="Set issue type"
+              disabled={!!disabledReason}
+              reason={disabledReason}
+            />
           }
         >
-          <DropdownMenuTrigger
-            disabled={!!disabledReason}
-            render={
-              <Button variant="ghost" size="xs" aria-label="Set issue type" />
-            }
-          >
-            {value ? (
-              <TypeDot color={value.color} data-icon="inline-start" />
-            ) : (
-              <ShapesIcon data-icon="inline-start" />
-            )}
-            {value?.name ?? "Type"}
-            <CaretDownIcon data-icon="inline-end" />
-          </DropdownMenuTrigger>
-        </span>
+          {value ? (
+            <TypeDot color={value.color} data-icon="inline-start" />
+          ) : (
+            <ShapesIcon data-icon="inline-start" />
+          )}
+          {value?.name ?? "Type"}
+          <CaretDownIcon data-icon="inline-end" />
+        </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem
             onClick={() => onChange(null)}

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -279,8 +279,8 @@ export function IssueSubIssues({
           <span className="flex-1" />
           {mode === null && (
             <DropdownMenu>
-              {/* Every item in this menu is a write, so the gate sits on the
-                  trigger rather than on each item. */}
+              {/* Every item in this menu is a write, so the whole trigger
+                  button disables rather than each item. */}
               <DropdownMenuTrigger
                 render={
                   <DisabledReasonButton
@@ -414,8 +414,8 @@ export function IssueRelationships({
         <span className="flex-1" />
         {addRelation === null && (
           <DropdownMenu>
-            {/* Every item in this menu is a write, so the gate sits on the
-                trigger rather than on each item. */}
+            {/* Every item in this menu is a write, so the whole trigger
+                button disables rather than each item. */}
             <DropdownMenuTrigger
               render={
                 <DisabledReasonButton

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -279,32 +279,23 @@ export function IssueSubIssues({
           <span className="flex-1" />
           {mode === null && (
             <DropdownMenu>
-              {/* A natively disabled button swallows `title`, so the reason
-                  rides a wrapping span. Every item in this menu is a write, so
-                  the gate sits on the trigger rather than on each item. */}
-              <span
-                title={disabledReason}
-                className={
-                  disabledReason
-                    ? "inline-flex cursor-not-allowed"
-                    : "inline-flex"
+              {/* Every item in this menu is a write, so the gate sits on the
+                  trigger rather than on each item. */}
+              <DropdownMenuTrigger
+                render={
+                  <DisabledReasonButton
+                    variant="ghost"
+                    size="xs"
+                    aria-label="Add a sub-issue"
+                    disabled={!!disabledReason}
+                    reason={disabledReason}
+                  />
                 }
               >
-                <DropdownMenuTrigger
-                  disabled={!!disabledReason}
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      aria-label="Add a sub-issue"
-                    />
-                  }
-                >
-                  <PlusIcon data-icon="inline-start" />
-                  Add sub-issue
-                  <CaretDownIcon data-icon="inline-end" />
-                </DropdownMenuTrigger>
-              </span>
+                <PlusIcon data-icon="inline-start" />
+                Add sub-issue
+                <CaretDownIcon data-icon="inline-end" />
+              </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-52">
                 <DropdownMenuItem onClick={() => setCreateOpen(true)}>
                   Create new sub-issue…
@@ -423,32 +414,23 @@ export function IssueRelationships({
         <span className="flex-1" />
         {addRelation === null && (
           <DropdownMenu>
-            {/* A natively disabled button swallows `title`, so the reason rides
-                a wrapping span. Every item in this menu is a write, so the gate
-                sits on the trigger rather than on each item. */}
-            <span
-              title={disabledReason}
-              className={
-                disabledReason
-                  ? "inline-flex cursor-not-allowed"
-                  : "inline-flex"
+            {/* Every item in this menu is a write, so the gate sits on the
+                trigger rather than on each item. */}
+            <DropdownMenuTrigger
+              render={
+                <DisabledReasonButton
+                  variant="ghost"
+                  size="xs"
+                  aria-label="Add a relationship"
+                  disabled={!!disabledReason}
+                  reason={disabledReason}
+                />
               }
             >
-              <DropdownMenuTrigger
-                disabled={!!disabledReason}
-                render={
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    aria-label="Add a relationship"
-                  />
-                }
-              >
-                <PlusIcon data-icon="inline-start" />
-                Add
-                <CaretDownIcon data-icon="inline-end" />
-              </DropdownMenuTrigger>
-            </span>
+              <PlusIcon data-icon="inline-start" />
+              Add
+              <CaretDownIcon data-icon="inline-end" />
+            </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-44">
               <DropdownMenuItem onClick={() => setAddRelation("blocked_by")}>
                 Blocked by…

--- a/src/features/pulls/CommitComments.tsx
+++ b/src/features/pulls/CommitComments.tsx
@@ -352,7 +352,11 @@ export function CommitComments({
     }
   })();
 
-  function submit() {
+  // These continuations ride the awaited promise, never per-call mutate
+  // callbacks: an `<Activity>` tab hide tears this observer's subscription down
+  // mid-write, and react-query drops per-call callbacks once an observer has no
+  // listeners — the toast and the draft restore would silently never run.
+  async function submit() {
     const text = draft.value.trim();
     if (!text || stale) return;
     // Clear the draft immediately (perceived-speed win); the hook appends the
@@ -360,29 +364,36 @@ export function CommitComments({
     // that commit's composer is still empty so newly-typed text is never clobbered.
     const submittedFor = commitIdentity;
     draft.set("");
-    createComment.mutate(
-      { sha, body: text },
-      {
-        onSuccess: () => toast.success("Comment added"),
-        onError: (e) => {
-          draft.setFor(submittedFor, (prev) => (prev.trim() ? prev : text));
-          toastError(e);
-        },
-      },
-    );
+    try {
+      await createComment.mutateAsync({ sha, body: text });
+      toast.success("Comment added");
+    } catch (e) {
+      draft.setFor(submittedFor, (prev) => (prev.trim() ? prev : text));
+      toastError(e);
+    }
   }
 
-  function saveEdit(commentId: string, next: string) {
+  async function saveEdit(commentId: string, next: string) {
     // The comment id is the previous commit's while the write addresses `sha`,
     // so a mismatched pair would edit against a commit that never showed it.
     if (stale) return;
-    editComment.mutate(
-      { sha, commentId, body: next },
-      {
-        onSuccess: () => toast.success("Comment updated"),
-        onError: (e) => toastError(e),
-      },
-    );
+    try {
+      await editComment.mutateAsync({ sha, commentId, body: next });
+      toast.success("Comment updated");
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function confirmDelete(commentId: string) {
+    try {
+      await deleteComment.mutateAsync({ sha, commentId });
+      toast.success("Comment deleted");
+    } catch (e) {
+      toastError(e);
+    } finally {
+      setDeletingId(null);
+    }
   }
 
   // After every hook: an unsupported commit renders nothing, but the mounted
@@ -404,7 +415,7 @@ export function CommitComments({
                 thread={toThread(c)}
                 onSaveEdit={
                   c.viewerDidAuthor && !stale
-                    ? (next) => saveEdit(c.id, next)
+                    ? (next) => void saveEdit(c.id, next)
                     : undefined
                 }
                 // Withholding the handler only drops the menu entry; an editor
@@ -486,7 +497,7 @@ export function CommitComments({
                         thread={toThread(c)}
                         onSaveEdit={
                           c.viewerDidAuthor && !stale
-                            ? (next) => saveEdit(c.id, next)
+                            ? (next) => void saveEdit(c.id, next)
                             : undefined
                         }
                         editHeld={stale}
@@ -518,7 +529,7 @@ export function CommitComments({
           placeholder="Leave a comment…"
           value={draft.value}
           onChange={draft.set}
-          onSubmit={submit}
+          onSubmit={() => void submit()}
           submitLabel="Comment"
           mentions={mentions}
           busy={busy}
@@ -531,21 +542,7 @@ export function CommitComments({
         onClose={() => setDeletingId(null)}
         pending={deleteComment.isPending}
         description={`This permanently deletes the comment on ${remoteLabel}. This cannot be undone.`}
-        onConfirm={(commentId) =>
-          deleteComment.mutate(
-            { sha, commentId },
-            {
-              onSuccess: () => {
-                toast.success("Comment deleted");
-                setDeletingId(null);
-              },
-              onError: (e) => {
-                toastError(e);
-                setDeletingId(null);
-              },
-            },
-          )
-        }
+        onConfirm={(commentId) => void confirmDelete(commentId)}
       />
     </div>
   );
@@ -626,8 +623,11 @@ export function CommitLineComposer({
     const text = body.trim();
     if (!text || !canPost) return;
     // Optimistic: the hook appends the synthetic comment, so close right away.
-    createComment.mutate(
-      {
+    // The outcome rides the promise (detached, so the close still happens on this
+    // tick): closing unmounts this composer, and react-query drops per-call mutate
+    // callbacks with the observer.
+    void createComment
+      .mutateAsync({
         sha,
         body: text,
         path,
@@ -636,12 +636,9 @@ export function CommitLineComposer({
         // real GitLab range. GitHub/Bitbucket stay end-anchored (single-line).
         ...(provider === "gitlab" && isRange ? { startLine: rangeFrom } : {}),
         ...(position !== null ? { position } : {}),
-      },
-      {
-        onSuccess: () => toast.success("Comment added"),
-        onError: (e) => toastError(e),
-      },
-    );
+      })
+      .then(() => toast.success("Comment added"))
+      .catch((e) => toastError(e));
     onClose();
   }
 

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -143,19 +143,23 @@ export function CreatePrDialog({
     forkRecord?.isFork === true &&
     forkParent !== null;
   const addRemote = useAddRemote(repoPath);
-  function addUpstreamRemote() {
+  // Awaited rather than per-call callbacks: this dialog can close (Esc, ✕,
+  // backdrop) mid-write, and react-query drops those once the observer has no
+  // listeners. On success the broad invalidation refreshes remotes →
+  // `useLensGate` flips true → the "Create in" picker appears (default Parent).
+  async function addUpstreamRemote() {
     if (!forkParent) return;
     // Derive the host — on GitHub Enterprise `isGithub` still holds, and a
     // hardcoded github.com would add a wrong-host remote that fails later.
     const ghHost = forge.data?.host || "github.com";
-    addRemote.mutate(
-      { name: "upstream", url: `https://${ghHost}/${forkParent}.git` },
-      {
-        // On success the broad invalidation refreshes remotes → `useLensGate` flips
-        // true → the "Create in" picker appears (default Parent).
-        onError: (e) => toastError(e),
-      },
-    );
+    try {
+      await addRemote.mutateAsync({
+        name: "upstream",
+        url: `https://${ghHost}/${forkParent}.git`,
+      });
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   // Create-TIME reviewers stay Bitbucket-only: `forge_pr_create` rejects a reviewer
@@ -797,7 +801,7 @@ export function CreatePrDialog({
                   variant="outline"
                   size="xs"
                   disabled={addRemote.isPending}
-                  onClick={addUpstreamRemote}
+                  onClick={() => void addUpstreamRemote()}
                 >
                   {addRemote.isPending
                     ? "Adding upstream remote…"

--- a/src/features/pulls/LinkedIssuesField.tsx
+++ b/src/features/pulls/LinkedIssuesField.tsx
@@ -1,9 +1,9 @@
 import { Popover } from "@base-ui/react/popover";
 import { LinkIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { type KeyboardEvent, useRef, useState } from "react";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { IssuePicker, StateIcon } from "@/features/issues/IssueRelations";
 import type { RemoteLens } from "@/lib/git/types";
 import type { JiraLink } from "@/lib/jira/store";
@@ -142,10 +142,10 @@ function NativeLinkedIssuesField({
   }
 
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-2">
-        <Label>Linked issues</Label>
-        <span className="flex-1" />
+    <LabeledGroup
+      label="Linked issues"
+      className="space-y-1.5"
+      actions={
         <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
           <Popover.Trigger
             render={
@@ -181,15 +181,11 @@ function NativeLinkedIssuesField({
             </Popover.Positioner>
           </Popover.Portal>
         </Popover.Root>
-      </div>
-
+      }
+    >
       {ordered.length > 0 && (
         <>
-          <div
-            role="group"
-            aria-label="Linked issues"
-            className="flex flex-wrap items-center gap-1.5"
-          >
+          <div className="flex flex-wrap items-center gap-1.5">
             {ordered.map((chip, index) => {
               const keywordLabel =
                 chip.keyword === "closes" ? "Closes" : "Relates to";
@@ -257,7 +253,7 @@ function NativeLinkedIssuesField({
           </p>
         </>
       )}
-    </div>
+    </LabeledGroup>
   );
 }
 
@@ -324,10 +320,10 @@ function JiraMentionsField({
   }
 
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-2">
-        <Label>Linked issues</Label>
-        <span className="flex-1" />
+    <LabeledGroup
+      label="Linked issues"
+      className="space-y-1.5"
+      actions={
         <Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
           <Popover.Trigger
             render={
@@ -363,15 +359,11 @@ function JiraMentionsField({
             </Popover.Positioner>
           </Popover.Portal>
         </Popover.Root>
-      </div>
-
+      }
+    >
       {ordered.length > 0 && (
         <>
-          <div
-            role="group"
-            aria-label="Linked issues"
-            className="flex flex-wrap items-center gap-1.5"
-          >
+          <div className="flex flex-wrap items-center gap-1.5">
             {ordered.map((chip, index) => {
               // State word omitted while unresolved (a just-picked issue seeds
               // statusCategory "" until the probe resolves) — no wrong "Open" and
@@ -427,6 +419,6 @@ function JiraMentionsField({
           </p>
         </>
       )}
-    </div>
+    </LabeledGroup>
   );
 }

--- a/src/features/pulls/LocalPrContextMenu.tsx
+++ b/src/features/pulls/LocalPrContextMenu.tsx
@@ -61,6 +61,20 @@ export function LocalPrContextMenu({
     }
   }
 
+  // Awaited rather than per-call mutate callbacks: confirming can unmount this row
+  // (the deleted PR leaves the list) and an `<Activity>` tab hide tears the observer
+  // down mid-write — react-query drops per-call callbacks once an observer has no
+  // listeners, stranding the confirm dialog open.
+  async function deletePr() {
+    try {
+      await del.mutateAsync(pr.id);
+      setConfirmDelete(false);
+      if (isSelected()) selectPr(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   return (
     <>
       <ContextMenu>
@@ -107,15 +121,7 @@ export function LocalPrContextMenu({
         confirmLabel="Delete"
         confirmVariant="destructive"
         pending={del.isPending}
-        onConfirm={() =>
-          del.mutate(pr.id, {
-            onSuccess: () => {
-              setConfirmDelete(false);
-              if (isSelected()) selectPr(null);
-            },
-            onError: toastError,
-          })
-        }
+        onConfirm={() => void deletePr()}
       />
     </>
   );

--- a/src/features/pulls/PendingReviewBar.tsx
+++ b/src/features/pulls/PendingReviewBar.tsx
@@ -54,12 +54,28 @@ export function DraftCommentCard({
   const next = body.trim();
   const canSave = next.length > 0 && next !== draft.body.trim();
 
-  function saveEdit() {
+  // Awaited rather than per-call mutate callbacks: these cards unmount on a tab
+  // switch away from Files, and react-query drops per-call callbacks once an
+  // observer has no listeners. The catches do nothing because both draft hooks
+  // toast failures at mutation level, which fires for `mutateAsync` rejections
+  // too, so a catch of our own would double-report.
+  async function saveEdit() {
     if (!canSave) return;
-    updateDraft.mutate(
-      { id: draft.id, body: next },
-      { onSuccess: () => setEditing(false) },
-    );
+    try {
+      await updateDraft.mutateAsync({ id: draft.id, body: next });
+      setEditing(false);
+    } catch {
+      // Reported at hook level (see above).
+    }
+  }
+
+  async function deleteDraft() {
+    try {
+      await removeDraft.mutateAsync(draft.id);
+      setConfirmDelete(false);
+    } catch {
+      // Reported at hook level (see above).
+    }
   }
 
   return (
@@ -100,7 +116,7 @@ export function DraftCommentCard({
         <CommentEditor
           value={body}
           onChange={setBody}
-          onSubmit={saveEdit}
+          onSubmit={() => void saveEdit()}
           onCancel={() => setEditing(false)}
           canSubmit={canSave}
           pending={updateDraft.isPending}
@@ -118,11 +134,7 @@ export function DraftCommentCard({
         confirmLabel="Delete"
         confirmVariant="destructive"
         pending={removeDraft.isPending}
-        onConfirm={() =>
-          removeDraft.mutate(draft.id, {
-            onSuccess: () => setConfirmDelete(false),
-          })
-        }
+        onConfirm={() => void deleteDraft()}
       />
     </div>
   );
@@ -153,6 +165,15 @@ export function PendingReviewBar({
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const count = drafts.data?.length ?? 0;
 
+  async function discard() {
+    try {
+      await clearDrafts.mutateAsync(undefined);
+      setConfirmDiscard(false);
+    } catch {
+      // Awaited with a do-nothing catch: see DraftCommentCard.
+    }
+  }
+
   if (count === 0) return null;
 
   return (
@@ -180,11 +201,7 @@ export function PendingReviewBar({
         confirmLabel="Discard review"
         confirmVariant="destructive"
         pending={clearDrafts.isPending}
-        onConfirm={() =>
-          clearDrafts.mutate(undefined, {
-            onSuccess: () => setConfirmDiscard(false),
-          })
-        }
+        onConfirm={() => void discard()}
       />
     </div>
   );

--- a/src/features/pulls/PrTasksSection.tsx
+++ b/src/features/pulls/PrTasksSection.tsx
@@ -291,13 +291,18 @@ export function PrTasksSection({
   if (!tasks && !tasksQuery.isError) return null;
 
   const list = tasks ?? [];
+  // Every continuation below rides the awaited promise, never per-call mutate
+  // callbacks: an `<Activity>` tab hide tears this observer's subscription down
+  // mid-write, and react-query drops per-call callbacks once an observer has no
+  // listeners — the rollback, the field clear, and the dialog close would silently
+  // never run.
   const total = list.length;
   const resolvedCount = total - unresolved(list);
 
   // Resolve toggle is optimistic: patch the one task's state in the cache, then
   // mutate with rollback on error (mirrors RemotePrView's toggleApproval). The
   // mutation's onSettled invalidation reconciles the real state.
-  function toggle(task: PrTask) {
+  async function toggle(task: PrTask) {
     const key = prTasksKey(repoPath, number);
     const prev = queryClient.getQueryData<PrTask[]>(key);
     const nextResolved = task.state !== "RESOLVED";
@@ -311,15 +316,16 @@ export function PrTasksSection({
         ),
       );
     }
-    setState.mutate(
-      { number, taskId: task.id, resolved: nextResolved },
-      {
-        onError: (e) => {
-          if (prev) queryClient.setQueryData(key, prev);
-          onError(e);
-        },
-      },
-    );
+    try {
+      await setState.mutateAsync({
+        number,
+        taskId: task.id,
+        resolved: nextResolved,
+      });
+    } catch (e) {
+      if (prev) queryClient.setQueryData(key, prev);
+      onError(e);
+    }
   }
 
   function openAdd() {
@@ -327,15 +333,14 @@ export function PrTasksSection({
     setAdding(true);
   }
 
-  function submitAdd(text: string) {
-    createTask.mutate(
-      { number, text },
-      {
-        // Clear the controlled field but keep the row open for rapid entry.
-        onSuccess: () => setAddText(""),
-        onError,
-      },
-    );
+  async function submitAdd(text: string) {
+    try {
+      await createTask.mutateAsync({ number, text });
+      // Clear the controlled field but keep the row open for rapid entry.
+      setAddText("");
+    } catch (e) {
+      onError(e);
+    }
   }
 
   function startEdit(task: PrTask) {
@@ -343,11 +348,23 @@ export function PrTasksSection({
     setEditingId(task.id);
   }
 
-  function submitEdit(taskId: string, text: string) {
-    editTask.mutate(
-      { number, taskId, text },
-      { onSuccess: () => setEditingId(null), onError },
-    );
+  async function submitEdit(taskId: string, text: string) {
+    try {
+      await editTask.mutateAsync({ number, taskId, text });
+      setEditingId(null);
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function confirmDelete(taskId: string) {
+    try {
+      await deleteTask.mutateAsync({ number, taskId });
+    } catch (e) {
+      onError(e);
+    } finally {
+      setDeletingId(null);
+    }
   }
 
   // Arrow keys walk the task rows (the helper moves DOM focus via rowKey);
@@ -408,7 +425,7 @@ export function PrTasksSection({
                 placeholder="Task text…"
                 submitLabel="Save"
                 pending={editTask.isPending}
-                onSubmit={(text) => submitEdit(task.id, text)}
+                onSubmit={(text) => void submitEdit(task.id, text)}
                 onCancel={() => setEditingId(null)}
               />
             ) : (
@@ -416,7 +433,7 @@ export function PrTasksSection({
                 key={task.id}
                 task={task}
                 editable={editable}
-                onToggle={() => toggle(task)}
+                onToggle={() => void toggle(task)}
                 onStartEdit={() => startEdit(task)}
                 onDelete={() => setDeletingId(task.id)}
                 onFocus={() => setFocusedId(task.id)}
@@ -439,7 +456,7 @@ export function PrTasksSection({
               placeholder="Add a task…"
               submitLabel="Add"
               pending={createTask.isPending}
-              onSubmit={submitAdd}
+              onSubmit={(text) => void submitAdd(text)}
               onCancel={() => setAdding(false)}
             />
           )}
@@ -452,18 +469,7 @@ export function PrTasksSection({
         pending={deleteTask.isPending}
         title="Delete task?"
         description="This permanently deletes the task on Bitbucket. This cannot be undone."
-        onConfirm={(taskId) =>
-          deleteTask.mutate(
-            { number, taskId },
-            {
-              onSuccess: () => setDeletingId(null),
-              onError: (e) => {
-                onError(e);
-                setDeletingId(null);
-              },
-            },
-          )
-        }
+        onConfirm={(taskId) => void confirmDelete(taskId)}
       />
     </div>
   );

--- a/src/features/pulls/PrTasksSection.tsx
+++ b/src/features/pulls/PrTasksSection.tsx
@@ -291,14 +291,14 @@ export function PrTasksSection({
   if (!tasks && !tasksQuery.isError) return null;
 
   const list = tasks ?? [];
-  // Every continuation below rides the awaited promise, never per-call mutate
-  // callbacks: an `<Activity>` tab hide tears this observer's subscription down
-  // mid-write, and react-query drops per-call callbacks once an observer has no
-  // listeners — the rollback, the field clear, and the dialog close would silently
-  // never run.
   const total = list.length;
   const resolvedCount = total - unresolved(list);
 
+  // Every continuation in the helpers below rides the awaited promise, never
+  // per-call mutate callbacks: an `<Activity>` tab hide tears this observer's
+  // subscription down mid-write, and react-query drops per-call callbacks once
+  // an observer has no listeners — the rollback, the field clears, and the
+  // dialog close would silently never run.
   // Resolve toggle is optimistic: patch the one task's state in the cache, then
   // mutate with rollback on error (mirrors RemotePrView's toggleApproval). The
   // mutation's onSettled invalidation reconciles the real state.

--- a/src/features/pulls/PrTasksSection.tsx
+++ b/src/features/pulls/PrTasksSection.tsx
@@ -299,6 +299,7 @@ export function PrTasksSection({
   // subscription down mid-write, and react-query drops per-call callbacks once
   // an observer has no listeners — the rollback, the field clears, and the
   // dialog close would silently never run.
+
   // Resolve toggle is optimistic: patch the one task's state in the cache, then
   // mutate with rollback on error (mirrors RemotePrView's toggleApproval). The
   // mutation's onSettled invalidation reconciles the real state.

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -204,6 +204,20 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
     selectedLocalPr !== undefined,
   );
 
+  // Awaited rather than per-call mutate callbacks: an `<Activity>` tab hide tears
+  // this observer's subscription down mid-delete, and react-query drops per-call
+  // callbacks once an observer has no listeners — the confirm dialog would stay
+  // open over a PR that was already gone.
+  async function deleteSelectedLocalPr(id: string) {
+    try {
+      await deleteLocalPr.mutateAsync(id);
+      setConfirmDeleteSelected(false);
+      selectPr(null);
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
   // Opened from the command palette / New menu via requestCreate (any tab).
   // Re-check the gate: the requester's own gate can lag this panel's (e.g. a
   // provider flip mid-flight) — never open a create dialog that can't submit.
@@ -507,13 +521,7 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
           pending={deleteLocalPr.isPending}
           onConfirm={() => {
             if (!selectedLocalPr) return;
-            deleteLocalPr.mutate(selectedLocalPr.id, {
-              onSuccess: () => {
-                setConfirmDeleteSelected(false);
-                selectPr(null);
-              },
-              onError: toastError,
-            });
+            void deleteSelectedLocalPr(selectedLocalPr.id);
           }}
         />
       </ConversationListPanel>

--- a/src/features/pulls/PullRequestsPanel.tsx
+++ b/src/features/pulls/PullRequestsPanel.tsx
@@ -212,7 +212,11 @@ export function PullRequestsPanel({ repoPath }: { repoPath: string }) {
     try {
       await deleteLocalPr.mutateAsync(id);
       setConfirmDeleteSelected(false);
-      selectPr(null);
+      // Deselect only if the deleted PR is still the selection — the await can
+      // resolve after the user has selected another PR or navigated, and a
+      // blind clear would wipe that newer selection.
+      const sel = useUiStore.getState().selectedPr;
+      if (sel?.kind === "local" && sel.id === id) selectPr(null);
     } catch (e) {
       toastError(e);
     }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2277,9 +2277,9 @@ export function RemotePrView({
     try {
       await deleteComment.mutateAsync({ number, commentId });
       toast.success("Comment deleted");
-      setDeletingCommentId(null);
     } catch (e) {
       onError(e);
+    } finally {
       setDeletingCommentId(null);
     }
   }
@@ -2288,9 +2288,9 @@ export function RemotePrView({
     try {
       await deleteReviewComment.mutateAsync({ number, commentId });
       toast.success("Comment deleted");
-      setDeletingThreadCommentId(null);
     } catch (e) {
       onError(e);
+    } finally {
       setDeletingThreadCommentId(null);
     }
   }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -688,6 +688,27 @@ export function RemotePrView({
     !details.isPlaceholderData,
   );
   const shownIsDraft = settledEntityKey === entityKey ? retainedIsDraft : null;
+  // Awaited, not per-call callbacks: an `<Activity>` hide (or a host unmount) tears
+  // this observer's subscription down, and react-query drops per-call callbacks once
+  // an observer has no listeners — the toast and the ready-review automation would
+  // never run for a write the forge had already taken.
+  async function markReadyForReview() {
+    try {
+      await setDraft.mutateAsync({ number, draft: false });
+      toast.success("Marked ready for review");
+      void fireReadyReview();
+    } catch (e) {
+      onError(e);
+    }
+  }
+  async function convertToDraft() {
+    try {
+      await setDraft.mutateAsync({ number, draft: true });
+      toast.success("Converted to draft");
+    } catch (e) {
+      onError(e);
+    }
+  }
   // Palette twins of the footer's draft controls — same `setDraft` mutation, same
   // frozen identity, and Ready also fires the ready-review automation. Registration
   // is effect-synced, so an `enabled` term alone still leaves the keypress a frame
@@ -696,16 +717,7 @@ export function RemotePrView({
     "pr-ready-for-review",
     () => {
       if (shownIsDraft !== true) return;
-      setDraft.mutate(
-        { number, draft: false },
-        {
-          onSuccess: () => {
-            toast.success("Marked ready for review");
-            void fireReadyReview();
-          },
-          onError,
-        },
-      );
+      void markReadyForReview();
     },
     isSelectedPr && draftPairVisible && shownIsDraft === true && !busy,
   );
@@ -713,13 +725,7 @@ export function RemotePrView({
     "pr-convert-to-draft",
     () => {
       if (shownIsDraft !== false) return;
-      setDraft.mutate(
-        { number, draft: true },
-        {
-          onSuccess: () => toast.success("Converted to draft"),
-          onError,
-        },
-      );
+      void convertToDraft();
     },
     isSelectedPr &&
       draftPairVisible &&
@@ -828,31 +834,36 @@ export function RemotePrView({
     }
   })();
 
-  function confirmStackOffer() {
+  async function confirmStackOffer() {
     // `offerEnabled` withholds the offer entirely until details are the selected
     // PR's, so the placeholder arm here is insurance against a looser gate later.
     if (!stackOffer || details.isPlaceholderData) return;
     if (stackOffer.kind === "create") {
-      stackCreate.mutate(stackOffer.members, {
-        onSuccess: (outcome) =>
-          toast.success(
-            `Stack created — ${outcome.members.length} pull requests`,
-          ),
-      });
+      try {
+        const outcome = await stackCreate.mutateAsync(stackOffer.members);
+        toast.success(
+          `Stack created — ${outcome.members.length} pull requests`,
+        );
+      } catch {
+        // A failed stack write renders inline beside the offer off the mutation's
+        // own `error`, so this path deliberately says nothing.
+      }
       return;
     }
     const { stackNumber } = stackOffer;
-    stackAdd.mutate(
-      { stackNumber, pullRequests: stackOffer.members },
-      {
-        // The response lists the stack's members AFTER the append, so its length
-        // is the new total — not just what this write added.
-        onSuccess: (outcome) =>
-          toast.success(
-            `Added to stack #${stackNumber} — ${outcome.members.length} pull requests`,
-          ),
-      },
-    );
+    try {
+      const outcome = await stackAdd.mutateAsync({
+        stackNumber,
+        pullRequests: stackOffer.members,
+      });
+      // The response lists the stack's members AFTER the append, so its length
+      // is the new total — not just what this write added.
+      toast.success(
+        `Added to stack #${stackNumber} — ${outcome.members.length} pull requests`,
+      );
+    } catch {
+      // Same inline-error contract as the create arm.
+    }
   }
 
   // A failed write's message belongs beside the affordance, not in a toast — so
@@ -905,10 +916,12 @@ export function RemotePrView({
       confirmVariant: "destructive",
     });
     if (!ok) return;
-    stackDissolve.mutate(dissolveStackNumber, {
-      onSuccess: () => toast.success(`Dissolved stack #${info.id}`),
-      onError,
-    });
+    try {
+      await stackDissolve.mutateAsync(dissolveStackNumber);
+      toast.success(`Dissolved stack #${info.id}`);
+    } catch (e) {
+      onError(e);
+    }
   }
 
   useHotkeyAction(
@@ -1217,16 +1230,15 @@ export function RemotePrView({
     const target = resolve ?? findResolve.data;
     if (!target) return;
     if (!(await useConfirm.getState().ask(DISCARD_RESOLVE_CONFIRM))) return;
-    abortRemotePrResolve.mutate(
-      { worktreePath: target.worktreePath },
-      {
-        onSuccess: () => {
-          setResolve(null);
-          toast.success("Resolution discarded");
-        },
-        onError,
-      },
-    );
+    try {
+      await abortRemotePrResolve.mutateAsync({
+        worktreePath: target.worktreePath,
+      });
+      setResolve(null);
+      toast.success("Resolution discarded");
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Also fires on the resume arm — a leftover worktree is resumable even once the
@@ -1274,21 +1286,18 @@ export function RemotePrView({
       });
       if (!ok) return;
     }
-    updateBranch.mutate(
-      { number, rebase, lens },
-      {
-        // GitHub only ACCEPTED the job here, so the word goes to the poll: the strip
-        // holds the updating line and `settleUpdate` speaks once a read has seen the
-        // head catch up (or the ladder concede). Arming only follows a ladder that
-        // actually took the request — a refused one would leave the ref waiting for a
-        // poll that never runs, and fire its toast on some later visit to this PR.
-        onSuccess: () => {
-          if (divergence.awaitUpdate())
-            awaitedUpdate.current = { identity: divergenceIdentity, base };
-        },
-        onError,
-      },
-    );
+    try {
+      await updateBranch.mutateAsync({ number, rebase, lens });
+      // GitHub only ACCEPTED the job here, so the word goes to the poll: the strip
+      // holds the updating line and `settleUpdate` speaks once a read has seen the
+      // head catch up (or the ladder concede). Arming only follows a ladder that
+      // actually took the request — a refused one would leave the ref waiting for a
+      // poll that never runs, and fire its toast on some later visit to this PR.
+      if (divergence.awaitUpdate())
+        awaitedUpdate.current = { identity: divergenceIdentity, base };
+    } catch (e) {
+      onError(e);
+    }
   }
 
   useHotkeyAction(
@@ -1461,16 +1470,13 @@ export function RemotePrView({
         viewerRequestedChanges: approved ? prev.viewerRequestedChanges : false,
       });
     }
-    action.mutate(number, {
-      onSuccess: () =>
-        toast.success(
-          approved ? "Approval revoked" : `Approved this ${prNoun}`,
-        ),
-      onError: (e) => {
-        if (prev) queryClient.setQueryData(key, prev);
-        onError(e);
-      },
-    });
+    try {
+      await action.mutateAsync(number);
+      toast.success(approved ? "Approval revoked" : `Approved this ${prNoun}`);
+    } catch (e) {
+      if (prev) queryClient.setQueryData(key, prev);
+      onError(e);
+    }
   }
 
   // Request changes — a true toggle on Bitbucket (revoke works on every plan);
@@ -1504,32 +1510,30 @@ export function RemotePrView({
       });
     }
     if (requested) {
-      unrequestChangesPr.mutate(number, {
-        onSuccess: () => toast.success("Change request revoked"),
-        onError: (e) => {
-          if (prev) queryClient.setQueryData(key, prev);
-          onError(e);
-        },
-      });
+      try {
+        await unrequestChangesPr.mutateAsync(number);
+        toast.success("Change request revoked");
+      } catch (e) {
+        if (prev) queryClient.setQueryData(key, prev);
+        onError(e);
+      }
       return;
     }
     const submittedFor = entityKey;
-    requestChangesPr.mutate(
-      { number, body: compose.value.trim() },
-      {
-        onSuccess: () => {
-          toast.success("Requested changes");
-          compose.clearFor(submittedFor);
-        },
-        onError: (e) => {
-          if (prev) queryClient.setQueryData(key, prev);
-          onError(e);
-        },
-      },
-    );
+    try {
+      await requestChangesPr.mutateAsync({
+        number,
+        body: compose.value.trim(),
+      });
+      toast.success("Requested changes");
+      compose.clearFor(submittedFor);
+    } catch (e) {
+      if (prev) queryClient.setQueryData(key, prev);
+      onError(e);
+    }
   }
 
-  function submitComment() {
+  async function submitComment() {
     const body = compose.value.trim();
     if (!body || details.isPlaceholderData) return;
     // Clear the draft immediately (the perceived-speed win) and append the
@@ -1537,16 +1541,17 @@ export function RemotePrView({
     // that PR's composer is still empty so we never clobber newly-typed text.
     const submittedFor = entityKey;
     compose.set("");
-    comment.mutate(
-      { number, body, author: forge.data?.login ?? "You" },
-      {
-        onSuccess: () => toast.success("Comment added"),
-        onError: (e) => {
-          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
-          onError(e);
-        },
-      },
-    );
+    try {
+      await comment.mutateAsync({
+        number,
+        body,
+        author: forge.data?.login ?? "You",
+      });
+      toast.success("Comment added");
+    } catch (e) {
+      compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
+      onError(e);
+    }
   }
 
   // A typed draft rides Close/Reopen rather than being discarded by them. Gated
@@ -1594,48 +1599,47 @@ export function RemotePrView({
     });
     if (!ok) return;
     if (!(await postRidingDraft())) return;
-    closePr.mutate(number, {
-      // The riding comment posts through `mutateAsync`, which skips the
-      // "Comment added" toast the ordinary submit gets, so the confirmation
-      // here has to account for both writes.
-      onSuccess: () =>
-        toast.success(
-          withComment
-            ? `Closed #${number} and posted your comment`
-            : `Closed #${number}`,
-        ),
-      onError: (e) =>
+    try {
+      await closePr.mutateAsync(number);
+      // The riding comment posts without the "Comment added" toast the ordinary
+      // submit gets, so the confirmation here has to account for both writes.
+      toast.success(
         withComment
-          ? toastErrorWithNote(
-              e,
-              "Your comment was posted, but closing failed — try Close again.",
-            )
-          : onError(e),
-    });
+          ? `Closed #${number} and posted your comment`
+          : `Closed #${number}`,
+      );
+    } catch (e) {
+      if (withComment)
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but closing failed — try Close again.",
+        );
+      else onError(e);
+    }
   }
 
   async function doReopen() {
     if (busy || triageBlocked) return;
     const withComment = draftRidesStateChange;
     if (!(await postRidingDraft())) return;
-    reopenPr.mutate(number, {
-      onSuccess: () =>
-        toast.success(
-          withComment
-            ? `Reopened #${number} and posted your comment`
-            : `Reopened #${number}`,
-        ),
-      onError: (e) =>
+    try {
+      await reopenPr.mutateAsync(number);
+      toast.success(
         withComment
-          ? toastErrorWithNote(
-              e,
-              "Your comment was posted, but reopening failed — try Reopen again.",
-            )
-          : onError(e),
-    });
+          ? `Reopened #${number} and posted your comment`
+          : `Reopened #${number}`,
+      );
+    } catch (e) {
+      if (withComment)
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but reopening failed — try Reopen again.",
+        );
+      else onError(e);
+    }
   }
 
-  function confirmMerge() {
+  async function confirmMerge() {
     // GitLab stale-view guard: the head sha the user is looking at (the same oid
     // the AI-review path uses). GitLab 409s if the head moved; GitHub ignores it.
     const sha = pr?.commits.at(-1)?.oid;
@@ -1644,75 +1648,66 @@ export function RemotePrView({
     const deleteHead = deleteBranch && !headIsDefault && !headDeletionBlocked;
     if (mergeAuto) {
       // Arm merge-when-pipeline-succeeds instead of merging now (GitLab-only).
-      armAutoMerge.mutate(
-        { number, strategy: mergeStrategy, deleteBranch: deleteHead, sha },
-        {
-          onSuccess: () => {
-            setMergeOpen(false);
-            toast.success(
-              "Auto-merge enabled — merges when the pipeline passes",
-            );
-          },
-          onError: (e) => {
-            onError(e);
-            setMergeOpen(false);
-          },
-        },
-      );
+      try {
+        await armAutoMerge.mutateAsync({
+          number,
+          strategy: mergeStrategy,
+          deleteBranch: deleteHead,
+          sha,
+        });
+        setMergeOpen(false);
+        toast.success("Auto-merge enabled — merges when the pipeline passes");
+      } catch (e) {
+        onError(e);
+        setMergeOpen(false);
+      }
       return;
     }
-    mergePr.mutate(
-      {
+    try {
+      const outcome = await mergePr.mutateAsync({
         number,
         strategy: mergeStrategy,
         deleteBranch: deleteHead,
         sha,
-      },
-      {
-        onSuccess: (outcome) => {
-          // A queued merge was accepted but hasn't landed, so announce the state
-          // once — mirroring the auto-merge arm — instead of a "Merged" success
-          // that the queue detail would immediately contradict.
-          if (outcome.queued) {
-            toast.success(
-              outcome.cleanupWarning ?? `Merge queued for #${number}`,
-            );
-            // The toast is gone in seconds and nothing fetchable carries queue
-            // state, so record it: the chip below is the only lasting sign the
-            // merge is waiting rather than done.
-            markMergeQueued(queuedKey);
-            setQueuedWarning(
-              outcome.cleanupWarning
-                ? { key: queuedKey, text: outcome.cleanupWarning }
-                : null,
-            );
-          } else {
-            toast.success(`Merged #${number}`);
-            // Merged for real; a cleanupWarning here means only the post-merge
-            // remote head-branch deletion failed. Surface it as a (non-error)
-            // warning so the successful merge isn't dressed up as a failure.
-            if (outcome.cleanupWarning) {
-              toast.warning(outcome.cleanupWarning, { duration: 10000 });
-            }
-          }
-          setMergeOpen(false);
-        },
-        onError: (e) => {
-          // Where the rules are the known reason, say which requirement is unmet
-          // alongside the refusal — the same line the strip is already showing, and
-          // on GitLab the only place the reason is worded at all (the backend's
-          // message deliberately doesn't duplicate this table).
-          if (bannerArm === "blocked")
-            toastErrorWithNote(
-              e,
-              gitlabBlockedNote ??
-                blockedMergeLine(blockedRequirements, blockedApprovals),
-            );
-          else onError(e);
-          setMergeOpen(false);
-        },
-      },
-    );
+      });
+      // A queued merge was accepted but hasn't landed, so announce the state
+      // once — mirroring the auto-merge arm — instead of a "Merged" success
+      // that the queue detail would immediately contradict.
+      if (outcome.queued) {
+        toast.success(outcome.cleanupWarning ?? `Merge queued for #${number}`);
+        // The toast is gone in seconds and nothing fetchable carries queue
+        // state, so record it: the chip below is the only lasting sign the
+        // merge is waiting rather than done.
+        markMergeQueued(queuedKey);
+        setQueuedWarning(
+          outcome.cleanupWarning
+            ? { key: queuedKey, text: outcome.cleanupWarning }
+            : null,
+        );
+      } else {
+        toast.success(`Merged #${number}`);
+        // Merged for real; a cleanupWarning here means only the post-merge
+        // remote head-branch deletion failed. Surface it as a (non-error)
+        // warning so the successful merge isn't dressed up as a failure.
+        if (outcome.cleanupWarning) {
+          toast.warning(outcome.cleanupWarning, { duration: 10000 });
+        }
+      }
+      setMergeOpen(false);
+    } catch (e) {
+      // Where the rules are the known reason, say which requirement is unmet
+      // alongside the refusal — the same line the strip is already showing, and
+      // on GitLab the only place the reason is worded at all (the backend's
+      // message deliberately doesn't duplicate this table).
+      if (bannerArm === "blocked")
+        toastErrorWithNote(
+          e,
+          gitlabBlockedNote ??
+            blockedMergeLine(blockedRequirements, blockedApprovals),
+        );
+      else onError(e);
+      setMergeOpen(false);
+    }
   }
 
   const pr = details.data;
@@ -2181,57 +2176,134 @@ export function RemotePrView({
   // list filters these out to avoid a duplicate pending+completed chip. GitHub never
   // overlaps (its completed reviewers have already left `pr.reviewers`).
   const completedLogins = new Set(completedReviewers.map((c) => c.login));
-  function saveCommentEdit(commentId: string, body: string) {
+  async function saveCommentEdit(commentId: string, body: string) {
     // The comment id is the rendered PR's while the write addresses `number` —
     // GitLab routes by both, so a mismatched pair edits nothing it showed.
     if (detailsStale) return;
-    editComment.mutate(
-      { number, commentId, body },
-      {
-        onSuccess: () => toast.success("Comment updated"),
-        onError,
-      },
-    );
+    try {
+      await editComment.mutateAsync({ number, commentId, body });
+      toast.success("Comment updated");
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function saveThreadCommentEdit(commentId: string, body: string) {
+  async function saveThreadCommentEdit(commentId: string, body: string) {
     // Same pairing as saveCommentEdit, on the review-thread side.
     if (detailsStale) return;
-    editReviewComment.mutate(
-      { number, commentId, body },
-      {
-        onSuccess: () => toast.success("Comment updated"),
-        onError,
-      },
-    );
+    try {
+      await editReviewComment.mutateAsync({ number, commentId, body });
+      toast.success("Comment updated");
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function toggleReaction(subjectId: string, content: string, active: boolean) {
+  async function toggleReaction(
+    subjectId: string,
+    content: string,
+    active: boolean,
+  ) {
     // The subject is the rendered PR's body or one of its comments, while the
     // write and its optimistic patch address `number` — GitLab routes by both, so
     // a mismatched pair awards the wrong note or 404s. The bars disable on the
     // same flag; this arm is the belt-and-braces behind them.
     if (detailsStale) return;
-    toggleReactionMutation.mutate({ subjectId, content, active }, { onError });
+    try {
+      await toggleReactionMutation.mutateAsync({ subjectId, content, active });
+    } catch (e) {
+      onError(e);
+    }
   }
 
   // Both take a comment id off the RENDERED pr, which through a switch is the
   // previous one, so either would hide a comment on the PR the viewer just left.
   // The menu items disable on the same wait; these arms back them up.
-  function hideComment(commentId: string, classifier: MinimizeReason) {
+  async function hideComment(commentId: string, classifier: MinimizeReason) {
     if (detailsStale) return;
-    minimizeComment.mutate(
-      { commentId, classifier },
-      { onSuccess: () => toast.success("Comment hidden"), onError },
-    );
+    try {
+      await minimizeComment.mutateAsync({ commentId, classifier });
+      toast.success("Comment hidden");
+    } catch (e) {
+      onError(e);
+    }
   }
 
-  function unhideComment(commentId: string) {
+  async function unhideComment(commentId: string) {
     if (detailsStale) return;
-    unminimizeComment.mutate(commentId, {
-      onSuccess: () => toast.success("Comment shown"),
-      onError,
-    });
+    try {
+      await unminimizeComment.mutateAsync(commentId);
+      toast.success("Comment shown");
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function saveAssignees(next: ForgeUserRef[]) {
+    try {
+      await setAssignees.mutateAsync({ number, assignees: next });
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function saveReviewers(next: ForgeUserRef[]) {
+    try {
+      await setReviewers.mutateAsync({ number, reviewers: next });
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  async function checkoutHead(headRefName: string) {
+    try {
+      await checkout.mutateAsync(number);
+      toast.success(`Checked out ${headRefName}`);
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function doCancelAutoMerge() {
+    try {
+      await cancelAutoMerge.mutateAsync(number);
+      toast.success("Auto-merge canceled");
+    } catch (e) {
+      onError(e);
+    }
+  }
+
+  async function deleteConversationComment(commentId: string) {
+    try {
+      await deleteComment.mutateAsync({ number, commentId });
+      toast.success("Comment deleted");
+      setDeletingCommentId(null);
+    } catch (e) {
+      onError(e);
+      setDeletingCommentId(null);
+    }
+  }
+
+  async function deleteThreadComment(commentId: string) {
+    try {
+      await deleteReviewComment.mutateAsync({ number, commentId });
+      toast.success("Comment deleted");
+      setDeletingThreadCommentId(null);
+    } catch (e) {
+      onError(e);
+      setDeletingThreadCommentId(null);
+    }
+  }
+
+  async function discardPendingReview() {
+    try {
+      await clearDrafts.mutateAsync(undefined);
+      setDiscardConfirmOpen(false);
+    } catch {
+      // `useClearReviewDrafts` toasts its own failure here (no `silent` opt-out),
+      // and react-query fires that mutation-level handler for a rejected
+      // `mutateAsync` too — a catch-toast would double-report.
+    }
   }
 
   // A conflict resolution in flight takes over the whole PR view: the merge lives in
@@ -2352,12 +2424,7 @@ export function RemotePrView({
         commitOnClose
         lens={lens}
         disabledReason={pickerReason}
-        onChange={(next) =>
-          setAssignees.mutate(
-            { number, assignees: next },
-            { onError: toastError },
-          )
-        }
+        onChange={(next) => void saveAssignees(next)}
       />,
     );
   } else if (pr.assignees.length > 0) {
@@ -2405,12 +2472,7 @@ export function RemotePrView({
         value={humanReviewers}
         lens={lens}
         disabledReason={pickerReason}
-        onChange={(next) =>
-          setReviewers.mutate(
-            { number, reviewers: next },
-            { onError: toastError },
-          )
-        }
+        onChange={(next) => void saveReviewers(next)}
       >
         {botReviewers.map((user) => (
           <BotReviewerChip key={user.id} user={user} ghHost={ghHost} />
@@ -2491,13 +2553,7 @@ export function RemotePrView({
                 variant="outline"
                 size="xs"
                 disabled={checkout.isPending}
-                onClick={() =>
-                  checkout.mutate(number, {
-                    onSuccess: () =>
-                      toast.success(`Checked out ${pr.headRefName}`),
-                    onError,
-                  })
-                }
+                onClick={() => void checkoutHead(pr.headRefName)}
                 title={`Check out ${pr.headRefName} locally`}
               >
                 {checkout.isPending ? (
@@ -3230,18 +3286,7 @@ export function RemotePrView({
               size="sm"
               disabled={busy || writeBlocked}
               reason={writeReason ?? staleReason}
-              onClick={() =>
-                setDraft.mutate(
-                  { number, draft: false },
-                  {
-                    onSuccess: () => {
-                      toast.success("Marked ready for review");
-                      void fireReadyReview();
-                    },
-                    onError,
-                  },
-                )
-              }
+              onClick={() => void markReadyForReview()}
             >
               Ready for review
             </DisabledReasonButton>
@@ -3253,15 +3298,7 @@ export function RemotePrView({
               disabled={busy || writeBlocked}
               reason={writeReason ?? staleReason}
               title="Turn this pull request back into a draft"
-              onClick={() =>
-                setDraft.mutate(
-                  { number, draft: true },
-                  {
-                    onSuccess: () => toast.success("Converted to draft"),
-                    onError,
-                  },
-                )
-              }
+              onClick={() => void convertToDraft()}
             >
               Convert to draft
             </DisabledReasonButton>
@@ -3304,12 +3341,7 @@ export function RemotePrView({
                 size="sm"
                 disabled={busy || writeBlocked}
                 reason={writeReason ?? staleReason}
-                onClick={() =>
-                  cancelAutoMerge.mutate(number, {
-                    onSuccess: () => toast.success("Auto-merge canceled"),
-                    onError,
-                  })
-                }
+                onClick={() => void doCancelAutoMerge()}
               >
                 Cancel auto-merge
               </DisabledReasonButton>
@@ -3543,21 +3575,7 @@ export function RemotePrView({
         onClose={() => setDeletingCommentId(null)}
         pending={deleteComment.isPending}
         description={`This permanently deletes the comment on ${remoteLabel}. This cannot be undone.`}
-        onConfirm={(commentId) =>
-          deleteComment.mutate(
-            { number, commentId },
-            {
-              onSuccess: () => {
-                toast.success("Comment deleted");
-                setDeletingCommentId(null);
-              },
-              onError: (e) => {
-                onError(e);
-                setDeletingCommentId(null);
-              },
-            },
-          )
-        }
+        onConfirm={(commentId) => void deleteConversationComment(commentId)}
       />
 
       <DeleteCommentDialog
@@ -3565,21 +3583,7 @@ export function RemotePrView({
         onClose={() => setDeletingThreadCommentId(null)}
         pending={deleteReviewComment.isPending}
         description={`This permanently deletes the comment on ${remoteLabel}. This cannot be undone.`}
-        onConfirm={(commentId) =>
-          deleteReviewComment.mutate(
-            { number, commentId },
-            {
-              onSuccess: () => {
-                toast.success("Comment deleted");
-                setDeletingThreadCommentId(null);
-              },
-              onError: (e) => {
-                onError(e);
-                setDeletingThreadCommentId(null);
-              },
-            },
-          )
-        }
+        onConfirm={(commentId) => void deleteThreadComment(commentId)}
       />
 
       {/* The batch submit-review dialog (Review control, pending-review bar, palette
@@ -3611,11 +3615,7 @@ export function RemotePrView({
         confirmLabel="Discard review"
         confirmVariant="destructive"
         pending={clearDrafts.isPending}
-        onConfirm={() =>
-          clearDrafts.mutate(undefined, {
-            onSuccess: () => setDiscardConfirmOpen(false),
-          })
-        }
+        onConfirm={() => void discardPendingReview()}
       />
     </div>
   );

--- a/src/features/pulls/ResolveRemotePrView.tsx
+++ b/src/features/pulls/ResolveRemotePrView.tsx
@@ -134,40 +134,41 @@ export function ResolveRemotePrView({
   const canResolveWithAi = aiEnabled && reviewConfigured && remaining > 0;
   const busy = finish.isPending || abort.isPending;
 
-  function onFinish() {
-    finish.mutate(
-      { head, worktreePath, worktreeId },
-      {
-        onSuccess: (outcome) => {
-          if (outcome.status === "pushed") {
-            toast.success(`Conflicts resolved — pushed ${head}`);
-            onDone();
-            return;
-          }
-          // Unreachable by contract: finish either pushes or errors — it never hands
-          // back conflicts (that shape belongs to the local sibling's rebase path).
-          // Surfaced rather than swallowed, so a contract drift can't pass silently.
-          toastError(
-            new Error("The resolve finished with an unexpected result."),
-          );
-        },
-        onError: toastError,
-      },
-    );
+  // Both continuations ride the awaited promise, never per-call mutate callbacks:
+  // finishing or discarding leaves this takeover, and an `<Activity>` tab hide tears
+  // the observer down mid-write — react-query drops per-call callbacks once an
+  // observer has no listeners, so `onDone()` would never fire and the surface would
+  // sit over a worktree the backend had already consumed.
+  async function onFinish() {
+    try {
+      const outcome = await finish.mutateAsync({
+        head,
+        worktreePath,
+        worktreeId,
+      });
+      if (outcome.status === "pushed") {
+        toast.success(`Conflicts resolved — pushed ${head}`);
+        onDone();
+        return;
+      }
+      // Unreachable by contract: finish either pushes or errors — it never hands
+      // back conflicts (that shape belongs to the local sibling's rebase path).
+      // Surfaced rather than swallowed, so a contract drift can't pass silently.
+      toastError(new Error("The resolve finished with an unexpected result."));
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   async function onAbort() {
     if (!(await useConfirm.getState().ask(DISCARD_RESOLVE_CONFIRM))) return;
-    abort.mutate(
-      { worktreePath },
-      {
-        onSuccess: () => {
-          toast.success("Resolution discarded");
-          onDone();
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await abort.mutateAsync({ worktreePath });
+      toast.success("Resolution discarded");
+      onDone();
+    } catch (e) {
+      toastError(e);
+    }
   }
 
   const activeIndex = selectedPath ? conflictedPaths.indexOf(selectedPath) : -1;
@@ -217,7 +218,7 @@ export function ResolveRemotePrView({
             size="xs"
             disabled={busy || remaining > 0}
             reason={remaining > 0 ? "Resolve every conflict first" : undefined}
-            onClick={onFinish}
+            onClick={() => void onFinish()}
           >
             {finish.isPending && <Spinner data-icon="inline-start" />}
             Finish &amp; push

--- a/src/features/pulls/ReviewComposer.tsx
+++ b/src/features/pulls/ReviewComposer.tsx
@@ -109,10 +109,12 @@ export function ReviewComposer({
     setPending(true);
     // Posting is optimistic (the thread lands in the cache immediately), so close
     // right away — the synthetic thread renders under the line without waiting.
-    createThread.mutate(
-      { number, path, line, side, startLine, body: body.trim() },
-      { onError: (e) => toastError(e) },
-    );
+    // The failure rides the promise (detached, so the close still happens on this
+    // tick): closing unmounts this composer, and react-query drops per-call mutate
+    // callbacks once an observer has no listeners.
+    void createThread
+      .mutateAsync({ number, path, line, side, startLine, body: body.trim() })
+      .catch((e) => toastError(e));
     onClose();
   }
 

--- a/src/features/pulls/ReviewHistory.tsx
+++ b/src/features/pulls/ReviewHistory.tsx
@@ -88,8 +88,28 @@ export function ReviewHistory({
     setDraft(text);
   }
 
-  function saveEdit(id: string) {
-    update.mutate({ id, text: draft }, { onSuccess: () => setEditingId(null) });
+  // Awaited rather than per-call mutate callbacks: an `<Activity>` tab hide tears
+  // this observer's subscription down mid-write, and react-query drops per-call
+  // callbacks once an observer has no listeners — the edit row would stay open and
+  // the confirm would stay armed. The catches do nothing: neither this surface nor
+  // the shared review-history mutation has a failure surface.
+  async function saveEdit(id: string) {
+    try {
+      await update.mutateAsync({ id, text: draft });
+      setEditingId(null);
+    } catch {
+      // No failure surface (see above).
+    }
+  }
+
+  async function clearHistory() {
+    try {
+      await clear.mutateAsync(undefined);
+    } catch {
+      // No failure surface (see above).
+    } finally {
+      setConfirmingClear(false);
+    }
   }
 
   const onKeyDown = listKeyboardNav({
@@ -131,11 +151,7 @@ export function ReviewHistory({
                 size="xs"
                 className="text-destructive"
                 disabled={clear.isPending}
-                onClick={() =>
-                  clear.mutate(undefined, {
-                    onSettled: () => setConfirmingClear(false),
-                  })
-                }
+                onClick={() => void clearHistory()}
               >
                 Yes
               </Button>
@@ -259,7 +275,7 @@ export function ReviewHistory({
                           <Button
                             size="xs"
                             disabled={update.isPending}
-                            onClick={() => saveEdit(r.id)}
+                            onClick={() => void saveEdit(r.id)}
                           >
                             Save
                           </Button>

--- a/src/features/pulls/ReviewersPopover.tsx
+++ b/src/features/pulls/ReviewersPopover.tsx
@@ -1,10 +1,10 @@
 import { Popover } from "@base-ui/react/popover";
 import { UserCheckIcon } from "@phosphor-icons/react";
 import { Children, type ReactNode, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import { MetaValueCell, UserChip } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useForgeGhHost } from "@/lib/git/host";
 import { useReviewerCandidates } from "@/lib/git/queries";
@@ -126,24 +126,22 @@ export function ReviewersPopover({
 
   const trigger = (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      {/* A natively disabled button swallows `title`, so the reason rides a
-          wrapping span. */}
-      <span
-        title={disabledReason}
-        className={
-          disabledReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+      {/* Disabled on the BUTTON, never the Trigger: a disabled Trigger leaves the
+          tab order, so its reason would reach hover only. */}
+      <Popover.Trigger
+        render={
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit reviewers"
+            disabled={!!disabledReason}
+            reason={disabledReason}
+          />
         }
       >
-        <Popover.Trigger
-          disabled={!!disabledReason}
-          render={
-            <Button variant="ghost" size="xs" aria-label="Edit reviewers" />
-          }
-        >
-          <UserCheckIcon data-icon="inline-start" />
-          Reviewers
-        </Popover.Trigger>
-      </span>
+        <UserCheckIcon data-icon="inline-start" />
+        Reviewers
+      </Popover.Trigger>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner
           align="start"

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -2,6 +2,7 @@ import { PlusIcon, SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
 import { Button } from "@/components/ui/button";
 import {
@@ -480,41 +481,44 @@ export function TaskDialog({
             </p>
           </div>
         ) : (
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <Label>Script</Label>
-              {aiEnabled &&
-                !aiConfigured &&
-                (scriptGen.generating ? null : (
+          <LabeledGroup
+            label="Script"
+            className="space-y-1.5"
+            actions={
+              <>
+                {aiEnabled &&
+                  !aiConfigured &&
+                  (scriptGen.generating ? null : (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      className="text-muted-foreground"
+                      title="Connect an AI provider to generate scripts"
+                      onClick={() => {
+                        onOpenChange(false);
+                        openSettings("ai");
+                      }}
+                    >
+                      <SparkleIcon data-icon="inline-start" />
+                      Set up AI to generate
+                    </Button>
+                  ))}
+                {aiEnabled && aiConfigured && scriptGen.generating && (
                   <Button
                     type="button"
                     variant="ghost"
                     size="xs"
                     className="text-muted-foreground"
-                    title="Connect an AI provider to generate scripts"
-                    onClick={() => {
-                      onOpenChange(false);
-                      openSettings("ai");
-                    }}
+                    onClick={scriptGen.cancel}
                   >
-                    <SparkleIcon data-icon="inline-start" />
-                    Set up AI to generate
+                    <Spinner data-icon="inline-start" />
+                    Generating…
                   </Button>
-                ))}
-              {aiEnabled && aiConfigured && scriptGen.generating && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="text-muted-foreground"
-                  onClick={scriptGen.cancel}
-                >
-                  <Spinner data-icon="inline-start" />
-                  Generating…
-                </Button>
-              )}
-            </div>
-
+                )}
+              </>
+            }
+          >
             {aiEnabled && aiConfigured && !scriptGen.generating && (
               <div className="flex gap-2">
                 <Input
@@ -567,7 +571,7 @@ export function TaskDialog({
               The script's contents, run by the selected interpreter — shell
               commands for PowerShell or bash, JavaScript for Node, and so on.
             </p>
-          </div>
+          </LabeledGroup>
         )}
 
         <div className="space-y-1.5">

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -10,6 +10,7 @@ import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
+import { LabeledGroup } from "@/components/form/labeled-group";
 import {
   MarkdownEditor,
   type MarkdownEditorHandle,
@@ -358,8 +359,7 @@ export function CreateReleaseDialog({
                 )}
               </div>
               {showTarget && (
-                <div className="space-y-1.5">
-                  <Label>Target</Label>
+                <LabeledGroup label="Target" className="space-y-1.5">
                   <TargetPicker
                     // Agent-session branches are app-internal — never a release
                     // target (same rule as BranchSwitcher).
@@ -370,7 +370,7 @@ export function CreateReleaseDialog({
                     value={target}
                     onChange={(v) => form.setFieldValue("target", v)}
                   />
-                </div>
+                </LabeledGroup>
               )}
             </div>
 
@@ -383,10 +383,14 @@ export function CreateReleaseDialog({
               )}
             </form.AppField>
 
-            <div className="flex flex-1 flex-col gap-1.5">
-              <div className="flex items-center justify-between gap-2">
-                <Label>Release notes</Label>
-                {existingTags.length > 0 && (
+            {/* `space-y-0` cancels LabeledGroup's default child margin, which
+                would ADD to this group's own `gap-1.5` (tailwind-merge doesn't
+                dedupe space-y against gap). */}
+            <LabeledGroup
+              label="Release notes"
+              className="flex flex-1 flex-col gap-1.5 space-y-0"
+              actions={
+                existingTags.length > 0 && (
                   <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                     <span className="shrink-0">Previous tag</span>
                     <Combobox
@@ -422,8 +426,9 @@ export function CreateReleaseDialog({
                       </ComboboxContent>
                     </Combobox>
                   </div>
-                )}
-              </div>
+                )
+              }
+            >
               <MarkdownEditor
                 ref={notesEditorRef}
                 aria-label="Release notes"
@@ -486,7 +491,7 @@ export function CreateReleaseDialog({
                   )
                 }
               />
-            </div>
+            </LabeledGroup>
 
             {/* GitLab computes "latest" itself and has no pre-release/draft. */}
             {!isGitLab && (


### PR DESCRIPTION
Pull-request writes lose their per-call react-query callbacks whenever the observer stops being listened to — and every `pulls/` surface now sits under an `<Activity>` tab hide, so switching repo tabs mid-write silently dropped toasts, dialog closes, optimistic rollbacks, and draft restores. This converts those call sites to awaited `mutateAsync` continuations, extends the `bare-mutate-in-converted-trees` ratchet over `src/features/pulls/`, and fixes three adjacent accessibility gaps found alongside them: disabled picker triggers that dropped out of the tab order, dialog captions that read as anonymous text, and select rows whose truncation never engaged.

### Awaited mutation continuations (`src/features/pulls/`)

- Converts the confirm-dialog writes to awaited helpers so each dialog's close rides the continuation instead of a droppable callback: `deletePr` in `LocalPrContextMenu.tsx`, `deleteSelectedLocalPr` in `PullRequestsPanel.tsx`, `confirmDelete` in `CommitComments.tsx` and `PrTasksSection.tsx`, and `deleteDraft` / `discard` in `PendingReviewBar.tsx`. (Close-on-failure semantics are preserved per site: `CommitComments` and `PrTasksSection` close on both arms via `finally`, as before; the rest close on success only, as before.)
- Rewrites `RemotePrView.tsx`'s draft controls (`markReadyForReview`, `convertToDraft` — both palette-registered), the stack create/add offer in `confirmStackOffer`, stack dissolve, the resolve-discard path, and the update-branch write to carry their outcomes in the continuation.
- `PrTasksSection.tsx`'s optimistic `toggle` now rolls the cache back from the `catch`, and `submitAdd` / `submitEdit` clear their fields after the await; `ResolveRemotePrView.tsx`'s `onFinish` / `onAbort` reach `onDone()` even if the takeover unmounts mid-write.
- Fire-and-forget composers (`ReviewComposer.tsx`, `CommitLineComposer` in `CommitComments.tsx`) detach the promise so the close still lands this tick while the toast rides `.then` / `.catch`; `ReviewHistory.tsx` and `PendingReviewBar.tsx` document their deliberate empty catches (PendingReviewBar's failures already toast at hook level; ReviewHistory's shared mutation has no failure surface at all, and the silence matches its prior behavior).
- `CreatePrDialog.tsx`'s `addUpstreamRemote` awaits, so a mid-write Esc/backdrop close can't swallow the error toast.

### Static check: extending the mutate ratchet

- `scripts/check-banned-patterns.mjs` adds `src/features/pulls/` to `bare-mutate-in-converted-trees`'s `appliesTo`, with a per-file allowlist covering the six files that still hold callback-free `.mutate(` calls (`LocalPrContextMenu.tsx`, `LocalPrView.tsx`, `PullRequestsPanel.tsx`, `RemotePrViewParts.tsx`, `ReviewHistory.tsx`, `useReconcileLocalPrs.ts`), each with rationale.
- `scripts/checks.test.mjs` updates the `appliesTo` coverage test to assert the pulls tree is scanned and `repository/` still isn't.

### Accessibility: disabled triggers keep their reason

- Replaces the `title`-on-a-wrapping-span pattern with `DisabledReasonButton` in `ReviewersPopover.tsx`, `LabelsPopover.tsx`, `IssueMetaPickers.tsx` (Assignees, Milestone, Type), and `IssueRelations.tsx` (sub-issue and relationship menus) — the trigger stays focusable and announces why it's unavailable instead of being reachable by hover only.

### Accessibility: named control groups

- `LinkedIssuesField.tsx` (both the native and Jira fields), `TaskDialog.tsx` ("Script"), and `CreateReleaseDialog.tsx` ("Target", "Release notes") now wrap their caption+actions rows in `LabeledGroup`, so the caption names its group rather than reading as loose text.
- `src/components/form/labeled-group.tsx` gains a `gap-2` collision floor under `justify-between`.
- `scripts/checks.test.mjs` drops the now-converted `LinkedIssuesField.tsx` deferral from the `bare-group-label` allowlist test.

### Select row truncation

- `src/components/form/fields.tsx` routes the simple `SelectItem` through `SelectClipText`, adds `clipTitleFromText` to `SelectValue`, and gives rich rows a `*:first:min-w-0 *:first:shrink` override so Base UI's shrink-refusing `ItemText` wrapper lets the label ellipsize while the popup still sizes to its widest option.
- `scripts/check-banned-patterns.mjs` adds `SELECT_ITEM_FLEX_TRUNCATE_RE` to catch the `min-w-0 flex-1 truncate` spelling of the dead clip span (window doubled to `PAIR_GAP * 2` to reach across the override), allowlisting `fields.tsx` as the one legal pairing; `scripts/checks.test.mjs` covers both the bare and overridden forms plus the per-file allowlist scoping.

### Changelog

- Four fragments: `changelog.d/fixed-pr-action-continuations.md`, `fixed-picker-disabled-reasons.md`, `fixed-dialog-group-captions.md`, and `fixed-branch-picker-clip.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Disabled pickers and menus now remain keyboard-focusable and explain why they are unavailable, including on hover.
  * Screen readers now correctly announce captions for linked issues, release notes, targets, and scripts.
* **Usability**
  * Long dropdown values are truncated with ellipses and reveal their full text on hover.
  * Form labels and action controls now have clearer spacing and grouping.
* **Bug Fixes**
  * Pull-request actions now reliably report success or failure and restore UI state when switching tabs during an operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->