### PR TITLE
chore(cold-start,automations): isolate parallel cold instances and default automations off

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release:prepare": "node scripts/changelog-release.mjs",
     "release": "node scripts/release.mjs",
     "cold-start": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/cold-start.ps1",
+    "cold-start-instance": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/cold-start-instance.ps1",
     "tauri": "tauri",
     "dev:site": "pnpm --filter site dev",
     "build:site": "pnpm --filter site build"

--- a/scripts/cold-start-instance.ps1
+++ b/scripts/cold-start-instance.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Launch ONE additional cold-start instance, with its own isolated state, against
+  an already-running cold-start dev server.
+
+.DESCRIPTION
+  Starts an already-built debug exe and points it at a cold-start Vite server that
+  is already up. It never builds and never starts Vite: run `./scripts/cold-start.ps1`
+  first, wait for the window, then run this once per extra instance you want.
+
+  The -Id is exported as GD_INSTANCE_ID. The app reads it at boot and namespaces its
+  throwaway stores `coldstart-<Id>-<name>.json`, so parallel cold instances never
+  share settings, local PRs, notifications or branch rules. An instance launched
+  without an id keeps the plain `coldstart-<name>.json` files.
+
+  Each instance NEEDS its own -DataRoot. Without one, WebView2 silently attaches to
+  a sibling instance's browser process and this instance's remote-debugging port
+  never opens.
+
+  -Id, -DebugPort and -DataRoot must be unique across every cold instance running on
+  the MACHINE, whichever worktree built it. All builds share the app identifier, so
+  they all write %APPDATA%\com.thebguy.gitdesktop — two worktrees each launching
+  `-Id a` land in the same coldstart-a-*.json files and clobber each other.
+
+  The exe must belong to a COLD-START Vite server. Cold start is a build-time Vite
+  flag, so under a normal `pnpm tauri dev` the id is ignored by design and the
+  instance reads your REAL data.
+
+  Automations follow the VITE server's flags (-Automations on cold-start.ps1), not
+  this script: every instance that server feeds inherits the same setting.
+
+.PARAMETER Id
+  Instance id, matching ^[A-Za-z0-9-]{1,32}$. It becomes part of the store filenames.
+
+.PARAMETER DebugPort
+  Remote-debugging (CDP) port for this instance. Must not already be listening.
+
+.PARAMETER ExePath
+  The already-built debug exe. Defaults to src-tauri\target\debug\gitdesktop.exe.
+
+.PARAMETER DataRoot
+  WebView2 user-data folder for this instance. Defaults to %TEMP%\gd-coldstart-<Id>.
+
+.EXAMPLE
+  ./scripts/cold-start-instance.ps1 -Id b -DebugPort 9223
+  ./scripts/cold-start-instance.ps1 -Id c -DebugPort 9224 -DataRoot D:\temp\gd-c
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][string]$Id,
+  [Parameter(Mandatory)][int]$DebugPort,
+  [string]$ExePath,
+  [string]$DataRoot
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+if (-not $ExePath) { $ExePath = "$repoRoot\src-tauri\target\debug\gitdesktop.exe" }
+if (-not $DataRoot) { $DataRoot = Join-Path $env:TEMP "gd-coldstart-$Id" }
+
+if ($Id -notmatch '^[A-Za-z0-9-]{1,32}$') {
+  throw "Invalid -Id '$Id'. It becomes part of the store filenames (coldstart-$Id-settings.json), so only letters, digits and hyphens are allowed, 1-32 characters."
+}
+if (-not (Test-Path -LiteralPath $ExePath)) {
+  throw "No exe at $ExePath. This script never builds — start ./scripts/cold-start.ps1 first and let it finish building."
+}
+if (Get-NetTCPConnection -LocalPort $DebugPort -State Listen -ErrorAction SilentlyContinue) {
+  throw "Port $DebugPort is already listening. Give each instance its own free -DebugPort."
+}
+
+$env:GD_INSTANCE_ID = $Id
+$env:WEBVIEW2_USER_DATA_FOLDER = $DataRoot
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort"
+
+# Hidden hides only the console (debug exes are console-subsystem; the GUI window
+# shows itself regardless). Sibling stdout is lost — the watcher instance keeps logs.
+$proc = Start-Process $ExePath -WindowStyle Hidden -PassThru
+
+Write-Host "Launched cold-start instance '$Id'" -ForegroundColor Cyan
+Write-Host "  pid        = $($proc.Id)"
+Write-Host "  stores     = coldstart-$Id-*.json"
+Write-Host "  debug port = $DebugPort"
+Write-Host "  data root  = $DataRoot"

--- a/scripts/cold-start-instance.ps1
+++ b/scripts/cold-start-instance.ps1
@@ -19,36 +19,48 @@
 
   -Id, -DebugPort and -DataRoot must be unique across every cold instance running on
   the MACHINE, whichever worktree built it. All builds share the app identifier, so
-  they all write %APPDATA%\com.thebguy.gitdesktop — two worktrees each launching
+  they all write %APPDATA%\com.thebguy.gitdesktop: two worktrees each launching
   `-Id a` land in the same coldstart-a-*.json files and clobber each other.
 
   The exe must belong to a COLD-START Vite server. Cold start is a build-time Vite
   flag, so under a normal `pnpm tauri dev` the id is ignored by design and the
-  instance reads your REAL data.
+  instance reads your REAL data. -DevPort is checked for a listening dev server,
+  which proves one EXISTS but cannot prove it is a cold-start one: the flag lives in
+  the modules Vite serves and is not detectable from outside. That check is yours.
 
   Automations follow the VITE server's flags (-Automations on cold-start.ps1), not
   this script: every instance that server feeds inherits the same setting.
 
 .PARAMETER Id
-  Instance id, matching ^[A-Za-z0-9-]{1,32}$. It becomes part of the store filenames.
+  Instance id, matching ^[a-z0-9-]{1,32}\z: lowercase letters, digits and hyphens.
+  It becomes part of the store filenames, and those are case-insensitive on disk, so
+  ids have to be unique case-insensitively.
 
 .PARAMETER DebugPort
   Remote-debugging (CDP) port for this instance. Must not already be listening.
 
+.PARAMETER DevPort
+  Port the cold-start Vite server is already serving on. Defaults to 1420; a worktree
+  build serves its own port, so pass -DevPort 1430 for one of those.
+
 .PARAMETER ExePath
   The already-built debug exe. Defaults to src-tauri\target\debug\gitdesktop.exe.
+  Debug builds only: a release exe hands the launch to the instance already running
+  (the single-instance plugin) instead of opening a second window.
 
 .PARAMETER DataRoot
   WebView2 user-data folder for this instance. Defaults to %TEMP%\gd-coldstart-<Id>.
 
 .EXAMPLE
   ./scripts/cold-start-instance.ps1 -Id b -DebugPort 9223
-  ./scripts/cold-start-instance.ps1 -Id c -DebugPort 9224 -DataRoot D:\temp\gd-c
+  ./scripts/cold-start-instance.ps1 -Id c -DebugPort 9224 -DevPort 1430
+  ./scripts/cold-start-instance.ps1 -Id d -DebugPort 9225 -DataRoot D:\temp\gd-d
 #>
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)][string]$Id,
-  [Parameter(Mandatory)][int]$DebugPort,
+  [Parameter(Mandatory)][ValidateRange(1024, 65535)][int]$DebugPort,
+  [ValidateRange(1024, 65535)][int]$DevPort = 1420,
   [string]$ExePath,
   [string]$DataRoot
 )
@@ -59,14 +71,37 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 if (-not $ExePath) { $ExePath = "$repoRoot\src-tauri\target\debug\gitdesktop.exe" }
 if (-not $DataRoot) { $DataRoot = Join-Path $env:TEMP "gd-coldstart-$Id" }
 
-if ($Id -notmatch '^[A-Za-z0-9-]{1,32}$') {
-  throw "Invalid -Id '$Id'. It becomes part of the store filenames (coldstart-$Id-settings.json), so only letters, digits and hyphens are allowed, 1-32 characters."
+# -cnotmatch, not -notmatch: PowerShell's default match operators are case-INSENSITIVE,
+# which would let -Id A through here and leave the Rust validator to reject it, silently
+# dropping the instance back onto the shared coldstart- store files.
+if ($Id -cnotmatch '^[a-z0-9-]{1,32}\z') {
+  throw "Invalid -Id '$Id'. It becomes part of the store filenames (coldstart-$Id-settings.json), so only lowercase letters, digits and hyphens are allowed, 1-32 characters. Those filenames are case-insensitive on disk, so ids must be unique case-insensitively."
 }
 if (-not (Test-Path -LiteralPath $ExePath)) {
-  throw "No exe at $ExePath. This script never builds — start ./scripts/cold-start.ps1 first and let it finish building."
+  throw "No exe at $ExePath. This script never builds; start ./scripts/cold-start.ps1 first and let it finish building."
 }
 if (Get-NetTCPConnection -LocalPort $DebugPort -State Listen -ErrorAction SilentlyContinue) {
   throw "Port $DebugPort is already listening. Give each instance its own free -DebugPort."
+}
+if (-not (Get-NetTCPConnection -LocalPort $DevPort -State Listen -ErrorAction SilentlyContinue)) {
+  throw "Nothing is listening on dev port $DevPort. Start ./scripts/cold-start.ps1 first and wait for its window; a worktree build serves its own port, so pass -DevPort 1430 for one of those."
+}
+
+# WebView2 keys its browser process on the user-data folder, so a launch pointed at a
+# live one silently attaches to that instance and this -DebugPort never opens. The
+# compare is extracted-arg equality or separator-bounded prefix (the browser appends
+# \EBWebView), never substring: gd-coldstart-b must not match inside gd-coldstart-b2.
+$dataRootKey = $DataRoot.TrimEnd('\', '/').ToLowerInvariant()
+$attached = @(Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue |
+  Where-Object {
+    if (-not $_.CommandLine) { return $false }
+    if ($_.CommandLine -notmatch '--user-data-dir=(?:"([^"]*)"|(\S+))') { return $false }
+    $val = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+    $val = $val.TrimEnd('\', '/').ToLowerInvariant()
+    $val -eq $dataRootKey -or $val.StartsWith("$dataRootKey\")
+  })
+if ($attached.Count -gt 0) {
+  throw "A WebView2 process (pid $($attached[0].ProcessId)) already owns $DataRoot. Launching now would attach to that instance's browser instead of opening -DebugPort $DebugPort. Use a different -Id, or close that instance first."
 }
 
 $env:GD_INSTANCE_ID = $Id
@@ -74,8 +109,14 @@ $env:WEBVIEW2_USER_DATA_FOLDER = $DataRoot
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort"
 
 # Hidden hides only the console (debug exes are console-subsystem; the GUI window
-# shows itself regardless). Sibling stdout is lost — the watcher instance keeps logs.
+# shows itself regardless). Sibling stdout is lost; the watcher instance keeps logs.
 $proc = Start-Process $ExePath -WindowStyle Hidden -PassThru
+
+# Start-Process snapshots the child's env at spawn, so clearing now is safe, and it has
+# to happen: a later cold-start.ps1 in this shell would inherit a sibling's identity.
+Remove-Item Env:\GD_INSTANCE_ID -ErrorAction SilentlyContinue
+Remove-Item Env:\WEBVIEW2_USER_DATA_FOLDER -ErrorAction SilentlyContinue
+Remove-Item Env:\WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS -ErrorAction SilentlyContinue
 
 Write-Host "Launched cold-start instance '$Id'" -ForegroundColor Cyan
 Write-Host "  pid        = $($proc.Id)"

--- a/scripts/cold-start-instance.ps1
+++ b/scripts/cold-start-instance.ps1
@@ -106,13 +106,13 @@ $attached = @(Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'
     if ($_.CommandLine -notmatch '--user-data-dir=(?:"([^"]*)"|(\S+))') { return $false }
     $val = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
     $val = $val.TrimEnd('\', '/').ToLowerInvariant()
-    $root = if ($val.EndsWith('\ebwebview')) { $val.Substring(0, $val.Length - 10) } else { $val }
+    $root = if ($val.EndsWith('\ebwebview')) { $val.Substring(0, $val.Length - '\ebwebview'.Length) } else { $val }
     $val -eq $dataRootKey -or
     $val.StartsWith("$dataRootKey\") -or
     ($root -split '[\\/]')[-1] -eq $defaultLeaf
   })
 if ($attached.Count -gt 0) {
-  throw "A WebView2 process (pid $($attached[0].ProcessId)) already owns $DataRoot. Launching now would attach to that instance's browser instead of opening -DebugPort $DebugPort. Use a different -Id, or close that instance first."
+  throw "A WebView2 process (pid $($attached[0].ProcessId)) already owns a profile for -Id '$Id' ($DataRoot, or another folder named gd-coldstart-$Id). Launching now would attach to that instance's browser instead of opening -DebugPort $DebugPort. Use a different -Id, or close that instance first."
 }
 
 # Start-Process snapshots the child's env at spawn, so clearing after it is safe, and it

--- a/scripts/cold-start-instance.ps1
+++ b/scripts/cold-start-instance.ps1
@@ -41,7 +41,9 @@
 
 .PARAMETER DevPort
   Port the cold-start Vite server is already serving on. Defaults to 1420; a worktree
-  build serves its own port, so pass -DevPort 1430 for one of those.
+  build serves its own port, so pass -DevPort 1430 for one of those. The exe's
+  dev-server URL is baked in at build time (tauri.conf devUrl), so this has to be the
+  port THAT exe was built against; the check only proves a server answers there.
 
 .PARAMETER ExePath
   The already-built debug exe. Defaults to src-tauri\target\debug\gitdesktop.exe.
@@ -50,6 +52,9 @@
 
 .PARAMETER DataRoot
   WebView2 user-data folder for this instance. Defaults to %TEMP%\gd-coldstart-<Id>.
+  Passing an explicit one while reusing an -Id that is already running forfeits the
+  double-launch guard, and both instances then share the same coldstart-<Id>-*.json
+  stores.
 
 .EXAMPLE
   ./scripts/cold-start-instance.ps1 -Id b -DebugPort 9223
@@ -91,32 +96,44 @@ if (-not (Get-NetTCPConnection -LocalPort $DevPort -State Listen -ErrorAction Si
 # live one silently attaches to that instance and this -DebugPort never opens. The
 # compare is extracted-arg equality or separator-bounded prefix (the browser appends
 # \EBWebView), never substring: gd-coldstart-b must not match inside gd-coldstart-b2.
+# The leaf arm catches the same id relaunched under a different parent path (another
+# TEMP, a moved default), where the resolved root no longer matches.
 $dataRootKey = $DataRoot.TrimEnd('\', '/').ToLowerInvariant()
+$defaultLeaf = "gd-coldstart-$Id".ToLowerInvariant()
 $attached = @(Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue |
   Where-Object {
     if (-not $_.CommandLine) { return $false }
     if ($_.CommandLine -notmatch '--user-data-dir=(?:"([^"]*)"|(\S+))') { return $false }
     $val = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
     $val = $val.TrimEnd('\', '/').ToLowerInvariant()
-    $val -eq $dataRootKey -or $val.StartsWith("$dataRootKey\")
+    $root = if ($val.EndsWith('\ebwebview')) { $val.Substring(0, $val.Length - 10) } else { $val }
+    $val -eq $dataRootKey -or
+    $val.StartsWith("$dataRootKey\") -or
+    ($root -split '[\\/]')[-1] -eq $defaultLeaf
   })
 if ($attached.Count -gt 0) {
   throw "A WebView2 process (pid $($attached[0].ProcessId)) already owns $DataRoot. Launching now would attach to that instance's browser instead of opening -DebugPort $DebugPort. Use a different -Id, or close that instance first."
 }
 
-$env:GD_INSTANCE_ID = $Id
-$env:WEBVIEW2_USER_DATA_FOLDER = $DataRoot
-$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort"
+# Start-Process snapshots the child's env at spawn, so clearing after it is safe, and it
+# has to happen: a later cold-start.ps1 in this shell would inherit a sibling's identity.
+# The finally is what makes that reliable: with $ErrorActionPreference = "Stop", a
+# Start-Process that throws (the watcher mid-relink, say) would otherwise leave all three
+# behind in the operator's shell.
+$proc = $null
+try {
+  $env:GD_INSTANCE_ID = $Id
+  $env:WEBVIEW2_USER_DATA_FOLDER = $DataRoot
+  $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$DebugPort"
 
-# Hidden hides only the console (debug exes are console-subsystem; the GUI window
-# shows itself regardless). Sibling stdout is lost; the watcher instance keeps logs.
-$proc = Start-Process $ExePath -WindowStyle Hidden -PassThru
-
-# Start-Process snapshots the child's env at spawn, so clearing now is safe, and it has
-# to happen: a later cold-start.ps1 in this shell would inherit a sibling's identity.
-Remove-Item Env:\GD_INSTANCE_ID -ErrorAction SilentlyContinue
-Remove-Item Env:\WEBVIEW2_USER_DATA_FOLDER -ErrorAction SilentlyContinue
-Remove-Item Env:\WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS -ErrorAction SilentlyContinue
+  # Hidden hides only the console (debug exes are console-subsystem; the GUI window
+  # shows itself regardless). Sibling stdout is lost; the watcher instance keeps logs.
+  $proc = Start-Process $ExePath -WindowStyle Hidden -PassThru
+} finally {
+  Remove-Item Env:\GD_INSTANCE_ID -ErrorAction SilentlyContinue
+  Remove-Item Env:\WEBVIEW2_USER_DATA_FOLDER -ErrorAction SilentlyContinue
+  Remove-Item Env:\WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS -ErrorAction SilentlyContinue
+}
 
 Write-Host "Launched cold-start instance '$Id'" -ForegroundColor Cyan
 Write-Host "  pid        = $($proc.Id)"

--- a/scripts/cold-start.ps1
+++ b/scripts/cold-start.ps1
@@ -79,12 +79,13 @@ Write-Host "Launching GitDesktop in COLD-START test mode" -ForegroundColor Cyan
 Write-Host "  NoGit = $NoGit   NoGh = $NoGh   Automations = $Automations" -ForegroundColor Cyan
 Write-Host "  Real settings / local PRs / API keys are untouched." -ForegroundColor DarkGray
 
-# The script runs in-process, so the flags above would outlive it in the calling
-# shell, and a later bare `pnpm tauri dev` there would silently boot a cold instance.
-# The finally clears the whole flag family once the dev server exits.
+# The script runs in-process, so the flags above (and a Set-Location) would outlive
+# it in the calling shell, and a later bare `pnpm tauri dev` there would silently
+# boot a cold instance. The finally restores the whole shell state on exit.
 try {
-  Set-Location $repoRoot
+  Push-Location $repoRoot
   pnpm tauri dev
 } finally {
+  Pop-Location
   Remove-Item Env:\VITE_COLD_START, Env:\VITE_COLD_START_NO_GIT, Env:\VITE_COLD_START_NO_GH, Env:\VITE_COLD_START_AUTOMATIONS -ErrorAction SilentlyContinue
 }

--- a/scripts/cold-start.ps1
+++ b/scripts/cold-start.ps1
@@ -79,5 +79,12 @@ Write-Host "Launching GitDesktop in COLD-START test mode" -ForegroundColor Cyan
 Write-Host "  NoGit = $NoGit   NoGh = $NoGh   Automations = $Automations" -ForegroundColor Cyan
 Write-Host "  Real settings / local PRs / API keys are untouched." -ForegroundColor DarkGray
 
-Set-Location $repoRoot
-pnpm tauri dev
+# The script runs in-process, so the flags above would outlive it in the calling
+# shell, and a later bare `pnpm tauri dev` there would silently boot a cold instance.
+# The finally clears the whole flag family once the dev server exits.
+try {
+  Set-Location $repoRoot
+  pnpm tauri dev
+} finally {
+  Remove-Item Env:\VITE_COLD_START, Env:\VITE_COLD_START_NO_GIT, Env:\VITE_COLD_START_NO_GH, Env:\VITE_COLD_START_AUTOMATIONS -ErrorAction SilentlyContinue
+}

--- a/scripts/cold-start.ps1
+++ b/scripts/cold-start.ps1
@@ -12,13 +12,19 @@
   Run a fresh repo (e.g. `git init` in a temp folder) inside it to see the
   unborn-repo "Make your first commit" state. Use -NoGit / -NoGh to exercise the
   GitMissingScreen and GitHub-not-connected empty states without uninstalling
-  anything.
+  anything. Automations are off by default in cold-start mode; -Automations
+  re-enables them.
 
 .PARAMETER NoGit
   Force the "Git is not installed" screen.
 
 .PARAMETER NoGh
   Force the "GitHub CLI not connected" empty states (Pull Requests / Actions).
+
+.PARAMETER Automations
+  Run automations in the cold instance. They are OFF by default in cold-start mode:
+  the automation claims are shared with your real instance, so an armed cold instance
+  can win a claim and suppress the real run's review. Pass this to re-enable them.
 
 .PARAMETER Reset
   Delete the throwaway cold-start store files, then exit (does not launch).
@@ -27,12 +33,14 @@
   ./scripts/cold-start.ps1
   ./scripts/cold-start.ps1 -NoGit
   ./scripts/cold-start.ps1 -NoGh
+  ./scripts/cold-start.ps1 -Automations
   ./scripts/cold-start.ps1 -Reset
 #>
 [CmdletBinding()]
 param(
   [switch]$NoGit,
   [switch]$NoGh,
+  [switch]$Automations,
   [switch]$Reset
 )
 
@@ -59,9 +67,11 @@ if ($NoGit) { $env:VITE_COLD_START_NO_GIT = "1" }
 else { Remove-Item Env:\VITE_COLD_START_NO_GIT -ErrorAction SilentlyContinue }
 if ($NoGh) { $env:VITE_COLD_START_NO_GH = "1" }
 else { Remove-Item Env:\VITE_COLD_START_NO_GH -ErrorAction SilentlyContinue }
+if ($Automations) { $env:VITE_COLD_START_AUTOMATIONS = "1" }
+else { Remove-Item Env:\VITE_COLD_START_AUTOMATIONS -ErrorAction SilentlyContinue }
 
 Write-Host "Launching GitDesktop in COLD-START test mode" -ForegroundColor Cyan
-Write-Host "  NoGit = $NoGit   NoGh = $NoGh" -ForegroundColor Cyan
+Write-Host "  NoGit = $NoGit   NoGh = $NoGh   Automations = $Automations" -ForegroundColor Cyan
 Write-Host "  Real settings / local PRs / API keys are untouched." -ForegroundColor DarkGray
 
 Set-Location $repoRoot

--- a/scripts/cold-start.ps1
+++ b/scripts/cold-start.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Launch GitDesktop in cold-start test mode — a brand-new-user simulation for
+  Launch GitDesktop in cold-start test mode, a brand-new-user simulation for
   walking the onboarding flow.
 
 .DESCRIPTION
@@ -13,7 +13,7 @@
   unborn-repo "Make your first commit" state. Use -NoGit / -NoGh to exercise the
   GitMissingScreen and GitHub-not-connected empty states without uninstalling
   anything. Automations are off by default in cold-start mode; -Automations
-  re-enables them.
+  enables them.
 
 .PARAMETER NoGit
   Force the "Git is not installed" screen.
@@ -24,10 +24,12 @@
 .PARAMETER Automations
   Run automations in the cold instance. They are OFF by default in cold-start mode:
   the automation claims are shared with your real instance, so an armed cold instance
-  can win a claim and suppress the real run's review. Pass this to re-enable them.
+  can win a claim and suppress the real run's review. Pass this to enable them.
 
 .PARAMETER Reset
-  Delete the throwaway cold-start store files, then exit (does not launch).
+  Delete the throwaway cold-start store files, then exit (does not launch). The
+  per-instance WebView2 profiles under %TEMP%\gd-coldstart-* are left alone; delete
+  those yourself if you want a sibling instance's browser state gone too.
 
 .EXAMPLE
   ./scripts/cold-start.ps1
@@ -58,7 +60,7 @@ if ($Reset) {
   } else {
     Write-Host "No cold-start store files to clear in $dataDir" -ForegroundColor Yellow
   }
-  Write-Host "Note: any test API keys live in the 'coldstart:' keychain namespace — clear them from the app's AI settings while in cold-start mode."
+  Write-Host "Note: any test API keys live in the 'coldstart:' keychain namespace; clear them from the app's AI settings while in cold-start mode."
   return
 }
 

--- a/scripts/cold-start.ps1
+++ b/scripts/cold-start.ps1
@@ -5,9 +5,9 @@
 
 .DESCRIPTION
   Boots `pnpm tauri dev` with the cold-start Vite flags set. The app then reads
-  and writes only throwaway namespaces (coldstart-*.json store files + a
-  `coldstart:` keychain namespace), so your real settings, local PRs, and API
-  keys are never touched.
+  and writes only throwaway namespaces: coldstart-*.json store files, and API keys
+  held in sessionStorage instead of the OS keychain. Your real settings, local PRs
+  and API keys are never touched.
 
   Run a fresh repo (e.g. `git init` in a temp folder) inside it to see the
   unborn-repo "Make your first commit" state. Use -NoGit / -NoGh to exercise the
@@ -60,7 +60,7 @@ if ($Reset) {
   } else {
     Write-Host "No cold-start store files to clear in $dataDir" -ForegroundColor Yellow
   }
-  Write-Host "Note: any test API keys live in the 'coldstart:' keychain namespace; clear them from the app's AI settings while in cold-start mode."
+  Write-Host "Note: test API keys never reach the OS keychain; they live in sessionStorage and are gone the moment the cold-start window closes."
   return
 }
 
@@ -71,6 +71,9 @@ if ($NoGh) { $env:VITE_COLD_START_NO_GH = "1" }
 else { Remove-Item Env:\VITE_COLD_START_NO_GH -ErrorAction SilentlyContinue }
 if ($Automations) { $env:VITE_COLD_START_AUTOMATIONS = "1" }
 else { Remove-Item Env:\VITE_COLD_START_AUTOMATIONS -ErrorAction SilentlyContinue }
+# A sibling launch may have left an id in this shell; the primary instance must not
+# adopt it. WEBVIEW2_* stay untouched: operators set those to get a CDP port here.
+Remove-Item Env:\GD_INSTANCE_ID -ErrorAction SilentlyContinue
 
 Write-Host "Launching GitDesktop in COLD-START test mode" -ForegroundColor Cyan
 Write-Host "  NoGit = $NoGit   NoGh = $NoGh   Automations = $Automations" -ForegroundColor Cyan

--- a/src-tauri/src/instance_id.rs
+++ b/src-tauri/src/instance_id.rs
@@ -1,0 +1,62 @@
+//! Runtime instance id for parallel cold-start instances.
+//!
+//! `scripts/cold-start-instance.ps1` exports `GD_INSTANCE_ID` before launching an
+//! extra cold instance against an already-running cold-start Vite server. Cold
+//! start itself is a build-time Vite flag, so every instance one server feeds sees
+//! the same env — this is the only channel that can tell them apart. `lib.rs` hands
+//! the id to the webview as a `window.__GD_INSTANCE_ID__` initialization script
+//! rather than a command: the script runs before any page script, so the frontend
+//! reads it synchronously at module scope and can name its store files
+//! `coldstart-<id>-<name>` before anything opens one. N instances, disjoint state,
+//! one dev server.
+
+/// Accepts exactly `^[A-Za-z0-9-]{1,32}$`.
+///
+/// A security boundary, not cosmetics: the id is interpolated into store
+/// FILENAMES (`coldstart-<id>-settings.json`), so path separators, `..`, dots and
+/// spaces must never pass — they would let an id escape the app-data dir or
+/// collide with an unrelated file. The TS side re-checks the same charset.
+fn valid_instance_id(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 32 && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+/// The launcher-supplied instance id, or `None` when unset, blank or invalid.
+/// Never fails: an unusable id must leave the instance on the shared `coldstart-`
+/// namespace rather than break the boot path that reads it.
+pub fn read() -> Option<String> {
+    let raw = std::env::var("GD_INSTANCE_ID").ok()?;
+    let id = raw.trim();
+    valid_instance_id(id).then(|| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_instance_id;
+
+    // Only the pure validator is covered. Testing `read` itself would mean
+    // mutating `GD_INSTANCE_ID` in-process, which races every other test's env
+    // reads in the same binary and on POSIX is unsound, not merely flaky (the
+    // same reason `app_store.rs` takes an in-process seam instead of an env var).
+
+    #[test]
+    fn accepts_alphanumeric_and_hyphenated_ids() {
+        assert!(valid_instance_id("a"));
+        assert!(valid_instance_id("b2"));
+        assert!(valid_instance_id("cold-start-2"));
+        assert!(valid_instance_id(&"x".repeat(32)));
+    }
+
+    #[test]
+    fn rejects_empty_and_overlong() {
+        assert!(!valid_instance_id(""));
+        assert!(!valid_instance_id(&"x".repeat(33)));
+    }
+
+    #[test]
+    fn rejects_path_and_whitespace_characters() {
+        assert!(!valid_instance_id(r"..\evil"));
+        assert!(!valid_instance_id("a/b"));
+        assert!(!valid_instance_id("a b"));
+        assert!(!valid_instance_id("a.b"));
+    }
+}

--- a/src-tauri/src/instance_id.rs
+++ b/src-tauri/src/instance_id.rs
@@ -28,6 +28,11 @@ fn valid_instance_id(s: &str) -> bool {
 /// The launcher-supplied instance id, or `None` when unset, blank or invalid.
 /// Never fails: an unusable id must leave the instance on the shared `coldstart-`
 /// namespace rather than break the boot path that reads it.
+///
+/// The trim is the one canonicalization step every consumer downstream of the env
+/// var inherits. Validating the raw value instead would drop a whitespace-padded id
+/// onto the SHARED legacy namespace — a worse collision than converging on the id
+/// the operator plainly meant.
 pub fn read() -> Option<String> {
     let raw = std::env::var("GD_INSTANCE_ID").ok()?;
     let id = raw.trim();

--- a/src-tauri/src/instance_id.rs
+++ b/src-tauri/src/instance_id.rs
@@ -3,21 +3,26 @@
 //! `scripts/cold-start-instance.ps1` exports `GD_INSTANCE_ID` before launching an
 //! extra cold instance against an already-running cold-start Vite server. Cold
 //! start itself is a build-time Vite flag, so every instance one server feeds sees
-//! the same env — this is the only channel that can tell them apart. `lib.rs` hands
+//! the same env — this is the channel chosen to tell them apart. `lib.rs` hands
 //! the id to the webview as a `window.__GD_INSTANCE_ID__` initialization script
 //! rather than a command: the script runs before any page script, so the frontend
 //! reads it synchronously at module scope and can name its store files
 //! `coldstart-<id>-<name>` before anything opens one. N instances, disjoint state,
 //! one dev server.
 
-/// Accepts exactly `^[A-Za-z0-9-]{1,32}$`.
+/// Accepts exactly `^[a-z0-9-]{1,32}$`.
 ///
 /// A security boundary, not cosmetics: the id is interpolated into store
 /// FILENAMES (`coldstart-<id>-settings.json`), so path separators, `..`, dots and
-/// spaces must never pass — they would let an id escape the app-data dir or
-/// collide with an unrelated file. The TS side re-checks the same charset.
+/// spaces must never pass — they would let an id escape the app-data dir or collide
+/// with unrelated files. Uppercase is barred for a second reason: NTFS and default
+/// APFS are case-insensitive, so `A` and `a` would name ONE set of store files while
+/// looking like two instances. The TS side re-checks the same charset.
 fn valid_instance_id(s: &str) -> bool {
-    !s.is_empty() && s.len() <= 32 && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+    !s.is_empty()
+        && s.len() <= 32
+        && s.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
 }
 
 /// The launcher-supplied instance id, or `None` when unset, blank or invalid.
@@ -39,11 +44,17 @@ mod tests {
     // same reason `app_store.rs` takes an in-process seam instead of an env var).
 
     #[test]
-    fn accepts_alphanumeric_and_hyphenated_ids() {
+    fn accepts_lowercase_and_hyphenated_ids() {
         assert!(valid_instance_id("a"));
         assert!(valid_instance_id("b2"));
         assert!(valid_instance_id("cold-start-2"));
         assert!(valid_instance_id(&"x".repeat(32)));
+    }
+
+    #[test]
+    fn rejects_uppercase() {
+        assert!(!valid_instance_id("A"));
+        assert!(!valid_instance_id("cold-START"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod git;
 mod github;
 mod health;
 mod hooks;
+mod instance_id;
 mod instructions;
 mod jira_field_maps;
 mod jira_links;
@@ -54,6 +55,15 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
         tray::show_main_window(app);
     }));
+    // Interpolating the id straight into JS source is safe only because
+    // `instance_id::read` enforces `[A-Za-z0-9-]{1,32}`. This script runs before any
+    // page script, so the frontend reads the global synchronously at module scope.
+    let builder = match instance_id::read() {
+        Some(id) => builder.append_invoke_initialization_script(format!(
+            "window.__GD_INSTANCE_ID__ = \"{id}\";"
+        )),
+        None => builder,
+    };
     builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_http::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,9 @@ mod git;
 mod github;
 mod health;
 mod hooks;
+// Dev-only, like the cold-start mode it serves: gated so release builds carry no
+// unused reader (and no dead_code warning for it).
+#[cfg(debug_assertions)]
 mod instance_id;
 mod instructions;
 mod jira_field_maps;
@@ -60,6 +63,7 @@ pub fn run() {
     // off the upstream invoke script's trailing newline for statement separation.
     // This script runs before any page script, so the frontend reads the global
     // synchronously at module scope.
+    #[cfg(debug_assertions)]
     let builder = match instance_id::read() {
         Some(id) => builder.append_invoke_initialization_script(format!(
             "\nwindow.__GD_INSTANCE_ID__ = \"{id}\";"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,11 +56,13 @@ pub fn run() {
         tray::show_main_window(app);
     }));
     // Interpolating the id straight into JS source is safe only because
-    // `instance_id::read` enforces `[A-Za-z0-9-]{1,32}`. This script runs before any
-    // page script, so the frontend reads the global synchronously at module scope.
+    // `instance_id::read` enforces `[a-z0-9-]{1,32}`. The leading newline keeps us
+    // off the upstream invoke script's trailing newline for statement separation.
+    // This script runs before any page script, so the frontend reads the global
+    // synchronously at module scope.
     let builder = match instance_id::read() {
         Some(id) => builder.append_invoke_initialization_script(format!(
-            "window.__GD_INSTANCE_ID__ = \"{id}\";"
+            "\nwindow.__GD_INSTANCE_ID__ = \"{id}\";"
         )),
         None => builder,
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ import {
   useSettings,
 } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
-import { COLD_START } from "@/lib/test-mode";
+import { COLD_INSTANCE_ID, COLD_START } from "@/lib/test-mode";
 import { nextTheme, THEME_LABELS } from "@/lib/theme";
 import { useLatestRef } from "@/lib/use-latest-ref";
 
@@ -262,6 +262,7 @@ function App() {
         <div className="pointer-events-none fixed right-2 bottom-2 z-50 flex items-center gap-1.5 border border-warning/40 bg-warning/10 px-2 py-1 text-[11px] font-medium text-warning">
           <span className="size-1.5 rounded-full bg-warning" />
           Cold-start test mode
+          {COLD_INSTANCE_ID ? ` · ${COLD_INSTANCE_ID}` : ""}
         </div>
       )}
     </>

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -243,27 +243,28 @@ interface RunOutcome {
 }
 
 /**
- * Runs the automation rules matching `event`, unless AI features are hidden — that
- * pauses automations, so it returns immediately with a zero outcome. `only` scopes a
- * re-run to a single mode. `replacesKey` is the stopped row a re-run replaces — removed
- * the instant its replacement registers, so the stopped row survives whenever nothing
- * registers. Returns a {@link RunOutcome} so a re-run can tell "rule gone" from
- * "blocked" from "started".
+ * Runs the automation rules matching `event`, unless AI features are hidden or this is
+ * a cold-start instance without the automations opt-in — either pauses automations, so
+ * it returns immediately with a zero outcome. `only` scopes a re-run to a single mode.
+ * `replacesKey` is the stopped row a re-run replaces — removed the instant its
+ * replacement registers, so the stopped row survives whenever nothing registers.
+ * Returns a {@link RunOutcome} so a re-run can tell "rule gone" from "blocked" from
+ * "started".
  */
 async function run(
   event: AutomationEvent,
   only?: ReviewMode,
   replacesKey?: string,
 ): Promise<RunOutcome> {
+  // Cold-start instances share the automation-claims dir with the real instance, so an
+  // armed cold instance can win a claim meant for the real run and suppress it. First
+  // gate of all, so a gated tick reads no store at all and takes no claim.
+  if (COLD_START_AUTOMATIONS_OFF) return { matched: 0, attempted: 0 };
   // Hiding AI features PAUSES automations: no NEW run starts while `hideAi` is set
   // (an in-flight run still completes and delivers — deliberate). Rules are kept and
   // resume when AI is shown again.
   const settings = await loadSettings();
   if (settings.hideAi) return { matched: 0, attempted: 0 };
-  // Cold-start instances share the automation-claims dir with the real instance, so an
-  // armed cold instance can win a claim meant for the real run and suppress it. Gate
-  // before loadAutomations() so a gated tick reads no config and takes no claim.
-  if (COLD_START_AUTOMATIONS_OFF) return { matched: 0, attempted: 0 };
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
@@ -684,8 +685,9 @@ async function run(
  * cancelled run wrote one, and the pr-sync `sameSha(dismissedHead, headSha)` gate would
  * otherwise make the re-run a silent no-op. The run then flows through the normal pipeline
  * scoped to `only`. If the rule was disabled since, nothing matches and we toast rather
- * than leave a dead button. While AI features are hidden it stops before the clear —
- * a paused re-run must not consume the watermark.
+ * than leave a dead button. While AI features are hidden — or in a cold-start instance
+ * that never opted automations in — it stops before the clear: a paused re-run must not
+ * consume the watermark.
  */
 export function rerunAutomation(
   event: AutomationEvent,

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -50,6 +50,7 @@ import {
   resetReview,
 } from "@/lib/stores/reviews";
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
+import { COLD_START, COLD_START_AUTOMATIONS } from "@/lib/test-mode";
 import {
   clearDismissedHead,
   getDismissedHeadMap,
@@ -233,7 +234,7 @@ export function triggerAutomations(event: AutomationEvent): void {
 
 /** What a {@link run} pass did, so a re-run can tell outcomes apart:
  *  - `matched`: rules that exist AND apply (past the `only` + branch gates). 0 = the rule
- *    no longer applies, or automations are paused (Hide AI).
+ *    no longer applies, or automations are paused (Hide AI, or cold start without opt-in).
  *  - `attempted`: runs actually started. `matched > 0 && attempted === 0` means a claim or
  *    an already-covered head blocked it — retryable. */
 interface RunOutcome {
@@ -259,6 +260,11 @@ async function run(
   // resume when AI is shown again.
   const settings = await loadSettings();
   if (settings.hideAi) return { matched: 0, attempted: 0 };
+  // Cold-start instances share the automation-claims dir with the real instance, so an
+  // armed cold instance can win a claim meant for the real run and suppress it. Gate
+  // before loadAutomations() so a gated tick reads no config and takes no claim.
+  if (COLD_START && !COLD_START_AUTOMATIONS)
+    return { matched: 0, attempted: 0 };
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
@@ -695,6 +701,12 @@ export function rerunAutomation(
       // re-run has to stop here — clearing nothing and running nothing.
       if ((await loadSettings()).hideAi) {
         toast.info("Automations are paused while AI features are hidden.");
+        return;
+      }
+      // Same reason: the clear below runs before run()'s cold-start gate, so an
+      // automations-off cold instance stops here rather than consuming the watermark.
+      if (COLD_START && !COLD_START_AUTOMATIONS) {
+        toast.info("Automations are off in cold-start test mode.");
         return;
       }
       // Best-effort ONLY here: a cleared-dismissal failure must not block the

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -698,16 +698,15 @@ export function rerunAutomation(
   const noun = event.kind === "commit" ? "commit" : "pull request";
   void (async () => {
     try {
-      // The dismissal clear below mutates BEFORE run()'s own pause gate, so a paused
-      // re-run has to stop here — clearing nothing and running nothing.
-      if ((await loadSettings()).hideAi) {
-        toast.info("Automations are paused while AI features are hidden.");
-        return;
-      }
-      // Same reason: the clear below runs before run()'s cold-start gate, so an
-      // automations-off cold instance stops here rather than consuming the watermark.
+      // The dismissal clear below mutates BEFORE run()'s own pause gates, so a paused
+      // re-run has to stop here — clearing nothing and running nothing. The cold-start
+      // gate comes first, like run()'s: a gated cold instance reads no store at all.
       if (COLD_START_AUTOMATIONS_OFF) {
         toast.info("Automations are off in cold-start test mode.");
+        return;
+      }
+      if ((await loadSettings()).hideAi) {
+        toast.info("Automations are paused while AI features are hidden.");
         return;
       }
       // Best-effort ONLY here: a cleared-dismissal failure must not block the

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -50,7 +50,7 @@ import {
   resetReview,
 } from "@/lib/stores/reviews";
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
-import { COLD_START, COLD_START_AUTOMATIONS } from "@/lib/test-mode";
+import { COLD_START_AUTOMATIONS_OFF } from "@/lib/test-mode";
 import {
   clearDismissedHead,
   getDismissedHeadMap,
@@ -263,8 +263,7 @@ async function run(
   // Cold-start instances share the automation-claims dir with the real instance, so an
   // armed cold instance can win a claim meant for the real run and suppress it. Gate
   // before loadAutomations() so a gated tick reads no config and takes no claim.
-  if (COLD_START && !COLD_START_AUTOMATIONS)
-    return { matched: 0, attempted: 0 };
+  if (COLD_START_AUTOMATIONS_OFF) return { matched: 0, attempted: 0 };
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   const actions = effectiveActions(config, repo, event.kind);
@@ -705,7 +704,7 @@ export function rerunAutomation(
       }
       // Same reason: the clear below runs before run()'s cold-start gate, so an
       // automations-off cold instance stops here rather than consuming the watermark.
-      if (COLD_START && !COLD_START_AUTOMATIONS) {
+      if (COLD_START_AUTOMATIONS_OFF) {
         toast.info("Automations are off in cold-start test mode.");
         return;
       }

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -7,7 +7,7 @@ import { forgeFeatureReady } from "@/lib/git/queries";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { loadSettings } from "@/lib/settings/api";
 import { useUiStore } from "@/lib/stores/ui";
-import { COLD_START, COLD_START_AUTOMATIONS } from "@/lib/test-mode";
+import { COLD_START_AUTOMATIONS_OFF } from "@/lib/test-mode";
 
 /**
  * Always-mounted background poller that keeps pr-sync automations (auto
@@ -53,9 +53,9 @@ export function useBackgroundPrSync(): void {
       // Hiding AI features pauses automations, so a paused tick makes no forge call.
       // Settings are read per tick, so flipping it takes effect on the next one.
       if (settings.hideAi) return { polled: 0 };
-      // A cold-start instance runs no automations unless opted in, so it makes no
-      // background forge polls either.
-      if (COLD_START && !COLD_START_AUTOMATIONS) return { polled: 0 };
+      // A cold-start instance runs no automations unless opted in, so this poller
+      // makes no forge calls.
+      if (COLD_START_AUTOMATIONS_OFF) return { polled: 0 };
       // No recents → nothing to watch; skip the config read and the loop.
       if (settings.recentRepos.length === 0) return { polled: 0 };
       const config = await loadAutomations();

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -49,13 +49,13 @@ export function useBackgroundPrSync(): void {
     staleTime: 55_000,
     retry: false,
     queryFn: async () => {
+      // A cold-start instance runs no automations unless opted in, so this poller
+      // makes no forge calls — and, gating first, no store reads either.
+      if (COLD_START_AUTOMATIONS_OFF) return { polled: 0 };
       const settings = await loadSettings();
       // Hiding AI features pauses automations, so a paused tick makes no forge call.
       // Settings are read per tick, so flipping it takes effect on the next one.
       if (settings.hideAi) return { polled: 0 };
-      // A cold-start instance runs no automations unless opted in, so this poller
-      // makes no forge calls.
-      if (COLD_START_AUTOMATIONS_OFF) return { polled: 0 };
       // No recents → nothing to watch; skip the config read and the loop.
       if (settings.recentRepos.length === 0) return { polled: 0 };
       const config = await loadAutomations();

--- a/src/lib/automations/useBackgroundPrSync.ts
+++ b/src/lib/automations/useBackgroundPrSync.ts
@@ -7,6 +7,7 @@ import { forgeFeatureReady } from "@/lib/git/queries";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { loadSettings } from "@/lib/settings/api";
 import { useUiStore } from "@/lib/stores/ui";
+import { COLD_START, COLD_START_AUTOMATIONS } from "@/lib/test-mode";
 
 /**
  * Always-mounted background poller that keeps pr-sync automations (auto
@@ -52,6 +53,9 @@ export function useBackgroundPrSync(): void {
       // Hiding AI features pauses automations, so a paused tick makes no forge call.
       // Settings are read per tick, so flipping it takes effect on the next one.
       if (settings.hideAi) return { polled: 0 };
+      // A cold-start instance runs no automations unless opted in, so it makes no
+      // background forge polls either.
+      if (COLD_START && !COLD_START_AUTOMATIONS) return { polled: 0 };
       // No recents → nothing to watch; skip the config read and the loop.
       if (settings.recentRepos.length === 0) return { polled: 0 };
       const config = await loadAutomations();

--- a/src/lib/test-mode.ts
+++ b/src/lib/test-mode.ts
@@ -4,15 +4,20 @@
  *
  * Enabled by Vite env flags set by `scripts/cold-start.ps1`. Inert (every flag
  * false) in normal `pnpm tauri dev` and in production builds, where the
- * `VITE_COLD_START*` vars are undefined and statically replaced.
+ * `VITE_COLD_START*` vars are undefined.
  *
  * When active it isolates every piece of personal state to a throwaway
  * namespace, so the real install is never read or written:
  *   - Tauri stores (settings, local PRs, branch rules, automations) →
- *     separate `coldstart-*.json` files in the same app-data dir.
+ *     separate `coldstart-*.json` files in the same app-data dir. Parallel
+ *     instances launched by `scripts/cold-start-instance.ps1` carry a
+ *     `GD_INSTANCE_ID`, which reaches the webview as `window.__GD_INSTANCE_ID__`
+ *     and namespaces those files further, to `coldstart-<id>-*.json`.
  *   - API keys → an isolated `sessionStorage` store instead of the OS keychain
  *     (the Rust keychain commands reject unknown provider ids anyway), so real
  *     keys are never read and test keys vanish when the window closes.
+ *   - Automations don't run at all unless `VITE_COLD_START_AUTOMATIONS` opts them
+ *     in, since the claims they take are shared with the real instance.
  *   - Optionally forces git / gh "missing" so the GitMissingScreen and
  *     gh-not-connected states can be exercised without uninstalling anything.
  */
@@ -25,10 +30,13 @@ export const COLD_START_NO_GIT =
   COLD_START && env.VITE_COLD_START_NO_GIT === "1";
 export const COLD_START_NO_GH = COLD_START && env.VITE_COLD_START_NO_GH === "1";
 // Polarity is deliberately inverted vs the NO_* flags above: automations are OFF
-// by default under cold start and this OPTS THEM BACK IN, because a cold instance
-// shares the automation-claims dir with the real one and could steal its claims.
-export const COLD_START_AUTOMATIONS =
-  COLD_START && env.VITE_COLD_START_AUTOMATIONS === "1";
+// by default under cold start and VITE_COLD_START_AUTOMATIONS opts them BACK IN,
+// because a cold instance shares the automation-claims dir with the real one and
+// could steal its claims. Only the composed gate is exported: the bare opt-in flag
+// is false in production too, where negating it would silence every real user's
+// automations.
+export const COLD_START_AUTOMATIONS_OFF =
+  COLD_START && env.VITE_COLD_START_AUTOMATIONS !== "1";
 
 // Per-instance namespace for parallel cold instances, set by
 // `scripts/cold-start-instance.ps1` → GD_INSTANCE_ID → a Tauri initialization
@@ -41,10 +49,14 @@ const rawInstanceId = COLD_START
 // into store FILENAMES. A stale binary — the old exe still running while the Rust
 // watcher rebuilds — simply never set the global, which reads as "no id".
 const coldInstanceId =
-  typeof rawInstanceId === "string" &&
-  /^[A-Za-z0-9-]{1,32}$/.test(rawInstanceId)
+  typeof rawInstanceId === "string" && /^[a-z0-9-]{1,32}$/.test(rawInstanceId)
     ? rawInstanceId
     : null;
+
+/** This instance's cold-start id, or null when it has none (a lone cold instance,
+ *  or a stale binary that never set the global). Surfaced in the cold-start badge
+ *  so parallel windows are tellable apart on screen. */
+export const COLD_INSTANCE_ID = coldInstanceId;
 
 /** Tauri store filename, redirected to a throwaway file under cold start. An
  *  instance id namespaces it further (`coldstart-<id>-<name>`); without one the

--- a/src/lib/test-mode.ts
+++ b/src/lib/test-mode.ts
@@ -24,10 +24,35 @@ export const COLD_START = env.VITE_COLD_START === "1";
 export const COLD_START_NO_GIT =
   COLD_START && env.VITE_COLD_START_NO_GIT === "1";
 export const COLD_START_NO_GH = COLD_START && env.VITE_COLD_START_NO_GH === "1";
+// Polarity is deliberately inverted vs the NO_* flags above: automations are OFF
+// by default under cold start and this OPTS THEM BACK IN, because a cold instance
+// shares the automation-claims dir with the real one and could steal its claims.
+export const COLD_START_AUTOMATIONS =
+  COLD_START && env.VITE_COLD_START_AUTOMATIONS === "1";
 
-/** Tauri store filename, redirected to a throwaway file under cold start. */
+// Per-instance namespace for parallel cold instances, set by
+// `scripts/cold-start-instance.ps1` → GD_INSTANCE_ID → a Tauri initialization
+// script (src-tauri/src/instance_id.rs). That script runs before any page script,
+// so the global is readable here at module scope, before any store is named.
+const rawInstanceId = COLD_START
+  ? (window as { __GD_INSTANCE_ID__?: unknown }).__GD_INSTANCE_ID__
+  : undefined;
+// Re-checked against the Rust validator's charset because the id is interpolated
+// into store FILENAMES. A stale binary — the old exe still running while the Rust
+// watcher rebuilds — simply never set the global, which reads as "no id".
+const coldInstanceId =
+  typeof rawInstanceId === "string" &&
+  /^[A-Za-z0-9-]{1,32}$/.test(rawInstanceId)
+    ? rawInstanceId
+    : null;
+
+/** Tauri store filename, redirected to a throwaway file under cold start. An
+ *  instance id namespaces it further (`coldstart-<id>-<name>`); without one the
+ *  name stays EXACTLY `coldstart-<name>`, so a lone cold instance keeps reading
+ *  the store files it wrote before ids existed. */
 export function storeName(name: string): string {
-  return COLD_START ? `coldstart-${name}` : name;
+  if (!COLD_START) return name;
+  return `coldstart-${coldInstanceId ? `${coldInstanceId}-` : ""}${name}`;
 }
 
 // Cold-start API keys live in sessionStorage, never the OS keychain — fresh

--- a/test/sandbox/setup.ps1
+++ b/test/sandbox/setup.ps1
@@ -2,7 +2,7 @@
   Runs inside Windows Sandbox at logon (invoked by onboarding.wsb).
 
   Installs GitDesktop into a genuinely bare Windows: no git, no gh, no keychain
-  entries, no app data — the real cold start a brand-new user gets. The NSIS
+  entries, no app data: the real cold start a brand-new user gets. The NSIS
   installer pulls in the WebView2 runtime if it's missing (the sandbox has
   internet by default).
 
@@ -40,7 +40,7 @@ if ($git) {
   Write-Host "Installing $($git.Name) (silent)..." -ForegroundColor Green
   Start-Process -FilePath $git.FullName -ArgumentList "/VERYSILENT","/NORESTART" -Wait
 } else {
-  Write-Host "No git installer in C:\Setup\tools — you'll see the 'Git is not installed' screen (that's the first onboarding surface)." -ForegroundColor Yellow
+  Write-Host "No git installer in C:\Setup\tools; you'll see the 'Git is not installed' screen (that's the first onboarding surface)." -ForegroundColor Yellow
 }
 
 Write-Host ""


### PR DESCRIPTION
Cold-start test mode wrote to a single throwaway store namespace and left automations armed, so two cold instances clobbered each other's `coldstart-*.json` files and an armed cold instance could win an automation claim meant for the real instance and suppress its run. This adds a per-instance id that namespaces the cold-start stores and turns automations off by default under cold start, with an explicit opt-in.

### Per-instance isolation

- Adds `scripts/cold-start-instance.ps1`, which launches one extra already-built debug exe against an already-running cold-start Vite server (it never builds and never starts Vite). It validates `-Id` against `^[a-z0-9-]{1,32}\z` with a case-sensitive match (lowercase only, since store filenames are case-insensitive on disk), fails fast when the exe is missing, when `-DebugPort` is already listening, when nothing is listening on `-DevPort`, or when a live WebView2 process already owns the resolved data folder (launching then would attach to that instance's browser and the new debug port would never open). It sets `GD_INSTANCE_ID`, `WEBVIEW2_USER_DATA_FOLDER` (defaulting to `%TEMP%\gd-coldstart-<Id>`) and the remote-debugging port before `Start-Process`, then removes all three from the calling shell so a later launch in the same terminal cannot inherit a sibling's identity.
- Adds `src-tauri/src/instance_id.rs`: `read()` pulls `GD_INSTANCE_ID`, trims it, and returns `None` when unset, blank or invalid so a bad id degrades to the shared namespace instead of breaking boot. `valid_instance_id` enforces the same lowercase charset as the launcher, with unit tests covering lowercase/hyphenated ids, empty and 33-char ids, uppercase rejection (`A`, `cold-START`), and path/whitespace characters (`..\evil`, `a/b`, `a b`, `a.b`).
- Registers the module in `src-tauri/src/lib.rs` and, when an id is present, appends an invoke initialization script setting `window.__GD_INSTANCE_ID__`, so the value is available before any page script runs. The script leads with a newline so statement separation never depends on the upstream bootstrap's tail.
- `src/lib/test-mode.ts` reads that global at module scope under `COLD_START`, re-checks it against the same regex, and makes `storeName()` return `coldstart-<id>-<name>`. Without an id the name stays exactly `coldstart-<name>`, so a lone cold instance keeps reading the files it wrote previously. The id is also exported as `COLD_INSTANCE_ID` and shown in the cold-start badge (`Cold-start test mode · <id>`), so parallel windows are tellable apart.

### Automations off by default in cold start

- `src/lib/test-mode.ts` gains a `COLD_START_AUTOMATIONS_OFF` export, composed from `COLD_START` and the `VITE_COLD_START_AUTOMATIONS` opt-in. Only the composed gate is exported: the bare opt-in flag is false in production too, where negating it by mistake would silence every real user's automations, so it stays module-private.
- `src/lib/automations/runner.ts` returns `{ matched: 0, attempted: 0 }` from `run()` ahead of `loadAutomations()`, so a gated tick reads no config and takes no claim; `rerunAutomation()` bails with an "Automations are off in cold-start test mode." toast before the dismissal watermark is cleared. The `RunOutcome` doc comment now names the new pause reason alongside Hide AI.
- `src/lib/automations/useBackgroundPrSync.ts` returns `{ polled: 0 }` under the same gate, so a cold instance makes no background forge polls from this poller.
- `scripts/cold-start.ps1` adds an `-Automations` switch that sets `VITE_COLD_START_AUTOMATIONS` (and clears it otherwise), plus updated help text, example and launch banner.

### Round-zero hardening

A pre-open review pass found that BOM-less UTF-8 em dashes inside double-quoted strings break parsing under Windows PowerShell 5.1 (the system code page decodes the dash's last byte as a smart closing quote). All ps1 files are now pure ASCII; that fix also covers two pre-existing 5.1 parse failures on master, in `scripts/cold-start.ps1` and `test/sandbox/setup.ps1`, which is why the sandbox script joins the diff. The Windows Sandbox logon path runs 5.1, so that script was broken in its real runtime.

No changelog fragment: cold start is a build-time Vite flag, so the gate and the instance id are inert in release builds and there is no user-facing change to record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for launching multiple isolated cold-start instances simultaneously.
  * Cold-start windows now display their instance identifier for easier tracking.
  * Added an option to enable automation execution during cold-start sessions.
  * Added a dedicated command for launching isolated cold-start instances.

* **Bug Fixes**
  * Prevented disabled cold-start automation and background pull-request synchronization from running.
  * Improved data isolation between parallel cold-start instances.

* **Documentation**
  * Clarified cold-start reset behavior and launch status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->