### PR TITLE
feat(diff): add a Raw/Preview toggle to markdown and MDX diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ delete), and deep links to the settings GitHub keeps browser-only.
 ### Changes and commits
 
 A unified or split diff with syntax highlighting, collapsible surrounding
-context, and image diffing. Filter the changes list by path or category, and
+context, and image diffing. Markdown and MDX files add a Raw/Preview toggle,
+so you can read a doc change as rendered prose — headings, tables, and code
+blocks — on the working tree, commits, stashes, and the other local views.
+Filter the changes list by path or category, and
 read a file's `+added -deleted` line counts without opening it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to

--- a/README.md
+++ b/README.md
@@ -120,10 +120,7 @@ delete), and deep links to the settings GitHub keeps browser-only.
 ### Changes and commits
 
 A unified or split diff with syntax highlighting, collapsible surrounding
-context, and image diffing. Markdown and MDX files add a Raw/Preview toggle,
-so you can read a doc change as rendered prose — headings, tables, and code
-blocks — on the working tree, commits, stashes, and the other local views.
-Filter the changes list by path or category, and
+context, and image diffing. Filter the changes list by path or category, and
 read a file's `+added -deleted` line counts without opening it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to
@@ -135,6 +132,11 @@ or discard single files or a multi-selection from the context menu (staging
 and unstaging a selection sit in the command palette too); discarding a
 whole untracked file goes to the recycle bin. Commit with title + body,
 co-authors suggested from history, amend, undo, reset, and revert.
+
+Markdown and MDX files add a Raw / Preview toggle to the diff, so you can
+read a doc change as rendered prose (headings, tables, and code blocks) on
+the working tree, commit details, stashes, and an agent session's worktree
+changes.
 
 ### Branches
 

--- a/changelog.d/added-markdown-preview-toggle.md
+++ b/changelog.d/added-markdown-preview-toggle.md
@@ -2,5 +2,6 @@
   toggle: Preview renders the file's new version as formatted prose (headings,
   tables, highlighted code fences), so a docs change reads the way it will ship.
   Deleted files preview their last version, frontmatter stays out of the render,
-  and it works on the working tree, commit details, and stashes (with *Toggle
-  Markdown preview* in the command palette).
+  and it works on the working tree, commit details, stashes, and an agent
+  session's worktree changes (with *Toggle Markdown preview* in the command
+  palette).

--- a/changelog.d/added-markdown-preview-toggle.md
+++ b/changelog.d/added-markdown-preview-toggle.md
@@ -1,7 +1,7 @@
 - **Markdown preview on diffs.** Markdown and MDX diffs add a **Raw / Preview**
   toggle: Preview renders the file's new version as formatted prose (headings,
   tables, highlighted code fences), so a docs change reads the way it will ship.
-  Deleted files preview their last version, frontmatter stays out of the render,
-  and it works on the working tree, commit details, stashes, and an agent
-  session's worktree changes (with *Toggle Markdown preview* in the command
-  palette).
+  Deleted files preview their last version, a leading frontmatter block stays
+  out of the render, and it works on the working tree, commit details, stashes,
+  and an agent session's worktree changes (with *Toggle Markdown preview* in
+  the command palette).

--- a/changelog.d/added-markdown-preview-toggle.md
+++ b/changelog.d/added-markdown-preview-toggle.md
@@ -1,0 +1,6 @@
+- **Markdown preview on diffs.** Markdown and MDX diffs add a **Raw / Preview**
+  toggle: Preview renders the file's new version as formatted prose (headings,
+  tables, highlighted code fences), so a docs change reads the way it will ship.
+  Deleted files preview their last version, frontmatter stays out of the render,
+  and it works on the working tree, commit details, and stashes (with *Toggle
+  Markdown preview* in the command palette).

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -55,6 +55,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Diffs & staging",
+    label:
+      "Raw ⇄ Preview toggle on markdown & MDX diffs — read the change as rendered prose",
+  },
+  {
+    group: "Diffs & staging",
     label: "Filter the changes list by path or category",
   },
   {

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -18,7 +18,6 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -67,7 +66,10 @@ import {
 } from "./shiki-highlighter";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 import { ensureCustomLanguages } from "./syntax";
-import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
+import {
+  useFocusOnControlsSwap,
+  useHiddenTriggerFocus,
+} from "./use-hidden-trigger-focus";
 import { useWorkerHighlight, type WorkerAsts } from "./use-worker-highlight";
 
 /**
@@ -1261,16 +1263,7 @@ export function DiffContent({
   const canPreview =
     showsToolbar && canPreviewMarkdown(filePath, repoPath, contentRevs);
   const previewOn = canPreview && mdView === "preview";
-  // A palette-driven flip unmounts the control that held focus (the picker and
-  // Unified/Split leave the cluster entering Preview), dropping focus to
-  // <body>; land it on the cluster's silent landing spot instead. Change-only
-  // (prev-ref guard), so a mount can never steal focus from elsewhere.
-  const prevPreviewOnRef = useRef(previewOn);
-  useLayoutEffect(() => {
-    if (prevPreviewOnRef.current === previewOn) return;
-    prevPreviewOnRef.current = previewOn;
-    if (document.activeElement === document.body) controlsRef.current?.focus();
-  }, [previewOn, controlsRef]);
+  useFocusOnControlsSwap(previewOn, controlsRef);
   useHotkeyAction(
     "change-diff-language",
     () => setLangOpen(true),

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -1244,8 +1244,8 @@ export function DiffContent({
     returnFocusIfTriggerHidden,
   } = useHiddenTriggerFocus();
   // Computed above the early-return chain (which the `emptyDiff` arm joins, so
-  // the text is trimmed once) because the registration below is a hook: offer
-  // the action only in the states that actually render the picker.
+  // the text is trimmed once) because the registrations below are hooks: offer
+  // each action only in the states that actually render its control.
   const emptyDiff = data !== undefined && data.text.trim() === "";
   const showsToolbar =
     !isPending &&

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -18,6 +18,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -182,7 +183,7 @@ export function DiffModeToggle({
     // DisabledReasonButton's wrapper span has no `data-slot`, so it opts out of
     // ButtonGroup's border-collapse/rounding child selectors — this call site
     // owns the seam on the Button instead (same arrangement as SyncControls).
-    <ButtonGroup>
+    <ButtonGroup aria-label="Diff view mode">
       <Button
         variant={effectiveViewMode === "unified" ? "secondary" : "ghost"}
         size="xs"
@@ -1234,6 +1235,9 @@ export function DiffContent({
   // that are most of a diff list, so every file opens on Raw.
   const [mdView, setMdView] = useState<MarkdownDiffView>("raw");
   const [prevMdPath, setPrevMdPath] = useState(filePath);
+  // Guarded same-component reset during render (React's adjust-state-when-
+  // props-change idiom, same as RenderedDiff's prevPath resets): it converges
+  // before commit, where an effect would paint the outgoing file's view first.
   if (prevMdPath !== filePath) {
     setPrevMdPath(filePath);
     if (mdView !== "raw") setMdView("raw");
@@ -1257,6 +1261,16 @@ export function DiffContent({
   const canPreview =
     showsToolbar && canPreviewMarkdown(filePath, repoPath, contentRevs);
   const previewOn = canPreview && mdView === "preview";
+  // A palette-driven flip unmounts the control that held focus (the picker and
+  // Unified/Split leave the cluster entering Preview), dropping focus to
+  // <body>; land it on the cluster's silent landing spot instead. Change-only
+  // (prev-ref guard), so a mount can never steal focus from elsewhere.
+  const prevPreviewOnRef = useRef(previewOn);
+  useLayoutEffect(() => {
+    if (prevPreviewOnRef.current === previewOn) return;
+    prevPreviewOnRef.current = previewOn;
+    if (document.activeElement === document.body) controlsRef.current?.focus();
+  }, [previewOn, controlsRef]);
   useHotkeyAction(
     "change-diff-language",
     () => setLangOpen(true),
@@ -1314,8 +1328,9 @@ export function DiffContent({
         </span>
         {/* ~200px of unshrinkable text, so it shows only where the pane has the
             room; the sr-only twin carries it at every width, and `aria-hidden`
-            on the visible copy keeps the two from announcing twice. */}
-        {data.isTruncated && (
+            on the visible copy keeps the two from announcing twice. Hidden in
+            Preview, which reads the full file rather than the truncated diff. */}
+        {data.isTruncated && !previewOn && (
           <>
             <span aria-hidden className="hidden shrink-0 @2xl/diff-pane:inline">
               (truncated — diff too large)

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -25,6 +25,7 @@ import {
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { decodeBase64Utf8 } from "@/lib/git/api";
 import { useFileAtRev } from "@/lib/git/queries";
 import type { FileDiff } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
@@ -49,6 +50,12 @@ import { diffLang, fileExt } from "./diff-lang";
 import { djb2 } from "./highlight-worker-shared";
 import { installHljsGapIsolation } from "./hljs-gap-isolation";
 import { ImageDiff, ImagePanes, type ImageRevs, imageMime } from "./ImageDiff";
+import {
+  canPreviewMarkdown,
+  type MarkdownDiffView,
+  MarkdownDocPreview,
+  MarkdownViewToggle,
+} from "./MarkdownPreview";
 import {
   ensureBuiltinShikiLang,
   ensureShikiGrammars,
@@ -156,14 +163,6 @@ function diffMaxLineNumbers(diffText: string): { old: number; new: number } {
   return { old: maxOld, new: maxNew };
 }
 
-/** Decode base64 file bytes (from git_file_base64) to a UTF-8 string. */
-function decodeBase64Utf8(b64: string): string {
-  const bin = atob(b64);
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
-}
-
 /** The persisted Unified/Split preference toggle. */
 export function DiffModeToggle({
   splitDisabled = false,
@@ -187,6 +186,7 @@ export function DiffModeToggle({
       <Button
         variant={effectiveViewMode === "unified" ? "secondary" : "ghost"}
         size="xs"
+        aria-pressed={effectiveViewMode === "unified"}
         onClick={() =>
           !splitDisabled &&
           settings.data &&
@@ -198,6 +198,7 @@ export function DiffModeToggle({
       <DisabledReasonButton
         variant={effectiveViewMode === "split" ? "secondary" : "ghost"}
         size="xs"
+        aria-pressed={effectiveViewMode === "split"}
         disabled={splitDisabled}
         reason="Pane too narrow for split view"
         className="border-l-0 focus-visible:relative focus-visible:z-10"
@@ -1228,6 +1229,15 @@ export function DiffContent({
   // The picker's trigger is hidden below @md, so the palette action is its only
   // route at narrow widths — which makes the open state the toolbar's to own.
   const [langOpen, setLangOpen] = useState(false);
+  // Raw ⇄ Preview for markdown/MDX files. Per-file and never persisted — a
+  // sticky global "preview" would be meaningless on the non-markdown files
+  // that are most of a diff list, so every file opens on Raw.
+  const [mdView, setMdView] = useState<MarkdownDiffView>("raw");
+  const [prevMdPath, setPrevMdPath] = useState(filePath);
+  if (prevMdPath !== filePath) {
+    setPrevMdPath(filePath);
+    if (mdView !== "raw") setMdView("raw");
+  }
   const {
     wrapRef: langWrapRef,
     controlsRef,
@@ -1244,10 +1254,19 @@ export function DiffContent({
     data.filePath === filePath &&
     !data.isBinary &&
     !emptyDiff;
+  const canPreview =
+    showsToolbar && canPreviewMarkdown(filePath, repoPath, contentRevs);
+  const previewOn = canPreview && mdView === "preview";
   useHotkeyAction(
     "change-diff-language",
     () => setLangOpen(true),
-    showsToolbar && Boolean(fileExt(filePath)),
+    // In Preview the picker isn't mounted, so the action would open nothing.
+    showsToolbar && !previewOn && Boolean(fileExt(filePath)),
+  );
+  useHotkeyAction(
+    "toggle-markdown-preview",
+    () => setMdView((v) => (v === "raw" ? "preview" : "raw")),
+    canPreview,
   );
 
   // Diffs load near-instantly from local git, so a skeleton only adds a flash
@@ -1314,49 +1333,74 @@ export function DiffContent({
           tabIndex={-1}
           className="flex min-h-7 shrink-0 items-center gap-1.5 outline-none"
         >
-          {/* The only variable-width control here (its label follows the
-              language name), so it's the one that goes under @md — leaving the
-              row a fixed floor. It must stay laid out while its popup is open,
-              though: Base UI anchors to the trigger, and a display:none trigger
-              positions the popup at 0,0. `empty:hidden` keeps the row's gap off
-              an extensionless file, where the picker renders nothing. */}
-          <span
-            ref={langWrapRef}
-            className="hidden @md/diff-pane:flex empty:hidden has-[[data-popup-open]]:flex"
-          >
-            <DiffLanguagePicker
-              filePath={filePath}
-              open={langOpen}
-              onOpenChange={(open) => {
-                setLangOpen(open);
-                if (!open) returnFocusIfTriggerHidden();
-              }}
-            />
-          </span>
-          <DiffModeToggle splitDisabled={narrowPane} />
+          {canPreview && (
+            <MarkdownViewToggle view={mdView} onChange={setMdView} />
+          )}
+          {/* The picker and Unified/Split configure the raw diff, so they
+              leave the cluster while Preview is up (the same swap this row
+              already does for the working-tree selection actions). */}
+          {!previewOn && (
+            <>
+              {/* The only variable-width control here (its label follows the
+                  language name), so it's the one that goes under @md — leaving
+                  the row a fixed floor. It must stay laid out while its popup
+                  is open, though: Base UI anchors to the trigger, and a
+                  display:none trigger positions the popup at 0,0.
+                  `empty:hidden` keeps the row's gap off an extensionless file,
+                  where the picker renders nothing. */}
+              <span
+                ref={langWrapRef}
+                className="hidden @md/diff-pane:flex empty:hidden has-[[data-popup-open]]:flex"
+              >
+                <DiffLanguagePicker
+                  filePath={filePath}
+                  open={langOpen}
+                  onOpenChange={(open) => {
+                    setLangOpen(open);
+                    if (!open) returnFocusIfTriggerHidden();
+                  }}
+                />
+              </span>
+              <DiffModeToggle splitDisabled={narrowPane} />
+            </>
+          )}
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
-        {svgPreview && repoPath && imageRevs && (
-          <div className="border-b">
-            <ImagePanes
-              repoPath={repoPath}
+        {previewOn && repoPath && contentRevs ? (
+          // Passed the raw revs, not the truncation-stripped pair below:
+          // preview reads the file, not the diff, so it works on exactly the
+          // truncated diffs content mode gives up on.
+          <MarkdownDocPreview
+            repoPath={repoPath}
+            filePath={filePath}
+            revs={contentRevs}
+          />
+        ) : (
+          <>
+            {svgPreview && repoPath && imageRevs && (
+              <div className="border-b">
+                <ImagePanes
+                  repoPath={repoPath}
+                  filePath={filePath}
+                  revs={imageRevs}
+                />
+              </div>
+            )}
+            <GitDiffView
               filePath={filePath}
-              revs={imageRevs}
+              text={data.text}
+              repoPath={repoPath}
+              // A truncated diff was cut by the byte cap and can't line up
+              // with the full file text, so don't try whole-file highlighting
+              // there.
+              contentRevs={data.isTruncated ? undefined : contentRevs}
+              lineAnchors={lineAnchors}
+              lineWidget={lineWidget}
+              forceUnified={narrowPane}
             />
-          </div>
+          </>
         )}
-        <GitDiffView
-          filePath={filePath}
-          text={data.text}
-          repoPath={repoPath}
-          // A truncated diff was cut by the byte cap and can't line up with the
-          // full file text, so don't try whole-file highlighting there.
-          contentRevs={data.isTruncated ? undefined : contentRevs}
-          lineAnchors={lineAnchors}
-          lineWidget={lineWidget}
-          forceUnified={narrowPane}
-        />
       </div>
     </div>
   );

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -73,6 +73,12 @@ import {
 } from "./DiffSurface";
 import { fileExt } from "./diff-lang";
 import { ImagePanes } from "./ImageDiff";
+import {
+  type MarkdownDiffView,
+  MarkdownDocPreview,
+  MarkdownViewToggle,
+} from "./MarkdownPreview";
+import { isMarkdownPath } from "./markdown-preview";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
 
@@ -203,6 +209,9 @@ function WorkingTreeDiff({
   // the trigger under @md like the read-only surface does, so below that width
   // the action is the only route to it.
   const [langOpen, setLangOpen] = useState(false);
+  // Raw ⇄ Preview for markdown/MDX. Never persisted, and this component is
+  // keyed per file, so every file opens on Raw.
+  const [mdView, setMdView] = useState<MarkdownDiffView>("raw");
   const {
     wrapRef: langWrapRef,
     controlsRef,
@@ -245,6 +254,11 @@ function WorkingTreeDiff({
     selectionState !== null && selectionState.forText === diff.data?.text
       ? selectionState.lines
       : null;
+  // Preview swaps the staging view out entirely, so the selection actions and
+  // the toggle can never be on screen together (the selection arm owns the
+  // whole cluster while a drag selection exists).
+  const canPreview = hunkMode && isMarkdownPath(file.path);
+  const previewOn = canPreview && mdView === "preview";
   // One contextual chord: stage the selection on an unstaged file's diff,
   // unstage it on a staged one — mirroring the toolbar's primary button. Dead
   // while the Discard confirm is open (the global listener has no dialog guard)
@@ -267,7 +281,15 @@ function WorkingTreeDiff({
   useHotkeyAction(
     "change-diff-language",
     () => setLangOpen(true),
-    hunkMode && selection === null && Boolean(fileExt(file.path)),
+    // In Preview the picker isn't mounted, so the action would open nothing.
+    hunkMode && selection === null && !previewOn && Boolean(fileExt(file.path)),
+  );
+  // Inert while a selection or the Discard confirm is up — the selection arm
+  // owns the cluster, and the global listener has no dialog guard.
+  useHotkeyAction(
+    "toggle-markdown-preview",
+    () => setMdView((v) => (v === "raw" ? "preview" : "raw")),
+    canPreview && selection === null && discard === null,
   );
   // Any Discard confirm's `run` captured line numbers (or a hunk) at open
   // time — close it the moment the diff text moves on from the text it was
@@ -351,6 +373,15 @@ function WorkingTreeDiff({
       { onError, onSuccess: clearSelection },
     );
   }
+
+  // Full-text revs aligned to the diff's actual sides: staged = HEAD↔index,
+  // unstaged = index↔worktree, added = worktree only. One pair feeds both the
+  // staging view's highlight context and the markdown preview.
+  const workingRevs: DiffContentRevs = untracked
+    ? { newRev: null }
+    : file.staged
+      ? { oldRev: "HEAD", newRev: ":0" }
+      : { oldRev: ":0", newRev: null };
 
   // A whole-hunk action, fired by the per-hunk overlay buttons.
   function onHunkAction(hunk: DiffHunk, kind: "stage" | "unstage" | "discard") {
@@ -476,27 +507,38 @@ function WorkingTreeDiff({
             </>
           ) : (
             <>
-              {/* Same treatment as the read-only surface's toolbar: the picker
-                  is this row's only variable-width control (its label follows
-                  the language name), so it goes under @md to give the row a
-                  fixed floor — but stays laid out while its popup is open,
-                  since Base UI anchors to the trigger and a display:none
-                  trigger positions the popup at 0,0. `empty:hidden` keeps the
-                  row's gap off an extensionless file. */}
-              <span
-                ref={langWrapRef}
-                className="hidden @md/staging-pane:flex empty:hidden has-[[data-popup-open]]:flex"
-              >
-                <DiffLanguagePicker
-                  filePath={file.path}
-                  open={langOpen}
-                  onOpenChange={(open) => {
-                    setLangOpen(open);
-                    if (!open) returnFocusIfTriggerHidden();
-                  }}
-                />
-              </span>
-              <DiffModeToggle splitDisabled={narrowPane} />
+              {canPreview && (
+                <MarkdownViewToggle view={mdView} onChange={setMdView} />
+              )}
+              {/* The picker and Unified/Split configure the raw diff, so they
+                  leave the cluster while Preview is up — the same swap this
+                  row already does for the selection actions. */}
+              {!previewOn && (
+                <>
+                  {/* Same treatment as the read-only surface's toolbar: the
+                      picker is this row's only variable-width control (its
+                      label follows the language name), so it goes under @md to
+                      give the row a fixed floor — but stays laid out while its
+                      popup is open, since Base UI anchors to the trigger and a
+                      display:none trigger positions the popup at 0,0.
+                      `empty:hidden` keeps the row's gap off an extensionless
+                      file. */}
+                  <span
+                    ref={langWrapRef}
+                    className="hidden @md/staging-pane:flex empty:hidden has-[[data-popup-open]]:flex"
+                  >
+                    <DiffLanguagePicker
+                      filePath={file.path}
+                      open={langOpen}
+                      onOpenChange={(open) => {
+                        setLangOpen(open);
+                        if (!open) returnFocusIfTriggerHidden();
+                      }}
+                    />
+                  </span>
+                  <DiffModeToggle splitDisabled={narrowPane} />
+                </>
+              )}
             </>
           )}
         </span>
@@ -521,59 +563,65 @@ function WorkingTreeDiff({
             />
           </div>
         )}
-        {(settings.data?.showLineStageHint ?? true) && (
-          <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
-            <InfoIcon className="size-3.5 shrink-0" />
-            <span className="flex-1 leading-snug">
-              Drag across the line numbers to{" "}
-              {file.staged ? "unstage" : "stage"} just those lines. Hold{" "}
-              {ADDITIVE_MODIFIER} while dragging to add to the selection, so one
-              selection can mix added and removed lines.
-              {selectionBinding !== null && (
-                <>
-                  {" "}
-                  Press {formatBinding(selectionBinding)} to{" "}
-                  {file.staged ? "unstage" : "stage"} the selection.
-                </>
-              )}
-            </span>
-            <button
-              type="button"
-              onClick={() =>
-                settings.data &&
-                saveSettings.mutate({
-                  ...settings.data,
-                  showLineStageHint: false,
-                })
+        {previewOn ? (
+          <MarkdownDocPreview
+            repoPath={repoPath}
+            filePath={file.path}
+            revs={workingRevs}
+          />
+        ) : (
+          <>
+            {/* The drag-the-line-numbers hint is about the staging gutter, so
+                it stays out of Preview, which has no line numbers at all. */}
+            {(settings.data?.showLineStageHint ?? true) && (
+              <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+                <InfoIcon className="size-3.5 shrink-0" />
+                <span className="flex-1 leading-snug">
+                  Drag across the line numbers to{" "}
+                  {file.staged ? "unstage" : "stage"} just those lines. Hold{" "}
+                  {ADDITIVE_MODIFIER} while dragging to add to the selection, so
+                  one selection can mix added and removed lines.
+                  {selectionBinding !== null && (
+                    <>
+                      {" "}
+                      Press {formatBinding(selectionBinding)} to{" "}
+                      {file.staged ? "unstage" : "stage"} the selection.
+                    </>
+                  )}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    settings.data &&
+                    saveSettings.mutate({
+                      ...settings.data,
+                      showLineStageHint: false,
+                    })
+                  }
+                  className="shrink-0 font-medium whitespace-nowrap underline underline-offset-2 hover:no-underline"
+                >
+                  Don't show again
+                </button>
+              </div>
+            )}
+            <StagingDiffView
+              repoPath={repoPath}
+              filePath={file.path}
+              diffText={diff.data?.text ?? ""}
+              contentRevs={workingRevs}
+              viewMode={viewMode}
+              isDark={isDark}
+              hunks={parsed.hunks}
+              staged={file.staged}
+              busy={busy}
+              selection={selection}
+              onSelect={(lines, forText) =>
+                setSelectionState(lines === null ? null : { lines, forText })
               }
-              className="shrink-0 font-medium whitespace-nowrap underline underline-offset-2 hover:no-underline"
-            >
-              Don't show again
-            </button>
-          </div>
+              onHunkAction={onHunkAction}
+            />
+          </>
         )}
-        <StagingDiffView
-          repoPath={repoPath}
-          filePath={file.path}
-          diffText={diff.data?.text ?? ""}
-          contentRevs={
-            untracked
-              ? { newRev: null }
-              : file.staged
-                ? { oldRev: "HEAD", newRev: ":0" }
-                : { oldRev: ":0", newRev: null }
-          }
-          viewMode={viewMode}
-          isDark={isDark}
-          hunks={parsed.hunks}
-          staged={file.staged}
-          busy={busy}
-          selection={selection}
-          onSelect={(lines, forText) =>
-            setSelectionState(lines === null ? null : { lines, forText })
-          }
-          onHunkAction={onHunkAction}
-        />
       </div>
 
       <Dialog

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -299,6 +299,16 @@ function WorkingTreeDiff({
     if (discard !== null && discard.forText !== liveText) setDiscard(null);
   }, [discard, liveText]);
 
+  // Full-text revs aligned to the diff's actual sides: staged = HEAD↔index,
+  // unstaged = index↔worktree, added = worktree only. ONE derivation for both
+  // arms — the fallback surface, the staging view's highlight context, and the
+  // markdown preview must all read the same pair.
+  const workingRevs: DiffContentRevs = untracked
+    ? { newRev: null }
+    : file.staged
+      ? { oldRev: "HEAD", newRev: ":0" }
+      : { oldRev: ":0", newRev: null };
+
   if (!hunkMode) {
     return (
       <DiffSurface
@@ -309,15 +319,7 @@ function WorkingTreeDiff({
         imageRevs={
           file.staged ? { old: "HEAD", new: ":0" } : { old: "HEAD", new: null }
         }
-        // Full-text highlight context, aligned to the diff's actual sides:
-        // staged = HEAD↔index, unstaged = index↔worktree, added = worktree only.
-        contentRevs={
-          untracked
-            ? { newRev: null }
-            : file.staged
-              ? { oldRev: "HEAD", newRev: ":0" }
-              : { oldRev: ":0", newRev: null }
-        }
+        contentRevs={workingRevs}
       />
     );
   }
@@ -373,15 +375,6 @@ function WorkingTreeDiff({
       { onError, onSuccess: clearSelection },
     );
   }
-
-  // Full-text revs aligned to the diff's actual sides: staged = HEAD↔index,
-  // unstaged = index↔worktree, added = worktree only. One pair feeds both the
-  // staging view's highlight context and the markdown preview.
-  const workingRevs: DiffContentRevs = untracked
-    ? { newRev: null }
-    : file.staged
-      ? { oldRev: "HEAD", newRev: ":0" }
-      : { oldRev: ":0", newRev: null };
 
   // A whole-hunk action, fired by the per-hunk overlay buttons.
   function onHunkAction(hunk: DiffHunk, kind: "stage" | "unstage" | "discard") {

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -74,11 +75,11 @@ import {
 import { fileExt } from "./diff-lang";
 import { ImagePanes } from "./ImageDiff";
 import {
+  canPreviewMarkdown,
   type MarkdownDiffView,
   MarkdownDocPreview,
   MarkdownViewToggle,
 } from "./MarkdownPreview";
-import { isMarkdownPath } from "./markdown-preview";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
 import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
 
@@ -171,6 +172,15 @@ function WorkingTreeDiff({
   const untracked =
     !file.staged &&
     (liveEntry ? liveEntry.unstaged === "untracked" : file.untracked);
+  // Full-text revs aligned to the diff's actual sides: staged = HEAD↔index,
+  // unstaged = index↔worktree, added = worktree only. ONE derivation for both
+  // arms — the fallback surface, the staging view's highlight context, the
+  // markdown preview, and the preview-availability predicate all read it.
+  const workingRevs: DiffContentRevs = untracked
+    ? { newRev: null }
+    : file.staged
+      ? { oldRev: "HEAD", newRev: ":0" }
+      : { oldRev: ":0", newRev: null };
   const diff = useFileDiff(repoPath, { ...file, untracked });
   const applyPatch = useApplyPatch(repoPath);
   const applyPartial = useApplyPartial(repoPath);
@@ -256,9 +266,21 @@ function WorkingTreeDiff({
       : null;
   // Preview swaps the staging view out entirely, so the selection actions and
   // the toggle can never be on screen together (the selection arm owns the
-  // whole cluster while a drag selection exists).
-  const canPreview = hunkMode && isMarkdownPath(file.path);
+  // whole cluster while a drag selection exists). Same predicate as the
+  // read-only surface, so the two hosts can't drift on what's previewable.
+  const canPreview =
+    hunkMode && canPreviewMarkdown(file.path, repoPath, workingRevs);
   const previewOn = canPreview && mdView === "preview";
+  // A palette-driven flip unmounts the control that held focus (the picker and
+  // Unified/Split leave the cluster entering Preview), dropping focus to
+  // <body>; land it on the cluster's silent landing spot instead. Change-only
+  // (prev-ref guard), so a mount can never steal focus from elsewhere.
+  const prevPreviewOnRef = useRef(previewOn);
+  useLayoutEffect(() => {
+    if (prevPreviewOnRef.current === previewOn) return;
+    prevPreviewOnRef.current = previewOn;
+    if (document.activeElement === document.body) controlsRef.current?.focus();
+  }, [previewOn, controlsRef]);
   // One contextual chord: stage the selection on an unstaged file's diff,
   // unstage it on a staged one — mirroring the toolbar's primary button. Dead
   // while the Discard confirm is open (the global listener has no dialog guard)
@@ -298,16 +320,6 @@ function WorkingTreeDiff({
   useEffect(() => {
     if (discard !== null && discard.forText !== liveText) setDiscard(null);
   }, [discard, liveText]);
-
-  // Full-text revs aligned to the diff's actual sides: staged = HEAD↔index,
-  // unstaged = index↔worktree, added = worktree only. ONE derivation for both
-  // arms — the fallback surface, the staging view's highlight context, and the
-  // markdown preview must all read the same pair.
-  const workingRevs: DiffContentRevs = untracked
-    ? { newRev: null }
-    : file.staged
-      ? { oldRev: "HEAD", newRev: ":0" }
-      : { oldRev: ":0", newRev: null };
 
   if (!hunkMode) {
     return (

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -8,7 +8,6 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -81,7 +80,10 @@ import {
   MarkdownViewToggle,
 } from "./MarkdownPreview";
 import { SPLIT_MIN_CONTAINER_PX } from "./split-threshold";
-import { useHiddenTriggerFocus } from "./use-hidden-trigger-focus";
+import {
+  useFocusOnControlsSwap,
+  useHiddenTriggerFocus,
+} from "./use-hidden-trigger-focus";
 
 /** Working-tree diff for the file selected in the changes panel. */
 export function DiffViewer({ repoPath }: { repoPath: string }) {
@@ -271,16 +273,7 @@ function WorkingTreeDiff({
   const canPreview =
     hunkMode && canPreviewMarkdown(file.path, repoPath, workingRevs);
   const previewOn = canPreview && mdView === "preview";
-  // A palette-driven flip unmounts the control that held focus (the picker and
-  // Unified/Split leave the cluster entering Preview), dropping focus to
-  // <body>; land it on the cluster's silent landing spot instead. Change-only
-  // (prev-ref guard), so a mount can never steal focus from elsewhere.
-  const prevPreviewOnRef = useRef(previewOn);
-  useLayoutEffect(() => {
-    if (prevPreviewOnRef.current === previewOn) return;
-    prevPreviewOnRef.current = previewOn;
-    if (document.activeElement === document.body) controlsRef.current?.focus();
-  }, [previewOn, controlsRef]);
+  useFocusOnControlsSwap(previewOn, controlsRef);
   // One contextual chord: stage the selection on an unstaged file's diff,
   // unstage it on a staged one — mirroring the toolbar's primary button. Dead
   // while the Discard confirm is open (the global listener has no dialog guard)

--- a/src/features/diff/MarkdownPreview.tsx
+++ b/src/features/diff/MarkdownPreview.tsx
@@ -1,0 +1,155 @@
+import { InfoIcon } from "@phosphor-icons/react";
+import { type ReactNode, useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import { Markdown } from "@/components/ui/markdown";
+import { decodeBase64Utf8 } from "@/lib/git/api";
+import { useFileAtRev } from "@/lib/git/queries";
+import { DiffPlaceholder } from "./DiffPlaceholder";
+import type { DiffContentRevs } from "./DiffSurface";
+import {
+  cleanMarkdownForPreview,
+  isMarkdownPath,
+  isMdxPath,
+  PREVIEW_MAX_CHARS,
+} from "./markdown-preview";
+
+/** The diff pane's view of a markdown file. A later rich-diff mode joins this
+ *  union as a third toggle segment. */
+export type MarkdownDiffView = "raw" | "preview";
+
+/** Preview needs somewhere to read the file's text from — surfaces that pass
+ *  no revs (the PR views) keep the plain raw diff, with no inert control. */
+export function canPreviewMarkdown(
+  filePath: string,
+  repoPath: string | undefined,
+  revs: DiffContentRevs | undefined,
+): boolean {
+  return (
+    isMarkdownPath(filePath) &&
+    !!repoPath &&
+    revs !== undefined &&
+    (revs.oldRev !== undefined || revs.newRev !== undefined)
+  );
+}
+
+/** The Raw ⇄ Preview segment pair, same vocabulary as {@link DiffModeToggle}. */
+export function MarkdownViewToggle({
+  view,
+  onChange,
+}: {
+  view: MarkdownDiffView;
+  onChange: (view: MarkdownDiffView) => void;
+}) {
+  return (
+    <ButtonGroup aria-label="Markdown view">
+      <Button
+        variant={view === "raw" ? "secondary" : "ghost"}
+        size="xs"
+        aria-pressed={view === "raw"}
+        onClick={() => onChange("raw")}
+      >
+        Raw
+      </Button>
+      <Button
+        variant={view === "preview" ? "secondary" : "ghost"}
+        size="xs"
+        aria-pressed={view === "preview"}
+        onClick={() => onChange("preview")}
+      >
+        Preview
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+/** One-line disclosure strip above the rendered body (same treatment as the
+ *  working-tree line-stage hint). */
+function PreviewNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+      <InfoIcon className="size-3.5 shrink-0" />
+      <span className="leading-snug">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * Rendered view of a markdown/MDX file for the diff pane's Preview mode: the
+ * NEW side of the change (a deleted file falls back to the old side, with a
+ * note). Reads share content mode's file-at-rev cache but deliberately don't
+ * depend on content mode itself — a long README past its line/char caps (or a
+ * truncated diff) is exactly the file that most wants a preview.
+ */
+export function MarkdownDocPreview({
+  repoPath,
+  filePath,
+  revs,
+}: {
+  repoPath: string;
+  filePath: string;
+  /** Must be the same pair the raw diff renders from. */
+  revs: DiffContentRevs;
+}) {
+  const hasNew = revs.newRev !== undefined;
+  const hasOld = revs.oldRev !== undefined;
+  const newQ = useFileAtRev(repoPath, revs.newRev ?? null, filePath, hasNew);
+  // The old side is read only once it's the side to show, so the common case
+  // costs one IPC read. Each read is gated on its own rev being defined, which
+  // is what keeps a disabled null-rev read from cache-hitting the other side.
+  const newAbsent =
+    hasNew && !newQ.isPending && !newQ.isError && newQ.data === null;
+  const showOld = hasOld && (!hasNew || newAbsent);
+  const oldQ = useFileAtRev(repoPath, revs.oldRev ?? null, filePath, showOld);
+  const activeQ = showOld ? oldQ : newQ;
+  const b64 = activeQ.data;
+  const text = useMemo(
+    () => (typeof b64 === "string" ? decodeBase64Utf8(b64) : null),
+    [b64],
+  );
+  const cleaned = useMemo(
+    () =>
+      text !== null && text.length <= PREVIEW_MAX_CHARS
+        ? cleanMarkdownForPreview(text, filePath)
+        : null,
+    [text, filePath],
+  );
+
+  if (!hasNew && !hasOld) {
+    return <DiffPlaceholder message="Nothing to preview" />;
+  }
+  // Local reads settle near-instantly — render nothing on the way, the same
+  // no-flash rule as the diff itself.
+  if (activeQ.isPending) return null;
+  if (activeQ.isError) {
+    return <DiffPlaceholder message="Could not load this file to preview" />;
+  }
+  if (text === null) {
+    return <DiffPlaceholder message="Nothing to preview" />;
+  }
+  if (cleaned === null) {
+    return <DiffPlaceholder message="File too large to preview" />;
+  }
+  if (cleaned.trim() === "") {
+    return <DiffPlaceholder message="Nothing to preview" />;
+  }
+  return (
+    <div>
+      {showOld && (
+        <PreviewNote>
+          File deleted — previewing the previous version.
+        </PreviewNote>
+      )}
+      {isMdxPath(filePath) && (
+        <PreviewNote>
+          Approximate preview: MDX components and expressions render as plain
+          text.
+        </PreviewNote>
+      )}
+      {/* Same reading measure as the in-app guide's rendered pages. */}
+      <div className="mx-auto w-full max-w-2xl p-6">
+        <Markdown>{cleaned}</Markdown>
+      </div>
+    </div>
+  );
+}

--- a/src/features/diff/MarkdownPreview.tsx
+++ b/src/features/diff/MarkdownPreview.tsx
@@ -103,9 +103,15 @@ export function MarkdownDocPreview({
   const oldQ = useFileAtRev(repoPath, revs.oldRev ?? null, filePath, showOld);
   const activeQ = showOld ? oldQ : newQ;
   const b64 = activeQ.data;
+  // The backend caps reads at 20MB — far past the preview cap — so a clearly
+  // oversized file is rejected on its base64 length instead of being decoded
+  // first: UTF-8 yields at least one UTF-16 unit per 3 bytes, so past 4× the
+  // cap in base64 (3× in bytes) the decoded length cannot come in under it.
+  const tooLarge =
+    typeof b64 === "string" && b64.length > PREVIEW_MAX_CHARS * 4;
   const text = useMemo(
-    () => (typeof b64 === "string" ? decodeBase64Utf8(b64) : null),
-    [b64],
+    () => (typeof b64 === "string" && !tooLarge ? decodeBase64Utf8(b64) : null),
+    [b64, tooLarge],
   );
   const cleaned = useMemo(
     () =>
@@ -124,6 +130,9 @@ export function MarkdownDocPreview({
   if (activeQ.isError) {
     return <DiffPlaceholder message="Could not load this file to preview" />;
   }
+  if (tooLarge) {
+    return <DiffPlaceholder message="File too large to preview" />;
+  }
   if (text === null) {
     return <DiffPlaceholder message="Nothing to preview" />;
   }
@@ -133,21 +142,19 @@ export function MarkdownDocPreview({
   if (cleaned.trim() === "") {
     return <DiffPlaceholder message="Nothing to preview" />;
   }
+  // Repo docs routinely carry repository-relative hrefs (LICENSE, docs/…).
+  // The shared renderer's dispatch opens only http(s)/mailto externally and
+  // leaves every other anchor its default navigation — which in the webview
+  // walks the SPA away to the app's own origin. Capture-phase, and on BOTH
+  // click and auxclick: a middle-click's default open rides auxclick, which
+  // never fires click. Mirrors markdown.tsx's module-private EXTERNAL_HREF
+  // set, kept in sync by hand.
+  const guardLinkClick = (e: React.MouseEvent) => {
+    const href = (e.target as HTMLElement).closest("a")?.getAttribute("href");
+    if (href && !/^(https?:|mailto:)/i.test(href)) e.preventDefault();
+  };
   return (
-    // Repo docs routinely carry repository-relative hrefs (LICENSE, docs/…).
-    // The shared renderer's dispatch opens only http(s)/mailto externally and
-    // leaves every other anchor its default navigation — which in the webview
-    // walks the SPA away to the app's own origin. Capture-phase, so this runs
-    // before that dispatch. Mirrors markdown.tsx's module-private
-    // EXTERNAL_HREF set, kept in sync by hand.
-    <div
-      onClickCapture={(e) => {
-        const href = (e.target as HTMLElement)
-          .closest("a")
-          ?.getAttribute("href");
-        if (href && !/^(https?:|mailto:)/i.test(href)) e.preventDefault();
-      }}
-    >
+    <div onClickCapture={guardLinkClick} onAuxClickCapture={guardLinkClick}>
       {showOld && (
         <PreviewNote>
           File deleted — previewing the previous version.

--- a/src/features/diff/MarkdownPreview.tsx
+++ b/src/features/diff/MarkdownPreview.tsx
@@ -95,8 +95,8 @@ export function MarkdownDocPreview({
   const hasOld = revs.oldRev !== undefined;
   const newQ = useFileAtRev(repoPath, revs.newRev ?? null, filePath, hasNew);
   // The old side is read only once it's the side to show, so the common case
-  // costs one IPC read. Each read is gated on its own rev being defined, which
-  // is what keeps a disabled null-rev read from cache-hitting the other side.
+  // costs one IPC read. Every ENABLED read has a defined rev, which is what
+  // keeps a disabled null-rev read from cache-hitting the other side.
   const newAbsent =
     hasNew && !newQ.isPending && !newQ.isError && newQ.data === null;
   const showOld = hasOld && (!hasNew || newAbsent);
@@ -134,7 +134,20 @@ export function MarkdownDocPreview({
     return <DiffPlaceholder message="Nothing to preview" />;
   }
   return (
-    <div>
+    // Repo docs routinely carry repository-relative hrefs (LICENSE, docs/…).
+    // The shared renderer's dispatch opens only http(s)/mailto externally and
+    // leaves every other anchor its default navigation — which in the webview
+    // walks the SPA away to the app's own origin. Capture-phase, so this runs
+    // before that dispatch. Mirrors markdown.tsx's module-private
+    // EXTERNAL_HREF set, kept in sync by hand.
+    <div
+      onClickCapture={(e) => {
+        const href = (e.target as HTMLElement)
+          .closest("a")
+          ?.getAttribute("href");
+        if (href && !/^(https?:|mailto:)/i.test(href)) e.preventDefault();
+      }}
+    >
       {showOld && (
         <PreviewNote>
           File deleted — previewing the previous version.

--- a/src/features/diff/markdown-preview.ts
+++ b/src/features/diff/markdown-preview.ts
@@ -11,34 +11,42 @@ export function isMdxPath(filePath: string): boolean {
   return fileExt(filePath) === "mdx";
 }
 
-// Preview parses + sanitizes + injects the whole document synchronously, so a
-// pathological file gets a placeholder instead of a freeze (the pane's
-// no-freeze invariant, same as the diff renderer's caps).
-export const PREVIEW_MAX_CHARS = 2_000_000;
+// Past this the preview shows a placeholder instead of parsing: marked, the
+// hljs fence pass, and DOMPurify all run synchronously on the main thread, so
+// the budget stays in the diff's own highlight-cap band
+// (HIGHLIGHT_MAX_CHARS_HLJS = 400_000).
+export const PREVIEW_MAX_CHARS = 400_000;
 
 const stripCr = (line: string): string =>
   line.endsWith("\r") ? line.slice(0, -1) : line;
 
 /**
- * Drop a leading YAML frontmatter block. marked renders one as an `<hr>`
- * followed by a giant setext `<h2>` of the raw YAML (the closing `---`
- * underlines it), so every Astro/Jekyll/Hugo post would open its preview with
- * heading-sized YAML. An unterminated opener is left alone (it's a thematic
- * break, not frontmatter).
+ * Drop a leading YAML (`---`) or TOML (`+++`) frontmatter block. marked
+ * renders a YAML block as an `<hr>` plus a giant setext `<h2>` of the raw
+ * YAML (the closing `---` underlines it), so every Astro/Jekyll/Hugo post
+ * would open its preview with heading-sized YAML. The scan bails at a blank
+ * line or a missing closer: a doc that merely opens with a thematic break
+ * keeps its content — this fails toward showing text, never toward eating it.
  */
 function stripFrontmatter(text: string): string {
   const lines = text.split("\n");
-  if (stripCr(lines[0] ?? "") !== "---") return text;
+  const open = stripCr(lines[0] ?? "");
+  if (open !== "---" && open !== "+++") return text;
   for (let i = 1; i < lines.length; i++) {
     const line = stripCr(lines[i]);
-    if (line === "---" || line === "...") return lines.slice(i + 1).join("\n");
+    if (line === open) return lines.slice(i + 1).join("\n");
+    if (line.trim() === "") return text;
   }
   return text;
 }
 
-// CommonMark fences: up to 3 leading spaces; closing needs the same char and
-// at least the opening run's length.
+// CommonMark fences: up to 3 leading spaces; closing needs the same char, at
+// least the opening run's length, and no info string — a fenced example like
+// ```js inside an open block must not close it.
 const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+const FENCE_CLOSE_RE = /^ {0,3}(`{3,}|~{3,})\s*$/;
+// An indented (≥4-space) line is a markdown code block — never transformed.
+const INDENTED_CODE_RE = /^(?: {4}|\t)/;
 // In MDX, any block starting with these words IS an ESM block (prose that
 // starts a line with them is a compile error there), running to the next
 // blank line.
@@ -51,9 +59,10 @@ const INLINE_CODE_RE = /(`[^`]*`)/;
 
 /**
  * Make MDX renderable by the plain markdown pipeline: drop top-level
- * import/export blocks and unwrap component JSX tags (keeping their text
- * children), leaving fenced code untouched. `{expr}` stays literal. The result
- * is approximate BY DESIGN — components resolve against the host project's own
+ * import/export blocks and unwrap single-line component JSX tags (keeping
+ * their text children), leaving fenced and indented code untouched. `{expr}`
+ * stays literal and a multi-line opening tag survives as text. The result is
+ * approximate BY DESIGN — components resolve against the host project's own
  * build, which this app cannot see, and compiling/evaluating MDX to close that
  * gap would be arbitrary code execution from repo content. Never do it.
  */
@@ -66,7 +75,7 @@ function cleanMdx(text: string): string {
     const line = stripCr(raw);
     if (fence !== null) {
       out.push(raw);
-      const close = line.match(FENCE_RE)?.[1];
+      const close = line.match(FENCE_CLOSE_RE)?.[1];
       if (close && close[0] === fence[0] && close.length >= fence.length) {
         fence = null;
       }
@@ -93,18 +102,20 @@ function cleanMdx(text: string): string {
     }
     prevBlank = line.trim() === "";
     out.push(
-      raw
-        .split(INLINE_CODE_RE)
-        .map((seg, i) => (i % 2 === 1 ? seg : seg.replace(JSX_TAG_RE, "")))
-        .join(""),
+      INDENTED_CODE_RE.test(line)
+        ? raw
+        : raw
+            .split(INLINE_CODE_RE)
+            .map((seg, i) => (i % 2 === 1 ? seg : seg.replace(JSX_TAG_RE, "")))
+            .join(""),
     );
   }
   return out.join("\n");
 }
 
 /** The pre-pass handing diff-pane text to the shared `<Markdown>` renderer.
- *  Lives here at the call-site layer deliberately — the shared component has
- *  31 consumers that must keep rendering their input verbatim. */
+ *  Lives here at the call-site layer deliberately — the shared component's
+ *  consumers must keep rendering their input verbatim. */
 export function cleanMarkdownForPreview(
   text: string,
   filePath: string,

--- a/src/features/diff/markdown-preview.ts
+++ b/src/features/diff/markdown-preview.ts
@@ -1,0 +1,114 @@
+import { fileExt } from "./diff-lang";
+
+/** Extensions the diff pane offers a rendered Preview for. */
+const MARKDOWN_EXTS = new Set(["md", "markdown", "mdx"]);
+
+export function isMarkdownPath(filePath: string): boolean {
+  return MARKDOWN_EXTS.has(fileExt(filePath));
+}
+
+export function isMdxPath(filePath: string): boolean {
+  return fileExt(filePath) === "mdx";
+}
+
+// Preview parses + sanitizes + injects the whole document synchronously, so a
+// pathological file gets a placeholder instead of a freeze (the pane's
+// no-freeze invariant, same as the diff renderer's caps).
+export const PREVIEW_MAX_CHARS = 2_000_000;
+
+const stripCr = (line: string): string =>
+  line.endsWith("\r") ? line.slice(0, -1) : line;
+
+/**
+ * Drop a leading YAML frontmatter block. marked renders one as an `<hr>`
+ * followed by a giant setext `<h2>` of the raw YAML (the closing `---`
+ * underlines it), so every Astro/Jekyll/Hugo post would open its preview with
+ * heading-sized YAML. An unterminated opener is left alone (it's a thematic
+ * break, not frontmatter).
+ */
+function stripFrontmatter(text: string): string {
+  const lines = text.split("\n");
+  if (stripCr(lines[0] ?? "") !== "---") return text;
+  for (let i = 1; i < lines.length; i++) {
+    const line = stripCr(lines[i]);
+    if (line === "---" || line === "...") return lines.slice(i + 1).join("\n");
+  }
+  return text;
+}
+
+// CommonMark fences: up to 3 leading spaces; closing needs the same char and
+// at least the opening run's length.
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+// In MDX, any block starting with these words IS an ESM block (prose that
+// starts a line with them is a compile error there), running to the next
+// blank line.
+const ESM_START_RE = /^(?:import|export)\s/;
+// Capitalized (component) JSX tags and fragments only — lowercase HTML in
+// markdown already flows through marked + DOMPurify.
+const JSX_TAG_RE = /<\/?[A-Z][\w.]*(?:\s[^<>]*)?\/?>|<\/?>/g;
+// Split that keeps inline code spans (odd indexes) untouched.
+const INLINE_CODE_RE = /(`[^`]*`)/;
+
+/**
+ * Make MDX renderable by the plain markdown pipeline: drop top-level
+ * import/export blocks and unwrap component JSX tags (keeping their text
+ * children), leaving fenced code untouched. `{expr}` stays literal. The result
+ * is approximate BY DESIGN — components resolve against the host project's own
+ * build, which this app cannot see, and compiling/evaluating MDX to close that
+ * gap would be arbitrary code execution from repo content. Never do it.
+ */
+function cleanMdx(text: string): string {
+  const out: string[] = [];
+  let fence: string | null = null;
+  let inEsm = false;
+  let prevBlank = true;
+  for (const raw of text.split("\n")) {
+    const line = stripCr(raw);
+    if (fence !== null) {
+      out.push(raw);
+      const close = line.match(FENCE_RE)?.[1];
+      if (close && close[0] === fence[0] && close.length >= fence.length) {
+        fence = null;
+      }
+      continue;
+    }
+    if (inEsm) {
+      if (line.trim() === "") {
+        inEsm = false;
+        prevBlank = true;
+        out.push(raw);
+      }
+      continue;
+    }
+    const open = line.match(FENCE_RE)?.[1];
+    if (open) {
+      fence = open;
+      prevBlank = false;
+      out.push(raw);
+      continue;
+    }
+    if (prevBlank && ESM_START_RE.test(line)) {
+      inEsm = true;
+      continue;
+    }
+    prevBlank = line.trim() === "";
+    out.push(
+      raw
+        .split(INLINE_CODE_RE)
+        .map((seg, i) => (i % 2 === 1 ? seg : seg.replace(JSX_TAG_RE, "")))
+        .join(""),
+    );
+  }
+  return out.join("\n");
+}
+
+/** The pre-pass handing diff-pane text to the shared `<Markdown>` renderer.
+ *  Lives here at the call-site layer deliberately — the shared component has
+ *  31 consumers that must keep rendering their input verbatim. */
+export function cleanMarkdownForPreview(
+  text: string,
+  filePath: string,
+): string {
+  const body = stripFrontmatter(text);
+  return isMdxPath(filePath) ? cleanMdx(body) : body;
+}

--- a/src/features/diff/use-hidden-trigger-focus.ts
+++ b/src/features/diff/use-hidden-trigger-focus.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useRef } from "react";
+import { type RefObject, useLayoutEffect, useRef } from "react";
 
 /**
  * Focus rescue for a popover whose trigger can be hidden by a container query.
@@ -25,4 +25,23 @@ export function useHiddenTriggerFocus(): {
       }
     });
   return { wrapRef, controlsRef, returnFocusIfTriggerHidden };
+}
+
+/**
+ * Focus rescue for a mode swap that unmounts the control holding focus (a
+ * palette-driven flip — the picker and mode toggle leave the cluster),
+ * dropping focus to `<body>`; land it on `controlsRef`'s silent landing spot
+ * instead. Change-only (prev-ref guard), so a mount can never steal focus
+ * from elsewhere.
+ */
+export function useFocusOnControlsSwap(
+  active: boolean,
+  controlsRef: RefObject<HTMLSpanElement | null>,
+) {
+  const prevRef = useRef(active);
+  useLayoutEffect(() => {
+    if (prevRef.current === active) return;
+    prevRef.current = active;
+    if (document.activeElement === document.body) controlsRef.current?.focus();
+  }, [active, controlsRef]);
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -411,13 +411,13 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **Markdown preview** — markdown and MDX diffs add a **Raw / Preview** toggle to the
   diff toolbar. **Preview** renders the file's new version as formatted prose
   (headings, tables, highlighted code fences), so a docs change reads the way it will
-  ship; a deleted file previews its last version instead, and frontmatter stays out of
-  the render. MDX renders approximately: components and expressions appear as plain
-  text. **Raw** stays the default for every file. The toggle appears on the working
-  tree, commit details, stashes, and an agent session's worktree changes; a pull
-  request's **Files** tab, which reads from the remote, doesn't offer it. *Toggle
-  Markdown preview* in the command palette (palette-only by default — bind a key in
-  **Settings → Keyboard**) flips it too.
+  ship; a deleted file previews its last version instead, and frontmatter (an unbroken
+  leading \`---\` or \`+++\` block) stays out of the render. MDX renders approximately:
+  components and expressions appear as plain text. **Raw** stays the default for
+  every file. The toggle appears on the working tree, commit details, stashes, and an
+  agent session's worktree changes; a pull request's **Files** tab, which reads from
+  the remote, doesn't offer it. *Toggle Markdown preview* in the command palette
+  (palette-only by default — bind a key in **Settings → Keyboard**) flips it too.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
 - Files that look **generated or minified** (one enormous line — bundles, source maps,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -408,6 +408,16 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   between the old and new sides; at **100%** the arrow keys pan the zoomed image, and
   Esc closes either way. The **SVG** preview above a text diff and the image diffs
   inside the stashes dialog open the same viewer.
+- **Markdown preview** — markdown and MDX diffs add a **Raw / Preview** toggle to the
+  diff toolbar. **Preview** renders the file's new version as formatted prose
+  (headings, tables, highlighted code fences), so a docs change reads the way it will
+  ship; a deleted file previews its last version instead, and frontmatter stays out of
+  the render. MDX renders approximately: components and expressions appear as plain
+  text. **Raw** stays the default for every file. The toggle appears wherever the file
+  is available locally — the working tree, commit details, and stashes — so a pull
+  request's **Files** tab, which reads from the remote, doesn't offer it. *Toggle
+  Markdown preview* in the command palette (palette-only by default — bind a key in
+  **Settings → Keyboard**) flips it too.
 - Very large diffs are capped (with a **Show full diff** escape hatch) so a huge file
   never freezes the view.
 - Files that look **generated or minified** (one enormous line — bundles, source maps,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -413,8 +413,8 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   (headings, tables, highlighted code fences), so a docs change reads the way it will
   ship; a deleted file previews its last version instead, and frontmatter stays out of
   the render. MDX renders approximately: components and expressions appear as plain
-  text. **Raw** stays the default for every file. The toggle appears wherever the file
-  is available locally — the working tree, commit details, and stashes — so a pull
+  text. **Raw** stays the default for every file. The toggle appears on the working
+  tree, commit details, stashes, and an agent session's worktree changes; a pull
   request's **Files** tab, which reads from the remote, doesn't offer it. *Toggle
   Markdown preview* in the command palette (palette-only by default — bind a key in
   **Settings → Keyboard**) flips it too.

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -348,6 +348,14 @@ export const gitFileBase64 = (
   filePath: string,
 ) => invoke<string | null>("git_file_base64", { repoPath, rev, filePath });
 
+/** Decode base64 file bytes (from git_file_base64) to a UTF-8 string. */
+export function decodeBase64Utf8(b64: string): string {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
 export const gitApplyPatch = (
   repoPath: string,
   patch: string,

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -669,6 +669,14 @@ export const ACTIONS = [
     // hides at narrow pane widths.
     defaultBinding: null,
   },
+  {
+    id: "toggle-markdown-preview",
+    label: "Toggle Markdown preview",
+    category: "Changes",
+    // Palette-only: live only while a markdown/MDX diff with readable local
+    // revs is on screen (the toolbar's Raw ⇄ Preview control).
+    defaultBinding: null,
+  },
 
   // Agent (only live on the Agent tab, which exists when AI features are on)
   {


### PR DESCRIPTION
Markdown and MDX diffs now carry a **Raw / Preview** toggle so a docs change can be read as rendered prose — headings, tables, highlighted code fences — instead of reconstructed from `+`/`-` lines. Preview reads the file at its rev rather than the diff text, so it also works on the long files whose diffs get truncated, which are the ones that want a preview most.

### Preview rendering

- Adds `src/features/diff/MarkdownPreview.tsx` with `MarkdownViewToggle` (the Raw ⇄ Preview segment pair), `MarkdownDocPreview` (renders the new side through the shared `<Markdown>` component), and `canPreviewMarkdown`, which requires a `repoPath` and a defined rev — so the PR **Files** tab, which reads from the remote, gets no inert control.
- `MarkdownDocPreview` falls back to the old side for a deleted file (with a `PreviewNote` strip saying so), renders nothing while the local read is pending to avoid a flash, and shows `DiffPlaceholder` copy for error, absent, empty, and over-cap files. The old-side query only runs once it's the side to show, keeping the common case at one IPC read.
- A capture-phase guard on the preview wrapper neutralizes repository-relative and other non-http(s)/mailto links, which would otherwise keep default navigation and walk the webview off the app; the same class on the shared renderer's other consumers is recorded as follow-up work.
- Adds `src/features/diff/markdown-preview.ts` with the pure text pre-pass: `isMarkdownPath` / `isMdxPath` (`md`, `markdown`, `mdx`), `PREVIEW_MAX_CHARS` (400K — the same band as the diff's own highlight caps, guarding the synchronous parse/sanitize/inject against a freeze), frontmatter stripping for YAML `---` and TOML `+++` (bailing at a blank line, so a doc that merely opens with a thematic break keeps its content; marked would otherwise render YAML frontmatter as an `<hr>` plus a setext `<h2>` of raw YAML), and `cleanMdx`, which drops top-level `import`/`export` blocks and unwraps single-line capitalized JSX tags while leaving fenced, indented, and inline code intact. MDX is deliberately approximate — a note strip says so — because resolving components would mean executing repo content.

### Diff surfaces and toolbar

- `src/features/diff/DiffSurface.tsx`: `DiffContent` holds per-file `mdView` state that resets to `raw` when `filePath` changes (never persisted), renders `MarkdownDocPreview` in place of `GitDiffView` when Preview is on, and passes the raw `contentRevs` rather than the truncation-stripped pair.
- `src/features/diff/DiffViewer.tsx`: `WorkingTreeDiff` gets the same toggle, hoists the staged/unstaged/untracked rev pair into a single `workingRevs` value feeding both `StagingDiffView` and the preview, and hides the drag-the-line-numbers hint in Preview since there is no staging gutter there.
- On both surfaces the language picker and the Unified/Split toggle leave the toolbar cluster while Preview is up, and `change-diff-language` is gated off so the palette action can't open an unmounted picker.
- Adds `aria-pressed` to both `DiffModeToggle` buttons alongside the new toggle's own pressed state.

### Plumbing

- Registers the `toggle-markdown-preview` action in `src/lib/hotkeys/registry.ts` under **Changes**, palette-only with no default binding; it's live only while a previewable markdown diff is on screen, and in the working tree it also stands down while a line selection or the Discard confirm is open.
- Moves `decodeBase64Utf8` out of `DiffSurface.tsx` into `src/lib/git/api.ts` next to `gitFileBase64` so both the diff surface and the preview share it.

### Documentation

- `README.md`: adds a paragraph to *Changes and commits* with the toggle and the four surfaces it applies to.
- `site/src/data/capabilities.ts`: new *Diffs & staging* capability line.
- `src/features/help/content.ts`: new **Markdown preview** bullet covering the toggle, the deleted-file and frontmatter behavior, the MDX caveat, why the PR **Files** tab doesn't offer it, and the palette action.
- `changelog.d/added-markdown-preview-toggle.md`: the Added fragment.

Relates to #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Raw/Preview toggle for Markdown and MDX files in diffs.
  * Preview renders formatted prose, excludes frontmatter, and supports deleted files using their last version.
  * Available across working tree changes, commits, stashes, and agent worktree changes.
  * Added a command palette action to toggle Markdown preview.
  * Improved focus handling and accessibility labels for diff controls.

* **Documentation**
  * Updated help content, capabilities, README, and changelog documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)