### PR TITLE
feat(ai,settings): add a Review effort setting for agent-CLI reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,10 @@ close the window.
   context budget to the reviewing model's window (Auto probes a local
   **Ollama** model's context length live), so a larger model sees more of
   the PR before agentic review is needed.
+- **Dial the review effort**: a **Review effort** setting picks how hard an
+  agent-CLI reviewer thinks, from a lighter, quicker pass to deepest
+  reasoning — for reviews and security audits alike, on Claude Code, GitHub
+  Copilot, and opencode. Default keeps each CLI's own setting.
 - **Timeboxed on your terms**: agent-CLI reviews are timeboxed. Agentic ones
   get 20 minutes before they're stopped (plain 5; Codex reviews are always
   agentic), and a **Review timeout** setting pins a fixed limit when your

--- a/changelog.d/added-review-effort-setting.md
+++ b/changelog.d/added-review-effort-setting.md
@@ -1,0 +1,4 @@
+- **Review effort** (Settings → AI): pick how hard an agent-CLI
+  reviewer thinks, from a lighter, quicker pass to deepest reasoning — for
+  reviews and security audits alike, on Claude Code, GitHub Copilot, and
+  opencode. Default keeps each CLI's own setting.

--- a/changelog.d/added-review-effort-setting.md
+++ b/changelog.d/added-review-effort-setting.md
@@ -1,4 +1,4 @@
-- **Review effort** (Settings → AI): pick how hard an agent-CLI
-  reviewer thinks, from a lighter, quicker pass to deepest reasoning — for
-  reviews and security audits alike, on Claude Code, GitHub Copilot, and
-  opencode. Default keeps each CLI's own setting.
+- **Review effort** (Settings → AI): pick how hard an agent-CLI reviewer
+  thinks, from a lighter, quicker pass to deepest reasoning — for reviews and
+  security audits alike, on Claude Code, GitHub Copilot, and opencode. Default
+  keeps each CLI's own setting.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -603,6 +603,12 @@ export const capabilities: Capability[] = [
     group: "AI · generate & review",
     ai: true,
     label:
+      "Review effort — dial the reviewer's reasoning from a light pass to Max",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
+    label:
       "Review timeout — agentic reviews get 20 minutes, or pin your own limit",
   },
   {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1449,7 +1449,8 @@ reviewing model's context window (probing Ollama live), or pick Compact / Standa
 Expanded. **Review effort** (shown when Claude Code, GitHub Copilot, or opencode drives
 reviews or security audits) picks how hard the reviewer thinks: **Default** keeps the
 CLI's own setting, or choose **Low** through **Max** for a lighter or deeper pass. Codex
-and the API providers always run at their own defaults. **Review timeout** (shown when an agent CLI drives reviews or security audits)
+and the API providers always run at their own defaults. **Review timeout** (shown
+when an agent CLI drives reviews or security audits)
 caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
 the review is agentic — always, for Codex), or pin a fixed limit that applies to every
 agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits, for an

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1448,18 +1448,19 @@ controls how much diff and prior-discussion context reviews send — **Auto** fi
 reviewing model's context window (probing Ollama live), or pick Compact / Standard /
 Expanded. **Review effort** (shown when Claude Code, GitHub Copilot, or opencode drives
 reviews or security audits) picks how hard the reviewer thinks: **Default** keeps the
-CLI's own setting, or choose **Low** through **Max** for a lighter or deeper pass. Codex
-and the API providers always run at their own defaults. **Review timeout** (shown
-when an agent CLI drives reviews or security audits)
-caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
-the review is agentic — always, for Codex), or pin a fixed limit that applies to every
-agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits, for an
-automated pull-request review as much as one you started yourself: it stays on screen and is saved with
-the pull request, labelled **Timed out — partial output kept**, so it's still there after a
-restart. It also gets its own row under **Previous reviews**, where you can read, copy, or
-delete it like any other record. Kept output is never treated as a finished review — it
-doesn't feed the next run's context and doesn't count as coverage for an automated review,
-so run it again for a full one.
+CLI's own setting, or choose **Low** through **Max** for a lighter or deeper pass. A deeper
+pass takes longer, so pair a high effort with a roomier **Review timeout**. Codex and the
+API providers always run at their own defaults. **Review timeout** (shown when an agent
+CLI drives reviews or security audits) caps how long such a review may run before it's
+stopped: **Auto** allows 5 minutes (20 when the review is agentic — always, for Codex), or
+pin a fixed limit that applies to every agent-CLI review. Whatever the reviewer already
+wrote is kept when the limit hits, for an automated pull-request review as much as one
+you started yourself: it stays on screen and is saved with the pull request, labelled
+**Timed out — partial output kept**, so it's still there after a restart. It also gets
+its own row under **Previous reviews**, where you can read, copy, or delete it like any
+other record. Kept output is never treated as a finished review — it doesn't feed the
+next run's context and doesn't count as coverage for an automated review, so run it
+again for a full one.
 
 **Critical** is the top severity an audit finding can carry — remote code execution,
 execution triggered by content you only clone or open, full compromise, or a mass data

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1446,7 +1446,10 @@ judge the change against, never as instructions that can rewrite the review.
 See *AI & automations* to pick the review model. The **Review context** size there
 controls how much diff and prior-discussion context reviews send — **Auto** fits it to the
 reviewing model's context window (probing Ollama live), or pick Compact / Standard /
-Expanded. **Review timeout** (shown when an agent CLI drives reviews or security audits)
+Expanded. **Review effort** (shown when Claude Code, GitHub Copilot, or opencode drives
+reviews or security audits) picks how hard the reviewer thinks: **Default** keeps the
+CLI's own setting, or choose **Low** through **Max** for a lighter or deeper pass. Codex
+and the API providers always run at their own defaults. **Review timeout** (shown when an agent CLI drives reviews or security audits)
 caps how long such a review may run before it's stopped: **Auto** allows 5 minutes (20 when
 the review is agentic — always, for Codex), or pin a fixed limit that applies to every
 agent-CLI review. Whatever the reviewer already wrote is kept when the limit hits, for an

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -690,10 +690,13 @@ export const AiProviderSection = withForm({
       form.store,
       (s) => s.values.reviewTimeout ?? "auto",
     );
-    const reviewEffort = useSelector(
-      form.store,
-      (s) => s.values.reviewEffort ?? "auto",
-    );
+    // Render-coerce junk from a hand-edited settings.json to "auto" so the
+    // trigger shows what the run will actually do (reviewEffortLevel treats
+    // unknown values as ""); the stored value heals on the next pick.
+    const reviewEffort = useSelector(form.store, (s) => {
+      const v = s.values.reviewEffort;
+      return v && REVIEW_EFFORTS.includes(v) ? v : "auto";
+    });
     // `undefined` = Auto (no explicit default; new runs follow `ai.provider`).
     const defaultAgent = useSelector(form.store, (s) => s.values.defaultAgent);
     const agentIsolation = useSelector(

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -59,6 +59,11 @@ import {
   PROVIDER_LABELS,
   PROVIDERS_REQUIRING_KEY,
 } from "@/lib/ai/providers";
+import {
+  REVIEW_EFFORTS,
+  type ReviewEffort,
+  reviewEffortCapable,
+} from "@/lib/ai/review-effort";
 import { REVIEW_TIMEOUTS, type ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiProviderId, AiSettings } from "@/lib/ai/types";
 import { required, useAppForm, withForm } from "@/lib/form";
@@ -349,6 +354,15 @@ const REVIEW_TIMEOUT_ITEMS: Record<ReviewTimeout, string> = {
   "30": "30 minutes",
   "45": "45 minutes",
   "60": "60 minutes",
+};
+
+/** Review-effort labels — same `items` contract as the maps above. */
+const REVIEW_EFFORT_ITEMS: Record<ReviewEffort, string> = {
+  auto: "Default — the CLI's own setting",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Max",
 };
 
 /** Default-agent labels — same `items` contract as the maps above. "auto" is the
@@ -675,6 +689,10 @@ export const AiProviderSection = withForm({
     const reviewTimeout = useSelector(
       form.store,
       (s) => s.values.reviewTimeout ?? "auto",
+    );
+    const reviewEffort = useSelector(
+      form.store,
+      (s) => s.values.reviewEffort ?? "auto",
     );
     // `undefined` = Auto (no explicit default; new runs follow `ai.provider`).
     const defaultAgent = useSelector(form.store, (s) => s.values.defaultAgent);
@@ -1104,6 +1122,39 @@ export const AiProviderSection = withForm({
               probes the model's context window where possible.
             </p>
           </div>
+          {/* Effort rides each CLI's own reasoning lever, so the row shows only
+              when an effort-capable CLI (see reviewEffortCapable) drives
+              reviews or security audits. */}
+          {(reviewEffortCapable(reviewAi.provider) ||
+            (securityReviewAi &&
+              reviewEffortCapable(securityReviewAi.provider))) && (
+            <div className="space-y-2">
+              <Label htmlFor="review-effort">Review effort</Label>
+              <Select
+                items={REVIEW_EFFORT_ITEMS}
+                value={reviewEffort}
+                onValueChange={(v) => {
+                  if (v) form.setFieldValue("reviewEffort", v as ReviewEffort);
+                }}
+              >
+                <SelectTrigger id="review-effort" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REVIEW_EFFORTS.map((id) => (
+                    <SelectItem key={id} value={id}>
+                      {REVIEW_EFFORT_ITEMS[id]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                How hard the reviewing agent thinks, for reviews and security
+                audits alike. Lower is a quicker, lighter pass; Codex and the
+                API providers always run at their own defaults.
+              </p>
+            </div>
+          )}
           {/* Only the agent-CLI providers run under a kill timeout, so the row
               shows when a CLI drives reviews or security audits. */}
           {(isCliProvider(reviewAi.provider) ||

--- a/src/lib/ai/review-effort.ts
+++ b/src/lib/ai/review-effort.ts
@@ -1,4 +1,3 @@
-import { isCliProvider } from "./providers";
 import type { AiProviderId } from "./types";
 
 /** The Review-effort choices offered in Settings, in render order. The
@@ -16,13 +15,21 @@ export const REVIEW_EFFORTS = [
  *  own configured default governs, exactly as before the setting existed. */
 export type ReviewEffort = (typeof REVIEW_EFFORTS)[number];
 
-/** Whether `provider`'s reviews honor the Review-effort setting: the agent
- *  CLIs with a reasoning lever the review path drives (Claude a thinking
- *  keyword, Copilot `--effort`, opencode `--variant`). Codex is deliberately
- *  out — its reasoning config tops out at "high", so the scale's Max would
- *  overpromise — and the HTTP providers have no effort plumbing at all. */
+/** The agent CLIs whose review path maps the Review-effort setting onto a real
+ *  lever (Claude a thinking keyword, Copilot `--effort`, opencode `--variant`).
+ *  Deliberately an allow-list, so a newly added CLI stays effort-hidden until
+ *  `agent_review` actually maps its level. Codex is out — its reasoning config
+ *  tops out at "high", so the scale's Max would overpromise — and the HTTP
+ *  providers have no effort plumbing at all. */
+const EFFORT_CLI_PROVIDERS: readonly AiProviderId[] = [
+  "claude-cli",
+  "copilot-cli",
+  "opencode-cli",
+];
+
+/** Whether `provider`'s reviews honor the Review-effort setting. */
 export function reviewEffortCapable(provider: AiProviderId): boolean {
-  return isCliProvider(provider) && provider !== "codex-cli";
+  return EFFORT_CLI_PROVIDERS.includes(provider);
 }
 
 /** The `agent_review` effort level for a review on `provider`, or `""` (the

--- a/src/lib/ai/review-effort.ts
+++ b/src/lib/ai/review-effort.ts
@@ -1,0 +1,40 @@
+import { isCliProvider } from "./providers";
+import type { AiProviderId } from "./types";
+
+/** The Review-effort choices offered in Settings, in render order. The
+ *  `ReviewEffort` union derives from this list, so the Settings labels map
+ *  stays exhaustive and the menu can't silently drop an option. */
+export const REVIEW_EFFORTS = [
+  "auto",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+
+/** How hard an agent-CLI review reasons. `"auto"` sends nothing — the CLI's
+ *  own configured default governs, exactly as before the setting existed. */
+export type ReviewEffort = (typeof REVIEW_EFFORTS)[number];
+
+/** Whether `provider`'s reviews honor the Review-effort setting: the agent
+ *  CLIs with a reasoning lever the review path drives (Claude a thinking
+ *  keyword, Copilot `--effort`, opencode `--variant`). Codex is deliberately
+ *  out — its reasoning config tops out at "high", so the scale's Max would
+ *  overpromise — and the HTTP providers have no effort plumbing at all. */
+export function reviewEffortCapable(provider: AiProviderId): boolean {
+  return isCliProvider(provider) && provider !== "codex-cli";
+}
+
+/** The `agent_review` effort level for a review on `provider`, or `""` (the
+ *  CLI's own default — Rust then omits the flag/keyword). Don't trust the
+ *  union at runtime: settings.json is hand-editable, so anything outside the
+ *  known levels resolves to `""`, and a non-capable provider always does. */
+export function reviewEffortLevel(
+  provider: AiProviderId,
+  effort: ReviewEffort | undefined,
+): string {
+  if (!effort || effort === "auto" || !reviewEffortCapable(provider)) {
+    return "";
+  }
+  return REVIEW_EFFORTS.includes(effort) ? effort : "";
+}

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -29,9 +29,9 @@ export interface CliStreamOpts {
   /** The run's reported cost (USD), delivered with the terminal `done` event.
    *  Null when the CLI doesn't report one. Optional — most callers ignore it. */
   onCost?: (costUsd: number | null) => void;
-  /** Reasoning/effort level for the run ("" / absent = provider default).
-   *  Review flows resolve it from the Review-effort setting; picker flows
-   *  (e.g. Plan) pass their per-run choice. */
+  /** Reasoning/effort level for the run ("" / absent = provider default) —
+   *  review flows resolve it from the Review-effort setting; other callers
+   *  leave it unset. (Plan/sessions route effort via `agent_session`.) */
   effort?: string;
   /** Attach GitDesktop's own read-only MCP server to the run (reviews only), so an agentic
    *  reviewer can pull the full PR diff and read files at any ref. Default off. */

--- a/src/lib/ai/stream.ts
+++ b/src/lib/ai/stream.ts
@@ -29,8 +29,9 @@ export interface CliStreamOpts {
   /** The run's reported cost (USD), delivered with the terminal `done` event.
    *  Null when the CLI doesn't report one. Optional — most callers ignore it. */
   onCost?: (costUsd: number | null) => void;
-  /** Reasoning/effort level for the run ("" = provider default). Optional — only
-   *  the repo-aware flows that expose a picker (e.g. Plan) set it. */
+  /** Reasoning/effort level for the run ("" / absent = provider default).
+   *  Review flows resolve it from the Review-effort setting; picker flows
+   *  (e.g. Plan) pass their per-run choice. */
   effort?: string;
   /** Attach GitDesktop's own read-only MCP server to the run (reviews only), so an agentic
    *  reviewer can pull the full PR diff and read files at any ref. Default off. */
@@ -225,6 +226,10 @@ export interface StreamAiOpts {
   /** True only for the AI-review flows the Review-timeout setting governs; drives
    *  the timed-out message's settings hint. CLI path only. */
   timeoutConfigurable?: boolean;
+  /** Reasoning/effort level for a CLI review run ("" / absent = the CLI's own
+   *  default). Review flows resolve it per-provider via `reviewEffortLevel`;
+   *  other callers omit it. CLI path only — HTTP providers have no lever. */
+  effort?: string;
   /** Native AI-SDK review tools for an HTTP-provider agentic review — the model explores
    *  via a tool loop (no MCP, no worktree). HTTP agentic reviews only; CLI and non-review
    *  callers omit it. */
@@ -261,6 +266,7 @@ export async function streamAi({
   mcpSelf,
   timeoutSecs,
   timeoutConfigurable,
+  effort,
   reviewTools,
   setText,
   setStatus,
@@ -279,6 +285,7 @@ export async function streamAi({
       mcpSelf,
       timeoutSecs,
       timeoutConfigurable,
+      effort,
       setText,
       setStatus,
       registerId: onCliId,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -16,6 +16,7 @@ import {
 import { type PriorContext, resolvePriorContext } from "@/lib/ai/prior-context";
 import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isCliProvider, isLocalProvider } from "@/lib/ai/providers";
+import { reviewEffortLevel } from "@/lib/ai/review-effort";
 import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
 import { runCliStream } from "@/lib/ai/stream";
 import { safeSlice } from "@/lib/ai/truncate";
@@ -983,6 +984,9 @@ async function generateReviewText(
       // The user's Review-timeout override (null = the backend's tier defaults).
       timeoutSecs: reviewTimeoutSecs(appSettings.reviewTimeout),
       timeoutConfigurable: true,
+      // The user's Review-effort override ("" = the CLI's own default; always ""
+      // for Codex, which the setting doesn't drive).
+      effort: reviewEffortLevel(ai.provider, appSettings.reviewEffort),
       // Sunk into the caller-owned `progress` rather than a local: a timed-out run
       // rejects, so a local would be unreachable exactly when the text matters most.
       // runCliStream replaces with the agent's final answer on done; the last

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { ReviewContextSize } from "@/lib/ai/context-budget";
+import type { ReviewEffort } from "@/lib/ai/review-effort";
 import type { ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
@@ -176,6 +177,10 @@ export interface AppSettings {
    *  security audits alike). Absent — settings written before this shipped — reads as
    *  `"auto"`, the backend's tier defaults. */
   reviewTimeout?: ReviewTimeout;
+  /** How hard an agent-CLI review reasons (interactive, automated, and security audits
+   *  alike), via each CLI's own effort lever. Absent/`"auto"` sends nothing — the CLI's
+   *  configured default governs, exactly as before the setting shipped. */
+  reviewEffort?: ReviewEffort;
   /** Hide every AI surface — commit/PR helpers, review panel, and the AI-related
    *  settings sections (AI, Slash commands, MCP servers, Automations) — and pause
    *  automations: no new automated run starts while set (an in-flight run finishes).
@@ -321,6 +326,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   },
   reviewContextSize: "auto",
   reviewTimeout: "auto",
+  reviewEffort: "auto",
   hideAi: false,
   notifications: {
     automations: true,

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -20,6 +20,7 @@ import {
 import { type PriorContext, resolvePriorContext } from "@/lib/ai/prior-context";
 import { buildReviewPrompt } from "@/lib/ai/prompt";
 import { isLocalProvider } from "@/lib/ai/providers";
+import { reviewEffortLevel } from "@/lib/ai/review-effort";
 import { reviewTimeoutSecs } from "@/lib/ai/review-timeout";
 import { buildReviewTools } from "@/lib/ai/review-tools";
 import { streamAi } from "@/lib/ai/stream";
@@ -599,6 +600,9 @@ export async function startReview(
     // The user's Review-timeout override (null = the backend's tier defaults).
     // CLI providers only; the HTTP path ignores it.
     const timeoutSecs = reviewTimeoutSecs(appSettings.reviewTimeout);
+    // The user's Review-effort override ("" = the CLI's own default; always ""
+    // for Codex and HTTP providers, which the setting doesn't drive).
+    const effort = reviewEffortLevel(ai.provider, appSettings.reviewEffort);
     if (control.cancelled) return;
     // Own-comments distillation runs a generation-model call that can outlast a dock
     // Cancel, and the review stream only gets an abort handle later (via `onAbort`).
@@ -740,6 +744,7 @@ export async function startReview(
       mcpSelf: mcpTools,
       timeoutSecs,
       timeoutConfigurable: true,
+      effort,
       reviewTools,
       setText: pushText,
       setStatus: (s) => patch({ status: s }),


### PR DESCRIPTION
Agent-CLI reviews previously ran at whatever reasoning level each CLI had configured, with no way to trade depth for speed from inside the app. This adds a **Review effort** setting under Settings → AI that dials how hard an agent-CLI reviewer thinks, from a lighter, quicker pass up to Max, across interactive reviews, automated reviews, and security audits. The default keeps each CLI's own setting, so nothing changes unless you opt in.

### Effort model

- New `src/lib/ai/review-effort.ts` defines `REVIEW_EFFORTS` (`auto`, `low`, `medium`, `high`, `xhigh`) and derives the `ReviewEffort` union from that list, so the Settings label map stays exhaustive and the menu can't silently drop an option.
- `reviewEffortCapable()` scopes the setting to the agent CLIs whose reasoning lever the review path drives, via an explicit fail-closed `EFFORT_CLI_PROVIDERS` allow-list (Claude Code, GitHub Copilot, opencode) — a newly added CLI stays effort-hidden until `agent_review` actually maps its level. `codex-cli` is deliberately excluded — its reasoning config tops out at "high", so the scale's Max would overpromise — and the HTTP providers have no effort plumbing.
- `reviewEffortLevel()` maps a provider plus the stored setting to the level string sent to `agent_review`, returning `""` for `auto`, for non-capable providers, and for any value outside the known levels, since `settings.json` is hand-editable.

### Settings

- `AppSettings.reviewEffort` added in `src/lib/settings/api.ts`, with `"auto"` in `DEFAULT_SETTINGS`; settings written before this shipped read as `auto`.
- `src/features/settings/AiProviderSection.tsx` adds the "Review effort" `Select` backed by a `REVIEW_EFFORT_ITEMS` label map ("Default — the CLI's own setting" through "Max"). The row renders only when an effort-capable CLI drives reviews *or* security audits (checking both `reviewAi.provider` and `securityReviewAi.provider`), matching how the existing Review-timeout row gates itself, and the helper text notes that Codex and the API providers run at their own defaults.

### Review paths

- `src/lib/ai/stream.ts` gains `effort` on `StreamAiOpts` and forwards it into `runCliStream`; the `CliStreamOpts.effort` doc comment is corrected — the field had no setters before this PR (Plan/sessions route effort through the separate `agent_session` command), so it now names the review flows as its only setters.
- `src/lib/stores/reviews.ts` (interactive reviews) and `src/lib/automations/runner.ts` (automated reviews) both resolve `reviewEffortLevel(ai.provider, appSettings.reviewEffort)` and pass it through to the stream.

### Documentation

- `README.md`: new "Dial the review effort" bullet alongside the review context and timeout bullets.
- `site/src/data/capabilities.ts`: capability entry under *AI · generate & review* with `ai: true`.
- `src/features/help/content.ts`: the AI review guide section now describes Review effort, its Default/Low–Max choices, and which providers honor it.
- `changelog.d/added-review-effort-setting.md`: `added-` fragment for the release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Review effort** setting under **Settings → AI**, ranging from a lighter pass to maximum reasoning.
  - Applies to reviews and security audits using Claude Code, GitHub Copilot, and opencode.
  - Defaults to each CLI’s configured setting; Codex and API providers continue using their own defaults.

- **Documentation**
  - Updated the in-app Help guide, README, capability catalog, and changelog with details about the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->