### PR TITLE
feat(settings): accent colour and UI font appearance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
+.cursor/
+.pnpm-store/
 .DS_Store
 *.suo
 *.ntvs*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+## Learned User Preferences
+
+- User dislikes GitDesktop's UI and information architecture; Clinically work should not extend or reskin it in this worktree.
+- Clinically product is "Clinically Code Control" (`au.clinically.codecontrol`): keep GitDesktop's Rust backend, replace the entire React shell from scratch.
+- Use Tauri + React for the Clinically shell, not native SwiftUI.
+- Do not port GitDesktop's `src/features/` or reskin to Clinically design tokens; build new flows and screens from scratch.
+- Clinically visual language comes from Stream's `.impeccable/design.json` (warm stone, clinical teal, Inter, light mode), not GitDesktop's mint/dark theme.
+- Active Clinically app development lives in `/Users/wojt/Code/clinically-au/code-control`, not this GitDesktop worktree.
+- Clinically JS repos should set pnpm `blockExoticSubdeps: true`, `trustPolicy: no-downgrade`, and `minimumReleaseAge: 10080`.
+- Code Control is intended as a daily-driver desktop Git client (stage/commit/push/PR/CI loop beside the editor), not an occasional specialist tool.
+- Cross-repo views are central to Code Control; home is a dashboard (open PRs + CI, running Actions, release cards), not a single-repo picker.
+- Code Control is editor-agnostic — no Cursor or IDE-specific hooks; use copy path, reveal in Finder, and OS default open only.
+- Code Control v0.1 hosted features are GitHub-only via `gh`; GitLab/Bitbucket are deferred.
+- Repo registry is built via multi-org scan (`gh repo list` matched to local clones), configured in settings.
+
+## Learned Workspace Facts
+
+- GitDesktop's Rust backend (`src-tauri/`) shells out to system `git` and `gh`; GitHub auth uses the existing `gh auth login` session, not app-managed OAuth.
+- GitDesktop is Apache 2.0; Clinically Code Control copies `src-tauri/` once with LICENSE/NOTICE preserved, without maintaining a tracking upstream fork.
+- The Tauri invoke surface (`*_core` functions, `src/lib/git/api.ts`) is the stable contract between frontend and Rust for Clinically builds.
+- GitDesktop's `com.thebguy.gitdesktop` bundle id, updater, and branding must not ship in Clinically Code Control builds.
+- Stream (`clinically-au/stream`): `main` is staging, `prod` is production; promotion is via tag + GitHub Release workflow.
+- Planned Code Control integrations (post-v0.1): Laravel Forge v2 API for deploy status/logs/commands; AWS CLI for Parameter Store secrets.
+- This worktree's `.gitignore` should exclude `.cursor/` and `.pnpm-store/`.

--- a/README.md
+++ b/README.md
@@ -910,7 +910,10 @@ review via its subscription login. The full list is under
   or key), and arrow-key navigation everywhere.
 - **Themes**: System, Light, Dark, and a softer **Slate** (a cool, lifted
   blue-gray) that eases eye strain; switch in **Settings → Appearance** or
-  cycle from the command palette.
+  cycle from the command palette. The same page has an **accent colour**
+  (hue that tints buttons, focus rings, and highlights) and a **UI font**
+  (JetBrains Mono, Inter, or your system UI font). Code, diffs, and the
+  terminal stay on JetBrains Mono.
 - **Privacy-first**: API keys live in the OS keychain (never in app files),
   local models keep code on your machine, AI-ignore patterns keep sensitive
   files out of context unless you opt into repo-aware review, and a single

--- a/changelog.d/added-appearance-accent-font.md
+++ b/changelog.d/added-appearance-accent-font.md
@@ -1,0 +1,5 @@
+- **Appearance.** Settings → Appearance now lets you pick an **accent colour**
+  (a hue that tints buttons, focus rings, and highlights on top of System /
+  Light / Dark / Slate) and a **UI font** (JetBrains Mono, Inter, or your
+  system UI font). Code, diffs, and the terminal stay on JetBrains Mono.
+  **Reset accent & font** restores the defaults.

--- a/changelog.d/added-linear-integration.md
+++ b/changelog.d/added-linear-integration.md
@@ -1,0 +1,4 @@
+- **Linear issue integration.** Link a Linear team to any repository to browse,
+  create, and comment on issues without leaving the app. Referenced Linear
+  identifiers (e.g. `ENG-123`) are detected in PR titles, descriptions, branch
+  names, and commit messages, with clickable links to the issue view.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@base-ui/react": "^1.7.0",
     "@codemirror/language": "^6.12.4",
     "@codemirror/legacy-modes": "^6.5.3",
+    "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.3.0",
     "@git-diff-view/core": "^0.1.7",
     "@git-diff-view/react": "^0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@codemirror/legacy-modes':
         specifier: ^6.5.3
         version: 6.5.3
+      '@fontsource-variable/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.3.0
         version: 5.3.0
@@ -754,6 +757,9 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
 
   '@fontsource-variable/jetbrains-mono@5.3.0':
     resolution: {integrity: sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==}
@@ -5388,6 +5394,8 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource-variable/inter@5.3.0': {}
 
   '@fontsource-variable/jetbrains-mono@5.3.0': {}
 

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -274,6 +274,16 @@ export const capabilities: Capability[] = [
     group: "Forges & trackers",
     label: "Jira keys in branches, commits & PRs link back to the Issues tab",
   },
+  {
+    group: "Forges & trackers",
+    label: "Linear — link a team, browse & create issues in-app",
+    highlight: true,
+  },
+  {
+    group: "Forges & trackers",
+    label:
+      "Linear identifiers in branches, commits & PRs link back to the Issues tab",
+  },
 
   // — Issues & discussions —
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -451,7 +451,7 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Repository & workspace",
-    label: "Themes — System, Light, Dark & a softer Slate",
+    label: "Themes — System, Light, Dark & Slate, plus accent colour and UI font",
   },
 
   // — Admin & settings —

--- a/src-tauri/src/forge/linear.rs
+++ b/src-tauri/src/forge/linear.rs
@@ -138,7 +138,7 @@ async fn graphql(token: &str, query: &str, variables: Value) -> AppResult<Value>
         .unwrap_or_default();
     let resp = client()
         .post(API_URL)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(reqwest::header::AUTHORIZATION, token)
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .body(body)
         .send()
@@ -164,14 +164,16 @@ async fn graphql(token: &str, query: &str, variables: Value) -> AppResult<Value>
             .and_then(|e| e.get("message"))
             .and_then(Value::as_str)
         {
-            return Err(AppError::Command(msg.to_string()));
+            return Err(AppError::Command(format!("Linear API: {msg}")));
         }
     }
 
-    payload
-        .get("data")
-        .cloned()
-        .ok_or_else(|| AppError::Command("Linear returned no data".to_string()))
+    match payload.get("data") {
+        Some(data) if !data.is_null() => Ok(data.clone()),
+        _ => Err(AppError::Command(
+            "Linear returned no data (authentication may have failed)".to_string(),
+        )),
+    }
 }
 
 fn linear_error_from_body(body: &str, status: u16) -> AppError {
@@ -336,8 +338,8 @@ pub async fn issue_list(team_key: &str, state: &str) -> AppResult<Vec<LinearIssu
     };
 
     let query = r#"
-        query($teamKey: String!, $filter: IssueFilter) {
-          team(key: $teamKey) {
+        query($teamId: String!, $filter: IssueFilter) {
+          team(id: $teamId) {
             issues(first: 50, filter: $filter, orderBy: updatedAt) {
               nodes {
                 identifier title url createdAt updatedAt estimate
@@ -353,15 +355,20 @@ pub async fn issue_list(team_key: &str, state: &str) -> AppResult<Vec<LinearIssu
         }
     "#;
 
-    let variables = json!({ "teamKey": team_key, "filter": filter });
+    let variables = json!({ "teamId": team_key, "filter": filter });
     let data = graphql(&token, query, variables).await?;
 
-    let nodes = data
-        .get("team")
-        .and_then(|t| t.get("issues"))
+    let team = data.get("team").filter(|v| !v.is_null()).ok_or_else(|| {
+        AppError::Command(format!(
+            "Linear team '{team_key}' not found — check the linked team key"
+        ))
+    })?;
+
+    let nodes = team
+        .get("issues")
         .and_then(|i| i.get("nodes"))
         .and_then(Value::as_array)
-        .ok_or_else(|| AppError::Command("Linear returned no issues".to_string()))?;
+        .ok_or_else(|| AppError::Command("Linear returned no issues for this team".to_string()))?;
 
     Ok(nodes.iter().filter_map(parse_issue_info).collect())
 }

--- a/src-tauri/src/forge/linear.rs
+++ b/src-tauri/src/forge/linear.rs
@@ -274,8 +274,7 @@ pub async fn set_account(token: &str) -> AppResult<LinearAccountInfo> {
         Ok::<_, AppError>(())
     })
     .await
-    .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))?
-    ?;
+    .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))??;
 
     Ok(info)
 }

--- a/src-tauri/src/forge/linear.rs
+++ b/src-tauri/src/forge/linear.rs
@@ -1,0 +1,713 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tauri_plugin_http::reqwest::{self, Client};
+
+use crate::error::{AppError, AppResult};
+use crate::forge::model::ForgeUserRef;
+
+// ── HTTP transport ──────────────────────────────────────────────────────────────
+
+const KEYRING_HOST: &str = "linear.app";
+const KEY_TOKEN: &str = "token";
+const KEY_EMAIL: &str = "email";
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+const API_URL: &str = "https://api.linear.app/graphql";
+
+static CLIENT: OnceLock<Client> = OnceLock::new();
+
+fn client() -> &'static Client {
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .user_agent(concat!("GitDesktop/", env!("CARGO_PKG_VERSION")))
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| Client::new())
+    })
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────────
+
+pub fn is_valid_team_key(s: &str) -> bool {
+    let mut bytes = s.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_uppercase() => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+}
+
+pub fn is_valid_identifier(s: &str) -> bool {
+    let Some((team, number)) = s.rsplit_once('-') else {
+        return false;
+    };
+    is_valid_team_key(team) && !number.is_empty() && number.bytes().all(|b| b.is_ascii_digit())
+}
+
+// ── Data types ──────────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearAccountInfo {
+    pub name: String,
+    pub email: String,
+    pub id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearStoredAccount {
+    pub email: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearTeam {
+    pub id: String,
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearIssueInfo {
+    pub identifier: String,
+    pub title: String,
+    pub status_name: String,
+    pub status_type: String,
+    pub priority_label: String,
+    pub assignee: Option<ForgeUserRef>,
+    pub labels: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub url: String,
+    pub estimate: Option<f64>,
+    pub cycle_name: Option<String>,
+    pub project_name: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearComment {
+    pub id: String,
+    pub body_md: String,
+    pub author: Option<ForgeUserRef>,
+    pub created_at: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearIssueDetails {
+    pub id: String,
+    pub identifier: String,
+    pub title: String,
+    pub status_name: String,
+    pub status_type: String,
+    pub priority_label: String,
+    pub assignee: Option<ForgeUserRef>,
+    pub labels: Vec<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub url: String,
+    pub estimate: Option<f64>,
+    pub cycle_name: Option<String>,
+    pub project_name: Option<String>,
+    pub description_md: String,
+    pub comments: Vec<LinearComment>,
+    pub viewer_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearCreatedIssue {
+    pub identifier: String,
+    pub url: String,
+}
+
+// ── GraphQL transport ───────────────────────────────────────────────────────────
+
+async fn graphql(token: &str, query: &str, variables: Value) -> AppResult<Value> {
+    let body = serde_json::to_string(&json!({ "query": query, "variables": variables }))
+        .unwrap_or_default();
+    let resp = client()
+        .post(API_URL)
+        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AppError::Command(format!("Linear request failed: {e}")))?;
+
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| AppError::Command(format!("could not read Linear response: {e}")))?;
+
+    if !(200..300).contains(&status) {
+        return Err(linear_error_from_body(&text, status));
+    }
+
+    let payload: Value = serde_json::from_str(&text)
+        .map_err(|e| AppError::Command(format!("could not parse Linear response: {e}")))?;
+
+    if let Some(errors) = payload.get("errors").and_then(Value::as_array) {
+        if let Some(msg) = errors
+            .first()
+            .and_then(|e| e.get("message"))
+            .and_then(Value::as_str)
+        {
+            return Err(AppError::Command(msg.to_string()));
+        }
+    }
+
+    payload
+        .get("data")
+        .cloned()
+        .ok_or_else(|| AppError::Command("Linear returned no data".to_string()))
+}
+
+fn linear_error_from_body(body: &str, status: u16) -> AppError {
+    #[derive(Deserialize)]
+    struct ErrorEnvelope {
+        #[serde(default)]
+        errors: Vec<ErrorItem>,
+    }
+    #[derive(Deserialize)]
+    struct ErrorItem {
+        #[serde(default)]
+        message: String,
+    }
+
+    if let Ok(envelope) = serde_json::from_str::<ErrorEnvelope>(body) {
+        if let Some(item) = envelope.errors.first() {
+            if !item.message.is_empty() {
+                return AppError::Command(item.message.clone());
+            }
+        }
+    }
+
+    let snippet = if body.len() > 200 { &body[..200] } else { body };
+    AppError::Command(format!("Linear API error (HTTP {status}): {snippet}"))
+}
+
+// ── Keyring helpers ─────────────────────────────────────────────────────────────
+
+fn read_token_blocking() -> AppResult<Option<String>> {
+    crate::secrets::read_forge_secret(KEYRING_HOST, KEY_TOKEN)
+}
+
+fn read_email_blocking() -> AppResult<Option<String>> {
+    crate::secrets::read_forge_secret(KEYRING_HOST, KEY_EMAIL)
+}
+
+async fn require_token() -> AppResult<String> {
+    let token = tauri::async_runtime::spawn_blocking(read_token_blocking)
+        .await
+        .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))?;
+    match token? {
+        Some(t) if !t.is_empty() => Ok(t),
+        _ => Err(AppError::Command(
+            "No Linear account is connected. Add your API key in Settings → Accounts.".to_string(),
+        )),
+    }
+}
+
+// ── Credential management ───────────────────────────────────────────────────────
+
+pub async fn validate_token(token: &str) -> AppResult<LinearAccountInfo> {
+    let query = r#"query { viewer { id name email } }"#;
+    let data = graphql(token, query, json!({})).await?;
+    let viewer = data
+        .get("viewer")
+        .ok_or_else(|| AppError::Command("Linear returned no viewer".to_string()))?;
+
+    Ok(LinearAccountInfo {
+        id: viewer
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        name: viewer
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        email: viewer
+            .get("email")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+pub async fn stored_account() -> AppResult<Option<LinearStoredAccount>> {
+    let email = tauri::async_runtime::spawn_blocking(read_email_blocking)
+        .await
+        .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))?;
+    match email? {
+        Some(e) if !e.is_empty() => Ok(Some(LinearStoredAccount { email: e })),
+        _ => Ok(None),
+    }
+}
+
+pub async fn set_account(token: &str) -> AppResult<LinearAccountInfo> {
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err(AppError::InvalidArgument("an API key is required".into()));
+    }
+
+    let info = validate_token(&token).await?;
+
+    let kr_token = token.clone();
+    let kr_email = info.email.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::secrets::set_forge_secret(KEYRING_HOST, KEY_TOKEN, &kr_token)?;
+        crate::secrets::set_forge_secret(KEYRING_HOST, KEY_EMAIL, &kr_email)?;
+        Ok::<_, AppError>(())
+    })
+    .await
+    .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))?
+    ?;
+
+    Ok(info)
+}
+
+pub async fn clear_account() -> AppResult<()> {
+    tauri::async_runtime::spawn_blocking(|| {
+        crate::secrets::delete_forge_secret(KEYRING_HOST, KEY_TOKEN)?;
+        crate::secrets::delete_forge_secret(KEYRING_HOST, KEY_EMAIL)?;
+        Ok::<_, AppError>(())
+    })
+    .await
+    .map_err(|e| AppError::Command(format!("keyring task failed: {e}")))?
+}
+
+// ── Team queries ────────────────────────────────────────────────────────────────
+
+pub async fn team_list(token_override: Option<&str>) -> AppResult<Vec<LinearTeam>> {
+    let token = match token_override {
+        Some(t) => t.to_string(),
+        None => require_token().await?,
+    };
+
+    let query = r#"query { teams { nodes { id key name } } }"#;
+    let data = graphql(&token, query, json!({})).await?;
+
+    let nodes = data
+        .get("teams")
+        .and_then(|t| t.get("nodes"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::Command("Linear returned no teams".to_string()))?;
+
+    Ok(nodes
+        .iter()
+        .filter_map(|node| {
+            Some(LinearTeam {
+                id: node.get("id").and_then(Value::as_str)?.to_string(),
+                key: node.get("key").and_then(Value::as_str)?.to_string(),
+                name: node.get("name").and_then(Value::as_str)?.to_string(),
+            })
+        })
+        .collect())
+}
+
+// ── Issue operations ────────────────────────────────────────────────────────────
+
+pub async fn issue_list(team_key: &str, state: &str) -> AppResult<Vec<LinearIssueInfo>> {
+    if !is_valid_team_key(team_key) {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid Linear team key: {team_key}"
+        )));
+    }
+
+    let token = require_token().await?;
+
+    let filter = match state {
+        "open" => json!({ "state": { "type": { "nin": ["completed", "cancelled"] } } }),
+        "closed" => json!({ "state": { "type": { "in": ["completed", "cancelled"] } } }),
+        _ => json!({}),
+    };
+
+    let query = r#"
+        query($teamKey: String!, $filter: IssueFilter) {
+          team(key: $teamKey) {
+            issues(first: 50, filter: $filter, orderBy: updatedAt) {
+              nodes {
+                identifier title url createdAt updatedAt estimate
+                state { name type }
+                priority priorityLabel
+                assignee { id name email avatarUrl }
+                labels { nodes { name } }
+                cycle { name }
+                project { name }
+              }
+            }
+          }
+        }
+    "#;
+
+    let variables = json!({ "teamKey": team_key, "filter": filter });
+    let data = graphql(&token, query, variables).await?;
+
+    let nodes = data
+        .get("team")
+        .and_then(|t| t.get("issues"))
+        .and_then(|i| i.get("nodes"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::Command("Linear returned no issues".to_string()))?;
+
+    Ok(nodes.iter().filter_map(parse_issue_info).collect())
+}
+
+pub async fn issue_view(identifier: &str) -> AppResult<LinearIssueDetails> {
+    if !is_valid_identifier(identifier) {
+        return Err(AppError::InvalidArgument(format!(
+            "invalid Linear issue identifier: {identifier}"
+        )));
+    }
+
+    let token = require_token().await?;
+
+    let query = r#"
+        query($id: String!) {
+          issue(id: $id) {
+            id identifier title url createdAt updatedAt estimate description
+            state { name type }
+            priority priorityLabel
+            assignee { id name email avatarUrl }
+            labels { nodes { name } }
+            cycle { name }
+            project { name }
+            comments { nodes { id body createdAt updatedAt user { id name email avatarUrl } } }
+          }
+        }
+    "#;
+
+    let variables = json!({ "id": identifier });
+    let data = graphql(&token, query, variables).await?;
+
+    let issue = data
+        .get("issue")
+        .ok_or_else(|| AppError::Command(format!("issue {identifier} not found")))?;
+
+    if issue.is_null() {
+        return Err(AppError::Command(format!("issue {identifier} not found")));
+    }
+
+    let viewer_id = resolve_viewer_id(&token).await;
+
+    let comments = issue
+        .get("comments")
+        .and_then(|c| c.get("nodes"))
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(parse_comment).collect())
+        .unwrap_or_default();
+
+    Ok(LinearIssueDetails {
+        id: str_field(issue, "id"),
+        identifier: str_field(issue, "identifier"),
+        title: str_field(issue, "title"),
+        status_name: issue
+            .get("state")
+            .and_then(|s| s.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        status_type: issue
+            .get("state")
+            .and_then(|s| s.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        priority_label: str_field(issue, "priorityLabel"),
+        assignee: issue.get("assignee").and_then(parse_user_ref),
+        labels: parse_labels(issue),
+        created_at: str_field(issue, "createdAt"),
+        updated_at: str_field(issue, "updatedAt"),
+        url: str_field(issue, "url"),
+        estimate: issue.get("estimate").and_then(Value::as_f64),
+        cycle_name: issue
+            .get("cycle")
+            .and_then(|c| c.get("name"))
+            .and_then(Value::as_str)
+            .map(String::from),
+        project_name: issue
+            .get("project")
+            .and_then(|p| p.get("name"))
+            .and_then(Value::as_str)
+            .map(String::from),
+        description_md: str_field(issue, "description"),
+        comments,
+        viewer_id,
+    })
+}
+
+pub async fn issue_comment(issue_id: &str, body_md: &str) -> AppResult<LinearComment> {
+    let token = require_token().await?;
+
+    let query = r#"
+        mutation($issueId: String!, $body: String!) {
+          commentCreate(input: { issueId: $issueId, body: $body }) {
+            success
+            comment { id body createdAt updatedAt user { id name email avatarUrl } }
+          }
+        }
+    "#;
+
+    let variables = json!({ "issueId": issue_id, "body": body_md });
+    let data = graphql(&token, query, variables).await?;
+
+    let comment = data
+        .get("commentCreate")
+        .and_then(|c| c.get("comment"))
+        .ok_or_else(|| {
+            AppError::Command("Linear did not return the created comment".to_string())
+        })?;
+
+    parse_comment(comment)
+        .ok_or_else(|| AppError::Command("could not parse Linear comment".to_string()))
+}
+
+pub async fn issue_create(
+    team_id: &str,
+    title: &str,
+    description_md: Option<&str>,
+) -> AppResult<LinearCreatedIssue> {
+    let token = require_token().await?;
+
+    let mut input = json!({ "teamId": team_id, "title": title });
+    if let Some(desc) = description_md {
+        input
+            .as_object_mut()
+            .unwrap()
+            .insert("description".to_string(), Value::String(desc.to_string()));
+    }
+
+    let query = r#"
+        mutation($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue { identifier url }
+          }
+        }
+    "#;
+
+    let variables = json!({ "input": input });
+    let data = graphql(&token, query, variables).await?;
+
+    let issue = data
+        .get("issueCreate")
+        .and_then(|c| c.get("issue"))
+        .ok_or_else(|| AppError::Command("Linear did not return the created issue".to_string()))?;
+
+    Ok(LinearCreatedIssue {
+        identifier: str_field(issue, "identifier"),
+        url: str_field(issue, "url"),
+    })
+}
+
+pub async fn issue_transition(issue_id: &str, state_id: &str) -> AppResult<()> {
+    let token = require_token().await?;
+
+    let query = r#"
+        mutation($id: String!, $stateId: String!) {
+          issueUpdate(id: $id, input: { stateId: $stateId }) {
+            success
+          }
+        }
+    "#;
+
+    let variables = json!({ "id": issue_id, "stateId": state_id });
+    let data = graphql(&token, query, variables).await?;
+
+    let success = data
+        .get("issueUpdate")
+        .and_then(|u| u.get("success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if !success {
+        return Err(AppError::Command(
+            "Linear issue transition failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub async fn issue_assign(issue_id: &str, assignee_id: Option<&str>) -> AppResult<()> {
+    let token = require_token().await?;
+
+    let query = r#"
+        mutation($id: String!, $assigneeId: String) {
+          issueUpdate(id: $id, input: { assigneeId: $assigneeId }) {
+            success
+          }
+        }
+    "#;
+
+    let variables = json!({ "id": issue_id, "assigneeId": assignee_id });
+    let data = graphql(&token, query, variables).await?;
+
+    let success = data
+        .get("issueUpdate")
+        .and_then(|u| u.get("success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if !success {
+        return Err(AppError::Command(
+            "Linear issue assignment failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+// ── Viewer cache ────────────────────────────────────────────────────────────────
+
+static VIEWER_ID: OnceLock<std::sync::Mutex<Option<String>>> = OnceLock::new();
+
+fn viewer_id_cache() -> &'static std::sync::Mutex<Option<String>> {
+    VIEWER_ID.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+async fn resolve_viewer_id(token: &str) -> Option<String> {
+    if let Ok(guard) = viewer_id_cache().lock() {
+        if let Some(ref id) = *guard {
+            return Some(id.clone());
+        }
+    }
+    let query = r#"query { viewer { id } }"#;
+    let data = graphql(token, query, json!({})).await.ok()?;
+    let id = data.get("viewer")?.get("id")?.as_str()?.to_string();
+    if let Ok(mut guard) = viewer_id_cache().lock() {
+        *guard = Some(id.clone());
+    }
+    Some(id)
+}
+
+// ── Parsing helpers ─────────────────────────────────────────────────────────────
+
+fn str_field(obj: &Value, key: &str) -> String {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn parse_user_ref(val: &Value) -> Option<ForgeUserRef> {
+    if val.is_null() {
+        return None;
+    }
+    Some(ForgeUserRef {
+        id: val.get("id").and_then(Value::as_str)?.to_string(),
+        label: val
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        avatar_url: val
+            .get("avatarUrl")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        is_bot: false,
+    })
+}
+
+fn parse_labels(issue: &Value) -> Vec<String> {
+    issue
+        .get("labels")
+        .and_then(|l| l.get("nodes"))
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|n| n.get("name").and_then(Value::as_str).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_issue_info(node: &Value) -> Option<LinearIssueInfo> {
+    Some(LinearIssueInfo {
+        identifier: node.get("identifier").and_then(Value::as_str)?.to_string(),
+        title: str_field(node, "title"),
+        status_name: node
+            .get("state")
+            .and_then(|s| s.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        status_type: node
+            .get("state")
+            .and_then(|s| s.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        priority_label: str_field(node, "priorityLabel"),
+        assignee: node.get("assignee").and_then(parse_user_ref),
+        labels: parse_labels(node),
+        created_at: str_field(node, "createdAt"),
+        updated_at: str_field(node, "updatedAt"),
+        url: str_field(node, "url"),
+        estimate: node.get("estimate").and_then(Value::as_f64),
+        cycle_name: node
+            .get("cycle")
+            .and_then(|c| c.get("name"))
+            .and_then(Value::as_str)
+            .map(String::from),
+        project_name: node
+            .get("project")
+            .and_then(|p| p.get("name"))
+            .and_then(Value::as_str)
+            .map(String::from),
+    })
+}
+
+fn parse_comment(node: &Value) -> Option<LinearComment> {
+    Some(LinearComment {
+        id: node.get("id").and_then(Value::as_str)?.to_string(),
+        body_md: str_field(node, "body"),
+        author: node.get("user").and_then(parse_user_ref),
+        created_at: str_field(node, "createdAt"),
+        updated_at: node
+            .get("updatedAt")
+            .and_then(Value::as_str)
+            .map(String::from),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_team_keys() {
+        assert!(is_valid_team_key("ENG"));
+        assert!(is_valid_team_key("A"));
+        assert!(is_valid_team_key("ENG2"));
+        assert!(!is_valid_team_key(""));
+        assert!(!is_valid_team_key("eng"));
+        assert!(!is_valid_team_key("2ENG"));
+        assert!(!is_valid_team_key("ENG-"));
+    }
+
+    #[test]
+    fn valid_identifiers() {
+        assert!(is_valid_identifier("ENG-123"));
+        assert!(is_valid_identifier("A-1"));
+        assert!(is_valid_identifier("AB2-99"));
+        assert!(!is_valid_identifier(""));
+        assert!(!is_valid_identifier("ENG"));
+        assert!(!is_valid_identifier("eng-123"));
+        assert!(!is_valid_identifier("ENG-"));
+        assert!(!is_valid_identifier("-123"));
+    }
+}

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -14,6 +14,7 @@ pub mod gitlab_findings;
 pub mod glab;
 pub mod http;
 pub mod jira;
+pub mod linear;
 pub mod model;
 pub mod session;
 
@@ -895,6 +896,79 @@ pub async fn jira_worklog_delete(
     worklog_id: String,
 ) -> AppResult<()> {
     jira::worklog_delete(&site, &key, &worklog_id).await
+}
+
+// ── Linear ─────────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn linear_validate_token(token: String) -> AppResult<linear::LinearAccountInfo> {
+    linear::validate_token(&token).await
+}
+
+#[tauri::command]
+pub async fn linear_stored_account() -> AppResult<Option<linear::LinearStoredAccount>> {
+    linear::stored_account().await
+}
+
+#[tauri::command]
+pub async fn linear_set_account(token: String) -> AppResult<linear::LinearAccountInfo> {
+    linear::set_account(&token).await
+}
+
+#[tauri::command]
+pub async fn linear_clear_account() -> AppResult<()> {
+    linear::clear_account().await
+}
+
+#[tauri::command]
+pub async fn linear_teams() -> AppResult<Vec<linear::LinearTeam>> {
+    linear::team_list(None).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_list(
+    team_key: String,
+    state: String,
+) -> AppResult<Vec<linear::LinearIssueInfo>> {
+    linear::issue_list(&team_key, &state).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_view(identifier: String) -> AppResult<linear::LinearIssueDetails> {
+    linear::issue_view(&identifier).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_comment(
+    issue_id: String,
+    body_md: String,
+) -> AppResult<linear::LinearComment> {
+    linear::issue_comment(&issue_id, &body_md).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_create(
+    team_id: String,
+    title: String,
+    description_md: Option<String>,
+) -> AppResult<linear::LinearCreatedIssue> {
+    linear::issue_create(&team_id, &title, description_md.as_deref()).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_transition(
+    issue_id: String,
+    state_id: String,
+) -> AppResult<()> {
+    linear::issue_transition(&issue_id, &state_id).await
+}
+
+#[tauri::command]
+pub async fn linear_issue_assign(
+    issue_id: String,
+    assignee_id: Option<String>,
+) -> AppResult<()> {
+    linear::issue_assign(&issue_id, assignee_id.as_deref()).await
 }
 
 /// The signed-in user's repositories on a provider, for the clone browser.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ mod hooks;
 mod instructions;
 mod jira_field_maps;
 mod jira_links;
+#[allow(dead_code)]
+mod linear_links;
 mod link_preview;
 mod local_issues;
 mod local_prs;
@@ -329,6 +331,17 @@ pub fn run() {
             forge::jira_worklog_add,
             forge::jira_worklog_update,
             forge::jira_worklog_delete,
+            forge::linear_validate_token,
+            forge::linear_stored_account,
+            forge::linear_set_account,
+            forge::linear_clear_account,
+            forge::linear_teams,
+            forge::linear_issue_list,
+            forge::linear_issue_view,
+            forge::linear_issue_comment,
+            forge::linear_issue_create,
+            forge::linear_issue_transition,
+            forge::linear_issue_assign,
             forge::forge_list_repos,
             forge::forge_owned_namespaces,
             forge::forge_clone,

--- a/src-tauri/src/linear_links.rs
+++ b/src-tauri/src/linear_links.rs
@@ -11,6 +11,7 @@ const STORE_FILE: &str = "linear-links.json";
 #[serde(rename_all = "camelCase")]
 pub struct LinearLinkEntry {
     pub workspace_slug: String,
+    pub team_id: String,
     pub team_key: String,
     pub team_name: String,
 }
@@ -65,10 +66,16 @@ fn link_from_value(value: &Value) -> Option<LinearLinkEntry> {
         .get("workspaceSlug")
         .and_then(Value::as_str)?
         .to_string();
+    let team_id = obj
+        .get("teamId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
     let team_key = obj.get("teamKey").and_then(Value::as_str)?.to_string();
     let team_name = obj.get("teamName").and_then(Value::as_str)?.to_string();
     Some(LinearLinkEntry {
         workspace_slug,
+        team_id,
         team_key,
         team_name,
     })
@@ -105,6 +112,7 @@ mod tests {
     fn link_json() -> Value {
         json!({
             "workspaceSlug": "acme",
+            "teamId": "team-uuid-123",
             "teamKey": "ENG",
             "teamName": "Engineering",
         })

--- a/src-tauri/src/linear_links.rs
+++ b/src-tauri/src/linear_links.rs
@@ -1,0 +1,194 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, AppResult};
+
+const STORE_FILE: &str = "linear-links.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinearLinkEntry {
+    pub workspace_slug: String,
+    pub team_key: String,
+    pub team_name: String,
+}
+
+pub fn store_path() -> AppResult<PathBuf> {
+    let data = dirs::data_dir()
+        .ok_or_else(|| AppError::Command("could not resolve the app-data directory".to_string()))?;
+    Ok(data.join(crate::local_prs::APP_IDENTIFIER).join(STORE_FILE))
+}
+
+fn read_store(path: &Path) -> AppResult<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Command(format!(
+                    "linear-links store at {} is not valid JSON: {e}",
+                    path.display()
+                ))
+            })?;
+            match value {
+                Value::Object(map) => Ok(map),
+                _ => Err(AppError::Command(format!(
+                    "linear-links store at {} is not a JSON object",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(e) => Err(AppError::Io(e)),
+    }
+}
+
+fn same_repo(a: &str, b: &str) -> bool {
+    fn norm(s: &str) -> String {
+        let slashed: String = s.chars().map(|c| if c == '\\' { '/' } else { c }).collect();
+        let bytes = slashed.as_bytes();
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            let mut out = String::with_capacity(slashed.len());
+            out.push(bytes[0].to_ascii_lowercase() as char);
+            out.push_str(&slashed[1..]);
+            out
+        } else {
+            slashed
+        }
+    }
+    norm(a) == norm(b)
+}
+
+fn link_from_value(value: &Value) -> Option<LinearLinkEntry> {
+    let obj = value.as_object()?;
+    let workspace_slug = obj
+        .get("workspaceSlug")
+        .and_then(Value::as_str)?
+        .to_string();
+    let team_key = obj.get("teamKey").and_then(Value::as_str)?.to_string();
+    let team_name = obj.get("teamName").and_then(Value::as_str)?.to_string();
+    Some(LinearLinkEntry {
+        workspace_slug,
+        team_key,
+        team_name,
+    })
+}
+
+fn lookup(store: &Map<String, Value>, identity: &str, legacy: &str) -> Option<LinearLinkEntry> {
+    if let Some(link) = store.get(identity).and_then(link_from_value) {
+        return Some(link);
+    }
+    if identity == legacy {
+        return None;
+    }
+    if let Some(link) = store.get(legacy).and_then(link_from_value) {
+        return Some(link);
+    }
+    store
+        .iter()
+        .find(|(k, _)| same_repo(k, legacy))
+        .and_then(|(_, v)| link_from_value(v))
+}
+
+pub async fn get_link(repo_path: &str) -> AppResult<Option<LinearLinkEntry>> {
+    let identity = crate::git::repo::repo_identity(repo_path).await;
+    let path = store_path()?;
+    let store = read_store(&path)?;
+    Ok(lookup(&store, &identity, repo_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn link_json() -> Value {
+        json!({
+            "workspaceSlug": "acme",
+            "teamKey": "ENG",
+            "teamName": "Engineering",
+        })
+    }
+
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("gd-linear-links-test-")
+            .tempdir()
+            .expect("create temp dir");
+        let path = dir.path().join("store.json");
+        (dir, path)
+    }
+
+    #[test]
+    fn read_missing_file_is_empty_object() {
+        let (_tmp, path) = tmp_store();
+        let store = read_store(&path).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn malformed_store_is_an_error() {
+        let (_tmp, path) = tmp_store();
+        std::fs::write(&path, b"{ this is not json").unwrap();
+        let err = read_store(&path).unwrap_err();
+        assert!(err.to_string().contains("not valid JSON"));
+    }
+
+    #[test]
+    fn parses_a_well_formed_entry() {
+        let link = link_from_value(&link_json()).unwrap();
+        assert_eq!(link.workspace_slug, "acme");
+        assert_eq!(link.team_key, "ENG");
+        assert_eq!(link.team_name, "Engineering");
+    }
+
+    #[test]
+    fn malformed_entry_reads_as_none() {
+        assert!(link_from_value(&json!("nope")).is_none());
+        assert!(link_from_value(&json!(42)).is_none());
+        assert!(link_from_value(&Value::Null).is_none());
+        assert!(link_from_value(&json!({ "workspaceSlug": "a", "teamKey": "B" })).is_none());
+    }
+
+    #[test]
+    fn lookup_prefers_identity_key() {
+        let identity = "C:/repo/.git";
+        let legacy = r"C:\repo";
+        let mut store = Map::new();
+        store.insert(identity.to_string(), link_json());
+        store.insert(
+            legacy.to_string(),
+            json!({ "workspaceSlug": "old", "teamKey": "OLD", "teamName": "Old" }),
+        );
+        let link = lookup(&store, identity, legacy).unwrap();
+        assert_eq!(link.workspace_slug, "acme");
+    }
+
+    #[test]
+    fn lookup_falls_back_to_legacy_path() {
+        let identity = "C:/repo/.git";
+        let legacy = r"C:\repo";
+        let mut store = Map::new();
+        store.insert(legacy.to_string(), link_json());
+        let link = lookup(&store, identity, legacy).unwrap();
+        assert_eq!(link.team_key, "ENG");
+    }
+
+    #[test]
+    fn lookup_legacy_is_slash_tolerant() {
+        let identity = "C:/repo/.git";
+        let stored = r"C:\repo";
+        let launched = "c:/repo";
+        let mut store = Map::new();
+        store.insert(stored.to_string(), link_json());
+        let link = lookup(&store, identity, launched).unwrap();
+        assert_eq!(link.workspace_slug, "acme");
+    }
+
+    #[test]
+    fn lookup_no_entry_is_none() {
+        let mut store = Map::new();
+        store.insert("C:/other/.git".to_string(), link_json());
+        assert_eq!(lookup(&store, "C:/repo/.git", r"C:\repo"), None);
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -2,11 +2,13 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/jetbrains-mono";
+@import "@fontsource-variable/inter";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-heading: var(--font-mono);
+  --font-heading: var(--gd-ui-font);
+  --font-sans: var(--gd-ui-font);
   --font-mono: "JetBrains Mono Variable", monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -61,23 +63,30 @@
      follow `color-scheme`, so driving it from the theme class — not the OS —
      keeps them in sync when the user forces a theme against their OS setting. */
   color-scheme: light;
+  /* Chrome typeface. Defaults to JetBrains Mono so a first paint before
+     theme.ts runs matches today's look; Settings overlays `--gd-ui-font`.
+     `--font-mono` stays JetBrains for code. */
+  --gd-ui-font: "JetBrains Mono Variable", monospace;
+  /* Brand hue. Lightness/chroma stay per-theme so a custom hue keeps the
+     same contrast the mint tokens were tuned for. */
+  --accent-hue: 175;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  /* Brand mint accent. Light mode uses a deeper teal (same hue ~175) so it
+  /* Brand mint accent (hue 175). Light mode uses a deeper teal so it
      stays legible as text/icon color on white AND as a button bg with white
      text; dark mode (below) uses the bright marketing mint. */
-  --primary: oklch(0.48 0.1 175);
+  --primary: oklch(0.48 0.1 var(--accent-hue));
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.516 0 0);
-  /* Selection/hover surfaces carry a whisper of mint instead of pure gray. */
-  --accent: oklch(0.93 0.035 175);
+  /* Selection/hover surfaces carry a whisper of the brand hue instead of pure gray. */
+  --accent: oklch(0.93 0.035 var(--accent-hue));
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --success: oklch(0.55 0.13 150);
@@ -86,7 +95,7 @@
   --merged: oklch(0.53 0.2 300);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.55 0.11 175);
+  --ring: oklch(0.55 0.11 var(--accent-hue));
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -95,12 +104,12 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.48 0.1 175);
+  --sidebar-primary: oklch(0.48 0.1 var(--accent-hue));
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.93 0.035 175);
+  --sidebar-accent: oklch(0.93 0.035 var(--accent-hue));
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.55 0.11 175);
+  --sidebar-ring: oklch(0.55 0.11 var(--accent-hue));
 }
 
 .dark {
@@ -111,15 +120,15 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  /* Bright marketing mint (#4FE0C4) reads well as text on the dark surface
-     and as a button bg with dark text. */
-  --primary: oklch(0.82 0.11 175);
+  /* Bright marketing mint (#4FE0C4 at hue 175) reads well as text on the dark
+     surface and as a button bg with dark text. */
+  --primary: oklch(0.82 0.11 var(--accent-hue));
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.715 0 0);
-  --accent: oklch(0.32 0.04 175);
+  --accent: oklch(0.32 0.04 var(--accent-hue));
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --success: oklch(0.8 0.17 150);
@@ -128,7 +137,7 @@
   --merged: oklch(0.75 0.16 305);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.82 0.11 175);
+  --ring: oklch(0.82 0.11 var(--accent-hue));
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -136,12 +145,12 @@
   --chart-5: oklch(0.269 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.82 0.11 175);
+  --sidebar-primary: oklch(0.82 0.11 var(--accent-hue));
   --sidebar-primary-foreground: oklch(0.205 0 0);
-  --sidebar-accent: oklch(0.32 0.04 175);
+  --sidebar-accent: oklch(0.32 0.04 var(--accent-hue));
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.82 0.11 175);
+  --sidebar-ring: oklch(0.82 0.11 var(--accent-hue));
 }
 
 /* "Slate" — a softer dark theme (Settings → Appearance) in the style of GitHub's
@@ -174,11 +183,11 @@
   /* Selection / hover surfaces pick up the same cool tint. */
   --accent: oklch(0.34 0.025 255);
   --sidebar-accent: oklch(0.34 0.025 255);
-  /* Brand mint + focus ring, gently desaturated for the softer field. */
-  --primary: oklch(0.8 0.095 175);
-  --sidebar-primary: oklch(0.8 0.095 175);
-  --ring: oklch(0.8 0.095 175);
-  --sidebar-ring: oklch(0.8 0.095 175);
+  /* Brand hue + focus ring, gently desaturated for the softer field. */
+  --primary: oklch(0.8 0.095 var(--accent-hue));
+  --sidebar-primary: oklch(0.8 0.095 var(--accent-hue));
+  --ring: oklch(0.8 0.095 var(--accent-hue));
+  --sidebar-ring: oklch(0.8 0.095 var(--accent-hue));
   /* Semantic state colors, desaturated so they don't glow on the lighter field. */
   --success: oklch(0.78 0.13 150);
   --warning: oklch(0.8 0.12 75);
@@ -229,7 +238,7 @@
     @apply bg-background text-foreground;
   }
   html {
-    @apply font-mono;
+    @apply font-sans;
   }
 }
 
@@ -290,4 +299,66 @@
 .diff-tailwindcss-wrapper .diff-widget-tooltip::before,
 .diff-tailwindcss-wrapper .diff-widget-tooltip::after {
   display: none !important;
+}
+
+/* Accent hue slider (Settings → Appearance). Native range so arrows work
+   without a vendored Slider; the track is a hue wheel at the token chroma. */
+.gd-hue-slider {
+  appearance: none;
+  height: 0.5rem;
+  border-radius: 0;
+  background: linear-gradient(
+    to right in oklch,
+    oklch(0.7 0.14 0),
+    oklch(0.7 0.14 60),
+    oklch(0.7 0.14 120),
+    oklch(0.7 0.14 180),
+    oklch(0.7 0.14 240),
+    oklch(0.7 0.14 300),
+    oklch(0.7 0.14 360)
+  );
+}
+.gd-hue-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0;
+  background: oklch(0.65 0.14 var(--accent-hue));
+  border: 1px solid var(--border);
+  box-shadow: 0 0 0 1px var(--background);
+}
+.gd-hue-slider::-moz-range-thumb {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0;
+  background: oklch(0.65 0.14 var(--accent-hue));
+  border: 1px solid var(--border);
+  box-shadow: 0 0 0 1px var(--background);
+}
+.gd-hue-slider::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 0;
+  background: linear-gradient(
+    to right in oklch,
+    oklch(0.7 0.14 0),
+    oklch(0.7 0.14 60),
+    oklch(0.7 0.14 120),
+    oklch(0.7 0.14 180),
+    oklch(0.7 0.14 240),
+    oklch(0.7 0.14 300),
+    oklch(0.7 0.14 360)
+  );
+}
+.gd-hue-slider:focus-visible {
+  outline: none;
+}
+.gd-hue-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 3px var(--ring);
+}
+.gd-hue-slider:focus-visible::-moz-range-thumb {
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 3px var(--ring);
 }

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -495,11 +495,14 @@ export function ConversationListPanel<L, R, J = never, LN = never>(props: {
                 )}
               </div>
               {linear.pending ? (
-                <div className="space-y-2 p-3">
-                  {Array.from({ length: linear.skeletonRows }, (_, i) => (
-                    <Skeleton key={i} className="h-9 w-full" />
-                  ))}
-                </div>
+                // Same three-line, chip-led rows as Jira (status · title ·
+                // identifier/updated), so the placeholder matches the real row.
+                <ListRowSkeletons
+                  rows={linear.skeletonRows}
+                  lines={3}
+                  name="Linear issues"
+                  indent={false}
+                />
               ) : linear.isError ? (
                 (linear.errorSlot ?? (
                   <p className="px-3 py-4 text-xs text-muted-foreground">

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -33,6 +33,9 @@ export interface NewMenuConfig {
    *  the user can create issues in it (permission-gated at the call site). */
   jiraLabel?: string;
   onJira?: () => void;
+  /** Optional Linear create item — present only when a Linear team is linked. */
+  linearLabel?: string;
+  onLinear?: () => void;
 }
 
 const ROW_CLASS = "block w-full border-b px-3 py-2 text-left";
@@ -84,7 +87,7 @@ function SectionHeader(props: {
  * (and thus the `data-row` keys arrow-key nav depends on) is baked in here; each
  * panel supplies only the inner row content via render props.
  */
-export function ConversationListPanel<L, R, J = never>(props: {
+export function ConversationListPanel<L, R, J = never, LN = never>(props: {
   repoPath: string;
   /** ForgeNotReady's `feature` (e.g. "pull requests"). */
   feature: string;
@@ -180,6 +183,22 @@ export function ConversationListPanel<L, R, J = never>(props: {
     /** Empty-state teaching copy when the linked project has no matching issues. */
     emptyLabel: ReactNode;
   };
+  /** Optional FOURTH section for a linked Linear team, rendered after Jira.
+   *  Rows carry `data-row="linear:<key>"` for arrow-key nav. */
+  linear?: {
+    header: ReactNode;
+    headerAction?: ReactNode;
+    pending: boolean;
+    isError: boolean;
+    errorSlot?: ReactNode;
+    items: LN[];
+    itemKey: (item: LN) => string;
+    isActive: (item: LN) => boolean;
+    onSelect: (item: LN) => void;
+    renderRow: (item: LN) => ReactNode;
+    skeletonRows: number;
+    emptyLabel: ReactNode;
+  };
   /** "Load more" for the REMOTE section: true when the remote list filled its
    *  requested limit (more may exist server-side). Renders a focusable row at the
    *  very bottom of the list; `onLoadMore` bumps the caller's limit, `loadingMore`
@@ -238,6 +257,7 @@ export function ConversationListPanel<L, R, J = never>(props: {
     localNoun,
     remoteNoun,
     jira,
+    linear,
     hasMore,
     onLoadMore,
     loadingMore,
@@ -284,6 +304,11 @@ export function ConversationListPanel<L, R, J = never>(props: {
             {newMenu.jiraLabel && newMenu.onJira && (
               <DropdownMenuItem onClick={newMenu.onJira}>
                 {newMenu.jiraLabel}
+              </DropdownMenuItem>
+            )}
+            {newMenu.linearLabel && newMenu.onLinear && (
+              <DropdownMenuItem onClick={newMenu.onLinear}>
+                {newMenu.linearLabel}
               </DropdownMenuItem>
             )}
           </DropdownMenuContent>
@@ -461,8 +486,50 @@ export function ConversationListPanel<L, R, J = never>(props: {
             </>
           )}
 
+          {linear && (
+            <>
+              <div className="flex items-center gap-1 px-3 pt-3 pb-1">
+                <p className="text-xs text-muted-foreground">
+                  {linear.header}
+                </p>
+                {linear.headerAction && (
+                  <span className="ml-auto">{linear.headerAction}</span>
+                )}
+              </div>
+              {linear.pending ? (
+                <div className="space-y-2 p-3">
+                  {Array.from({ length: linear.skeletonRows }, (_, i) => (
+                    <Skeleton key={i} className="h-9 w-full" />
+                  ))}
+                </div>
+              ) : linear.isError ? (
+                (linear.errorSlot ?? (
+                  <p className="px-3 py-4 text-xs text-muted-foreground">
+                    Couldn't load Linear issues.
+                  </p>
+                ))
+              ) : linear.items.length === 0 ? (
+                <p className="px-3 py-4 text-xs text-muted-foreground">
+                  {linear.emptyLabel}
+                </p>
+              ) : (
+                linear.items.map((item) => (
+                  <button
+                    type="button"
+                    key={linear.itemKey(item)}
+                    data-row={`linear:${linear.itemKey(item)}`}
+                    className={rowClass(linear.isActive(item))}
+                    onClick={() => linear.onSelect(item)}
+                  >
+                    {linear.renderRow(item)}
+                  </button>
+                ))
+              )}
+            </>
+          )}
+
           {/* "Load more" for the remote section, at the very bottom of the list.
-              Only the remote list paginates (local + Jira load in full). */}
+              Only the remote list paginates (local + Jira + Linear load in full). */}
           {hasMore && onLoadMore && (
             <LoadMoreRow
               count={remoteCount ?? 0}

--- a/src/features/conversations/ConversationListPanel.tsx
+++ b/src/features/conversations/ConversationListPanel.tsx
@@ -489,9 +489,7 @@ export function ConversationListPanel<L, R, J = never, LN = never>(props: {
           {linear && (
             <>
               <div className="flex items-center gap-1 px-3 pt-3 pb-1">
-                <p className="text-xs text-muted-foreground">
-                  {linear.header}
-                </p>
+                <p className="text-xs text-muted-foreground">{linear.header}</p>
                 {linear.headerAction && (
                   <span className="ml-auto">{linear.headerAction}</span>
                 )}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -57,7 +57,11 @@ A few things worth knowing up front:
   read and act on pull requests and Pipelines. (See **Bitbucket repositories** below.)
 - **Make it yours.** Pick a theme — **System**, **Light**, **Dark**, or a softer
   **Slate** that's easier on the eyes — in **Settings → Appearance**, or cycle
-  themes anytime from the command palette ({{kbd:command-palette}}).
+  themes anytime from the command palette ({{kbd:command-palette}}). The same
+  page has an **accent colour** (a hue that tints buttons, focus rings, and
+  highlights) and a **UI font** (**JetBrains Mono**, **Inter**, or your system
+  UI font). Code, diffs, and the terminal stay on JetBrains Mono.
+  **Reset accent & font** restores those two to defaults.
 {{ai}}- **AI is optional.** Commit messages, PR descriptions, reviews, CI debugging, and
   agent sessions can use Anthropic, OpenAI, Google AI Studio, OpenRouter, Ollama
   (local or cloud), an OpenAI-compatible endpoint, or the Claude Code / Codex /
@@ -2514,7 +2518,11 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   the destination alone), and privacy options.
 - **Appearance** — pick a theme: **System** (follows your OS's light/dark setting),
   **Light**, **Dark**, or **Slate** (a softer, blue-gray dark). Applies as you pick it,
-  and *Cycle theme* in the command palette steps through them.
+  and *Cycle theme* in the command palette steps through them. **Accent colour** tints
+  buttons, focus rings, and highlights on top of that theme (status colours stay put).
+  **UI font** switches chrome, headings, and body copy between **JetBrains Mono**,
+  **Inter**, and your system UI font; code, diffs, and the terminal stay on JetBrains
+  Mono. **Reset accent & font** restores those two to defaults.
 {{ai}}- **AI** — providers, models, keys, instructions, and agent-session defaults: the
   default agent, isolation (worktree / container), and the container image.
 - **Slash commands** — manage built-in and custom agent commands.

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -20,6 +20,7 @@ import { AmendForcePushDialog } from "@/features/commit/AmendForcePushDialog";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { DiffSurface, type LineWidget } from "@/features/diff/DiffSurfaceLazy";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
+import { LinearRefRow } from "@/features/issues/LinearRefRow";
 import {
   CommitComments,
   CommitLineComposer,
@@ -399,13 +400,22 @@ export function CommitDetailView({
             are CLICKABLE links mined from the message text, and a dimmed one
             still navigates to the previous commit's issue. */}
         {!details.isPlaceholderData && (
-          <JiraRefRow
-            repoPath={repoPath}
-            sources={[
-              { label: "commit subject", text: commit.subject },
-              { label: "commit message body", text: commit.body },
-            ]}
-          />
+          <>
+            <JiraRefRow
+              repoPath={repoPath}
+              sources={[
+                { label: "commit subject", text: commit.subject },
+                { label: "commit message body", text: commit.body },
+              ]}
+            />
+            <LinearRefRow
+              repoPath={repoPath}
+              sources={[
+                { label: "commit subject", text: commit.subject },
+                { label: "commit message body", text: commit.body },
+              ]}
+            />
+          </>
         )}
       </header>
 

--- a/src/features/issues/CreateLinearIssueDialog.tsx
+++ b/src/features/issues/CreateLinearIssueDialog.tsx
@@ -48,7 +48,7 @@ export function CreateLinearIssueDialog({
     if (!canSubmit) return;
     try {
       const result = await create.mutateAsync({
-        teamId: "",
+        teamId: link.teamId,
         title: title.trim(),
         descriptionMd: description.trim() || undefined,
       });

--- a/src/features/issues/CreateLinearIssueDialog.tsx
+++ b/src/features/issues/CreateLinearIssueDialog.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { useLinearCreateIssue, useLinearLink } from "@/lib/linear/queries";
+import { useLinearCreateIssue } from "@/lib/linear/queries";
 import type { LinearLink } from "@/lib/linear/store";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
@@ -42,9 +42,7 @@ export function CreateLinearIssueDialog({
   });
 
   const canSubmit = title.trim().length > 0;
-  const disabledReason = !title.trim()
-    ? "Enter a title for the issue"
-    : null;
+  const disabledReason = !title.trim() ? "Enter a title for the issue" : null;
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -66,9 +64,7 @@ export function CreateLinearIssueDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>
-            New issue in {link.teamKey}
-          </DialogTitle>
+          <DialogTitle>New issue in {link.teamKey}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-3">

--- a/src/features/issues/CreateLinearIssueDialog.tsx
+++ b/src/features/issues/CreateLinearIssueDialog.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { useLinearCreateIssue, useLinearLink } from "@/lib/linear/queries";
+import type { LinearLink } from "@/lib/linear/store";
+import { useUiStore } from "@/lib/stores/ui";
+import { errorMessage } from "@/lib/tauri/invoke";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
+
+export function CreateLinearIssueDialog({
+  repoPath,
+  link,
+  open,
+  onOpenChange,
+}: {
+  repoPath: string;
+  link: LinearLink;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const create = useLinearCreateIssue(repoPath, link);
+  const selectIssue = useUiStore((s) => s.selectIssue);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  useSeedOnOpen(open, () => {
+    setTitle("");
+    setDescription("");
+  });
+
+  const canSubmit = title.trim().length > 0;
+  const disabledReason = !title.trim()
+    ? "Enter a title for the issue"
+    : null;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    try {
+      const result = await create.mutateAsync({
+        teamId: "",
+        title: title.trim(),
+        descriptionMd: description.trim() || undefined,
+      });
+      toast.success(`Created ${result.identifier}`);
+      selectIssue({ kind: "linear", id: result.identifier });
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(errorMessage(e));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            New issue in {link.teamKey}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="linear-title">Title</Label>
+            <Input
+              id="linear-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Issue title"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey && canSubmit) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="linear-desc">Description</Label>
+            <Textarea
+              id="linear-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the issue (markdown)"
+              rows={5}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="cursor-pointer"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <DisabledReasonButton
+            size="sm"
+            className="cursor-pointer"
+            onClick={handleSubmit}
+            disabled={!canSubmit || create.isPending}
+            reason={disabledReason}
+          >
+            {create.isPending && <Spinner className="mr-1.5 size-3" />}
+            Create
+          </DisabledReasonButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/issues/IssuesPanel.tsx
+++ b/src/features/issues/IssuesPanel.tsx
@@ -175,7 +175,11 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   const linearLinkQ = useLinearLink(repoPath);
   const linearLink = linearLinkQ.data ?? null;
   const linearStateFilter =
-    stateFilter === "open" ? "open" : stateFilter === "closed" ? "closed" : "all";
+    stateFilter === "open"
+      ? "open"
+      : stateFilter === "closed"
+        ? "closed"
+        : "all";
   const linearIssues = useLinearIssues(repoPath, linearLink, linearStateFilter);
   const canCreateLinear = !!linearLink;
   const pendingIssueDraft = useUiStore((s) => s.pendingIssueDraft);

--- a/src/features/issues/IssuesPanel.tsx
+++ b/src/features/issues/IssuesPanel.tsx
@@ -33,6 +33,8 @@ import {
   useJiraPermissions,
 } from "@/lib/jira/queries";
 import { formatStoryPoints, type JiraIssueInfo } from "@/lib/jira/types";
+import { useLinearIssues, useLinearLink } from "@/lib/linear/queries";
+import type { LinearIssueInfo } from "@/lib/linear/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
   useLensGate,
@@ -46,8 +48,10 @@ import { parseableDate } from "@/lib/time";
 import { toastError } from "@/lib/toast";
 import { CreateIssueDialog } from "./CreateIssueDialog";
 import { CreateJiraIssueDialog } from "./CreateJiraIssueDialog";
+import { CreateLinearIssueDialog } from "./CreateLinearIssueDialog";
 import { CreateLocalIssueDialog } from "./CreateLocalIssueDialog";
 import { RepoJiraDialog } from "./RepoJiraDialog";
+import { RepoLinearDialog } from "./RepoLinearDialog";
 
 /** Where the "New" menu's forge item creates the issue. An unrecognized or
  *  absent provider routes through gh, so GitHub is the fallback (mirrors
@@ -80,6 +84,20 @@ function BitbucketLinkJiraCta({ onLink }: { onLink: () => void }) {
  *  status name is the text (meaning is never color-only). */
 function JiraStatusChip({ issue }: { issue: JiraIssueInfo }) {
   const done = issue.statusCategory === "done";
+  const Icon = done ? CheckCircleIcon : CircleDashedIcon;
+  return (
+    <span className="inline-flex w-fit items-center gap-1 whitespace-nowrap border px-1 py-px text-[10px] text-muted-foreground">
+      <Icon
+        className={`size-3 shrink-0 ${done ? "text-merged" : "text-success"}`}
+      />
+      {issue.statusName}
+    </span>
+  );
+}
+
+function LinearStatusChip({ issue }: { issue: LinearIssueInfo }) {
+  const done =
+    issue.statusType === "completed" || issue.statusType === "cancelled";
   const Icon = done ? CheckCircleIcon : CircleDashedIcon;
   return (
     <span className="inline-flex w-fit items-center gap-1 whitespace-nowrap border px-1 py-px text-[10px] text-muted-foreground">
@@ -140,7 +158,9 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   const [createOpen, setCreateOpen] = useState(false);
   const [createLocalOpen, setCreateLocalOpen] = useState(false);
   const [createJiraOpen, setCreateJiraOpen] = useState(false);
+  const [createLinearOpen, setCreateLinearOpen] = useState(false);
   const [jiraOpen, setJiraOpen] = useState(false);
+  const [linearOpen, setLinearOpen] = useState(false);
   const localIssues = useLocalIssues(repoPath);
   // A linked Jira project is a third issue source, independent of the git host.
   const jiraLink = useJiraLink(repoPath);
@@ -150,6 +170,14 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
   // linked AND the user can create issues (a failed probe → `?? false` → absent).
   const jiraPerms = useJiraPermissions(repoPath, link);
   const canCreateJira = !!link && (jiraPerms.data?.createIssues ?? false);
+  // A linked Linear team is another issue source, orthogonal to the git host
+  // and Jira. Linear's API key is user-scoped, so no project-level permission.
+  const linearLinkQ = useLinearLink(repoPath);
+  const linearLink = linearLinkQ.data ?? null;
+  const linearStateFilter =
+    stateFilter === "open" ? "open" : stateFilter === "closed" ? "closed" : "all";
+  const linearIssues = useLinearIssues(repoPath, linearLink, linearStateFilter);
+  const canCreateLinear = !!linearLink;
   const pendingIssueDraft = useUiStore((s) => s.pendingIssueDraft);
   const setPendingIssueDraft = useUiStore((s) => s.setPendingIssueDraft);
   const pendingCreate = useUiStore((s) => s.pendingCreate);
@@ -166,6 +194,12 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
     canCreateJira,
   );
   useHotkeyAction("link-jira-project", () => setJiraOpen(true));
+  useHotkeyAction(
+    "create-linear-issue",
+    () => setCreateLinearOpen(true),
+    canCreateLinear,
+  );
+  useHotkeyAction("link-linear-team", () => setLinearOpen(true));
 
   // "Reference in new issue" / "Duplicate issue" seeds + opens the create dialog.
   // Re-check the gate (like the PR panel): the seeder's own gate can lag this
@@ -190,13 +224,19 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
       setCreateLocalOpen(true);
       clearPendingCreate();
     } else if (pendingCreate === "jira-issue") {
-      // Re-check the gate: RepositoryView's fallback fired from another tab, so
-      // its snapshot of the permission can lag this panel's — never open a
-      // create dialog that can't submit (mirrors the canCreateGh guard above).
       if (canCreateJira) setCreateJiraOpen(true);
       clearPendingCreate();
+    } else if (pendingCreate === "linear-issue") {
+      if (canCreateLinear) setCreateLinearOpen(true);
+      clearPendingCreate();
     }
-  }, [pendingCreate, clearPendingCreate, canOpenGhCreate, canCreateJira]);
+  }, [
+    pendingCreate,
+    clearPendingCreate,
+    canOpenGhCreate,
+    canCreateJira,
+    canCreateLinear,
+  ]);
 
   const {
     filterText,
@@ -238,14 +278,24 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
             i.summary.toLowerCase().includes(jiraQuery),
         );
 
+  // Linear issues: apply the same free-text filter. Author/label filters from
+  // the host's vocabulary exclude the section (same as Jira).
+  const linearQuery = filterText.trim().toLowerCase();
+  const visibleLinear =
+    authorFilter.size > 0 || labelFilter.size > 0
+      ? []
+      : (linearIssues.data ?? []).filter(
+          (i) =>
+            !linearQuery ||
+            i.identifier.toLowerCase().includes(linearQuery) ||
+            i.title.toLowerCase().includes(linearQuery),
+        );
+
   const { localCollapsed, remoteCollapsed, toggleLocal, toggleRemote } =
     useCollapsedSections("issues");
 
-  // Arrow keys walk the visible rows: local → remote → jira, matching the render
-  // order (navTargets is flattened for the shared keyboard-nav helper). A
-  // collapsed section's rows leave the registry (its body is unmounted), so an
-  // arrow key can never land on an invisible row. The Jira section isn't
-  // collapsible, so it always contributes.
+  // Arrow keys walk the visible rows: local → remote → jira → linear, matching
+  // the render order. Collapsed sections' rows leave the registry.
   const navTargets = [
     ...(localCollapsed
       ? []
@@ -257,6 +307,10 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
           id: String(i.number),
         }))),
     ...visibleJira.map((i) => ({ kind: "jira" as const, id: i.key })),
+    ...visibleLinear.map((i) => ({
+      kind: "linear" as const,
+      id: i.identifier,
+    })),
   ];
 
   const onListKeyDown = listKeyboardNav({
@@ -320,6 +374,12 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
             ? `Jira issue in ${link?.projectKey}…`
             : undefined,
           onJira: canCreateJira ? () => setCreateJiraOpen(true) : undefined,
+          linearLabel: canCreateLinear
+            ? `Linear issue in ${linearLink?.teamKey}…`
+            : undefined,
+          onLinear: canCreateLinear
+            ? () => setCreateLinearOpen(true)
+            : undefined,
         }}
         filterSlot={
           <ConversationFilterPopover
@@ -549,6 +609,81 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
               }
             : undefined
         }
+        linear={
+          linearLink
+            ? {
+                header: `Linear · ${linearLink.teamKey}`,
+                headerAction: (
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="cursor-pointer text-muted-foreground"
+                    onClick={() => setLinearOpen(true)}
+                    title={`Edit Linear link (${linearLink.teamKey})`}
+                  >
+                    Edit
+                  </Button>
+                ),
+                pending: linearIssues.isPending,
+                isError: linearIssues.isError,
+                errorSlot: (
+                  <div className="space-y-2 px-3 py-4 text-xs text-muted-foreground">
+                    <p>
+                      Couldn't load {linearLink.teamKey} — your Linear API key
+                      may have expired.
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="cursor-pointer"
+                      onClick={() => setLinearOpen(true)}
+                    >
+                      Reconnect
+                    </Button>
+                  </div>
+                ),
+                items: visibleLinear,
+                itemKey: (issue: LinearIssueInfo) => issue.identifier,
+                isActive: (issue: LinearIssueInfo) =>
+                  selectedIssue?.kind === "linear" &&
+                  selectedIssue.id === issue.identifier,
+                onSelect: (issue: LinearIssueInfo) =>
+                  selectIssue({ kind: "linear", id: issue.identifier }),
+                renderRow: (issue: LinearIssueInfo) => (
+                  <>
+                    <div className="flex min-h-6 items-center gap-1.5">
+                      <LinearStatusChip issue={issue} />
+                      {issue.assignee && (
+                        <span className="ml-auto shrink-0">
+                          <ForgeUserAvatar
+                            user={issue.assignee}
+                            ghHost={null}
+                          />
+                        </span>
+                      )}
+                    </div>
+                    <p
+                      className="mt-0.5 truncate text-xs font-medium"
+                      title={issue.title}
+                    >
+                      {issue.title}
+                    </p>
+                    <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+                      {issue.identifier}
+                      {parseableDate(issue.updatedAt) && (
+                        <>
+                          {" · "}
+                          <RelativeTime date={issue.updatedAt} />
+                        </>
+                      )}
+                    </p>
+                  </>
+                ),
+                skeletonRows: 3,
+                emptyLabel: `No ${stateFilter} issues in ${linearLink.teamKey} — switch the filter or view the team in Linear.`,
+              }
+            : undefined
+        }
       >
         <CreateIssueDialog
           repoPath={repoPath}
@@ -573,11 +708,25 @@ export function IssuesPanel({ repoPath }: { repoPath: string }) {
             onOpenChange={setCreateJiraOpen}
           />
         )}
+        {linearLink && (
+          <CreateLinearIssueDialog
+            repoPath={repoPath}
+            link={linearLink}
+            open={createLinearOpen}
+            onOpenChange={setCreateLinearOpen}
+          />
+        )}
         <RepoJiraDialog
           repoPath={repoPath}
           open={jiraOpen}
           onOpenChange={setJiraOpen}
           existingLink={link}
+        />
+        <RepoLinearDialog
+          repoPath={repoPath}
+          open={linearOpen}
+          onOpenChange={setLinearOpen}
+          existingLink={linearLink}
         />
       </ConversationListPanel>
     </div>

--- a/src/features/issues/LinearIssueView.tsx
+++ b/src/features/issues/LinearIssueView.tsx
@@ -1,0 +1,200 @@
+import {
+  ArrowSquareOutIcon,
+  CheckCircleIcon,
+  CircleDashedIcon,
+} from "@phosphor-icons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useRef } from "react";
+import type { MarkdownEditorHandle } from "@/components/markdown-editor";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/ui/markdown";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CommentComposer } from "@/features/conversations/CommentComposer";
+import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
+import {
+  useLinearComment,
+  useLinearIssue,
+  useLinearLink,
+} from "@/lib/linear/queries";
+import type { LinearComment, LinearIssueDetails } from "@/lib/linear/types";
+import { parseableDate } from "@/lib/time";
+import { toastError } from "@/lib/toast";
+
+function LinearStatusChip({ issue }: { issue: LinearIssueDetails }) {
+  const done =
+    issue.statusType === "completed" || issue.statusType === "cancelled";
+  const Icon = done ? CheckCircleIcon : CircleDashedIcon;
+  return (
+    <span className="inline-flex w-fit items-center gap-1 whitespace-nowrap border px-1 py-px text-[10px] text-muted-foreground">
+      <Icon
+        className={`size-3 shrink-0 ${done ? "text-merged" : "text-success"}`}
+      />
+      {issue.statusName}
+    </span>
+  );
+}
+
+function CommentRow({ comment }: { comment: LinearComment }) {
+  return (
+    <div className="space-y-1 border-t px-4 py-3">
+      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+        {comment.author && (
+          <>
+            <ForgeUserAvatar user={comment.author} ghHost={null} />
+            <span className="font-medium text-foreground">
+              {comment.author.label}
+            </span>
+          </>
+        )}
+        {parseableDate(comment.createdAt) && (
+          <RelativeTime date={comment.createdAt} />
+        )}
+        {comment.updatedAt && comment.updatedAt !== comment.createdAt && (
+          <span>(edited)</span>
+        )}
+      </div>
+      <Markdown text={comment.bodyMd} />
+    </div>
+  );
+}
+
+export function LinearIssueView({
+  repoPath,
+  issueIdentifier,
+}: {
+  repoPath: string;
+  issueIdentifier: string;
+}) {
+  const link = useLinearLink(repoPath);
+  const issue = useLinearIssue(repoPath, link.data, issueIdentifier);
+  const comment = useLinearComment(repoPath);
+  const editorRef = useRef<MarkdownEditorHandle>(null);
+
+  if (issue.isPending) {
+    return (
+      <div className="space-y-3 p-4">
+        <Skeleton className="h-6 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (issue.isError || !issue.data) {
+    return (
+      <DiffPlaceholder
+        icon={CircleDashedIcon}
+        heading="Couldn't load issue"
+        copy={`${issueIdentifier} could not be loaded.`}
+      />
+    );
+  }
+
+  const d = issue.data;
+
+  async function handleComment(body: string) {
+    if (!d) return;
+    await comment.mutateAsync({
+      issueId: d.id,
+      issueIdentifier: d.identifier,
+      bodyMd: body,
+    });
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-3 p-4">
+          <div className="flex items-start justify-between gap-2">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold">{d.title}</h2>
+              <div className="flex items-center gap-2">
+                <LinearStatusChip issue={d} />
+                <span className="font-mono text-xs text-muted-foreground">
+                  {d.identifier}
+                </span>
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="xs"
+              className="cursor-pointer shrink-0 text-muted-foreground"
+              onClick={() => openUrl(d.url).catch(toastError)}
+              title={`Open ${d.identifier} in Linear`}
+            >
+              <ArrowSquareOutIcon data-icon="inline-start" />
+              Open in Linear
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+            {d.assignee && (
+              <span className="inline-flex items-center gap-1">
+                <ForgeUserAvatar user={d.assignee} ghHost={null} />
+                {d.assignee.label}
+              </span>
+            )}
+            {d.priorityLabel && (
+              <span className="border px-1 py-px">{d.priorityLabel}</span>
+            )}
+            {d.labels.map((l) => (
+              <span key={l} className="border px-1 py-px">
+                {l}
+              </span>
+            ))}
+            {d.estimate != null && (
+              <span className="border px-1 py-px" title="Estimate">
+                {d.estimate}
+              </span>
+            )}
+            {d.cycleName && (
+              <span className="border px-1 py-px">{d.cycleName}</span>
+            )}
+            {d.projectName && (
+              <span className="border px-1 py-px">{d.projectName}</span>
+            )}
+          </div>
+
+          {parseableDate(d.createdAt) && (
+            <p className="text-[11px] text-muted-foreground">
+              Opened <RelativeTime date={d.createdAt} />
+              {parseableDate(d.updatedAt) &&
+                d.updatedAt !== d.createdAt && (
+                  <>
+                    {" · updated "}
+                    <RelativeTime date={d.updatedAt} />
+                  </>
+                )}
+            </p>
+          )}
+
+          {d.descriptionMd && (
+            <div className="border-t pt-3">
+              <Markdown text={d.descriptionMd} />
+            </div>
+          )}
+        </div>
+
+        {d.comments.length > 0 && (
+          <div>
+            {d.comments.map((c) => (
+              <CommentRow key={c.id} comment={c} />
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+
+      <div className="border-t p-3">
+        <CommentComposer
+          ref={editorRef}
+          onSubmit={handleComment}
+          submitting={comment.isPending}
+          placeholder="Leave a comment…"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/issues/LinearIssueView.tsx
+++ b/src/features/issues/LinearIssueView.tsx
@@ -4,7 +4,8 @@ import {
   CircleDashedIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useRef } from "react";
+import { useRef, useState } from "react";
+import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import type { MarkdownEditorHandle } from "@/components/markdown-editor";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -13,7 +14,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CommentComposer } from "@/features/conversations/CommentComposer";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
-import { ForgeUserAvatar } from "@/components/forge-user-avatar";
 import {
   useLinearComment,
   useLinearIssue,
@@ -56,7 +56,7 @@ function CommentRow({ comment }: { comment: LinearComment }) {
           <span>(edited)</span>
         )}
       </div>
-      <Markdown text={comment.bodyMd} />
+      <Markdown>{comment.bodyMd}</Markdown>
     </div>
   );
 }
@@ -72,6 +72,7 @@ export function LinearIssueView({
   const issue = useLinearIssue(repoPath, link.data, issueIdentifier);
   const comment = useLinearComment(repoPath);
   const editorRef = useRef<MarkdownEditorHandle>(null);
+  const [draft, setDraft] = useState("");
 
   if (issue.isPending) {
     return (
@@ -87,21 +88,21 @@ export function LinearIssueView({
     return (
       <DiffPlaceholder
         icon={CircleDashedIcon}
-        heading="Couldn't load issue"
-        copy={`${issueIdentifier} could not be loaded.`}
+        message={`${issueIdentifier} could not be loaded.`}
       />
     );
   }
 
   const d = issue.data;
 
-  async function handleComment(body: string) {
-    if (!d) return;
+  async function submitComment() {
+    if (!d || !draft.trim()) return;
     await comment.mutateAsync({
       issueId: d.id,
       issueIdentifier: d.identifier,
-      bodyMd: body,
+      bodyMd: draft.trim(),
     });
+    setDraft("");
   }
 
   return (
@@ -161,19 +162,18 @@ export function LinearIssueView({
           {parseableDate(d.createdAt) && (
             <p className="text-[11px] text-muted-foreground">
               Opened <RelativeTime date={d.createdAt} />
-              {parseableDate(d.updatedAt) &&
-                d.updatedAt !== d.createdAt && (
-                  <>
-                    {" · updated "}
-                    <RelativeTime date={d.updatedAt} />
-                  </>
-                )}
+              {parseableDate(d.updatedAt) && d.updatedAt !== d.createdAt && (
+                <>
+                  {" · updated "}
+                  <RelativeTime date={d.updatedAt} />
+                </>
+              )}
             </p>
           )}
 
           {d.descriptionMd && (
             <div className="border-t pt-3">
-              <Markdown text={d.descriptionMd} />
+              <Markdown>{d.descriptionMd}</Markdown>
             </div>
           )}
         </div>
@@ -187,14 +187,17 @@ export function LinearIssueView({
         )}
       </ScrollArea>
 
-      <div className="border-t p-3">
-        <CommentComposer
-          ref={editorRef}
-          onSubmit={handleComment}
-          submitting={comment.isPending}
-          placeholder="Leave a comment…"
-        />
-      </div>
+      <CommentComposer
+        ref={editorRef}
+        value={draft}
+        onChange={setDraft}
+        onSubmit={submitComment}
+        onClear={() => setDraft("")}
+        submitLabel="Comment"
+        ariaLabel="Leave a comment"
+        placeholder="Leave a comment…"
+        busy={comment.isPending}
+      />
     </div>
   );
 }

--- a/src/features/issues/LinearRefRow.tsx
+++ b/src/features/issues/LinearRefRow.tsx
@@ -34,7 +34,11 @@ export function LinearRefRow({
     }
   }
 
-  const issues = useLinearIssues(repoPath, keys.length > 0 ? link : null, "all");
+  const issues = useLinearIssues(
+    repoPath,
+    keys.length > 0 ? link : null,
+    "all",
+  );
   const selectIssue = useUiStore((s) => s.selectIssue);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
 
@@ -72,9 +76,7 @@ export function LinearRefRow({
             <span className="shrink-0 font-mono text-muted-foreground">
               {key}
             </span>
-            {title && (
-              <span className="min-w-0 flex-1 truncate">{title}</span>
-            )}
+            {title && <span className="min-w-0 flex-1 truncate">{title}</span>}
           </button>
         );
       })}

--- a/src/features/issues/LinearRefRow.tsx
+++ b/src/features/issues/LinearRefRow.tsx
@@ -1,0 +1,83 @@
+import { StackIcon } from "@phosphor-icons/react";
+import { extractLinearKeys } from "@/lib/linear/keys";
+import { useLinearIssues, useLinearLink } from "@/lib/linear/queries";
+import { useUiStore } from "@/lib/stores/ui";
+
+export interface LinearRefSource {
+  label: string;
+  text: string | null | undefined;
+}
+
+/**
+ * The shared "Linear issues referenced" presentation: one full-width row per
+ * matched identifier. Same idiom as JiraRefRow — clicking a row selects the
+ * issue in the Linear panel AND switches to the Issues tab.
+ */
+export function LinearRefRow({
+  repoPath,
+  sources,
+}: {
+  repoPath: string;
+  sources: LinearRefSource[];
+}) {
+  const link = useLinearLink(repoPath).data;
+  const keys: string[] = [];
+  const attribution = new Map<string, string>();
+  if (link) {
+    for (const source of sources) {
+      for (const key of extractLinearKeys(source.text, link.teamKey)) {
+        if (!attribution.has(key)) {
+          attribution.set(key, source.label);
+          keys.push(key);
+        }
+      }
+    }
+  }
+
+  const issues = useLinearIssues(repoPath, keys.length > 0 ? link : null, "all");
+  const selectIssue = useUiStore((s) => s.selectIssue);
+  const setRepoTab = useUiStore((s) => s.setRepoTab);
+
+  if (!link || keys.length === 0) return null;
+
+  const titleFor = (key: string) =>
+    issues.data?.find((i) => i.identifier === key)?.title;
+
+  function open(key: string) {
+    selectIssue({ kind: "linear", id: key });
+    setRepoTab("issues");
+  }
+
+  return (
+    <div className="space-y-1">
+      <p className="text-[11px] font-medium text-muted-foreground">
+        Linear issues
+      </p>
+      {keys.map((key) => {
+        const title = titleFor(key);
+        const source = attribution.get(key);
+        const attributionSuffix = source
+          ? ` — referenced in the ${source}`
+          : "";
+        const tooltip = (title ? `${key} ${title}` : key) + attributionSuffix;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => open(key)}
+            className="flex w-full cursor-pointer items-center gap-1.5 text-left text-xs hover:underline"
+            title={tooltip}
+          >
+            <StackIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 font-mono text-muted-foreground">
+              {key}
+            </span>
+            {title && (
+              <span className="min-w-0 flex-1 truncate">{title}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/issues/RepoLinearDialog.tsx
+++ b/src/features/issues/RepoLinearDialog.tsx
@@ -14,11 +14,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { linearSetAccount, linearValidateToken } from "@/lib/linear/api";
+import { linearSetAccount } from "@/lib/linear/api";
 import {
+  useClearLinearLink,
   useLinearAccount,
   useLinearTeams,
-  useClearLinearLink,
   useSaveLinearLink,
 } from "@/lib/linear/queries";
 import type { LinearLink } from "@/lib/linear/store";
@@ -26,8 +26,7 @@ import type { LinearAccountInfo, LinearTeam } from "@/lib/linear/types";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
-const LINEAR_API_KEY_URL =
-  "https://linear.app/settings/api";
+const LINEAR_API_KEY_URL = "https://linear.app/settings/api";
 
 export function RepoLinearDialog({
   repoPath,
@@ -106,9 +105,7 @@ export function RepoLinearDialog({
       },
       {
         onSuccess: () => {
-          toast.success(
-            `Linked to Linear team ${selectedTeam.key}`,
-          );
+          toast.success(`Linked to Linear team ${selectedTeam.key}`);
           onOpenChange(false);
         },
       },
@@ -125,9 +122,7 @@ export function RepoLinearDialog({
   }
 
   const canSave = selectedTeam !== null;
-  const disabledReason = !selectedTeam
-    ? "Select a team to link"
-    : null;
+  const disabledReason = !selectedTeam ? "Select a team to link" : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/issues/RepoLinearDialog.tsx
+++ b/src/features/issues/RepoLinearDialog.tsx
@@ -100,6 +100,7 @@ export function RepoLinearDialog({
     save.mutate(
       {
         workspaceSlug: "",
+        teamId: selectedTeam.id,
         teamKey: selectedTeam.key,
         teamName: selectedTeam.name,
       },

--- a/src/features/issues/RepoLinearDialog.tsx
+++ b/src/features/issues/RepoLinearDialog.tsx
@@ -1,0 +1,277 @@
+import { CheckCircleIcon, LinkBreakIcon } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { linearSetAccount, linearValidateToken } from "@/lib/linear/api";
+import {
+  useLinearAccount,
+  useLinearTeams,
+  useClearLinearLink,
+  useSaveLinearLink,
+} from "@/lib/linear/queries";
+import type { LinearLink } from "@/lib/linear/store";
+import type { LinearAccountInfo, LinearTeam } from "@/lib/linear/types";
+import { errorMessage } from "@/lib/tauri/invoke";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
+
+const LINEAR_API_KEY_URL =
+  "https://linear.app/settings/api";
+
+export function RepoLinearDialog({
+  repoPath,
+  open,
+  onOpenChange,
+  existingLink,
+}: {
+  repoPath: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingLink: LinearLink | null;
+}) {
+  const save = useSaveLinearLink(repoPath);
+  const clear = useClearLinearLink(repoPath);
+
+  const [tokenInput, setTokenInput] = useState("");
+  const [account, setAccount] = useState<LinearAccountInfo | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [showTokenForm, setShowTokenForm] = useState(false);
+
+  const stored = useLinearAccount();
+  const hasStored = !!stored.data;
+
+  const [selectedTeam, setSelectedTeam] = useState<LinearTeam | null>(null);
+
+  const connected = account !== null || hasStored;
+  const teams = useLinearTeams(connected && open);
+
+  useSeedOnOpen(open, () => {
+    if (existingLink) {
+      setSelectedTeam({
+        id: "",
+        key: existingLink.teamKey,
+        name: existingLink.teamName,
+      });
+    }
+    setTokenInput("");
+    setAccount(null);
+    setConnectError(null);
+    setShowTokenForm(false);
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setTokenInput("");
+      setAccount(null);
+      setConnectError(null);
+      setShowTokenForm(false);
+      setSelectedTeam(null);
+    }
+  }, [open]);
+
+  async function handleValidate() {
+    if (!tokenInput.trim()) return;
+    setValidating(true);
+    setConnectError(null);
+    try {
+      const info = await linearSetAccount(tokenInput.trim());
+      setAccount(info);
+      setShowTokenForm(false);
+    } catch (e) {
+      setConnectError(errorMessage(e));
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  function handleSave() {
+    if (!selectedTeam) return;
+    save.mutate(
+      {
+        workspaceSlug: "",
+        teamKey: selectedTeam.key,
+        teamName: selectedTeam.name,
+      },
+      {
+        onSuccess: () => {
+          toast.success(
+            `Linked to Linear team ${selectedTeam.key}`,
+          );
+          onOpenChange(false);
+        },
+      },
+    );
+  }
+
+  function handleUnlink() {
+    clear.mutate(undefined, {
+      onSuccess: () => {
+        toast.success("Linear team unlinked");
+        onOpenChange(false);
+      },
+    });
+  }
+
+  const canSave = selectedTeam !== null;
+  const disabledReason = !selectedTeam
+    ? "Select a team to link"
+    : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {existingLink ? "Edit Linear link" : "Link a Linear team"}
+          </DialogTitle>
+          <DialogDescription>
+            Connect your Linear account and pick a team to browse its issues
+            here.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {!connected || showTokenForm ? (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="linear-token">API key</Label>
+                <Input
+                  id="linear-token"
+                  type="password"
+                  value={tokenInput}
+                  onChange={(e) => setTokenInput(e.target.value)}
+                  placeholder="lin_api_…"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleValidate();
+                  }}
+                />
+                <p className="text-[11px] text-muted-foreground">
+                  Create a personal API key at{" "}
+                  <button
+                    type="button"
+                    className="cursor-pointer underline underline-offset-2"
+                    onClick={() =>
+                      import("@tauri-apps/plugin-opener").then((m) =>
+                        m.openUrl(LINEAR_API_KEY_URL),
+                      )
+                    }
+                  >
+                    linear.app/settings/api
+                  </button>
+                  .
+                </p>
+              </div>
+              {connectError && (
+                <p className="text-xs text-destructive">{connectError}</p>
+              )}
+              <Button
+                onClick={handleValidate}
+                disabled={!tokenInput.trim() || validating}
+                className="cursor-pointer"
+              >
+                {validating && <Spinner className="mr-1.5 size-3" />}
+                Connect
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-xs">
+              <CheckCircleIcon className="size-4 text-success" />
+              <span>
+                Connected as{" "}
+                <span className="font-medium">
+                  {account?.email ?? stored.data?.email}
+                </span>
+              </span>
+              <Button
+                variant="ghost"
+                size="xs"
+                className="ml-auto cursor-pointer text-muted-foreground"
+                onClick={() => setShowTokenForm(true)}
+              >
+                Change
+              </Button>
+            </div>
+          )}
+
+          {connected && !showTokenForm && (
+            <div className="space-y-1.5">
+              <Label>Team</Label>
+              {teams.isPending ? (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Spinner className="size-3" /> Loading teams…
+                </div>
+              ) : teams.isError ? (
+                <p className="text-xs text-destructive">
+                  Couldn't load teams — your API key may have expired.
+                </p>
+              ) : (
+                <div className="space-y-1">
+                  {(teams.data ?? []).map((team) => (
+                    <button
+                      key={team.id}
+                      type="button"
+                      onClick={() => setSelectedTeam(team)}
+                      className={`flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-xs ${
+                        selectedTeam?.key === team.key
+                          ? "bg-accent text-accent-foreground"
+                          : "hover:bg-muted/60"
+                      }`}
+                    >
+                      <span className="font-mono text-muted-foreground">
+                        {team.key}
+                      </span>
+                      <span className="truncate">{team.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {existingLink && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mr-auto cursor-pointer text-destructive"
+              onClick={handleUnlink}
+            >
+              <LinkBreakIcon data-icon="inline-start" />
+              Unlink
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="cursor-pointer"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <DisabledReasonButton
+            size="sm"
+            className="cursor-pointer"
+            onClick={handleSave}
+            disabled={!canSave}
+            reason={disabledReason}
+          >
+            Save
+          </DisabledReasonButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -46,6 +46,7 @@ import { useMentionCandidates } from "@/features/conversations/useMentionCandida
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { CommitDetailView } from "@/features/history/CommitDetailView";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
+import { LinearRefRow } from "@/features/issues/LinearRefRow";
 import { useStashReapplyRecovery } from "@/features/repository/useStashReapplyRecovery";
 import {
   isMergeMethodAllowed,
@@ -374,10 +375,10 @@ export function LocalPrView({
     );
   }
   const fileCount = diffFiles.data?.length;
-  // Shared JiraRefRow sources for both header branches (conflict-takeover +
+  // Shared ref-row sources for both header branches (conflict-takeover +
   // normal) so the two can't diverge. Branch name LAST so title/description
   // attribution wins a key that also appears in the branch name.
-  const jiraRefSources = [
+  const refSources = [
     { label: "title", text: pr.title },
     { label: "description", text: pr.body },
     { label: "branch name", text: pr.head },
@@ -640,7 +641,8 @@ export function LocalPrView({
               {pr.status}
             </Badge>
           </div>
-          <JiraRefRow repoPath={repoPath} sources={jiraRefSources} />
+          <JiraRefRow repoPath={repoPath} sources={refSources} />
+          <LinearRefRow repoPath={repoPath} sources={refSources} />
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <span className="font-mono">{pr.head}</span>
             <span>→</span>
@@ -698,7 +700,8 @@ export function LocalPrView({
           )}
           {pr.archived && <Badge variant="secondary">archived</Badge>}
         </div>
-        <JiraRefRow repoPath={repoPath} sources={jiraRefSources} />
+        <JiraRefRow repoPath={repoPath} sources={refSources} />
+        <LinearRefRow repoPath={repoPath} sources={refSources} />
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="font-mono">{pr.head}</span>
           <span>→</span>

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -70,6 +70,7 @@ import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { JiraRefRow } from "@/features/issues/JiraRefRow";
+import { LinearRefRow } from "@/features/issues/LinearRefRow";
 import { aiExcludePatterns, filterDiffByAiIgnore } from "@/lib/ai/ignore";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { prOpenEligible } from "@/lib/automations/sync";
@@ -2512,6 +2513,14 @@ export function RemotePrView({
           </Button>
         </div>
         <JiraRefRow
+          repoPath={repoPath}
+          sources={[
+            { label: "title", text: pr.title },
+            { label: "description", text: pr.body },
+            { label: "branch name", text: pr.headRefName },
+          ]}
+        />
+        <LinearRefRow
           repoPath={repoPath}
           sources={[
             { label: "title", text: pr.title },

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -59,6 +59,7 @@ import { CommitDetailView } from "@/features/history/CommitDetailView";
 import { HistoryPanel } from "@/features/history/HistoryPanel";
 import { IssuesPanel } from "@/features/issues/IssuesPanel";
 import { JiraIssueView } from "@/features/issues/JiraIssueView";
+import { LinearIssueView } from "@/features/issues/LinearIssueView";
 import { LocalIssueView } from "@/features/issues/LocalIssueView";
 import { RemoteIssueView } from "@/features/issues/RemoteIssueView";
 import { CreateLocalPrDialog } from "@/features/pulls/CreateLocalPrDialog";
@@ -87,6 +88,7 @@ import {
 } from "@/lib/hotkeys/binding";
 import { useEffectiveBindings, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink, useJiraPermissions } from "@/lib/jira/queries";
+import { useLinearLink } from "@/lib/linear/queries";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useLensGate, useSetRepoLens } from "@/lib/repo-lens/queries";
 import { useScripts } from "@/lib/scripts/queries";
@@ -434,6 +436,10 @@ export function RepositoryView() {
   const jiraPerms = useJiraPermissions(repoPath ?? "", jiraLink.data);
   const canCreateJira =
     !!jiraLink.data && (jiraPerms.data?.createIssues ?? false);
+  // Linear create: gated on a linked team (no project-level permission check —
+  // Linear's API key is user-scoped). Dedupes with IssuesPanel's identical key.
+  const linearLink = useLinearLink(repoPath ?? "");
+  const canCreateLinear = !!linearLink.data;
   // Tab switches are transitions: a heavy first render of the target panel
   // never blocks the click, and hidden Activities pre-render at low priority.
   const [, startTabTransition] = useTransition();
@@ -591,6 +597,11 @@ export function RepositoryView() {
     "create-jira-issue",
     () => requestCreate("jira-issue"),
     canCreateJira,
+  );
+  useHotkeyAction(
+    "create-linear-issue",
+    () => requestCreate("linear-issue"),
+    canCreateLinear,
   );
   useHotkeyAction("create-pr", () => requestCreate("pr"), canCreatePr);
   useHotkeyAction("create-local-pr", () => requestCreate("local-pr"));
@@ -997,6 +1008,11 @@ export function RepositoryView() {
               <LocalIssueView repoPath={repoPath} id={deferredIssue.id} />
             ) : deferredIssue?.kind === "jira" ? (
               <JiraIssueView repoPath={repoPath} issueKey={deferredIssue.id} />
+            ) : deferredIssue?.kind === "linear" ? (
+              <LinearIssueView
+                repoPath={repoPath}
+                issueIdentifier={deferredIssue.id}
+              />
             ) : (
               <DiffPlaceholder
                 icon={CircleDashedIcon}

--- a/src/features/settings/AppearanceSection.tsx
+++ b/src/features/settings/AppearanceSection.tsx
@@ -1,4 +1,5 @@
 import { useId } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -6,22 +7,56 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useApplyTheme, useSettings } from "@/lib/settings/queries";
-import { THEME_LABELS, THEME_ORDER, type ThemeSetting } from "@/lib/theme";
+import { useApplyAppearance, useSettings } from "@/lib/settings/queries";
+import {
+  DEFAULT_ACCENT_HUE,
+  DEFAULT_UI_FONT,
+  isDefaultAccentAndFont,
+  sanitizeAccentHue,
+  THEME_LABELS,
+  THEME_ORDER,
+  type ThemeSetting,
+  UI_FONT_LABELS,
+  UI_FONT_ORDER,
+  type UiFont,
+} from "@/lib/theme";
 
 /**
- * Settings → Appearance. The theme picker is an apply-on-change preference owned
- * by this control (not the bulk Save bar), mirroring `diffViewMode`: it persists
- * and applies the class immediately, so picking a theme previews it live.
+ * Settings → Appearance. Theme, accent hue, and UI font are apply-on-change
+ * (not the bulk Save bar), mirroring `diffViewMode`: they persist and apply
+ * immediately so picking a value previews it live.
  */
 export function AppearanceSection() {
   const settings = useSettings();
-  const applyTheme = useApplyTheme();
-  const labelId = useId();
-  const theme = settings.data?.theme ?? "system";
+  const apply = useApplyAppearance();
+  const themeLabelId = useId();
+  const hueLabelId = useId();
+  const fontLabelId = useId();
+
+  const current = settings.data;
+  const theme = current?.theme ?? "system";
+  const accentHue = current?.accentHue ?? DEFAULT_ACCENT_HUE;
+  const uiFont = current?.uiFont ?? DEFAULT_UI_FONT;
+  const atDefault = isDefaultAccentAndFont(accentHue, uiFont);
 
   function selectTheme(next: ThemeSetting) {
-    if (settings.data) applyTheme(settings.data, next);
+    if (current) apply(current, { theme: next });
+  }
+
+  function selectHue(raw: number) {
+    if (current) apply(current, { accentHue: sanitizeAccentHue(raw) });
+  }
+
+  function selectFont(next: UiFont) {
+    if (current) apply(current, { uiFont: next });
+  }
+
+  function resetAccentAndFont() {
+    if (!current || atDefault) return;
+    apply(current, {
+      accentHue: DEFAULT_ACCENT_HUE,
+      uiFont: DEFAULT_UI_FONT,
+    });
   }
 
   return (
@@ -33,7 +68,7 @@ export function AppearanceSection() {
         </p>
       </div>
       <div className="space-y-1.5">
-        <span id={labelId} className="text-xs font-medium">
+        <span id={themeLabelId} className="text-xs font-medium">
           Theme
         </span>
         <div className="max-w-xs">
@@ -42,7 +77,7 @@ export function AppearanceSection() {
             value={theme}
             onValueChange={(value) => selectTheme(value as ThemeSetting)}
           >
-            <SelectTrigger aria-labelledby={labelId} className="w-full">
+            <SelectTrigger aria-labelledby={themeLabelId} className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -61,6 +96,74 @@ export function AppearanceSection() {
           dark theme — a lifted, cool blue-gray canvas that eases eye strain on
           long sessions. You can also cycle themes from the command palette.
         </p>
+      </div>
+      <div className="space-y-1.5">
+        <span id={hueLabelId} className="text-xs font-medium">
+          Accent colour
+        </span>
+        <div className="flex max-w-xs items-center gap-2">
+          <span
+            className="size-6 shrink-0 border bg-primary"
+            aria-hidden="true"
+          />
+          <input
+            type="range"
+            min={0}
+            max={360}
+            step={1}
+            value={accentHue}
+            aria-labelledby={hueLabelId}
+            aria-valuetext={`${accentHue} degrees`}
+            className="gd-hue-slider min-w-0 flex-1"
+            onChange={(e) => selectHue(Number(e.currentTarget.value))}
+          />
+          <span className="w-8 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
+            {accentHue}°
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Tints buttons, focus rings, and highlights. Light, Dark, and Slate
+          keep their own surfaces. Status colours (added, deleted, warning) stay
+          put.
+        </p>
+      </div>
+      <div className="space-y-1.5">
+        <span id={fontLabelId} className="text-xs font-medium">
+          UI font
+        </span>
+        <div className="max-w-xs">
+          <Select
+            items={UI_FONT_LABELS}
+            value={uiFont}
+            onValueChange={(value) => selectFont(value as UiFont)}
+          >
+            <SelectTrigger aria-labelledby={fontLabelId} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {UI_FONT_ORDER.map((id) => (
+                <SelectItem key={id} value={id}>
+                  {UI_FONT_LABELS[id]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Chrome, headings, and body copy. Code, diffs, and the terminal stay on
+          JetBrains Mono.
+        </p>
+      </div>
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={atDefault}
+          onClick={resetAccentAndFont}
+        >
+          Reset accent & font
+        </Button>
       </div>
     </section>
   );

--- a/src/features/settings/settings-form.ts
+++ b/src/features/settings/settings-form.ts
@@ -12,19 +12,24 @@ export type SettingsDraft = Omit<
   | "diffViewMode"
   | "defaultBranch"
   | "theme"
+  | "accentHue"
+  | "uiFont"
   | "diffFileListCollapsed"
   | "sidebarCollapsed"
 >;
 
 export function toDraft(settings: AppSettings): SettingsDraft {
   // defaultBranch is dropped: it now lives in global git config, edited by its
-  // own form in GitSection, not the bulk Save bar. theme, diffViewMode, and the
-  // two collapse prefs are apply-on-change, owned by their own controls.
+  // own form in GitSection, not the bulk Save bar. theme + accentHue + uiFont,
+  // diffViewMode, and the two collapse prefs are apply-on-change, owned by
+  // their own controls.
   const {
     recentRepos,
     diffViewMode,
     defaultBranch,
     theme,
+    accentHue,
+    uiFont,
     diffFileListCollapsed,
     sidebarCollapsed,
     ...draft

--- a/src/features/terminal/Terminal.tsx
+++ b/src/features/terminal/Terminal.tsx
@@ -9,6 +9,8 @@ import {
   ptyResize,
   ptyWrite,
 } from "@/lib/pty";
+import { MONO_FONT_STACK } from "@/lib/theme";
+import { cn } from "@/lib/utils";
 
 /** Decode a base64 PTY chunk to bytes for `term.write` (xterm reassembles any
  *  partial UTF-8 across chunks itself). */
@@ -63,8 +65,9 @@ export function Terminal({
     if (!host) return;
 
     const term = new XTerm({
-      fontFamily:
-        'ui-monospace, "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace',
+      // Match `--font-mono` (JetBrains Mono Variable). xterm paints its own
+      // canvas, so it cannot inherit the host's CSS font-family.
+      fontFamily: MONO_FONT_STACK,
       fontSize: 12,
       cursorBlink: true,
       // A terminal stays dark regardless of app theme (conventional + readable).
@@ -129,5 +132,5 @@ export function Terminal({
     };
   }, []);
 
-  return <div ref={hostRef} className={className} />;
+  return <div ref={hostRef} className={cn("font-mono", className)} />;
 }

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -312,6 +312,12 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "create-linear-issue",
+    label: "Create Linear issue…",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
     id: "create-discussion",
     label: "Create discussion",
     category: "Repository",
@@ -362,6 +368,12 @@ export const ACTIONS = [
   {
     id: "link-jira-project",
     label: "Link Jira project…",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
+    id: "link-linear-team",
+    label: "Link Linear team…",
     category: "Repository",
     defaultBinding: null,
   },

--- a/src/lib/linear/api.ts
+++ b/src/lib/linear/api.ts
@@ -11,48 +11,35 @@ import type {
   LinearTeam,
 } from "./types";
 
-// Thin wrappers over the `linear.rs` command family. The Linear personal API
-// token lives in the OS keychain; the raw token never crosses IPC — the set
-// command validates against the API and returns account info, never the token.
-// The link config (teamKey) is read from app-data by the frontend (see
-// store.ts) and passed into the data commands, keeping Rust stateless about
-// linkage.
+// Thin wrappers over the `linear.rs` command family. Linear credentials live
+// in the OS keychain under `forge/linear.app/token`; the raw token never
+// crosses IPC.
 
-/** Validate a personal API token against Linear's viewer query without
- *  persisting it. Throws with a human message on a bad/expired token. */
 export const linearValidateToken = (token: string) =>
   invoke<LinearAccountInfo>("linear_validate_token", { token });
 
-/** Validate and persist the token. Throws (nothing saved) on a bad token. */
 export const linearSetAccount = (token: string) =>
   invoke<LinearAccountInfo>("linear_set_account", { token });
 
-/** The stored account (fast keyring check, no network); `null` when none.
- *  Cold-start test mode has no keychain, so reports "not connected". */
 export const linearStoredAccount = () =>
   COLD_START
     ? Promise.resolve<LinearStoredAccount | null>(null)
     : invoke<LinearStoredAccount | null>("linear_stored_account");
 
-/** Remove the saved Linear credential from the keychain. */
-export const linearClearAccount = () => invoke<void>("linear_clear_account");
+export const linearClearAccount = () =>
+  invoke<void>("linear_clear_account");
 
-/** The viewer's teams (for the link picker). */
 export const linearTeams = () => invoke<LinearTeam[]>("linear_teams");
 
-/** One bounded page of a team's issues, filtered by state. */
 export const linearIssueList = (teamKey: string, state: LinearIssueState) =>
   invoke<LinearIssueInfo[]>("linear_issue_list", { teamKey, state });
 
-/** The full read-only detail for one issue (description + comments as markdown). */
 export const linearIssueView = (identifier: string) =>
   invoke<LinearIssueDetails>("linear_issue_view", { identifier });
 
-/** Add a comment (markdown); returns the created comment. */
 export const linearIssueComment = (issueId: string, bodyMd: string) =>
   invoke<LinearComment>("linear_issue_comment", { issueId, bodyMd });
 
-/** Create an issue; returns the new identifier + URL. `descriptionMd` optional. */
 export const linearIssueCreate = (
   teamId: string,
   title: string,
@@ -64,10 +51,10 @@ export const linearIssueCreate = (
     descriptionMd,
   });
 
-/** Transition an issue to a different workflow state by state id. */
 export const linearIssueTransition = (issueId: string, stateId: string) =>
   invoke<void>("linear_issue_transition", { issueId, stateId });
 
-/** Assign (userId) or unassign (null) the issue's single assignee. */
-export const linearIssueAssign = (issueId: string, assigneeId: string | null) =>
-  invoke<void>("linear_issue_assign", { issueId, assigneeId });
+export const linearIssueAssign = (
+  issueId: string,
+  assigneeId: string | null,
+) => invoke<void>("linear_issue_assign", { issueId, assigneeId });

--- a/src/lib/linear/api.ts
+++ b/src/lib/linear/api.ts
@@ -1,0 +1,73 @@
+import { invoke } from "@/lib/tauri/invoke";
+import { COLD_START } from "@/lib/test-mode";
+import type {
+  LinearAccountInfo,
+  LinearComment,
+  LinearCreatedIssue,
+  LinearIssueDetails,
+  LinearIssueInfo,
+  LinearIssueState,
+  LinearStoredAccount,
+  LinearTeam,
+} from "./types";
+
+// Thin wrappers over the `linear.rs` command family. The Linear personal API
+// token lives in the OS keychain; the raw token never crosses IPC — the set
+// command validates against the API and returns account info, never the token.
+// The link config (teamKey) is read from app-data by the frontend (see
+// store.ts) and passed into the data commands, keeping Rust stateless about
+// linkage.
+
+/** Validate a personal API token against Linear's viewer query without
+ *  persisting it. Throws with a human message on a bad/expired token. */
+export const linearValidateToken = (token: string) =>
+  invoke<LinearAccountInfo>("linear_validate_token", { token });
+
+/** Validate and persist the token. Throws (nothing saved) on a bad token. */
+export const linearSetAccount = (token: string) =>
+  invoke<LinearAccountInfo>("linear_set_account", { token });
+
+/** The stored account (fast keyring check, no network); `null` when none.
+ *  Cold-start test mode has no keychain, so reports "not connected". */
+export const linearStoredAccount = () =>
+  COLD_START
+    ? Promise.resolve<LinearStoredAccount | null>(null)
+    : invoke<LinearStoredAccount | null>("linear_stored_account");
+
+/** Remove the saved Linear credential from the keychain. */
+export const linearClearAccount = () => invoke<void>("linear_clear_account");
+
+/** The viewer's teams (for the link picker). */
+export const linearTeams = () => invoke<LinearTeam[]>("linear_teams");
+
+/** One bounded page of a team's issues, filtered by state. */
+export const linearIssueList = (teamKey: string, state: LinearIssueState) =>
+  invoke<LinearIssueInfo[]>("linear_issue_list", { teamKey, state });
+
+/** The full read-only detail for one issue (description + comments as markdown). */
+export const linearIssueView = (identifier: string) =>
+  invoke<LinearIssueDetails>("linear_issue_view", { identifier });
+
+/** Add a comment (markdown); returns the created comment. */
+export const linearIssueComment = (issueId: string, bodyMd: string) =>
+  invoke<LinearComment>("linear_issue_comment", { issueId, bodyMd });
+
+/** Create an issue; returns the new identifier + URL. `descriptionMd` optional. */
+export const linearIssueCreate = (
+  teamId: string,
+  title: string,
+  descriptionMd?: string,
+) =>
+  invoke<LinearCreatedIssue>("linear_issue_create", {
+    teamId,
+    title,
+    descriptionMd,
+  });
+
+/** Transition an issue to a different workflow state by state id. */
+export const linearIssueTransition = (issueId: string, stateId: string) =>
+  invoke<void>("linear_issue_transition", { issueId, stateId });
+
+/** Assign (userId) or unassign (null) the issue's single assignee. */
+export const linearIssueAssign = (issueId: string, assigneeId: string | null) =>
+  invoke<void>("linear_issue_assign", { issueId, assigneeId });

--- a/src/lib/linear/api.ts
+++ b/src/lib/linear/api.ts
@@ -26,8 +26,7 @@ export const linearStoredAccount = () =>
     ? Promise.resolve<LinearStoredAccount | null>(null)
     : invoke<LinearStoredAccount | null>("linear_stored_account");
 
-export const linearClearAccount = () =>
-  invoke<void>("linear_clear_account");
+export const linearClearAccount = () => invoke<void>("linear_clear_account");
 
 export const linearTeams = () => invoke<LinearTeam[]>("linear_teams");
 
@@ -54,7 +53,5 @@ export const linearIssueCreate = (
 export const linearIssueTransition = (issueId: string, stateId: string) =>
   invoke<void>("linear_issue_transition", { issueId, stateId });
 
-export const linearIssueAssign = (
-  issueId: string,
-  assigneeId: string | null,
-) => invoke<void>("linear_issue_assign", { issueId, assigneeId });
+export const linearIssueAssign = (issueId: string, assigneeId: string | null) =>
+  invoke<void>("linear_issue_assign", { issueId, assigneeId });

--- a/src/lib/linear/keys.ts
+++ b/src/lib/linear/keys.ts
@@ -1,0 +1,49 @@
+/** Escape a string for safe embedding inside a `RegExp`. The team key is
+ *  grammar-validated at link time, but escaping keeps this util correct for any
+ *  caller and immune to a metacharacter ever slipping through. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Extract the Linear issue identifiers of the *linked team only* referenced in
+ * a piece of git text (commit message, PR title/body, branch name). Matches
+ * `<TEAMKEY>-\d+` case-insensitively — never a generic `[A-Z]+-\d+`, which
+ * would false-positive on ISO-8601 dates, UTF-8, and the like. Deduplicated,
+ * ordered by first occurrence.
+ *
+ * Boundary semantics (deliberately NOT plain `\b`, which counts underscore as a
+ * word char and treats a bare `.` like any non-word char):
+ *   - LEFT `(?<![A-Za-z0-9])`: reject a letter/digit prefix (`XENG-1` → no),
+ *     but ALLOW underscore adjacency — `_` is a common branch-name separator, so
+ *     `feature_ENG-5` must yield ENG-5.
+ *   - RIGHT `(?![A-Za-z])`: reject a letter suffix (`ENG-12a` → no).
+ *   - RIGHT `(?!\.\d)`: reject a version-like `dot+digit` (`ENG-1.2` → no),
+ *     while a sentence-ending period still matches (`fixes ENG-1.` → ENG-1).
+ * Case table (all verified against this regex):
+ *   feature_ENG-5 → ENG-5   |  ENG-5_x → ENG-5      |  feat/eng-2-fix → ENG-2
+ *   fixes ENG-1.  → ENG-1   |  ENG-21  → ENG-21     |  (greedy \d+, no ENG-2)
+ *   XENG-1 → []  |  ENG-12a → []  |  ENG-1.2 → []  |  2024-01-02 → [] (key ≠ 2024)
+ *
+ * Null/empty text or an empty team key yields an empty array.
+ */
+export function extractLinearKeys(
+  text: string | null | undefined,
+  teamKey: string,
+): string[] {
+  if (!text || !teamKey) return [];
+  const re = new RegExp(
+    `(?<![A-Za-z0-9])${escapeRegExp(teamKey)}-\\d+(?![A-Za-z])(?!\\.\\d)`,
+    "gi",
+  );
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of text.matchAll(re)) {
+    const key = m[0].toUpperCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(key);
+    }
+  }
+  return out;
+}

--- a/src/lib/linear/keys.ts
+++ b/src/lib/linear/keys.ts
@@ -1,31 +1,12 @@
-/** Escape a string for safe embedding inside a `RegExp`. The team key is
- *  grammar-validated at link time, but escaping keeps this util correct for any
- *  caller and immune to a metacharacter ever slipping through. */
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
- * Extract the Linear issue identifiers of the *linked team only* referenced in
- * a piece of git text (commit message, PR title/body, branch name). Matches
- * `<TEAMKEY>-\d+` case-insensitively — never a generic `[A-Z]+-\d+`, which
- * would false-positive on ISO-8601 dates, UTF-8, and the like. Deduplicated,
- * ordered by first occurrence.
- *
- * Boundary semantics (deliberately NOT plain `\b`, which counts underscore as a
- * word char and treats a bare `.` like any non-word char):
- *   - LEFT `(?<![A-Za-z0-9])`: reject a letter/digit prefix (`XENG-1` → no),
- *     but ALLOW underscore adjacency — `_` is a common branch-name separator, so
- *     `feature_ENG-5` must yield ENG-5.
- *   - RIGHT `(?![A-Za-z])`: reject a letter suffix (`ENG-12a` → no).
- *   - RIGHT `(?!\.\d)`: reject a version-like `dot+digit` (`ENG-1.2` → no),
- *     while a sentence-ending period still matches (`fixes ENG-1.` → ENG-1).
- * Case table (all verified against this regex):
- *   feature_ENG-5 → ENG-5   |  ENG-5_x → ENG-5      |  feat/eng-2-fix → ENG-2
- *   fixes ENG-1.  → ENG-1   |  ENG-21  → ENG-21     |  (greedy \d+, no ENG-2)
- *   XENG-1 → []  |  ENG-12a → []  |  ENG-1.2 → []  |  2024-01-02 → [] (key ≠ 2024)
- *
- * Null/empty text or an empty team key yields an empty array.
+ * Extract Linear issue identifiers (`ENG-123`) from git text (commit messages,
+ * PR titles, branch names). Same boundary semantics as the Jira key extractor:
+ * scoped to the linked team key only, case-insensitive, deduplicated by first
+ * occurrence.
  */
 export function extractLinearKeys(
   text: string | null | undefined,

--- a/src/lib/linear/queries.ts
+++ b/src/lib/linear/queries.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { keepPreviousDataForRepo } from "@/lib/git/queries";
 import {
+  linearIssueAssign,
   linearIssueComment,
   linearIssueCreate,
   linearIssueList,
   linearIssueTransition,
-  linearIssueAssign,
   linearIssueView,
   linearStoredAccount,
   linearTeams,
@@ -16,10 +16,7 @@ import {
   type LinearLink,
   setLinearLink,
 } from "./store";
-import type {
-  LinearIssueDetails,
-  LinearIssueState,
-} from "./types";
+import type { LinearIssueDetails, LinearIssueState } from "./types";
 
 const linearLinkKey = (repo: string) => ["linear-link", repo] as const;
 
@@ -39,8 +36,7 @@ function invalidateLinearForRepo(
     predicate: (q) =>
       q.queryKey[0] === "repo" &&
       q.queryKey[1] === repo &&
-      (q.queryKey[2] === "linear-issues" ||
-        q.queryKey[2] === "linear-issue"),
+      (q.queryKey[2] === "linear-issues" || q.queryKey[2] === "linear-issue"),
   });
 }
 
@@ -102,8 +98,7 @@ export function useLinearIssues(
       link?.teamKey ?? "",
       state,
     ] as const,
-    queryFn: () =>
-      linearIssueList((link as LinearLink).teamKey, state),
+    queryFn: () => linearIssueList((link as LinearLink).teamKey, state),
     enabled: !!link,
     staleTime: 30_000,
   });
@@ -122,9 +117,7 @@ export function useLinearIssue(
   });
 }
 
-export function useLinearComment(
-  repo: string,
-) {
+export function useLinearComment(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (args: {
@@ -133,12 +126,7 @@ export function useLinearComment(
       bodyMd: string;
     }) => linearIssueComment(args.issueId, args.bodyMd),
     onSuccess: (comment, args) => {
-      const key = [
-        "repo",
-        repo,
-        "linear-issue",
-        args.issueIdentifier,
-      ] as const;
+      const key = ["repo", repo, "linear-issue", args.issueIdentifier] as const;
       queryClient.setQueryData<LinearIssueDetails>(key, (d) =>
         d ? { ...d, comments: [...d.comments, comment] } : d,
       );
@@ -160,17 +148,15 @@ export function useLinearTransition(repo: string) {
 export function useLinearAssign(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (args: {
-      issueId: string;
-      assigneeId: string | null;
-    }) => linearIssueAssign(args.issueId, args.assigneeId),
+    mutationFn: (args: { issueId: string; assigneeId: string | null }) =>
+      linearIssueAssign(args.issueId, args.assigneeId),
     onSettled: () => invalidateLinearForRepo(queryClient, repo),
   });
 }
 
 export function useLinearCreateIssue(
   repo: string,
-  link: LinearLink | null | undefined,
+  _link: LinearLink | null | undefined,
 ) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/lib/linear/queries.ts
+++ b/src/lib/linear/queries.ts
@@ -1,0 +1,190 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousDataForRepo } from "@/lib/git/queries";
+import {
+  linearIssueAssign,
+  linearIssueComment,
+  linearIssueCreate,
+  linearIssueList,
+  linearIssueTransition,
+  linearIssueView,
+  linearStoredAccount,
+  linearTeams,
+} from "./api";
+import {
+  clearLinearLink,
+  getLinearLink,
+  type LinearLink,
+  setLinearLink,
+} from "./store";
+import type { LinearIssueDetails, LinearIssueState } from "./types";
+
+const linearLinkKey = (repo: string) => ["linear-link", repo] as const;
+
+/** This repo's Linear link (or `null` when unlinked). */
+export function useLinearLink(repo: string) {
+  return useQuery({
+    queryKey: linearLinkKey(repo),
+    queryFn: () => getLinearLink(repo),
+  });
+}
+
+/** Invalidate the link query AND every Linear issue-list/issue-detail query for
+ *  this repo. */
+function invalidateLinearForRepo(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+) {
+  queryClient.invalidateQueries({ queryKey: linearLinkKey(repo) });
+  queryClient.invalidateQueries({
+    predicate: (q) =>
+      q.queryKey[0] === "repo" &&
+      q.queryKey[1] === repo &&
+      (q.queryKey[2] === "linear-issues" || q.queryKey[2] === "linear-issue"),
+  });
+}
+
+/** Narrow reconciliation for a single-issue write: just that issue's detail key
+ *  plus the repo's linear-issues LIST keys. */
+function invalidateLinearIssue(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+  issueIdentifier: string,
+) {
+  queryClient.invalidateQueries({
+    queryKey: ["repo", repo, "linear-issue", issueIdentifier],
+  });
+  queryClient.invalidateQueries({
+    queryKey: ["repo", repo, "linear-issues"],
+  });
+}
+
+export function useSaveLinearLink(repo: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (link: LinearLink) => setLinearLink(repo, link),
+    onSettled: () => invalidateLinearForRepo(queryClient, repo),
+  });
+}
+
+export function useClearLinearLink(repo: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => clearLinearLink(repo),
+    onSettled: () => invalidateLinearForRepo(queryClient, repo),
+  });
+}
+
+/** The stored Linear account (fast keyring check, no network); `null` when none. */
+export function useLinearAccount() {
+  return useQuery({
+    queryKey: ["linear-account"] as const,
+    queryFn: () => linearStoredAccount(),
+  });
+}
+
+/** The viewer's teams (for the link picker). */
+export function useLinearTeams(enabled: boolean) {
+  return useQuery({
+    queryKey: ["linear-teams"] as const,
+    queryFn: () => linearTeams(),
+    enabled,
+    staleTime: 5 * 60_000,
+  });
+}
+
+/** The linked team's issues for a state filter. Enabled only when the repo is
+ *  linked. */
+export function useLinearIssues(
+  repo: string,
+  link: LinearLink | null | undefined,
+  state: LinearIssueState,
+) {
+  return useQuery({
+    queryKey: [
+      "repo",
+      repo,
+      "linear-issues",
+      link?.teamKey ?? "",
+      state,
+    ] as const,
+    queryFn: () => linearIssueList((link as LinearLink).teamKey, state),
+    enabled: !!link,
+    staleTime: 30_000,
+  });
+}
+
+/** One Linear issue's full detail. Enabled only when linked and an identifier is
+ *  selected. */
+export function useLinearIssue(
+  repo: string,
+  link: LinearLink | null | undefined,
+  identifier: string | null,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "linear-issue", identifier] as const,
+    queryFn: () => linearIssueView(identifier as string),
+    enabled: !!link && identifier !== null,
+    placeholderData: keepPreviousDataForRepo(repo),
+  });
+}
+
+/** Add a comment. The returned comment is appended to the detail cache on
+ *  success, and the repo's Linear caches reconcile on settle. */
+export function useLinearComment(
+  repo: string,
+  link: LinearLink | null | undefined,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      issueId: string;
+      issueIdentifier: string;
+      bodyMd: string;
+    }) => linearIssueComment(args.issueId, args.bodyMd),
+    onSuccess: (comment, args) => {
+      const key = ["repo", repo, "linear-issue", args.issueIdentifier] as const;
+      queryClient.setQueryData<LinearIssueDetails>(key, (d) =>
+        d ? { ...d, comments: [...d.comments, comment] } : d,
+      );
+    },
+    onSettled: (_d, _e, args) =>
+      invalidateLinearIssue(queryClient, repo, args.issueIdentifier),
+  });
+}
+
+/** Transition an issue to a different workflow state. */
+export function useLinearTransition(repo: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { issueId: string; stateId: string }) =>
+      linearIssueTransition(args.issueId, args.stateId),
+    onSettled: () => invalidateLinearForRepo(queryClient, repo),
+  });
+}
+
+/** Set/clear the single assignee. */
+export function useLinearAssign(repo: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { issueId: string; assigneeId: string | null }) =>
+      linearIssueAssign(args.issueId, args.assigneeId),
+    onSettled: () => invalidateLinearForRepo(queryClient, repo),
+  });
+}
+
+/** Create an issue. Invalidates the repo's Linear caches on settle so the new
+ *  issue appears in the list. */
+export function useLinearCreateIssue(
+  repo: string,
+  link: LinearLink | null | undefined,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      teamId: string;
+      title: string;
+      descriptionMd?: string;
+    }) => linearIssueCreate(args.teamId, args.title, args.descriptionMd),
+    onSettled: () => invalidateLinearForRepo(queryClient, repo),
+  });
+}

--- a/src/lib/linear/queries.ts
+++ b/src/lib/linear/queries.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { keepPreviousDataForRepo } from "@/lib/git/queries";
 import {
-  linearIssueAssign,
   linearIssueComment,
   linearIssueCreate,
   linearIssueList,
   linearIssueTransition,
+  linearIssueAssign,
   linearIssueView,
   linearStoredAccount,
   linearTeams,
@@ -16,11 +16,13 @@ import {
   type LinearLink,
   setLinearLink,
 } from "./store";
-import type { LinearIssueDetails, LinearIssueState } from "./types";
+import type {
+  LinearIssueDetails,
+  LinearIssueState,
+} from "./types";
 
 const linearLinkKey = (repo: string) => ["linear-link", repo] as const;
 
-/** This repo's Linear link (or `null` when unlinked). */
 export function useLinearLink(repo: string) {
   return useQuery({
     queryKey: linearLinkKey(repo),
@@ -28,8 +30,6 @@ export function useLinearLink(repo: string) {
   });
 }
 
-/** Invalidate the link query AND every Linear issue-list/issue-detail query for
- *  this repo. */
 function invalidateLinearForRepo(
   queryClient: ReturnType<typeof useQueryClient>,
   repo: string,
@@ -39,12 +39,11 @@ function invalidateLinearForRepo(
     predicate: (q) =>
       q.queryKey[0] === "repo" &&
       q.queryKey[1] === repo &&
-      (q.queryKey[2] === "linear-issues" || q.queryKey[2] === "linear-issue"),
+      (q.queryKey[2] === "linear-issues" ||
+        q.queryKey[2] === "linear-issue"),
   });
 }
 
-/** Narrow reconciliation for a single-issue write: just that issue's detail key
- *  plus the repo's linear-issues LIST keys. */
 function invalidateLinearIssue(
   queryClient: ReturnType<typeof useQueryClient>,
   repo: string,
@@ -74,7 +73,6 @@ export function useClearLinearLink(repo: string) {
   });
 }
 
-/** The stored Linear account (fast keyring check, no network); `null` when none. */
 export function useLinearAccount() {
   return useQuery({
     queryKey: ["linear-account"] as const,
@@ -82,7 +80,6 @@ export function useLinearAccount() {
   });
 }
 
-/** The viewer's teams (for the link picker). */
 export function useLinearTeams(enabled: boolean) {
   return useQuery({
     queryKey: ["linear-teams"] as const,
@@ -92,8 +89,6 @@ export function useLinearTeams(enabled: boolean) {
   });
 }
 
-/** The linked team's issues for a state filter. Enabled only when the repo is
- *  linked. */
 export function useLinearIssues(
   repo: string,
   link: LinearLink | null | undefined,
@@ -107,14 +102,13 @@ export function useLinearIssues(
       link?.teamKey ?? "",
       state,
     ] as const,
-    queryFn: () => linearIssueList((link as LinearLink).teamKey, state),
+    queryFn: () =>
+      linearIssueList((link as LinearLink).teamKey, state),
     enabled: !!link,
     staleTime: 30_000,
   });
 }
 
-/** One Linear issue's full detail. Enabled only when linked and an identifier is
- *  selected. */
 export function useLinearIssue(
   repo: string,
   link: LinearLink | null | undefined,
@@ -128,11 +122,8 @@ export function useLinearIssue(
   });
 }
 
-/** Add a comment. The returned comment is appended to the detail cache on
- *  success, and the repo's Linear caches reconcile on settle. */
 export function useLinearComment(
   repo: string,
-  link: LinearLink | null | undefined,
 ) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -142,7 +133,12 @@ export function useLinearComment(
       bodyMd: string;
     }) => linearIssueComment(args.issueId, args.bodyMd),
     onSuccess: (comment, args) => {
-      const key = ["repo", repo, "linear-issue", args.issueIdentifier] as const;
+      const key = [
+        "repo",
+        repo,
+        "linear-issue",
+        args.issueIdentifier,
+      ] as const;
       queryClient.setQueryData<LinearIssueDetails>(key, (d) =>
         d ? { ...d, comments: [...d.comments, comment] } : d,
       );
@@ -152,7 +148,6 @@ export function useLinearComment(
   });
 }
 
-/** Transition an issue to a different workflow state. */
 export function useLinearTransition(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -162,18 +157,17 @@ export function useLinearTransition(repo: string) {
   });
 }
 
-/** Set/clear the single assignee. */
 export function useLinearAssign(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (args: { issueId: string; assigneeId: string | null }) =>
-      linearIssueAssign(args.issueId, args.assigneeId),
+    mutationFn: (args: {
+      issueId: string;
+      assigneeId: string | null;
+    }) => linearIssueAssign(args.issueId, args.assigneeId),
     onSettled: () => invalidateLinearForRepo(queryClient, repo),
   });
 }
 
-/** Create an issue. Invalidates the repo's Linear caches on settle so the new
- *  issue appears in the list. */
 export function useLinearCreateIssue(
   repo: string,
   link: LinearLink | null | undefined,

--- a/src/lib/linear/store.ts
+++ b/src/lib/linear/store.ts
@@ -7,6 +7,8 @@ import { storeName } from "@/lib/test-mode";
 export interface LinearLink {
   /** The workspace slug, for building URLs. */
   workspaceSlug: string;
+  /** The team UUID from the Linear API. Required for issue creation. */
+  teamId: string;
   /** The team key, e.g. `ENG`. */
   teamKey: string;
   /** The team's display name, cached for the section header. */
@@ -50,6 +52,7 @@ function asLink(v: unknown): LinearLink | null {
   }
   return {
     workspaceSlug: o.workspaceSlug,
+    teamId: typeof o.teamId === "string" ? o.teamId : "",
     teamKey: o.teamKey,
     teamName: o.teamName,
   };

--- a/src/lib/linear/store.ts
+++ b/src/lib/linear/store.ts
@@ -1,0 +1,110 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { identityKeyFor, repoIdentity } from "@/lib/git/repo-identity";
+import { storeName } from "@/lib/test-mode";
+
+/** A repo's link to a Linear team. Personal app-data — never written into the
+ *  repo itself — keyed by the repo's worktree-stable identity so the link is
+ *  shared across the main checkout and every worktree. */
+export interface LinearLink {
+  /** The team's short key, e.g. `ENG`. */
+  teamKey: string;
+  /** The team's display name, cached for the section header + picker. */
+  teamName: string;
+}
+
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("linear-links.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write on this store (and the reload) through one
+// in-process queue — mirrors the Jira/local-issue/PR stores. Without it two
+// overlapping mutations each reload the SAME pre-flush disk snapshot (autoSave
+// persists on a ~100ms debounce) and the later write drops the earlier one's
+// change. writeLink force-saves so each reload sees a current one.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing/unreadable file — proceed with in-memory state; the next save()
+    // creates it.
+  }
+}
+
+/** Type-guard an untrusted stored value into a LinearLink; `null` when malformed. */
+function asLink(v: unknown): LinearLink | null {
+  if (!v || typeof v !== "object") return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.teamKey !== "string" || typeof o.teamName !== "string") {
+    return null;
+  }
+  return { teamKey: o.teamKey, teamName: o.teamName };
+}
+
+const preferIdentity = (
+  id: LinearLink | undefined,
+  legacy: LinearLink,
+): LinearLink => id ?? legacy;
+
+/** This repo's Linear link (or `null` when unlinked). Read-only path: merges in
+ *  a record still under a legacy checkout-path key (folded on the next mutation),
+ *  so a worktree-created link shows up right away. */
+export async function getLinearLink(repo: string): Promise<LinearLink | null> {
+  const store = await getStore();
+  const id = await repoIdentity(repo);
+  const primary = asLink(await store.get(id));
+  if (primary) return primary;
+  if (id === repo) return null;
+  return asLink(await store.get(repo));
+}
+
+/** Identity store key for `repo`, folding any legacy checkout-path record onto
+ *  it once. Call inside the serialized queue (after `reloadRaw`). */
+async function keyFor(repo: string): Promise<string> {
+  const store = await getStore();
+  return identityKeyFor<LinearLink>(
+    store,
+    "linear-links",
+    repo,
+    preferIdentity,
+  );
+}
+
+/** Link (or re-link) `repo` to a Linear team. */
+export async function setLinearLink(
+  repo: string,
+  link: LinearLink,
+): Promise<LinearLink> {
+  return serialize(async () => {
+    await reloadRaw();
+    const store = await getStore();
+    const key = await keyFor(repo);
+    await store.set(key, link);
+    await store.save();
+    return link;
+  });
+}
+
+/** Remove `repo`'s Linear link (does NOT clear the keyring credential — the
+ *  account may serve other repos). */
+export async function clearLinearLink(repo: string): Promise<void> {
+  return serialize(async () => {
+    await reloadRaw();
+    const store = await getStore();
+    const key = await keyFor(repo);
+    await store.delete(key);
+    await store.save();
+  });
+}

--- a/src/lib/linear/store.ts
+++ b/src/lib/linear/store.ts
@@ -3,12 +3,13 @@ import { identityKeyFor, repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
 
 /** A repo's link to a Linear team. Personal app-data — never written into the
- *  repo itself — keyed by the repo's worktree-stable identity so the link is
- *  shared across the main checkout and every worktree. */
+ *  repo itself — keyed by the repo's worktree-stable identity. */
 export interface LinearLink {
-  /** The team's short key, e.g. `ENG`. */
+  /** The workspace slug, for building URLs. */
+  workspaceSlug: string;
+  /** The team key, e.g. `ENG`. */
   teamKey: string;
-  /** The team's display name, cached for the section header + picker. */
+  /** The team's display name, cached for the section header. */
   teamName: string;
 }
 
@@ -21,11 +22,6 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
-// Serialize every read-modify-write on this store (and the reload) through one
-// in-process queue — mirrors the Jira/local-issue/PR stores. Without it two
-// overlapping mutations each reload the SAME pre-flush disk snapshot (autoSave
-// persists on a ~100ms debounce) and the later write drops the earlier one's
-// change. writeLink force-saves so each reload sees a current one.
 let opChain: Promise<unknown> = Promise.resolve();
 function serialize<T>(op: () => Promise<T>): Promise<T> {
   const run = opChain.then(op, op);
@@ -38,19 +34,25 @@ async function reloadRaw(): Promise<void> {
   try {
     await store.reload({ ignoreDefaults: true });
   } catch {
-    // Missing/unreadable file — proceed with in-memory state; the next save()
-    // creates it.
+    // Missing/unreadable file — proceed with in-memory state.
   }
 }
 
-/** Type-guard an untrusted stored value into a LinearLink; `null` when malformed. */
 function asLink(v: unknown): LinearLink | null {
   if (!v || typeof v !== "object") return null;
   const o = v as Record<string, unknown>;
-  if (typeof o.teamKey !== "string" || typeof o.teamName !== "string") {
+  if (
+    typeof o.workspaceSlug !== "string" ||
+    typeof o.teamKey !== "string" ||
+    typeof o.teamName !== "string"
+  ) {
     return null;
   }
-  return { teamKey: o.teamKey, teamName: o.teamName };
+  return {
+    workspaceSlug: o.workspaceSlug,
+    teamKey: o.teamKey,
+    teamName: o.teamName,
+  };
 }
 
 const preferIdentity = (
@@ -58,9 +60,6 @@ const preferIdentity = (
   legacy: LinearLink,
 ): LinearLink => id ?? legacy;
 
-/** This repo's Linear link (or `null` when unlinked). Read-only path: merges in
- *  a record still under a legacy checkout-path key (folded on the next mutation),
- *  so a worktree-created link shows up right away. */
 export async function getLinearLink(repo: string): Promise<LinearLink | null> {
   const store = await getStore();
   const id = await repoIdentity(repo);
@@ -70,8 +69,6 @@ export async function getLinearLink(repo: string): Promise<LinearLink | null> {
   return asLink(await store.get(repo));
 }
 
-/** Identity store key for `repo`, folding any legacy checkout-path record onto
- *  it once. Call inside the serialized queue (after `reloadRaw`). */
 async function keyFor(repo: string): Promise<string> {
   const store = await getStore();
   return identityKeyFor<LinearLink>(
@@ -82,7 +79,6 @@ async function keyFor(repo: string): Promise<string> {
   );
 }
 
-/** Link (or re-link) `repo` to a Linear team. */
 export async function setLinearLink(
   repo: string,
   link: LinearLink,
@@ -97,8 +93,6 @@ export async function setLinearLink(
   });
 }
 
-/** Remove `repo`'s Linear link (does NOT clear the keyring credential — the
- *  account may serve other repos). */
 export async function clearLinearLink(repo: string): Promise<void> {
   return serialize(async () => {
     await reloadRaw();

--- a/src/lib/linear/types.ts
+++ b/src/lib/linear/types.ts
@@ -1,0 +1,75 @@
+import type { ForgeUserRef } from "@/lib/git/types";
+
+// TS mirrors of the Rust `linear.rs` command shapes (frozen contract). Linear is
+// a per-repo *linked* issue provider — never a git host — so these types live in
+// their own module and never touch `IssueInfo`/`IssueDetails` or the
+// `forge_issue_*` surface. Issue identity is the human identifier (`ENG-123`) as
+// a string end-to-end; internal UUIDs, where surfaced, travel as strings.
+
+/** The account resolved by validating a personal API token against Linear's
+ *  `/viewer` query. Never carries the token. */
+export interface LinearAccountInfo {
+  name: string;
+  email: string;
+  id: string;
+}
+
+/** The stored account (fast keyring check, no network); `null` when no
+ *  credential is saved. */
+export interface LinearStoredAccount {
+  email: string;
+}
+
+/** A team row for the link picker. */
+export interface LinearTeam {
+  id: string;
+  key: string;
+  name: string;
+}
+
+/** The open/closed/all filter, mapped through `statusType` on the backend. */
+export type LinearIssueState = "open" | "closed" | "all";
+
+/** A Linear issue as it appears in the list (bounded page). */
+export interface LinearIssueInfo {
+  identifier: string;
+  title: string;
+  statusName: string;
+  /** Linear's workflow state type: "backlog"|"unstarted"|"started"|"completed"|"cancelled". */
+  statusType: string;
+  priorityLabel: string;
+  assignee: ForgeUserRef | null;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  estimate: number | null;
+  cycleName: string | null;
+  projectName: string | null;
+}
+
+/** One comment on a Linear issue, body already as markdown. */
+export interface LinearComment {
+  id: string;
+  bodyMd: string;
+  author: ForgeUserRef | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/** The full read-only detail for one Linear issue (list fields + description,
+ *  comments, viewer id). */
+export interface LinearIssueDetails extends LinearIssueInfo {
+  id: string;
+  descriptionMd: string;
+  comments: LinearComment[];
+  /** The calling account's Linear user id, so the UI can recognise the viewer's
+   *  own comments. `null` = unknown (hide own-comment affordances). */
+  viewerId: string | null;
+}
+
+/** The result of creating an issue: the new identifier + its browser URL. */
+export interface LinearCreatedIssue {
+  identifier: string;
+  url: string;
+}

--- a/src/lib/linear/types.ts
+++ b/src/lib/linear/types.ts
@@ -1,41 +1,33 @@
 import type { ForgeUserRef } from "@/lib/git/types";
 
-// TS mirrors of the Rust `linear.rs` command shapes (frozen contract). Linear is
-// a per-repo *linked* issue provider — never a git host — so these types live in
-// their own module and never touch `IssueInfo`/`IssueDetails` or the
-// `forge_issue_*` surface. Issue identity is the human identifier (`ENG-123`) as
-// a string end-to-end; internal UUIDs, where surfaced, travel as strings.
+// TS mirrors of the Rust `linear.rs` command shapes. Linear is a per-repo
+// *linked* issue provider (like Jira) — never a git host — so these types live
+// in their own module. Issue identity is the human identifier (`ENG-123`) as a
+// string end-to-end.
 
-/** The account resolved by validating a personal API token against Linear's
- *  `/viewer` query. Never carries the token. */
 export interface LinearAccountInfo {
   name: string;
   email: string;
   id: string;
 }
 
-/** The stored account (fast keyring check, no network); `null` when no
- *  credential is saved. */
 export interface LinearStoredAccount {
   email: string;
 }
 
-/** A team row for the link picker. */
 export interface LinearTeam {
   id: string;
   key: string;
   name: string;
 }
 
-/** The open/closed/all filter, mapped through `statusType` on the backend. */
 export type LinearIssueState = "open" | "closed" | "all";
 
-/** A Linear issue as it appears in the list (bounded page). */
 export interface LinearIssueInfo {
   identifier: string;
   title: string;
   statusName: string;
-  /** Linear's workflow state type: "backlog"|"unstarted"|"started"|"completed"|"cancelled". */
+  /** "backlog"|"unstarted"|"started"|"completed"|"cancelled" */
   statusType: string;
   priorityLabel: string;
   assignee: ForgeUserRef | null;
@@ -48,7 +40,6 @@ export interface LinearIssueInfo {
   projectName: string | null;
 }
 
-/** One comment on a Linear issue, body already as markdown. */
 export interface LinearComment {
   id: string;
   bodyMd: string;
@@ -57,18 +48,13 @@ export interface LinearComment {
   updatedAt: string | null;
 }
 
-/** The full read-only detail for one Linear issue (list fields + description,
- *  comments, viewer id). */
 export interface LinearIssueDetails extends LinearIssueInfo {
   id: string;
   descriptionMd: string;
   comments: LinearComment[];
-  /** The calling account's Linear user id, so the UI can recognise the viewer's
-   *  own comments. `null` = unknown (hide own-comment affordances). */
   viewerId: string | null;
 }
 
-/** The result of creating an issue: the new identifier + its browser URL. */
 export interface LinearCreatedIssue {
   identifier: string;
   url: string;

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -4,7 +4,14 @@ import type { ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
-import type { ThemeSetting } from "@/lib/theme";
+import {
+  DEFAULT_ACCENT_HUE,
+  DEFAULT_UI_FONT,
+  sanitizeAccentHue,
+  sanitizeUiFont,
+  type ThemeSetting,
+  type UiFont,
+} from "@/lib/theme";
 
 export interface RecentRepo {
   path: string;
@@ -285,6 +292,11 @@ export interface AppSettings {
    *  softer dark variant that lifts surfaces off pure black to reduce eye strain. Applied
    *  outside the bulk settings form (apply-on-change), like diffViewMode. */
   theme: ThemeSetting;
+  /** Accent hue in degrees (OKLCH). Default 175 is brand mint. Overlay on the
+   *  active theme — lightness/chroma stay per-theme. Apply-on-change. */
+  accentHue: number;
+  /** Chrome typeface. Code, diffs, and the in-app terminal stay JetBrains Mono. Apply-on-change. */
+  uiFont: UiFont;
   diffViewMode: "unified" | "split";
   /** Which conversation-list sections the user collapsed, keyed `"<feature>:<kind>"`
    *  (`pulls:local`, `issues:remote`, …); a missing key = expanded. Global and
@@ -366,6 +378,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   mcpServers: [],
   recentRepos: [],
   theme: "system",
+  accentHue: DEFAULT_ACCENT_HUE,
+  uiFont: DEFAULT_UI_FONT,
   diffViewMode: "unified",
   collapsedConversationSections: [],
   commentComposerCollapsed: false,
@@ -426,6 +440,8 @@ export async function loadSettings(): Promise<AppSettings> {
       ...DEFAULT_SETTINGS.notifications,
       ...saved?.notifications,
     },
+    accentHue: sanitizeAccentHue(saved?.accentHue),
+    uiFont: sanitizeUiFont(saved?.uiFont),
   };
 }
 

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -4,7 +4,13 @@ import { PROVIDERS_REQUIRING_KEY } from "@/lib/ai/providers";
 import type { AiProviderId } from "@/lib/ai/types";
 import { getSecret } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
-import { commitTheme, type ThemeSetting } from "@/lib/theme";
+import {
+  commitAppearance,
+  sanitizeAccentHue,
+  sanitizeUiFont,
+  type ThemeSetting,
+  type UiFont,
+} from "@/lib/theme";
 import {
   type AppSettings,
   addRecentRepo,
@@ -117,37 +123,82 @@ export function useSaveSettings() {
 }
 
 /**
- * Apply a theme change from any entry point — the Appearance picker and the
- * `cycle-theme` command both go through this, so the two paths can't drift. It
- * optimistically patches the settings cache (so a bound `<Select>` reflects the
- * choice immediately, not a refetch later), persists it, applies the DOM class,
- * and rolls all three back if the store write throws. `useSaveSettings`'s
- * success-invalidate reconciles the cache on the happy path.
+ * Apply an appearance change from any entry point — the Appearance pickers
+ * and the `cycle-theme` command all go through this, so the paths can't drift.
+ * It optimistically patches the settings cache (so a bound `<Select>` or
+ * slider reflects the choice immediately), persists it, applies the DOM, and
+ * rolls back if the store write throws. `useSaveSettings`'s success-invalidate
+ * reconciles the cache on the happy path.
  */
-export function useApplyTheme() {
+export type AppearancePatch = {
+  theme?: ThemeSetting;
+  accentHue?: number;
+  uiFont?: UiFont;
+};
+
+export function useApplyAppearance() {
   const queryClient = useQueryClient();
   const saveSettings = useSaveSettings();
+
   return useCallback(
-    (current: AppSettings, next: ThemeSetting) => {
-      if (next === current.theme) return;
-      const updated = { ...current, theme: next };
+    (current: AppSettings, patch: AppearancePatch) => {
+      // Merge onto the cache, not the caller's snapshot: a hue drag writes the
+      // cache on every tick, and a theme/font persist in the same gesture must
+      // keep that hue rather than the pre-drag snapshot.
+      const base =
+        queryClient.getQueryData<AppSettings>(settingsKeys.settings) ?? current;
+      const updated: AppSettings = {
+        ...base,
+        ...patch,
+        accentHue:
+          patch.accentHue !== undefined
+            ? sanitizeAccentHue(patch.accentHue)
+            : base.accentHue,
+        uiFont:
+          patch.uiFont !== undefined
+            ? sanitizeUiFont(patch.uiFont)
+            : base.uiFont,
+      };
+      if (
+        updated.theme === base.theme &&
+        updated.accentHue === base.accentHue &&
+        updated.uiFont === base.uiFont
+      ) {
+        return;
+      }
       queryClient.setQueryData(settingsKeys.settings, updated);
-      commitTheme(next);
+      commitAppearance(updated);
       saveSettings.mutate(updated, {
         onError: () => {
           // Only roll back if this call's change is still the latest: otherwise a
-          // late-failing earlier write would stomp a newer successful one (two
-          // fast cycles where the first write rejects after the second lands).
+          // late-failing earlier write would stomp a newer successful one.
           const latest = queryClient.getQueryData<AppSettings>(
             settingsKeys.settings,
           );
-          if (latest?.theme !== next) return;
-          queryClient.setQueryData(settingsKeys.settings, current);
-          commitTheme(current.theme);
+          if (
+            latest?.theme !== updated.theme ||
+            latest?.accentHue !== updated.accentHue ||
+            latest?.uiFont !== updated.uiFont
+          ) {
+            return;
+          }
+          queryClient.setQueryData(settingsKeys.settings, base);
+          commitAppearance(base);
         },
       });
     },
     [queryClient, saveSettings],
+  );
+}
+
+/** Theme-only wrapper so Cycle-theme and the theme picker stay one-liners. */
+export function useApplyTheme() {
+  const apply = useApplyAppearance();
+  return useCallback(
+    (current: AppSettings, next: ThemeSetting) => {
+      apply(current, { theme: next });
+    },
+    [apply],
   );
 }
 

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -23,6 +23,7 @@ export type CreateKind =
   | "issue"
   | "local-issue"
   | "jira-issue"
+  | "linear-issue"
   | "pr"
   | "local-pr"
   | "release"
@@ -33,6 +34,7 @@ const CREATE_TAB: Record<CreateKind, RepoTab> = {
   issue: "issues",
   "local-issue": "issues",
   "jira-issue": "issues",
+  "linear-issue": "issues",
   pr: "pulls",
   "local-pr": "pulls",
   release: "tags",
@@ -60,9 +62,9 @@ export interface SelectedPr {
 }
 
 export interface SelectedIssue {
-  kind: "local" | "remote" | "jira";
-  /** Local issue id, the remote issue number as a string, or the Jira issue key
-   *  (e.g. `PROJ-123`). */
+  kind: "local" | "remote" | "jira" | "linear";
+  /** Local issue id, the remote issue number as a string, the Jira issue key
+   *  (e.g. `PROJ-123`), or the Linear issue identifier (e.g. `ENG-123`). */
   id: string;
 }
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -28,7 +28,42 @@ export function nextTheme(current: ThemeSetting): ThemeSetting {
   return THEME_ORDER[(i + 1) % THEME_ORDER.length];
 }
 
-const LS_KEY = "gd-theme";
+/**
+ * Chrome typeface (Settings → Appearance). Code, diffs, and the terminal keep
+ * JetBrains Mono via `--font-mono`; this only drives `--gd-ui-font`.
+ */
+export type UiFont = "jetbrains-mono" | "inter" | "system";
+
+export const UI_FONT_LABELS: Record<UiFont, string> = {
+  "jetbrains-mono": "JetBrains Mono",
+  inter: "Inter",
+  system: "System UI",
+};
+
+export const UI_FONT_ORDER: UiFont[] = ["jetbrains-mono", "inter", "system"];
+
+export const DEFAULT_ACCENT_HUE = 175;
+export const DEFAULT_UI_FONT: UiFont = "jetbrains-mono";
+
+/** Same stack as `--font-mono` in App.css. xterm can't inherit CSS font-family
+ *  (it paints its own canvas), so the in-app terminal reads this string. */
+export const MONO_FONT_STACK = '"JetBrains Mono Variable", monospace';
+
+const FONT_STACKS: Record<UiFont, string> = {
+  "jetbrains-mono": MONO_FONT_STACK,
+  inter: '"Inter Variable", ui-sans-serif, system-ui, sans-serif',
+  system: "ui-sans-serif, system-ui, sans-serif",
+};
+
+const LS_THEME = "gd-theme";
+const LS_HUE = "gd-accent-hue";
+const LS_FONT = "gd-ui-font";
+
+export type AppearancePrefs = {
+  theme: ThemeSetting;
+  accentHue: number;
+  uiFont: UiFont;
+};
 
 function isTheme(value: unknown): value is ThemeSetting {
   return (
@@ -39,56 +74,109 @@ function isTheme(value: unknown): value is ThemeSetting {
   );
 }
 
-// The last applied preference. The OS-change listener re-reads it so a `"system"`
-// user keeps tracking the OS while an explicit override stays pinned.
-let active: ThemeSetting = "system";
+export function isUiFont(value: unknown): value is UiFont {
+  return value === "jetbrains-mono" || value === "inter" || value === "system";
+}
+
+/** Round and clamp a stored hue; garbage from an older or hand-edited store
+ *  heals to the mint default instead of writing `NaN` into `oklch()`. */
+export function sanitizeAccentHue(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_ACCENT_HUE;
+  }
+  const rounded = Math.round(value);
+  if (rounded < 0 || rounded > 360) return DEFAULT_ACCENT_HUE;
+  return rounded;
+}
+
+export function sanitizeUiFont(value: unknown): UiFont {
+  return isUiFont(value) ? value : DEFAULT_UI_FONT;
+}
+
+export function isDefaultAccentAndFont(
+  accentHue: number,
+  uiFont: UiFont,
+): boolean {
+  return accentHue === DEFAULT_ACCENT_HUE && uiFont === DEFAULT_UI_FONT;
+}
+
+// Last applied preference. The OS-change listener re-reads it so a `"system"`
+// user keeps tracking the OS while an explicit override stays pinned; hue and
+// font overlay whichever base is active.
+let active: AppearancePrefs = {
+  theme: "system",
+  accentHue: DEFAULT_ACCENT_HUE,
+  uiFont: DEFAULT_UI_FONT,
+};
 
 function apply(): void {
   const dark =
-    active === "dark" ||
-    active === "slate" ||
-    (active === "system" && darkQuery.matches);
+    active.theme === "dark" ||
+    active.theme === "slate" ||
+    (active.theme === "system" && darkQuery.matches);
   const root = document.documentElement;
   root.classList.toggle("dark", dark);
   // `slate` only ever rides alongside `dark` (it forces dark above), so the
   // cool-ramp override in App.css (`.dark.slate`) always has its base surface.
-  root.classList.toggle("slate", active === "slate");
+  root.classList.toggle("slate", active.theme === "slate");
+  root.style.setProperty("--accent-hue", String(active.accentHue));
+  root.style.setProperty("--gd-ui-font", FONT_STACKS[active.uiFont]);
+}
+
+function writeMirror(prefs: AppearancePrefs): void {
+  try {
+    localStorage.setItem(LS_THEME, prefs.theme);
+    localStorage.setItem(LS_HUE, String(prefs.accentHue));
+    localStorage.setItem(LS_FONT, prefs.uiFont);
+  } catch {
+    // A locked-down webview can throw on localStorage; the class/vars are still
+    // applied and the settings store stays the source of truth, so the only
+    // cost is a possible flash on the next cold boot.
+  }
 }
 
 /**
- * Apply a theme preference to the document, remember it as the source of truth
- * for boot + OS-change reconciliation, and mirror it to `localStorage` for a
- * flash-free next boot. Call on save (Settings picker, Cycle-theme command) and
- * whenever the persisted value resolves from the store.
+ * Apply appearance prefs to the document, remember them as the source of
+ * truth for boot + OS-change reconciliation, and mirror them to `localStorage`
+ * for a flash-free next boot. Call on save (Settings pickers, Cycle-theme)
+ * and whenever the persisted value resolves from the store.
  */
-export function commitTheme(theme: ThemeSetting): void {
-  active = theme;
-  try {
-    localStorage.setItem(LS_KEY, theme);
-  } catch {
-    // A locked-down webview can throw on localStorage; the class is still applied
-    // and the settings store stays the source of truth, so the only cost is a
-    // possible flash on the next cold boot.
-  }
+export function commitAppearance(prefs: AppearancePrefs): void {
+  active = {
+    theme: prefs.theme,
+    accentHue: sanitizeAccentHue(prefs.accentHue),
+    uiFont: sanitizeUiFont(prefs.uiFont),
+  };
+  writeMirror(active);
   apply();
 }
 
 /**
  * Read the mirrored preference synchronously and apply it before first paint,
  * then keep `"system"` tracking the OS. Called once from `main.tsx`; the
- * authoritative value from the settings store reconciles via {@link commitTheme}
+ * authoritative value from the settings store reconciles via {@link commitAppearance}
  * once it loads.
  */
 export function initTheme(): void {
-  let stored: string | null = null;
+  let storedTheme: string | null = null;
+  let storedHue: string | null = null;
+  let storedFont: string | null = null;
   try {
-    stored = localStorage.getItem(LS_KEY);
+    storedTheme = localStorage.getItem(LS_THEME);
+    storedHue = localStorage.getItem(LS_HUE);
+    storedFont = localStorage.getItem(LS_FONT);
   } catch {
     // Some locked-down webviews throw on any localStorage access. initTheme runs
     // before first paint, so an unguarded throw here would crash startup; fall
-    // back to "system" — the store still reconciles the real value via commitTheme.
+    // back to defaults — the store still reconciles the real value via commitAppearance.
   }
-  active = isTheme(stored) ? stored : "system";
+  const hue =
+    storedHue === null ? DEFAULT_ACCENT_HUE : Number.parseInt(storedHue, 10);
+  active = {
+    theme: isTheme(storedTheme) ? storedTheme : "system",
+    accentHue: sanitizeAccentHue(hue),
+    uiFont: sanitizeUiFont(storedFont),
+  };
   apply();
   darkQuery.addEventListener("change", apply);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import { initAnalytics, trackCaughtError } from "@/lib/analytics";
 import { calmTransition } from "@/lib/motion";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
-import { commitTheme, initTheme } from "@/lib/theme";
+import { commitAppearance, initTheme } from "@/lib/theme";
 import App from "./App.tsx";
 import "./App.css";
 // Position is load-bearing: the vendored diff-view CSS must be imported plain
@@ -24,8 +24,8 @@ import "./App.css";
 // at build time instead (see vite.config.ts), so no layering is needed.
 import "@git-diff-view/react/styles/diff-view.css";
 
-// Apply the saved theme (System / Light / Dark / Slate) before first paint,
-// reading a localStorage mirror synchronously so a saved override doesn't flash
+// Apply the saved theme / accent / font before first paint, reading a
+// localStorage mirror synchronously so a saved override doesn't flash
 // through the OS default; the authoritative store value reconciles below.
 initTheme();
 
@@ -34,7 +34,7 @@ initTheme();
 loadSettings()
   .then((s) => {
     // Reconcile the flash-mirror against the authoritative persisted value.
-    commitTheme(s.theme);
+    commitAppearance(s);
     initAnalytics(s.analyticsEnabled, s.recordReplay);
   })
   .catch(() => {


### PR DESCRIPTION
## Summary
- Settings → Appearance: pick accent hue (tints buttons, focus rings, highlights) and UI font (JetBrains Mono, Inter, or system)
- Code, diffs, and terminal stay on JetBrains Mono
- Reset accent & font restores defaults
- Ignore local `.cursor/` and `.pnpm-store/` in git

## Test plan
- [ ] Open Settings → Appearance, change accent and font; confirm chrome updates
- [ ] Reset accent & font restores defaults
- [ ] Code/diff/terminal views still use JetBrains Mono
- [ ] Light/dark/slate themes still work with custom accent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linear integration for linking teams to repositories, browsing and creating issues, commenting, assigning, changing status, and opening issues in Linear.
  - Linear issue references in branches, commits, pull requests, and descriptions are now clickable.
  - Added customizable accent colour and UI font settings, with a reset option. Code, diffs, and terminal text remain in JetBrains Mono.
- **Documentation**
  - Updated the README, in-app guide, and capability listings with Linear and appearance customization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->