### PR TITLE
fix(issues,discussions,tags,history): await writes so outcomes land

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -289,6 +289,14 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   that lived in them silently never runs. The house idiom is `form.ts`'s
   awaited-submit convention (`SquashDialog` in
   `src/features/history/RewriteDialogs.tsx` is the reference).
+- An awaited continuation that writes GLOBAL selection/navigation state
+  (`selectIssue` / `selectTag` / `selectDiscussion`, `setRepoTab`,
+  `setCommitDraft`) guards on the live `repoPath` — and the live entity, for
+  deselects — read via `useUiStore.getState()` after the await: mutateAsync
+  continuations outlive Activity hides AND unmounts, so an unguarded write
+  retargets whatever repo/entity the user switched to (reference:
+  `deselectIfStillHere` in `src/features/issues/RemoteIssueView.tsx`). Toasts
+  stay unconditional — the operation happened regardless.
 - A follow-up that needs the DOM from a state flip (focus a just-revealed
   input, re-pin a grown scroll region) never rides a bare
   `requestAnimationFrame` from the event handler: when the state lives in

--- a/changelog.d/changed-discussion-scope-reconnect.md
+++ b/changelog.d/changed-discussion-scope-reconnect.md
@@ -1,0 +1,4 @@
+- Discussions now flag a classic GitHub sign-in whose scopes can't write
+  discussions: the list, the New discussion dialog, and the thread offer an
+  in-app reconnect (or a copyable refresh command) before a write fails, and
+  scope failures read as a plain sentence.

--- a/changelog.d/changed-discussion-scope-reconnect.md
+++ b/changelog.d/changed-discussion-scope-reconnect.md
@@ -1,4 +1,3 @@
-- Discussions now flag a classic GitHub sign-in whose scopes can't write
-  discussions: the list, the New discussion dialog, and the thread offer an
-  in-app reconnect (or a copyable refresh command) before a write fails, and
-  scope failures read as a plain sentence.
+- When your GitHub sign-in's scopes can't write discussions, the list, the
+  New discussion dialog, and the thread now offer an in-app reconnect (or a
+  copyable refresh command) before a write fails.

--- a/changelog.d/fixed-issue-discussion-tag-history-continuations.md
+++ b/changelog.d/fixed-issue-discussion-tag-history-continuations.md
@@ -1,0 +1,4 @@
+- Issue, discussion, tag, and history actions now finish reliably when you
+  switch tabs or close their dialog mid-operation: toasts arrive, confirm
+  dialogs close, drafts clear or restore, and the view moves on even if the
+  write settles while you're elsewhere.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -549,16 +549,18 @@ export const CHECKS = [
   {
     name: "bare-mutate-in-converted-trees",
     // Scoped to the trees that are fully converted, so the check can only ever
-    // see a NEW site: the settings dialog's own sections (which unmount on BOTH
-    // dialog close and every rail section switch — the keyed crossfade), Explore,
+    // see a NEW site: the repo-settings dialog's own sections (which unmount on
+    // BOTH dialog close and every rail section switch — the keyed crossfade), Explore,
     // whose detail pane is keyed per repo, Actions, whose run detail is keyed per
     // run and whose dispatch dialog unmounts with the repo view, the repository
     // and commit trees, whose panels ride <Activity>-hidden tabs and whose
     // dialogs close mid-flight, and pulls / issues / history / discussions /
     // tags, whose surfaces go through an `<Activity>` tab hide on every repo-tab
-    // switch. What is left is scattered singles (diff, compare, settings,
+    // switch. What is left is scattered singles (diff, compare, app settings,
     // welcome, automations, conversations, scripts, hooks, branch-rules,
-    // updates, App.tsx, the detail rail), each joining on its own conversion.
+    // updates, App.tsx, the detail rail), each joining on its own conversion —
+    // plus src/lib/settings/queries.ts's theme write, which STAYS: its onError
+    // is the synchronous rollback the async-settings-rollback check pins.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||
@@ -575,8 +577,9 @@ export const CHECKS = [
     // nothing an unmount can drop; the token match is the ratchet, and an
     // exemption is an entry here rather than a hole in the pattern.
     allowlist: [
-      // Three single-arg `update.mutate(vars)` field write-throughs; nothing to
-      // drop.
+      // The local-conversation write-through and the archive/unarchive toggles,
+      // all single-arg `update.mutate(vars)` — the deselect the archive pairs
+      // with is synchronous.
       "src/features/issues/LocalIssueView.tsx",
       // Eight single-arg picker/field writes; their hooks report failures at the
       // mutation level.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -552,25 +552,35 @@ export const CHECKS = [
     // see a NEW site: the settings dialog's own sections (which unmount on BOTH
     // dialog close and every rail section switch — the keyed crossfade), Explore,
     // whose detail pane is keyed per repo, Actions, whose run detail is keyed per
-    // run and whose dispatch dialog unmounts with the repo view, pulls, whose
-    // surfaces go through an `<Activity>` tab hide on every repo-tab switch,
-    // and the repository + commit trees, whose panels ride <Activity>-hidden
-    // tabs and whose dialogs close mid-flight. The wider app is a separate
-    // tier — issues/ and the smaller trees still carry per-call callback sites
-    // in bulk, so scanning them would report a backlog rather than a
-    // regression. Each tree joins this check on the change that converts it.
+    // run and whose dispatch dialog unmounts with the repo view, the repository
+    // and commit trees, whose panels ride <Activity>-hidden tabs and whose
+    // dialogs close mid-flight, and pulls / issues / history / discussions /
+    // tags, whose surfaces go through an `<Activity>` tab hide on every repo-tab
+    // switch. What is left is scattered singles (diff, compare, settings,
+    // welcome, automations, conversations, scripts, hooks, branch-rules,
+    // updates, App.tsx, the detail rail), each joining on its own conversion.
     appliesTo: (file) =>
       file.startsWith("src/features/repo-settings/") ||
       file.startsWith("src/features/explore/") ||
       file.startsWith("src/features/actions/") ||
       file.startsWith("src/features/pulls/") ||
       file.startsWith("src/features/repository/") ||
-      file.startsWith("src/features/commit/"),
+      file.startsWith("src/features/commit/") ||
+      file.startsWith("src/features/issues/") ||
+      file.startsWith("src/features/history/") ||
+      file.startsWith("src/features/discussions/") ||
+      file.startsWith("src/features/tags/"),
     scan: anyOf([perLine(MUTATE_CALL_RE), perFile(DESTRUCTURED_MUTATE_RE)]),
-    // Every pulls entry is a call carrying NO per-call callbacks object, so
-    // there is nothing an unmount can drop; the token match is the ratchet, and
-    // an exemption is an entry here rather than a hole in the pattern.
+    // Every entry is a call carrying NO per-call callbacks object, so there is
+    // nothing an unmount can drop; the token match is the ratchet, and an
+    // exemption is an entry here rather than a hole in the pattern.
     allowlist: [
+      // Three single-arg `update.mutate(vars)` field write-throughs; nothing to
+      // drop.
+      "src/features/issues/LocalIssueView.tsx",
+      // Eight single-arg picker/field writes; their hooks report failures at the
+      // mutation level.
+      "src/features/issues/RemoteIssueViewParts.tsx",
       // Archive/unarchive, single-arg `update.mutate(vars)` — the deselect it
       // pairs with is synchronous.
       "src/features/pulls/LocalPrContextMenu.tsx",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -585,10 +585,19 @@ test("bare-mutate-in-converted-trees applies to the converted trees only", () =>
     // Joined when the repository/commit conversions landed:
     "src/features/repository/ChangesPanel.tsx",
     "src/features/commit/CommitBox.tsx",
+    // Joined when the issues/history/discussions/tags conversions landed:
+    "src/features/issues/RemoteIssueView.tsx",
+    "src/features/history/HistoryPanel.tsx",
+    "src/features/discussions/DiscussionView.tsx",
+    "src/features/tags/TagDetailView.tsx",
   ]) {
     assert.equal(appliesTo(file), true, `should scan ${file}`);
   }
-  for (const file of ["src/features/issues/RemoteIssueView.tsx"]) {
+  for (const file of [
+    "src/features/diff/DiffViewer.tsx",
+    "src/features/welcome/WelcomeScreen.tsx",
+    "src/lib/settings/queries.ts",
+  ]) {
     assert.equal(appliesTo(file), false, `should not scan ${file}`);
   }
 });

--- a/src-tauri/src/github/discussion.rs
+++ b/src-tauri/src/github/discussion.rs
@@ -578,10 +578,11 @@ pub async fn gh_discussion_view(
     })
 }
 
-const DISCUSSION_SCOPE_HINT: &str = "Writing discussions needs the write:discussion scope. Run:  gh auth refresh -s write:discussion";
+const DISCUSSION_SCOPE_HINT: &str = "Writing discussions needs the write:discussion scope.";
 
 /// Discussion mutations need the `write:discussion` OAuth scope, which a default
-/// `gh auth login` often lacks — turn that failure into an actionable hint.
+/// `gh auth login` often lacks — name that cause instead of the raw gh failure.
+/// The discussions surfaces carry the reconnect path, so this stays a sentence.
 fn map_scope_error(e: AppError) -> AppError {
     if let AppError::Gh(ref msg) = e {
         let lower = msg.to_lowercase();
@@ -978,4 +979,44 @@ pub async fn gh_discussion_delete(
     )
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_scope_becomes_the_actionable_hint() {
+        // A realistic GraphQL denial carries both substrings; the trailing two
+        // pin each arm of the match on its own.
+        for raw in [
+            "GraphQL: Your token has not been granted the required scopes to execute this query. \
+             The 'addDiscussionComment' field requires one of the following scopes: \
+             ['write:discussion']",
+            "error: the token is missing the write:discussion scope",
+            "GraphQL: Your token has not been granted the required scopes.",
+        ] {
+            let AppError::Gh(msg) = map_scope_error(AppError::Gh(raw.into())) else {
+                panic!("expected the Gh variant");
+            };
+            assert_eq!(msg, DISCUSSION_SCOPE_HINT);
+        }
+    }
+
+    #[test]
+    fn unrelated_failures_pass_through_untouched() {
+        let AppError::Gh(msg) = map_scope_error(AppError::Gh(
+            "GraphQL: Could not resolve to a Discussion with the number 999.".into(),
+        )) else {
+            panic!("expected the Gh variant");
+        };
+        assert_eq!(
+            msg,
+            "GraphQL: Could not resolve to a Discussion with the number 999."
+        );
+        assert!(matches!(
+            map_scope_error(AppError::InvalidArgument("write:discussion".into())),
+            AppError::InvalidArgument(_)
+        ));
+    }
 }

--- a/src-tauri/src/github/discussion.rs
+++ b/src-tauri/src/github/discussion.rs
@@ -582,7 +582,8 @@ const DISCUSSION_SCOPE_HINT: &str = "Writing discussions needs the write:discuss
 
 /// Discussion mutations need the `write:discussion` OAuth scope, which a default
 /// `gh auth login` often lacks — name that cause instead of the raw gh failure.
-/// The discussions surfaces carry the reconnect path, so this stays a sentence.
+/// The GUI discussions surfaces carry the reconnect path; other callers (MCP)
+/// get the cause alone, so this stays a sentence.
 fn map_scope_error(e: AppError) -> AppError {
     if let AppError::Gh(ref msg) = e {
         let lower = msg.to_lowercase();
@@ -986,7 +987,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn a_missing_scope_becomes_the_actionable_hint() {
+    fn a_missing_scope_becomes_the_scope_sentence() {
         // A realistic GraphQL denial carries both substrings; the trailing two
         // pin each arm of the match on its own.
         for raw in [

--- a/src/features/conversations/DeleteCommentDialog.tsx
+++ b/src/features/conversations/DeleteCommentDialog.tsx
@@ -13,8 +13,8 @@ import {
  * "Delete comment?" confirmation, shared by every PR/issue/discussion view.
  * Open while `commentId` is non-null. The dialog does NOT close itself on
  * confirm — `onConfirm(id)` runs the caller's delete and the caller closes
- * (synchronously for local comments; in onSuccess AND onError for remote ones,
- * where close-on-error is deliberate). `pending` disables Delete during a
+ * (synchronously for local comments; for remote ones in BOTH arms of the
+ * awaited continuation — close-on-error is deliberate). `pending` disables Delete during a
  * remote mutation; local callers omit it.
  */
 export function DeleteCommentDialog({

--- a/src/features/conversations/DeleteCommentDialog.tsx
+++ b/src/features/conversations/DeleteCommentDialog.tsx
@@ -14,8 +14,8 @@ import {
  * Open while `commentId` is non-null. The dialog does NOT close itself on
  * confirm — `onConfirm(id)` runs the caller's delete and the caller closes
  * (synchronously for local comments; for remote ones in BOTH arms of the
- * awaited continuation — close-on-error is deliberate). `pending` disables Delete during a
- * remote mutation; local callers omit it.
+ * awaited continuation — close-on-error is deliberate). `pending` disables
+ * Delete during a remote mutation; local callers omit it.
  */
 export function DeleteCommentDialog({
   commentId,

--- a/src/features/discussions/CreateDiscussionDialog.tsx
+++ b/src/features/discussions/CreateDiscussionDialog.tsx
@@ -48,7 +48,10 @@ export function CreateDiscussionDialog({
           action: { label: "View", onClick: () => openUrl(url) },
         });
         onOpenChange(false);
-        if (number > 0) selectDiscussion({ number });
+        // Adopt the new discussion only while this repo is still on screen —
+        // the create can settle after a repo switch.
+        if (number > 0 && useUiStore.getState().repoPath === repoPath)
+          selectDiscussion({ number });
       } catch (e) {
         toastError(e);
       }
@@ -100,7 +103,7 @@ export function CreateDiscussionDialog({
             <ScopeRefreshHint
               scope="write:discussion"
               action="Creating a discussion"
-              coveredBy={["repo", "write:discussion"]}
+              coveredBy={["repo"]}
             />
             <div className="min-w-0">
               <form.AppField name="categoryId">

--- a/src/features/discussions/CreateDiscussionDialog.tsx
+++ b/src/features/discussions/CreateDiscussionDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ScopeRefreshHint } from "@/features/repo-settings/ScopeRefreshHint";
 import { required, useAppForm } from "@/lib/form";
 import { useCreateDiscussion, useDiscussionMeta } from "@/lib/git/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -96,6 +97,11 @@ export function CreateDiscussionDialog({
 
           {/* Fields scroll; header and submit footer stay pinned. */}
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+            <ScopeRefreshHint
+              scope="write:discussion"
+              action="Creating a discussion"
+              coveredBy={["repo", "write:discussion"]}
+            />
             <div className="min-w-0">
               <form.AppField name="categoryId">
                 {(field) => (

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -552,7 +552,6 @@ export function DiscussionView({
 
   async function doDelete() {
     if (!d || detailsStale) return;
-    const deleted = number;
     try {
       await deleteDiscussion.mutateAsync(d.id);
     } catch (e) {
@@ -568,7 +567,7 @@ export function DiscussionView({
     const live = useUiStore.getState();
     if (
       live.repoPath === repoPath &&
-      live.selectedDiscussion?.number === deleted
+      live.selectedDiscussion?.number === number
     )
       selectDiscussion(null);
   }
@@ -1016,7 +1015,7 @@ export function DiscussionView({
         <ScopeRefreshHint
           scope="write:discussion"
           action="Writing in discussions"
-          coveredBy={["repo", "write:discussion"]}
+          coveredBy={["repo"]}
         />
       </div>
       <CommentComposer

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -336,9 +336,10 @@ export function DiscussionView({
   const draftSuffix =
     staleSuffix || (draftRidesStateChange ? " — posts your draft" : "");
 
-  // Every write below awaits `mutateAsync`: react-query drops per-call callbacks
-  // once the observer loses its listeners, so a tab hide or unmount mid-flight
-  // would land the mutation and silently lose the toast, draft clear, or close.
+  // Every write below awaits `mutateAsync` (or detaches with a `.catch`):
+  // react-query drops per-call callbacks once the observer loses its listeners,
+  // so a tab hide or unmount mid-flight would land the mutation and silently
+  // lose the toast, draft clear, or close.
   async function submitComment() {
     if (!d || detailsStale || !compose.value.trim()) return;
     const submittedFor = discussionIdentity;

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -1007,8 +1007,9 @@ export function DiscussionView({
           )}
         </div>
       </ScrollArea>
-      {/* empty:hidden: the hint self-gates to null when the scope is present, and
-          the wrapper must then contribute no border or padding of its own. */}
+      {/* empty:hidden: the hint self-gates to null (scopes covered, non-classic
+          token, or still loading), and the wrapper must then contribute no
+          border or padding of its own. */}
       <div className="empty:hidden shrink-0 border-t p-2">
         {/* GitHub's scope error names write:discussion, but `repo` covers
             repository-discussion writes — warn only when neither is present. */}

--- a/src/features/discussions/DiscussionView.tsx
+++ b/src/features/discussions/DiscussionView.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/features/conversations/Thread";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
+import { ScopeRefreshHint } from "@/features/repo-settings/ScopeRefreshHint";
 import { copyText } from "@/lib/clipboard";
 import type {
   DiscussionCloseReason,
@@ -335,29 +336,38 @@ export function DiscussionView({
   const draftSuffix =
     staleSuffix || (draftRidesStateChange ? " — posts your draft" : "");
 
-  function submitComment() {
+  // Every write below awaits `mutateAsync`: react-query drops per-call callbacks
+  // once the observer loses its listeners, so a tab hide or unmount mid-flight
+  // would land the mutation and silently lose the toast, draft clear, or close.
+  async function submitComment() {
     if (!d || detailsStale || !compose.value.trim()) return;
     const submittedFor = discussionIdentity;
-    addComment.mutate(
-      { discussionId: d.id, body: compose.value.trim() },
-      { onSuccess: () => compose.clearFor(submittedFor), onError },
-    );
+    try {
+      await addComment.mutateAsync({
+        discussionId: d.id,
+        body: compose.value.trim(),
+      });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    compose.clearFor(submittedFor);
   }
 
-  function submitReply(commentId: string) {
+  async function submitReply(commentId: string) {
     if (!d || detailsStale || !reply.value.body.trim()) return;
     const submittedFor = discussionIdentity;
-    addComment.mutate(
-      {
+    try {
+      await addComment.mutateAsync({
         discussionId: d.id,
         body: reply.value.body.trim(),
         replyToId: commentId,
-      },
-      {
-        onSuccess: () => reply.clearFor(submittedFor),
-        onError,
-      },
-    );
+      });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    reply.clearFor(submittedFor);
   }
 
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
@@ -373,40 +383,48 @@ export function DiscussionView({
   // Every comment id below comes off the rendered discussion, which mid-switch is
   // the previous one — so each write would land on the discussion the viewer just
   // left. The affordances withhold or disable too; these arms back them up.
-  function saveCommentEdit(commentId: string, body: string) {
+  async function saveCommentEdit(commentId: string, body: string) {
     if (detailsStale) return;
-    updateComment.mutate(
-      { commentId, body },
-      { onSuccess: () => toast.success("Comment updated"), onError },
-    );
+    try {
+      await updateComment.mutateAsync({ commentId, body });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Comment updated");
   }
 
-  function hideComment(commentId: string, classifier: MinimizeReason) {
+  async function hideComment(commentId: string, classifier: MinimizeReason) {
     if (detailsStale) return;
-    minimizeComment.mutate(
-      { commentId, classifier },
-      { onSuccess: () => toast.success("Comment hidden"), onError },
-    );
+    try {
+      await minimizeComment.mutateAsync({ commentId, classifier });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Comment hidden");
   }
 
-  function unhideComment(commentId: string) {
+  async function unhideComment(commentId: string) {
     if (detailsStale) return;
-    unminimizeComment.mutate(commentId, {
-      onSuccess: () => toast.success("Comment shown"),
-      onError,
-    });
+    try {
+      await unminimizeComment.mutateAsync(commentId);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Comment shown");
   }
 
-  function toggleAnswer(commentId: string, isAnswer: boolean) {
+  async function toggleAnswer(commentId: string, isAnswer: boolean) {
     if (detailsStale) return;
-    markAnswer.mutate(
-      { commentId, answer: !isAnswer },
-      {
-        onSuccess: () =>
-          toast.success(isAnswer ? "Answer unmarked" : "Marked as answer"),
-        onError,
-      },
-    );
+    try {
+      await markAnswer.mutateAsync({ commentId, answer: !isAnswer });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(isAnswer ? "Answer unmarked" : "Marked as answer");
   }
 
   // Both subjects come off the rendered discussion while the optimistic patch
@@ -414,12 +432,16 @@ export function DiscussionView({
   // controls disable too; these arms are the belt-and-braces behind them.
   function toggleUpvote(subjectId: string, upvoted: boolean) {
     if (detailsStale) return;
-    toggleUpvoteMutation.mutate({ subjectId, up: !upvoted }, { onError });
+    void toggleUpvoteMutation
+      .mutateAsync({ subjectId, up: !upvoted })
+      .catch(onError);
   }
 
   function toggleReaction(subjectId: string, content: string, active: boolean) {
     if (detailsStale) return;
-    toggleReactionMutation.mutate({ subjectId, content, active }, { onError });
+    void toggleReactionMutation
+      .mutateAsync({ subjectId, content, active })
+      .catch(onError);
   }
 
   function referenceInNewIssue() {
@@ -435,20 +457,26 @@ export function DiscussionView({
 
   // Each of these addresses the rendered discussion's id while the menu belongs to
   // the selected one; the items disable too, and these arms back them up.
-  function doLock(reason: DiscussionLockReason | null) {
+  async function doLock(reason: DiscussionLockReason | null) {
     if (!d || detailsStale) return;
-    lockDiscussion.mutate(
-      { discussionId: d.id, reason },
-      { onSuccess: () => toast.success("Conversation locked"), onError },
-    );
+    try {
+      await lockDiscussion.mutateAsync({ discussionId: d.id, reason });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Conversation locked");
   }
 
-  function doUnlock() {
+  async function doUnlock() {
     if (!d || detailsStale) return;
-    unlockDiscussion.mutate(d.id, {
-      onSuccess: () => toast.success("Conversation unlocked"),
-      onError,
-    });
+    try {
+      await unlockDiscussion.mutateAsync(d.id);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Conversation unlocked");
   }
 
   /** Posts the riding draft ahead of a state change. False means the comment
@@ -490,50 +518,72 @@ export function DiscussionView({
     });
     if (!ok) return;
     if (!(await postRidingDraft(d.id))) return;
-    closeDiscussion.mutate(
-      { discussionId: d.id, reason },
-      {
-        onSuccess: () => toast.success("Discussion closed"),
-        onError: (e) =>
-          withComment
-            ? toastErrorWithNote(
-                e,
-                "Your comment was posted, but closing failed — try Close again.",
-              )
-            : onError(e),
-      },
-    );
+    try {
+      await closeDiscussion.mutateAsync({ discussionId: d.id, reason });
+    } catch (e) {
+      if (withComment)
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but closing failed — try Close again.",
+        );
+      else onError(e);
+      return;
+    }
+    toast.success("Discussion closed");
   }
 
   async function doReopen() {
     if (!d || detailsStale || addComment.isPending) return;
     const withComment = draftRidesStateChange;
     if (!(await postRidingDraft(d.id))) return;
-    reopenDiscussion.mutate(d.id, {
-      onSuccess: () => toast.success("Discussion reopened"),
-      onError: (e) =>
-        withComment
-          ? toastErrorWithNote(
-              e,
-              "Your comment was posted, but reopening failed — try Reopen again.",
-            )
-          : onError(e),
-    });
+    try {
+      await reopenDiscussion.mutateAsync(d.id);
+    } catch (e) {
+      if (withComment)
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but reopening failed — try Reopen again.",
+        );
+      else onError(e);
+      return;
+    }
+    toast.success("Discussion reopened");
   }
 
-  function doDelete() {
+  async function doDelete() {
     if (!d || detailsStale) return;
-    deleteDiscussion.mutate(d.id, {
-      onSuccess: () => {
-        toast.success("Discussion deleted");
-        setDeletingDiscussion(false);
-        selectDiscussion(null);
-      },
-      onError: (e) => {
-        onError(e);
-        setDeletingDiscussion(false);
-      },
-    });
+    const deleted = number;
+    try {
+      await deleteDiscussion.mutateAsync(d.id);
+    } catch (e) {
+      onError(e);
+      setDeletingDiscussion(false);
+      return;
+    }
+    toast.success("Discussion deleted");
+    setDeletingDiscussion(false);
+    // `selectDiscussion` is a global store write that outlives this view, so a
+    // delete settling after the viewer moved on (another discussion, another
+    // repo) must not clear their live selection.
+    const live = useUiStore.getState();
+    if (
+      live.repoPath === repoPath &&
+      live.selectedDiscussion?.number === deleted
+    )
+      selectDiscussion(null);
+  }
+
+  /** Close-on-error is the dialog's documented contract, so both arms close it. */
+  async function doDeleteComment(commentId: string) {
+    try {
+      await deleteComment.mutateAsync(commentId);
+    } catch (e) {
+      onError(e);
+      setDeletingCommentId(null);
+      return;
+    }
+    toast.success("Comment deleted");
+    setDeletingCommentId(null);
   }
 
   return (
@@ -587,7 +637,7 @@ export function DiscussionView({
               {d.closed ? (
                 <DropdownMenuItem
                   disabled={reopenDiscussion.isPending || detailsStale}
-                  onClick={doReopen}
+                  onClick={() => void doReopen()}
                 >
                   Reopen discussion{draftSuffix}
                 </DropdownMenuItem>
@@ -606,7 +656,7 @@ export function DiscussionView({
                       <DropdownMenuItem
                         key={reason}
                         disabled={closeDiscussion.isPending || detailsStale}
-                        onClick={() => doClose(reason)}
+                        onClick={() => void doClose(reason)}
                       >
                         {label}
                       </DropdownMenuItem>
@@ -617,7 +667,7 @@ export function DiscussionView({
               {d.locked ? (
                 <DropdownMenuItem
                   disabled={unlockDiscussion.isPending || detailsStale}
-                  onClick={doUnlock}
+                  onClick={() => void doUnlock()}
                 >
                   Unlock conversation{staleSuffix}
                 </DropdownMenuItem>
@@ -634,7 +684,7 @@ export function DiscussionView({
                       <DropdownMenuItem
                         key={reason ?? "none"}
                         disabled={lockDiscussion.isPending || detailsStale}
-                        onClick={() => doLock(reason)}
+                        onClick={() => void doLock(reason)}
                       >
                         {label}
                       </DropdownMenuItem>
@@ -793,7 +843,7 @@ export function DiscussionView({
                   onQuote={detailsStale ? undefined : () => quoteReply(c.body)}
                   onSaveEdit={
                     c.viewerDidAuthor && !detailsStale
-                      ? (body) => saveCommentEdit(c.id, body)
+                      ? (body) => void saveCommentEdit(c.id, body)
                       : undefined
                   }
                   // Withholding the handler only drops the menu entry; an editor
@@ -807,10 +857,10 @@ export function DiscussionView({
                   onHide={
                     c.isMinimized
                       ? undefined
-                      : (classifier) => hideComment(c.id, classifier)
+                      : (classifier) => void hideComment(c.id, classifier)
                   }
                   onUnhide={
-                    c.isMinimized ? () => unhideComment(c.id) : undefined
+                    c.isMinimized ? () => void unhideComment(c.id) : undefined
                   }
                   // Hide/Unhide stay visible but disabled — the items carry their
                   // own reason, unlike the entries withheld above.
@@ -853,7 +903,7 @@ export function DiscussionView({
                     variant={c.isAnswer ? "secondary" : "outline"}
                     disabled={busy}
                     reason={busyReason}
-                    onClick={() => toggleAnswer(c.id, c.isAnswer)}
+                    onClick={() => void toggleAnswer(c.id, c.isAnswer)}
                   >
                     <CheckCircleIcon data-icon="inline-start" />
                     {c.isAnswer ? "Unmark answer" : "Mark as answer"}
@@ -871,7 +921,7 @@ export function DiscussionView({
                       }
                       onSaveEdit={
                         r.viewerDidAuthor && !detailsStale
-                          ? (body) => saveCommentEdit(r.id, body)
+                          ? (body) => void saveCommentEdit(r.id, body)
                           : undefined
                       }
                       editHeld={detailsStale}
@@ -883,10 +933,12 @@ export function DiscussionView({
                       onHide={
                         r.isMinimized
                           ? undefined
-                          : (classifier) => hideComment(r.id, classifier)
+                          : (classifier) => void hideComment(r.id, classifier)
                       }
                       onUnhide={
-                        r.isMinimized ? () => unhideComment(r.id) : undefined
+                        r.isMinimized
+                          ? () => void unhideComment(r.id)
+                          : undefined
                       }
                       disabledReason={staleReason}
                       reactions={reactions.data?.comments[r.id]}
@@ -916,7 +968,7 @@ export function DiscussionView({
                             // the global action.
                             e.preventDefault();
                             if (reply.value.body.trim() && !busy)
-                              submitReply(c.id);
+                              void submitReply(c.id);
                           }
                         }}
                         rows={2}
@@ -931,7 +983,7 @@ export function DiscussionView({
                           // An empty draft explains itself; only the `busy` hold
                           // needs words.
                           reason={busy ? busyReason : null}
-                          onClick={() => submitReply(c.id)}
+                          onClick={() => void submitReply(c.id)}
                           title={SUBMIT_HINT}
                         >
                           Reply
@@ -955,11 +1007,22 @@ export function DiscussionView({
           )}
         </div>
       </ScrollArea>
+      {/* empty:hidden: the hint self-gates to null when the scope is present, and
+          the wrapper must then contribute no border or padding of its own. */}
+      <div className="empty:hidden shrink-0 border-t p-2">
+        {/* GitHub's scope error names write:discussion, but `repo` covers
+            repository-discussion writes — warn only when neither is present. */}
+        <ScopeRefreshHint
+          scope="write:discussion"
+          action="Writing in discussions"
+          coveredBy={["repo", "write:discussion"]}
+        />
+      </div>
       <CommentComposer
         ref={composerRef}
         value={compose.value}
         onChange={compose.set}
-        onSubmit={submitComment}
+        onSubmit={() => void submitComment()}
         onClear={() => compose.set("")}
         submitLabel="Comment"
         ariaLabel="Add to the discussion"
@@ -973,18 +1036,7 @@ export function DiscussionView({
         commentId={deletingCommentId}
         onClose={() => setDeletingCommentId(null)}
         pending={deleteComment.isPending}
-        onConfirm={(commentId) =>
-          deleteComment.mutate(commentId, {
-            onSuccess: () => {
-              toast.success("Comment deleted");
-              setDeletingCommentId(null);
-            },
-            onError: (e) => {
-              onError(e);
-              setDeletingCommentId(null);
-            },
-          })
-        }
+        onConfirm={(commentId) => void doDeleteComment(commentId)}
       />
 
       <Dialog open={deletingDiscussion} onOpenChange={setDeletingDiscussion}>
@@ -1007,7 +1059,7 @@ export function DiscussionView({
               variant="destructive"
               disabled={deleteDiscussion.isPending || detailsStale}
               reason={staleReason}
-              onClick={doDelete}
+              onClick={() => void doDelete()}
             >
               {deleteDiscussion.isPending && (
                 <Spinner data-icon="inline-start" />

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { LoadMoreRow, PAGE_SIZE } from "@/features/conversations/LoadMoreRow";
 import { LabelChip } from "@/features/conversations/Thread";
+import { ScopeRefreshHint } from "@/features/repo-settings/ScopeRefreshHint";
 import { ForgeNotReady } from "@/features/repository/ForgeNotReady";
 import {
   forgeReady,
@@ -173,7 +174,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
           New
         </DisabledReasonButton>
       </div>
-      <div className="border-b p-2">
+      <div className="space-y-2 border-b p-2">
         <Input
           ref={filterRef}
           value={filterText}
@@ -182,6 +183,13 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
           className="h-7"
           autoComplete="off"
         />
+        {listEnabled && (
+          <ScopeRefreshHint
+            scope="write:discussion"
+            action="Writing in discussions"
+            coveredBy={["repo", "write:discussion"]}
+          />
+        )}
       </div>
       {/* overflow-hidden: the vendored ScrollArea Root is upstream-faithful
           (`relative` only), so without containment the list's natural height

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -187,7 +187,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
           <ScopeRefreshHint
             scope="write:discussion"
             action="Writing in discussions"
-            coveredBy={["repo", "write:discussion"]}
+            coveredBy={["repo"]}
           />
         )}
       </div>

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1705,7 +1705,7 @@ part in GitHub Discussions for the repo. (Discussions must be enabled on the rep
   unsend that. The command palette's **Focus the comment box** works here too.
 - **Create a discussion**, or **create an issue from a discussion** when a thread turns
   into actionable work (the new issue links back to it).
-- When your sign-in's scopes are readable and don't cover writing discussions, the
+- If GitDesktop can see that your GitHub sign-in can't write discussions, the
   discussion list, the New discussion dialog, and the thread all say so up front and
   offer an in-app reconnect (or a copyable refresh command) before a write fails.`,
   },

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1704,7 +1704,10 @@ part in GitHub Discussions for the repo. (Discussions must be enabled on the rep
   everyone watching is notified, and reopening puts the discussion back but can't
   unsend that. The command palette's **Focus the comment box** works here too.
 - **Create a discussion**, or **create an issue from a discussion** when a thread turns
-  into actionable work (the new issue links back to it).`,
+  into actionable work (the new issue links back to it).
+- When your sign-in's scopes are readable and don't cover writing discussions, the
+  discussion list, the New discussion dialog, and the thread all say so up front and
+  offer an in-app reconnect (or a copyable refresh command) before a write fails.`,
   },
   {
     id: "releases",

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -251,15 +251,18 @@ export function CommitDetailView({
   // menu. All three act on the `hash` PROP for the same reason `copyHash` does.
   async function doCheckoutCommit() {
     if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
-    checkoutCommit.mutate(hash, {
-      onSuccess: () => toast.success(checkoutCommitSuccessToast(hash)),
-      onError,
-    });
+    try {
+      await checkoutCommit.mutateAsync(hash);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(checkoutCommitSuccessToast(hash));
   }
 
   async function doRevertCommit() {
     if (!(await useConfirm.getState().ask(revertCommitConfirm(hash)))) return;
-    revertCommit.mutate(hash, { onError });
+    void revertCommit.mutateAsync(hash).catch(onError);
   }
 
   // No branch name: this view doesn't subscribe to repo status, and doing so for
@@ -269,18 +272,20 @@ export function CommitDetailView({
       .getState()
       .ask(cherryPickCommitConfirm(hash, null));
     if (!ok) return;
-    cherryPick.mutate(hash, {
-      onSuccess: (applied) => {
-        if (applied) {
-          toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
-        } else {
-          toast.info(
-            "Nothing to cherry-pick — these changes are already on this branch.",
-          );
-        }
-      },
-      onError,
-    });
+    let applied: boolean;
+    try {
+      applied = await cherryPick.mutateAsync(hash);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    if (applied) {
+      toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
+    } else {
+      toast.info(
+        "Nothing to cherry-pick — these changes are already on this branch.",
+      );
+    }
   }
 
   const fileList = files.data;

--- a/src/features/history/HistoryDialogs.tsx
+++ b/src/features/history/HistoryDialogs.tsx
@@ -23,6 +23,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { clipTitleFromText } from "@/lib/clip-title";
 import { required, withForm } from "@/lib/form";
+import type { CherryPickRangeResult } from "@/lib/git/api";
 import {
   useCherryPickOnto,
   useDeleteTag,
@@ -52,6 +53,18 @@ export function DeleteTagDialog({
 }) {
   const deleteTag = useDeleteTag(repoPath);
   const shownName = useRetained(name);
+  async function run() {
+    if (!name) return;
+    try {
+      await deleteTag.mutateAsync({ name, onRemote: remote });
+    } catch (e) {
+      onError(e);
+      onClose();
+      return;
+    }
+    toast.success(`Deleted tag ${name}${remote ? " (local and origin)" : ""}`);
+    onClose();
+  }
   return (
     <Dialog
       open={name !== null}
@@ -81,24 +94,7 @@ export function DeleteTagDialog({
           <Button
             variant="destructive"
             disabled={deleteTag.isPending}
-            onClick={() => {
-              if (!name) return;
-              deleteTag.mutate(
-                { name, onRemote: remote },
-                {
-                  onSuccess: () => {
-                    toast.success(
-                      `Deleted tag ${name}${remote ? " (local and origin)" : ""}`,
-                    );
-                    onClose();
-                  },
-                  onError: (e) => {
-                    onError(e);
-                    onClose();
-                  },
-                },
-              );
-            }}
+            onClick={() => void run()}
           >
             {deleteTag.isPending && <Spinner data-icon="inline-start" />}
             Delete tag
@@ -121,6 +117,18 @@ export function ResetCommitDialog({
 }) {
   const resetMutation = useResetToCommit(repoPath);
   const shownHash = useRetained(hash);
+  async function run() {
+    if (!hash) return;
+    try {
+      await resetMutation.mutateAsync(hash);
+    } catch (e) {
+      onError(e);
+      onClose();
+      return;
+    }
+    toast.success(`Reset to ${hash.slice(0, 7)}`);
+    onClose();
+  }
   return (
     <Dialog
       open={hash !== null}
@@ -145,19 +153,7 @@ export function ResetCommitDialog({
           <Button
             variant="destructive"
             disabled={resetMutation.isPending}
-            onClick={() => {
-              if (!hash) return;
-              resetMutation.mutate(hash, {
-                onSuccess: () => {
-                  toast.success(`Reset to ${hash.slice(0, 7)}`);
-                  onClose();
-                },
-                onError: (e) => {
-                  onError(e);
-                  onClose();
-                },
-              });
-            }}
+            onClick={() => void run()}
           >
             Reset
           </Button>
@@ -193,42 +189,43 @@ export function CherryPickOntoDialog({
   const destId = useId();
   const shownHashes = useRetained(hashes);
   const count = shownHashes?.length ?? 0;
-  function run() {
+  async function run() {
     if (!hashes || !branch) return;
     const target = branch;
-    cherryPickOnto.mutate(
-      { hashes, targetBranch: target },
-      {
-        onSuccess: ({ applied, skipped }) => {
-          if (applied === 0) {
-            toast.info(
-              `Nothing to copy onto ${target} — those changes are already there.`,
-            );
-          } else {
-            const note = skipped > 0 ? ` (${skipped} already present)` : "";
-            toast.success(
-              `Copied ${applied} commit${applied === 1 ? "" : "s"} onto ${target}${note}`,
-            );
-          }
-          onClose();
-          onDone();
-        },
-        onError: (e) => {
-          // A paused pick leaves you on the destination branch and closes this
-          // dialog, so the toast is the only place left that can say where you
-          // are; the generic summary names the operation, never the branch.
-          if (isAppError(e) && e.kind === "conflict") {
-            toastErrorWithNote(
-              e,
-              `You're now on ${target} — resolve the conflicts there, then continue the cherry-pick.`,
-            );
-          } else {
-            onError(e);
-          }
-          onClose();
-        },
-      },
-    );
+    let result: CherryPickRangeResult;
+    try {
+      result = await cherryPickOnto.mutateAsync({
+        hashes,
+        targetBranch: target,
+      });
+    } catch (e) {
+      // A paused pick leaves you on the destination branch and closes this
+      // dialog, so the toast is the only place left that can say where you
+      // are; the generic summary names the operation, never the branch.
+      if (isAppError(e) && e.kind === "conflict") {
+        toastErrorWithNote(
+          e,
+          `You're now on ${target} — resolve the conflicts there, then continue the cherry-pick.`,
+        );
+      } else {
+        onError(e);
+      }
+      onClose();
+      return;
+    }
+    const { applied, skipped } = result;
+    if (applied === 0) {
+      toast.info(
+        `Nothing to copy onto ${target} — those changes are already there.`,
+      );
+    } else {
+      const note = skipped > 0 ? ` (${skipped} already present)` : "";
+      toast.success(
+        `Copied ${applied} commit${applied === 1 ? "" : "s"} onto ${target}${note}`,
+      );
+    }
+    onClose();
+    onDone();
   }
   return (
     <Dialog
@@ -282,7 +279,10 @@ export function CherryPickOntoDialog({
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={run} disabled={!branch || cherryPickOnto.isPending}>
+          <Button
+            onClick={() => void run()}
+            disabled={!branch || cherryPickOnto.isPending}
+          >
             Cherry-pick
           </Button>
         </DialogFooter>

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -248,8 +248,13 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       onError(e);
       return;
     }
-    setCommitDraft(details.subject, details.body);
-    setRepoTab("changes");
+    // The draft restore and tab flip write the LIVE repo's state — a repo
+    // switch mid-undo must not land this repo's message in another repo's
+    // draft. The toast stays: the undo itself happened regardless.
+    if (useUiStore.getState().repoPath === repoPath) {
+      setCommitDraft(details.subject, details.body);
+      setRepoTab("changes");
+    }
     toast.success(
       `Undid ${lastCommit.hash.slice(0, 7)} — changes are staged again`,
     );

--- a/src/features/history/HistoryPanel.tsx
+++ b/src/features/history/HistoryPanel.tsx
@@ -53,7 +53,11 @@ import {
   useUnpushedCount,
 } from "@/lib/git/queries";
 import { sanitizeRefName } from "@/lib/git/ref-name";
-import type { CommitSummary, RewriteStep } from "@/lib/git/types";
+import type {
+  CommitDetails,
+  CommitSummary,
+  RewriteStep,
+} from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useConfirm } from "@/lib/stores/confirm";
@@ -226,6 +230,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
     ) {
       return;
     }
+    let details: CommitDetails;
     try {
       // The undo names no commit — it always unwinds whatever HEAD is at the
       // moment it runs — so re-read HEAD across the prompt's await. A commit
@@ -236,35 +241,36 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         toast.info("The latest commit changed — nothing was undone.");
         return;
       }
-      const details = await gitCommitDetails(repoPath, lastCommit.hash);
-      undoCommit.mutate(undefined, {
-        onSuccess: () => {
-          setCommitDraft(details.subject, details.body);
-          setRepoTab("changes");
-          toast.success(
-            `Undid ${lastCommit.hash.slice(0, 7)} — changes are staged again`,
-          );
-        },
-        onError,
-      });
+      // Read the message BEFORE the undo removes the commit it belongs to.
+      details = await gitCommitDetails(repoPath, lastCommit.hash);
+      await undoCommit.mutateAsync(undefined);
     } catch (e) {
       onError(e);
+      return;
     }
+    setCommitDraft(details.subject, details.body);
+    setRepoTab("changes");
+    toast.success(
+      `Undid ${lastCommit.hash.slice(0, 7)} — changes are staged again`,
+    );
   }
 
   // The confirm sits here rather than on the menu items, so the search menu and
   // the single-commit menu can't diverge on whether they ask.
   async function doCheckoutCommit(hash: string) {
     if (!(await useConfirm.getState().ask(checkoutCommitConfirm(hash)))) return;
-    checkoutCommit.mutate(hash, {
-      onSuccess: () => toast.success(checkoutCommitSuccessToast(hash)),
-      onError,
-    });
+    try {
+      await checkoutCommit.mutateAsync(hash);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(checkoutCommitSuccessToast(hash));
   }
 
   async function doRevertCommit(hash: string) {
     if (!(await useConfirm.getState().ask(revertCommitConfirm(hash)))) return;
-    revertCommit.mutate(hash, { onError });
+    void revertCommit.mutateAsync(hash).catch(onError);
   }
 
   // `alreadyApplied` is the one thing the two menus word differently.
@@ -273,16 +279,28 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
       .getState()
       .ask(cherryPickCommitConfirm(hash, currentBranch));
     if (!ok) return;
-    cherryPick.mutate(hash, {
-      onSuccess: (applied) => {
-        if (applied) {
-          toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
-        } else {
-          toast.info(alreadyApplied);
-        }
-      },
-      onError,
-    });
+    let applied: boolean;
+    try {
+      applied = await cherryPick.mutateAsync(hash);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    if (applied) {
+      toast.success(`Cherry-picked ${hash.slice(0, 7)}`);
+    } else {
+      toast.info(alreadyApplied);
+    }
+  }
+
+  async function pushTagToOrigin(tag: string) {
+    try {
+      await pushTag.mutateAsync(tag);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(`Pushed tag ${tag} to origin`);
   }
 
   useHotkeyAction("undo-commit", undoLast, canUndo && !undoCommit.isPending);
@@ -711,12 +729,7 @@ export function HistoryPanel({ repoPath }: { repoPath: string }) {
         {commit.tags.map((tag) => (
           <ContextMenuItem
             key={`push:${tag}`}
-            onClick={() =>
-              pushTag.mutate(tag, {
-                onSuccess: () => toast.success(`Pushed tag ${tag} to origin`),
-                onError,
-              })
-            }
+            onClick={() => void pushTagToOrigin(tag)}
           >
             Push tag {tag} to origin
           </ContextMenuItem>

--- a/src/features/issues/IssueDevelopment.tsx
+++ b/src/features/issues/IssueDevelopment.tsx
@@ -109,21 +109,19 @@ export function IssueDevelopment({
     setRepoTab("pulls");
   }
 
-  function submitBranch() {
+  async function submitBranch() {
     const name = branchName.trim();
     if (!name) return;
-    createBranch.mutate(
-      { issueId, name },
-      {
-        onSuccess: () => {
-          toast.success(`Created branch ${name}`, {
-            description: "Fetch to check it out locally.",
-          });
-          setBranchOpen(false);
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await createBranch.mutateAsync({ issueId, name });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(`Created branch ${name}`, {
+      description: "Fetch to check it out locally.",
+    });
+    setBranchOpen(false);
   }
 
   return (
@@ -200,7 +198,7 @@ export function IssueDevelopment({
             className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
-              submitBranch();
+              void submitBranch();
             }}
           >
             <DialogHeader>

--- a/src/features/issues/IssueRelations.tsx
+++ b/src/features/issues/IssueRelations.tsx
@@ -243,11 +243,14 @@ export function IssueSubIssues({
     selectIssue({ kind: "remote", id: String(n) });
   }
 
-  function pickExisting(n: number) {
-    addSub.mutate(
-      { parentId: issueId, subNumber: n },
-      { onSuccess: () => setMode(null), onError },
-    );
+  async function pickExisting(n: number) {
+    try {
+      await addSub.mutateAsync({ parentId: issueId, subNumber: n });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    setMode(null);
   }
 
   return (
@@ -323,7 +326,9 @@ export function IssueSubIssues({
             issue={s}
             onOpen={open}
             onRemove={() =>
-              removeSub.mutate({ parentId: issueId, subId: s.id }, { onError })
+              void removeSub
+                .mutateAsync({ parentId: issueId, subId: s.id })
+                .catch(onError)
             }
             pending={removeSub.isPending && removeSub.variables?.subId === s.id}
             removeDisabledReason={disabledReason}
@@ -343,7 +348,7 @@ export function IssueSubIssues({
                 repoPath={repoPath}
                 exclude={exclude}
                 pending={addSub.isPending}
-                onPick={pickExisting}
+                onPick={(n) => void pickExisting(n)}
                 lens={lens}
               />
             </div>
@@ -405,6 +410,22 @@ export function IssueRelationships({
     selectIssue({ kind: "remote", id: String(n) });
   }
 
+  function removeDependency(relation: IssueRelation, target: number) {
+    void setDep
+      .mutateAsync({ number, relation, target, add: false })
+      .catch(onError);
+  }
+
+  async function addDependency(relation: IssueRelation, target: number) {
+    try {
+      await setDep.mutateAsync({ number, relation, target, add: true });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    setAddRelation(null);
+  }
+
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2">
@@ -448,12 +469,7 @@ export function IssueRelationships({
           label="Blocked by"
           items={blockedBy}
           onOpen={open}
-          onRemove={(t) =>
-            setDep.mutate(
-              { number, relation: "blocked_by", target: t, add: false },
-              { onError },
-            )
-          }
+          onRemove={(t) => removeDependency("blocked_by", t)}
           isRemoving={(t) =>
             setDep.isPending &&
             setDep.variables?.add === false &&
@@ -468,12 +484,7 @@ export function IssueRelationships({
           label="Blocking"
           items={blocking}
           onOpen={open}
-          onRemove={(t) =>
-            setDep.mutate(
-              { number, relation: "blocking", target: t, add: false },
-              { onError },
-            )
-          }
+          onRemove={(t) => removeDependency("blocking", t)}
           isRemoving={(t) =>
             setDep.isPending &&
             setDep.variables?.add === false &&
@@ -507,12 +518,7 @@ export function IssueRelationships({
                     : excludeBlocking
                 }
                 pending={setDep.isPending}
-                onPick={(t) =>
-                  setDep.mutate(
-                    { number, relation: addRelation, target: t, add: true },
-                    { onSuccess: () => setAddRelation(null), onError },
-                  )
-                }
+                onPick={(t) => void addDependency(addRelation, t)}
                 lens={lens}
               />
             </div>

--- a/src/features/issues/JiraIssueSidebar.tsx
+++ b/src/features/issues/JiraIssueSidebar.tsx
@@ -155,7 +155,7 @@ export function JiraIssueSidebar({
           open={issue.statusCategory !== "done"}
           pending={setDueDate.isPending}
           onChange={(dueDate) =>
-            setDueDate.mutate({ issueKey, dueDate }, { onError: toastError })
+            void setDueDate.mutateAsync({ issueKey, dueDate }).catch(toastError)
           }
         />
       ) : (

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -147,23 +147,24 @@ function StatusMenu({
   const [open, setOpen] = useState(false);
   const transitions = useJiraTransitions(repoPath, link, issueKey, open);
 
-  function apply(t: {
+  async function apply(t: {
     id: string;
     toStatusName: string;
     toStatusCategory: JiraStatusCategory;
   }) {
-    transitionTo.mutate(
-      {
+    let result: Awaited<ReturnType<typeof transitionTo.mutateAsync>>;
+    try {
+      result = await transitionTo.mutateAsync({
         issueKey,
         transitionId: t.id,
         toStatusName: t.toStatusName,
         toStatusCategory: t.toStatusCategory,
-      },
-      {
-        onSuccess: (r) => toast.success(`${issueKey} · ${r.statusName}`),
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(`${issueKey} · ${result.statusName}`);
   }
 
   return (
@@ -204,7 +205,7 @@ function StatusMenu({
               );
             }
             return (
-              <DropdownMenuItem key={t.id} onClick={() => apply(t)}>
+              <DropdownMenuItem key={t.id} onClick={() => void apply(t)}>
                 <Icon className={`size-3.5 shrink-0 ${tone}`} />
                 {t.toStatusName}
               </DropdownMenuItem>
@@ -284,20 +285,19 @@ export function JiraAssigneePicker({
     ...(users.data ?? []).filter((u) => u.id !== ""),
   ];
 
-  function apply(next: ForgeUserRef | null) {
+  async function apply(next: ForgeUserRef | null) {
     setOpen(false);
     setQuery("");
     // Skip a no-op assign (re-picking the current assignee, or clearing an
     // already-empty one) so we never fire a redundant PUT.
     if ((next?.id ?? null) === (assignee?.id ?? null)) return;
-    assign.mutate(
-      { issueKey, assignee: next },
-      {
-        onSuccess: () =>
-          toast.success(next ? `Assigned to ${next.label}` : "Unassigned"),
-        onError: toastError,
-      },
-    );
+    try {
+      await assign.mutateAsync({ issueKey, assignee: next });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(next ? `Assigned to ${next.label}` : "Unassigned");
   }
 
   return (
@@ -308,7 +308,7 @@ export function JiraAssigneePicker({
       itemToStringLabel={(u: ForgeUserRef) => u.label}
       value={null}
       onValueChange={(u: ForgeUserRef | null) => {
-        if (u) apply(u.id === UNASSIGN.id ? null : u);
+        if (u) void apply(u.id === UNASSIGN.id ? null : u);
       }}
       inputValue={query}
       onInputValueChange={setQuery}
@@ -372,16 +372,20 @@ export function JiraPriorityMenu({
   const priorities = useJiraPriorities(link, open);
   const setPriority = useJiraSetPriority(repoPath, link);
 
-  function apply(p: { id: string; name: string }) {
+  async function apply(p: { id: string; name: string }) {
     // Skip a no-op re-pick of the current priority.
     if (p.name === priorityName) return;
-    setPriority.mutate(
-      { issueKey, priorityId: p.id, priorityName: p.name },
-      {
-        onSuccess: () => toast.success(`${issueKey} · ${p.name}`),
-        onError: toastError,
-      },
-    );
+    try {
+      await setPriority.mutateAsync({
+        issueKey,
+        priorityId: p.id,
+        priorityName: p.name,
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(`${issueKey} · ${p.name}`);
   }
 
   return (
@@ -422,7 +426,7 @@ export function JiraPriorityMenu({
               // fires) and it toggles its own check. closeOnClick because checkbox
               // items default to staying OPEN — priority is single-select.
               closeOnClick
-              onClick={() => apply(p)}
+              onClick={() => void apply(p)}
             >
               <Avatar size="sm" className="size-3.5 shrink-0 rounded-none">
                 {p.iconUrl && <AvatarImage src={p.iconUrl} alt="" />}
@@ -532,10 +536,9 @@ export function JiraLabelsPopover({
     const changed =
       draft.size !== applied.size || [...draft].some((n) => !applied.has(n));
     if (changed) {
-      setLabels.mutate(
-        { issueKey, labels: [...draft].sort() },
-        { onError: toastError },
-      );
+      void setLabels
+        .mutateAsync({ issueKey, labels: [...draft].sort() })
+        .catch(toastError);
     }
   }
 
@@ -770,30 +773,33 @@ function JiraCommentItem({
     setEditing(true);
   }
 
-  function saveEdit() {
+  async function saveEdit() {
     const body = draft.trim();
     // An editor opened before the switch would pair this comment's id with the
     // newly selected `issueKey`, which Jira routes as a 404.
     if (stale) return;
-    edit.mutate(
-      { issueKey, commentId: comment.id, bodyMd: body },
-      {
-        onSuccess: () => setEditing(false),
-        onError: toastError,
-      },
-    );
+    try {
+      await edit.mutateAsync({ issueKey, commentId: comment.id, bodyMd: body });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    setEditing(false);
   }
 
-  function doDelete() {
+  async function doDelete() {
     if (stale) return;
-    del.mutate(
-      { issueKey, commentId: comment.id },
-      {
-        onSuccess: () => toast.success("Comment deleted"),
-        onError: toastError,
-      },
-    );
+    // The confirm dialog closes on the same tick as the request rather than on
+    // its outcome — the hook removes the comment optimistically.
+    const deleted = del.mutateAsync({ issueKey, commentId: comment.id });
     setConfirmDelete(false);
+    try {
+      await deleted;
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success("Comment deleted");
   }
 
   return (
@@ -849,7 +855,7 @@ function JiraCommentItem({
           ariaLabel="Edit comment"
           value={draft}
           onChange={setDraft}
-          onSubmit={saveEdit}
+          onSubmit={() => void saveEdit()}
           onCancel={() => setEditing(false)}
           canSubmit={
             draft.trim().length > 0 &&
@@ -876,7 +882,7 @@ function JiraCommentItem({
         confirmLabel="Delete comment"
         confirmVariant="destructive"
         pending={del.isPending}
-        onConfirm={doDelete}
+        onConfirm={() => void doDelete()}
       />
     </div>
   );
@@ -955,10 +961,10 @@ function JiraWorklogItem({
     setEditing(true);
   }
 
-  function saveEdit() {
+  async function saveEdit() {
     if (!canSaveEdit) return;
-    update.mutate(
-      {
+    try {
+      await update.mutateAsync({
         issueKey,
         worklogId: worklog.id,
         timeSpent: durationTrimmed,
@@ -968,24 +974,27 @@ function JiraWorklogItem({
         // rather than tripping the backend's can't-remove-a-note error.
         commentMd:
           noteChanged && noteDraft.trim().length > 0 ? noteDraft : undefined,
-      },
-      {
-        onSuccess: () => setEditing(false),
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    setEditing(false);
   }
 
-  function doDelete() {
+  async function doDelete() {
     if (stale) return;
-    del.mutate(
-      { issueKey, worklogId: worklog.id },
-      {
-        onSuccess: () => toast.success("Worklog deleted"),
-        onError: toastError,
-      },
-    );
+    // The confirm dialog closes on the same tick as the request rather than on
+    // its outcome, matching the comment-delete sibling.
+    const deleted = del.mutateAsync({ issueKey, worklogId: worklog.id });
     setConfirmDelete(false);
+    try {
+      await deleted;
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success("Worklog deleted");
   }
 
   return (
@@ -1045,7 +1054,7 @@ function JiraWorklogItem({
               }
               if (e.key === "Enter" && canSaveEdit) {
                 e.preventDefault();
-                saveEdit();
+                void saveEdit();
               }
             }}
             placeholder="Time spent (e.g. 3h 30m)"
@@ -1065,7 +1074,7 @@ function JiraWorklogItem({
               }
               if (e.key === "Enter" && canSaveEdit) {
                 e.preventDefault();
-                saveEdit();
+                void saveEdit();
               }
             }}
             placeholder="Note (optional)"
@@ -1088,7 +1097,7 @@ function JiraWorklogItem({
               size="xs"
               variant="outline"
               disabled={!canSaveEdit}
-              onClick={saveEdit}
+              onClick={() => void saveEdit()}
             >
               Save
             </Button>
@@ -1117,7 +1126,7 @@ function JiraWorklogItem({
         confirmLabel="Delete worklog"
         confirmVariant="destructive"
         pending={del.isPending}
-        onConfirm={doDelete}
+        onConfirm={() => void doDelete()}
       />
     </div>
   );
@@ -1197,25 +1206,23 @@ export function JiraTimeTrackingSection({
   const logTrimmed = logDuration.trim();
   const logValid = isValidJiraDuration(logTrimmed);
 
-  function submitLog() {
+  async function submitLog() {
     if (!logValid || logWork.isPending) return;
     const note = logNote.trim();
-    logWork.mutate(
-      {
+    try {
+      await logWork.mutateAsync({
         issueKey,
         timeSpent: logTrimmed,
         // Only send a note when the user typed one (empty ⇒ noteless entry).
         commentMd: note ? note : undefined,
-      },
-      {
-        onSuccess: () => {
-          setLogDuration("");
-          setLogNote("");
-          toast.success(`Logged ${logTrimmed} on ${issueKey}`);
-        },
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    setLogDuration("");
+    setLogNote("");
+    toast.success(`Logged ${logTrimmed} on ${issueKey}`);
   }
 
   return (
@@ -1274,7 +1281,7 @@ export function JiraTimeTrackingSection({
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
-                submitLog();
+                void submitLog();
               }
             }}
             placeholder="Log work (e.g. 3h 30m)"
@@ -1289,7 +1296,7 @@ export function JiraTimeTrackingSection({
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
-                submitLog();
+                void submitLog();
               }
             }}
             placeholder="Note (optional)"
@@ -1305,7 +1312,7 @@ export function JiraTimeTrackingSection({
             size="xs"
             variant="outline"
             disabled={!logValid || logWork.isPending}
-            onClick={submitLog}
+            onClick={() => void submitLog()}
           >
             Log
           </Button>
@@ -1323,10 +1330,9 @@ export function JiraTimeTrackingSection({
             hasValue={originalSeconds > 0}
             pending={setOriginal.isPending}
             onSet={(estimate) =>
-              setOriginal.mutate(
-                { issueKey, estimate },
-                { onError: toastError },
-              )
+              void setOriginal
+                .mutateAsync({ issueKey, estimate })
+                .catch(toastError)
             }
           />
           <JiraEstimateInput
@@ -1336,10 +1342,9 @@ export function JiraTimeTrackingSection({
             hasValue={(tracking.remainingEstimateSeconds ?? 0) > 0}
             pending={setRemaining.isPending}
             onSet={(estimate) =>
-              setRemaining.mutate(
-                { issueKey, estimate },
-                { onError: toastError },
-              )
+              void setRemaining
+                .mutateAsync({ issueKey, estimate })
+                .catch(toastError)
             }
           />
         </div>
@@ -1598,29 +1603,24 @@ export function JiraIssueView({
     // if that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
     compose.set("");
-    comment.mutate(
-      { issueKey, bodyMd: body },
-      {
-        onError: (e) => {
-          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
-          toastError(e);
-        },
-      },
-    );
+    void comment.mutateAsync({ issueKey, bodyMd: body }).catch((e) => {
+      compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
+      toastError(e);
+    });
   }
 
-  function doTransition(direction: "close" | "reopen") {
-    transition.mutate(
-      { issueKey, direction },
-      {
-        onSuccess: (r) =>
-          toast.success(
-            direction === "close"
-              ? `Closed ${issueKey} · ${r.statusName}`
-              : `Reopened ${issueKey} · ${r.statusName}`,
-          ),
-        onError: toastError,
-      },
+  async function doTransition(direction: "close" | "reopen") {
+    let result: Awaited<ReturnType<typeof transition.mutateAsync>>;
+    try {
+      result = await transition.mutateAsync({ issueKey, direction });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(
+      direction === "close"
+        ? `Closed ${issueKey} · ${result.statusName}`
+        : `Reopened ${issueKey} · ${result.statusName}`,
     );
   }
 
@@ -1659,7 +1659,7 @@ export function JiraIssueView({
                 variant="outline"
                 size="xs"
                 disabled={busy}
-                onClick={() => doTransition("reopen")}
+                onClick={() => void doTransition("reopen")}
                 title="Reopen this issue"
               >
                 <ArrowCounterClockwiseIcon data-icon="inline-start" />
@@ -1670,7 +1670,7 @@ export function JiraIssueView({
                 variant="outline"
                 size="xs"
                 disabled={busy}
-                onClick={() => doTransition("close")}
+                onClick={() => void doTransition("close")}
                 title="Close this issue"
               >
                 <CheckCircleIcon data-icon="inline-start" />

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -79,6 +79,7 @@ import {
   type JiraIssueDetails,
   type JiraStatusCategory,
   type JiraTimeTracking as JiraTimeTrackingData,
+  type JiraTransitionResult,
   type JiraWorklog,
 } from "@/lib/jira/types";
 import { useUiStore } from "@/lib/stores/ui";
@@ -152,7 +153,7 @@ function StatusMenu({
     toStatusName: string;
     toStatusCategory: JiraStatusCategory;
   }) {
-    let result: Awaited<ReturnType<typeof transitionTo.mutateAsync>>;
+    let result: JiraTransitionResult;
     try {
       result = await transitionTo.mutateAsync({
         issueKey,
@@ -1611,7 +1612,7 @@ export function JiraIssueView({
   }
 
   async function doTransition(direction: "close" | "reopen") {
-    let result: Awaited<ReturnType<typeof transition.mutateAsync>>;
+    let result: JiraTransitionResult;
     try {
       result = await transition.mutateAsync({ issueKey, direction });
     } catch (e) {

--- a/src/features/issues/JiraIssueView.tsx
+++ b/src/features/issues/JiraIssueView.tsx
@@ -985,7 +985,8 @@ function JiraWorklogItem({
   async function doDelete() {
     if (stale) return;
     // The confirm dialog closes on the same tick as the request rather than on
-    // its outcome, matching the comment-delete sibling.
+    // its outcome — its pre-conversion timing; the delete hook is
+    // non-optimistic, so the row leaves on the refetch, not an optimistic patch.
     const deleted = del.mutateAsync({ issueKey, worklogId: worklog.id });
     setConfirmDelete(false);
     try {

--- a/src/features/issues/LocalIssueView.tsx
+++ b/src/features/issues/LocalIssueView.tsx
@@ -153,14 +153,14 @@ export function LocalIssueView({
   /** Close/Reopen, carrying any typed note. The note is appended in the SAME
    *  record mutation as the status flip, so the store can never persist one
    *  without the other; the draft clears only once that write lands. */
-  function setStatus(next: "open" | "closed") {
+  async function setStatus(next: "open" | "closed") {
     // Appending the note makes this non-idempotent, and the mutate callback
     // re-reads the record from disk — so a second click lands after the first
     // note is already stored and would post it twice.
     if (!issue || update.isPending) return;
     const note = comment.trim();
-    update.mutate(
-      {
+    try {
+      await update.mutateAsync({
         id: issue.id,
         mutate: (cur) => ({
           ...cur,
@@ -177,14 +177,29 @@ export function LocalIssueView({
           status: next,
           closedAt: next === "closed" ? new Date().toISOString() : undefined,
         }),
-      },
-      {
-        onSuccess: () => setComment(""),
-        // Nothing was written, the note included — say so rather than leave a
-        // silent no-op behind a button that promised to post it.
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      // Nothing was written, the note included — say so rather than leave a
+      // silent no-op behind a button that promised to post it.
+      toastError(e);
+      return;
+    }
+    setComment("");
+  }
+
+  async function deleteIssue(issueId: string) {
+    try {
+      await del.mutateAsync(issueId);
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    setConfirmDelete(false);
+    // Deselect only while the deleted issue is still the selection in THIS
+    // repo — the write can settle after the user has moved on.
+    const { selectedIssue: sel, repoPath: liveRepo } = useUiStore.getState();
+    if (liveRepo === repoPath && sel?.kind === "local" && sel.id === issueId)
+      selectIssue(null);
   }
 
   return (
@@ -442,7 +457,7 @@ export function LocalIssueView({
               size="sm"
               disabled={update.isPending}
               reason="Saving…"
-              onClick={() => setStatus("closed")}
+              onClick={() => void setStatus("closed")}
               title={
                 draftRidesStateChange
                   ? "Closes and posts your draft as a comment"
@@ -459,7 +474,7 @@ export function LocalIssueView({
             size="sm"
             disabled={update.isPending}
             reason="Saving…"
-            onClick={() => setStatus("open")}
+            onClick={() => void setStatus("open")}
             title={
               draftRidesStateChange
                 ? "Reopens and posts your draft as a comment"
@@ -500,15 +515,7 @@ export function LocalIssueView({
             <Button
               variant="destructive"
               disabled={del.isPending}
-              onClick={() =>
-                del.mutate(issue.id, {
-                  onSuccess: () => {
-                    setConfirmDelete(false);
-                    selectIssue(null);
-                  },
-                  onError: toastError,
-                })
-              }
+              onClick={() => void deleteIssue(issue.id)}
             >
               Delete
             </Button>

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -554,12 +554,11 @@ export function RemoteIssueView({
     selectIssue({ kind: "remote", id: String(refNumber) });
   }
 
-  /** Clear the selection only while it still points at this issue — the write
-   *  can settle after the user has selected another one. */
-  // `selectedIssue` carries no lens, so a continuation fired on one side of a
-  // fork pair must not clear a same-numbered selection made on the other. The
-  // lens is read from the query cache, which outlives this instance (the lens
-  // switcher unmounts it); an undefined read is a cold cache, not "origin".
+  /** Clear the selection only while it still points at this issue under the
+   *  lens the write fired on (`firedUnder`, a pre-await read of the lens
+   *  cache) — the write can settle after the user selected another issue or
+   *  flipped the fork/upstream switcher, which unmounts this view; the cache
+   *  outlives it. An undefined read is a cold cache, not "origin". */
   function deselectIfStillHere(firedUnder: RemoteLens | undefined) {
     const liveLens = queryClient.getQueryData<RemoteLens>(lensKey(repoPath));
     if (firedUnder !== undefined && liveLens !== firedUnder) return;

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -138,6 +138,11 @@ export function RemoteIssueView({
   // The single lens-resolution point for this surface (package B2): every issue
   // read/write below targets the fork (origin) or its parent (upstream).
   const lens = useRepoLens(repoPath);
+  // Live lens for post-await guards: `selectedIssue` carries no lens, so a
+  // continuation fired on one side of a fork pair must not clear a
+  // same-numbered selection made on the other.
+  const lensRef = useRef(lens);
+  lensRef.current = lens;
   // The viewer's permission on the lens repo — a PERMISSION axis the per-action
   // flags below don't cover, so it never hides a control: it only disables one,
   // and only on an explicit denial. Triage is its own, LOWER tier: labels,
@@ -556,14 +561,14 @@ export function RemoteIssueView({
    *  can settle after the user has selected another one. */
   function deselectIfStillHere() {
     const { selectedIssue: sel, repoPath: liveRepo } = useUiStore.getState();
-    if (liveRepo !== repoPath) return;
+    if (liveRepo !== repoPath || lensRef.current !== lens) return;
     if (sel?.kind === "remote" && sel.id === String(number)) selectIssue(null);
   }
 
   async function submitTransfer() {
     const destination = transferDest.trim();
     if (!destination) return;
-    let url: Awaited<ReturnType<typeof transferIssue.mutateAsync>>;
+    let url: string;
     try {
       url = await transferIssue.mutateAsync({ number, destination });
     } catch (e) {

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -373,15 +373,12 @@ export function RemoteIssueView({
     // that issue's composer is still empty so we never clobber newly-typed text.
     const submittedFor = issueIdentity;
     compose.set("");
-    comment.mutate(
-      { number, body, author: forge.data?.login ?? "You" },
-      {
-        onError: (e) => {
-          compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
-          onError(e);
-        },
-      },
-    );
+    void comment
+      .mutateAsync({ number, body, author: forge.data?.login ?? "You" })
+      .catch((e) => {
+        compose.setFor(submittedFor, (prev) => (prev.trim() ? prev : body));
+        onError(e);
+      });
   }
 
   // Deferred into the handler: calling makeQuoteReply(ref) during render made the
@@ -441,64 +438,77 @@ export function RemoteIssueView({
     });
     if (!ok) return;
     if (!(await postRidingDraft())) return;
-    closeIssue.mutate(
-      { number, reason },
-      {
-        onSuccess: () => toast.success(`Closed #${number}`),
-        onError: (e) =>
-          withComment
-            ? toastErrorWithNote(
-                e,
-                "Your comment was posted, but closing failed — try Close again.",
-              )
-            : onError(e),
-      },
-    );
+    try {
+      await closeIssue.mutateAsync({ number, reason });
+    } catch (e) {
+      if (withComment) {
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but closing failed — try Close again.",
+        );
+      } else {
+        onError(e);
+      }
+      return;
+    }
+    toast.success(`Closed #${number}`);
   }
 
   async function doReopen() {
     if (busy || triageBlocked) return;
     const withComment = draftRidesStateChange;
     if (!(await postRidingDraft())) return;
-    reopenIssue.mutate(number, {
-      onSuccess: () => toast.success(`Reopened #${number}`),
-      onError: (e) =>
-        withComment
-          ? toastErrorWithNote(
-              e,
-              "Your comment was posted, but reopening failed — try Reopen again.",
-            )
-          : onError(e),
-    });
+    try {
+      await reopenIssue.mutateAsync(number);
+    } catch (e) {
+      if (withComment) {
+        toastErrorWithNote(
+          e,
+          "Your comment was posted, but reopening failed — try Reopen again.",
+        );
+      } else {
+        onError(e);
+      }
+      return;
+    }
+    toast.success(`Reopened #${number}`);
   }
 
   function saveCommentEdit(commentId: string, body: string) {
     // The comment id is the rendered issue's while the write addresses `number`
     // — GitLab routes by both, so a mismatched pair 404s.
     if (detailsStale) return;
-    editComment.mutate(
-      { number, commentId, body },
-      { onSuccess: () => toast.success("Comment updated"), onError },
-    );
+    // Detached: Thread closes its inline editor on submit, so there is nothing
+    // left for an await to hold open.
+    void editComment
+      .mutateAsync({ number, commentId, body })
+      .then(() => toast.success("Comment updated"))
+      .catch(onError);
   }
 
   // Both take a comment id off the RENDERED issue, which through a switch is the
   // previous one, so either would hide a comment on the issue the viewer just
   // left. The menu items disable on the same wait; these arms back them up.
-  function hideComment(commentId: string, classifier: MinimizeReason) {
+  async function hideComment(commentId: string, classifier: MinimizeReason) {
     if (detailsStale) return;
-    minimizeComment.mutate(
-      { commentId, classifier },
-      { onSuccess: () => toast.success("Comment hidden"), onError },
-    );
+    try {
+      await minimizeComment.mutateAsync({ commentId, classifier });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Comment hidden");
   }
 
-  function unhideComment(commentId: string) {
+  async function unhideComment(commentId: string) {
     if (detailsStale) return;
-    unminimizeComment.mutate(commentId, {
-      onSuccess: () => toast.success("Comment shown"),
-      onError,
-    });
+    try {
+      await unminimizeComment.mutateAsync(commentId);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Comment shown");
   }
 
   function toggleReaction(subjectId: string, content: string, active: boolean) {
@@ -507,7 +517,9 @@ export function RemoteIssueView({
     // a mismatched pair awards the wrong note or 404s. The bars disable on the
     // same flag; this arm is the belt-and-braces behind them.
     if (detailsStale) return;
-    toggleReactionMutation.mutate({ subjectId, content, active }, { onError });
+    void toggleReactionMutation
+      .mutateAsync({ subjectId, content, active })
+      .catch(onError);
   }
 
   /** Opens the title/body editor seeded from the issue as it stands. */
@@ -540,43 +552,95 @@ export function RemoteIssueView({
     selectIssue({ kind: "remote", id: String(refNumber) });
   }
 
-  function submitTransfer() {
-    const destination = transferDest.trim();
-    if (!destination) return;
-    transferIssue.mutate(
-      { number, destination },
-      {
-        onSuccess: (url) => {
-          toast.success(
-            `${isGitLab ? "Moved" : "Transferred"} #${number}`,
-            url
-              ? {
-                  description: url,
-                  action: { label: "View", onClick: () => openUrl(url) },
-                }
-              : undefined,
-          );
-          setTransferOpen(false);
-          // The issue no longer lives in this repo; clear the now-stale view.
-          selectIssue(null);
-        },
-        onError,
-      },
-    );
+  /** Clear the selection only while it still points at this issue — the write
+   *  can settle after the user has selected another one. */
+  function deselectIfStillHere() {
+    const { selectedIssue: sel, repoPath: liveRepo } = useUiStore.getState();
+    if (liveRepo !== repoPath) return;
+    if (sel?.kind === "remote" && sel.id === String(number)) selectIssue(null);
   }
 
-  function confirmDelete() {
-    deleteIssue.mutate(number, {
-      onSuccess: () => {
-        toast.success(`Deleted #${number}`);
-        setDeleteOpen(false);
-        selectIssue(null);
-      },
-      onError: (e) => {
-        onError(e);
-        setDeleteOpen(false);
-      },
-    });
+  async function submitTransfer() {
+    const destination = transferDest.trim();
+    if (!destination) return;
+    let url: Awaited<ReturnType<typeof transferIssue.mutateAsync>>;
+    try {
+      url = await transferIssue.mutateAsync({ number, destination });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(
+      `${isGitLab ? "Moved" : "Transferred"} #${number}`,
+      url
+        ? {
+            description: url,
+            action: { label: "View", onClick: () => openUrl(url) },
+          }
+        : undefined,
+    );
+    setTransferOpen(false);
+    // The issue no longer lives in this repo; clear the now-stale view.
+    deselectIfStillHere();
+  }
+
+  async function confirmDelete() {
+    try {
+      await deleteIssue.mutateAsync(number);
+    } catch (e) {
+      onError(e);
+      setDeleteOpen(false);
+      return;
+    }
+    toast.success(`Deleted #${number}`);
+    setDeleteOpen(false);
+    deselectIfStillHere();
+  }
+
+  /** `wasPinned` comes from the render the click landed on: the refetch that
+   *  follows already carries the new state, so the verb has to be captured. */
+  async function togglePin(wasPinned: boolean) {
+    try {
+      await pinIssue.mutateAsync({ number, pinned: !wasPinned });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(wasPinned ? "Unpinned" : "Pinned");
+  }
+
+  async function doLock(reason: LockReason | null) {
+    try {
+      await lockIssue.mutateAsync({ number, reason });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Conversation locked");
+  }
+
+  async function doUnlock() {
+    try {
+      await unlockIssue.mutateAsync(number);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Conversation unlocked");
+  }
+
+  async function removeComment(commentId: string) {
+    try {
+      await deleteComment.mutateAsync({ number, commentId });
+    } catch (e) {
+      // Closes on failure too: DeleteCommentDialog never closes itself, and the
+      // toast already carries the outcome.
+      onError(e);
+      setDeletingCommentId(null);
+      return;
+    }
+    toast.success("Comment deleted");
+    setDeletingCommentId(null);
   }
 
   // Repo suggestions for the transfer/move destination (excludes archived
@@ -622,11 +686,13 @@ export function RemoteIssueView({
           }
           onHide={
             canWrite && !c.isMinimized
-              ? (classifier) => hideComment(c.id, classifier)
+              ? (classifier) => void hideComment(c.id, classifier)
               : undefined
           }
           onUnhide={
-            canWrite && c.isMinimized ? () => unhideComment(c.id) : undefined
+            canWrite && c.isMinimized
+              ? () => void unhideComment(c.id)
+              : undefined
           }
           // Hide/Unhide stay visible but disabled through the switch. The
           // permission reason ranks first — it's the one still true once
@@ -835,18 +901,7 @@ export function RemoteIssueView({
                 {canWrite && !detailsStale && (
                   <DropdownMenuItem
                     disabled={writeBlocked}
-                    onClick={() =>
-                      pinIssue.mutate(
-                        { number, pinned: !issue.isPinned },
-                        {
-                          onSuccess: () =>
-                            toast.success(
-                              issue.isPinned ? "Unpinned" : "Pinned",
-                            ),
-                          onError,
-                        },
-                      )
-                    }
+                    onClick={() => void togglePin(issue.isPinned)}
                   >
                     {issue.isPinned ? "Unpin issue" : "Pin issue"}
                     {itemSuffix}
@@ -860,13 +915,7 @@ export function RemoteIssueView({
                   (issue.locked ? (
                     <DropdownMenuItem
                       disabled={lockBlocked}
-                      onClick={() =>
-                        unlockIssue.mutate(number, {
-                          onSuccess: () =>
-                            toast.success("Conversation unlocked"),
-                          onError,
-                        })
-                      }
+                      onClick={() => void doUnlock()}
                     >
                       Unlock conversation{lockSuffix}
                     </DropdownMenuItem>
@@ -874,16 +923,7 @@ export function RemoteIssueView({
                     // GitLab locks without a reason — a plain item, no submenu.
                     <DropdownMenuItem
                       disabled={lockBlocked}
-                      onClick={() =>
-                        lockIssue.mutate(
-                          { number, reason: null },
-                          {
-                            onSuccess: () =>
-                              toast.success("Conversation locked"),
-                            onError,
-                          },
-                        )
-                      }
+                      onClick={() => void doLock(null)}
                     >
                       Lock conversation{lockSuffix}
                     </DropdownMenuItem>
@@ -902,16 +942,7 @@ export function RemoteIssueView({
                         {LOCK_REASONS.map(([label, reason]) => (
                           <DropdownMenuItem
                             key={reason ?? "none"}
-                            onClick={() =>
-                              lockIssue.mutate(
-                                { number, reason },
-                                {
-                                  onSuccess: () =>
-                                    toast.success("Conversation locked"),
-                                  onError,
-                                },
-                              )
-                            }
+                            onClick={() => void doLock(reason)}
                           >
                             {label}
                           </DropdownMenuItem>
@@ -1201,21 +1232,7 @@ export function RemoteIssueView({
         onClose={() => setDeletingCommentId(null)}
         pending={deleteComment.isPending}
         description={`This permanently deletes the comment on ${remoteLabel}. This cannot be undone.`}
-        onConfirm={(commentId) =>
-          deleteComment.mutate(
-            { number, commentId },
-            {
-              onSuccess: () => {
-                toast.success("Comment deleted");
-                setDeletingCommentId(null);
-              },
-              onError: (e) => {
-                onError(e);
-                setDeletingCommentId(null);
-              },
-            },
-          )
-        }
+        onConfirm={(commentId) => void removeComment(commentId)}
       />
 
       <TransferIssueDialog
@@ -1226,7 +1243,7 @@ export function RemoteIssueView({
         onDestChange={setTransferDest}
         suggestions={repoSuggestions}
         pending={transferIssue.isPending}
-        onSubmit={submitTransfer}
+        onSubmit={() => void submitTransfer()}
         move={isGitLab}
       />
 
@@ -1236,7 +1253,7 @@ export function RemoteIssueView({
         number={number}
         title={issue.title}
         pending={deleteIssue.isPending}
-        onConfirm={confirmDelete}
+        onConfirm={() => void confirmDelete()}
         remoteLabel={remoteLabel}
         roleHint={
           isGitLab ? "needs Owner access" : "requires admin or triage access"

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -5,6 +5,7 @@ import {
   DotsThreeIcon,
   PencilSimpleIcon,
 } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -78,9 +79,9 @@ import {
   WRITE_ACCESS_ITEM_REASON,
   writeAccessReason,
 } from "@/lib/git/queries";
-import { providerLabel } from "@/lib/git/types";
+import { providerLabel, type RemoteLens } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
-import { useRepoLens } from "@/lib/repo-lens/queries";
+import { lensKey, useRepoLens } from "@/lib/repo-lens/queries";
 import { useConfirm } from "@/lib/stores/confirm";
 import { useUiStore } from "@/lib/stores/ui";
 import { parseableDate } from "@/lib/time";
@@ -138,11 +139,7 @@ export function RemoteIssueView({
   // The single lens-resolution point for this surface (package B2): every issue
   // read/write below targets the fork (origin) or its parent (upstream).
   const lens = useRepoLens(repoPath);
-  // Live lens for post-await guards: `selectedIssue` carries no lens, so a
-  // continuation fired on one side of a fork pair must not clear a
-  // same-numbered selection made on the other.
-  const lensRef = useRef(lens);
-  lensRef.current = lens;
+  const queryClient = useQueryClient();
   // The viewer's permission on the lens repo — a PERMISSION axis the per-action
   // flags below don't cover, so it never hides a control: it only disables one,
   // and only on an explicit denial. Triage is its own, LOWER tier: labels,
@@ -559,15 +556,22 @@ export function RemoteIssueView({
 
   /** Clear the selection only while it still points at this issue — the write
    *  can settle after the user has selected another one. */
-  function deselectIfStillHere() {
+  // `selectedIssue` carries no lens, so a continuation fired on one side of a
+  // fork pair must not clear a same-numbered selection made on the other. The
+  // lens is read from the query cache, which outlives this instance (the lens
+  // switcher unmounts it); an undefined read is a cold cache, not "origin".
+  function deselectIfStillHere(firedUnder: RemoteLens | undefined) {
+    const liveLens = queryClient.getQueryData<RemoteLens>(lensKey(repoPath));
+    if (firedUnder !== undefined && liveLens !== firedUnder) return;
     const { selectedIssue: sel, repoPath: liveRepo } = useUiStore.getState();
-    if (liveRepo !== repoPath || lensRef.current !== lens) return;
+    if (liveRepo !== repoPath) return;
     if (sel?.kind === "remote" && sel.id === String(number)) selectIssue(null);
   }
 
   async function submitTransfer() {
     const destination = transferDest.trim();
     if (!destination) return;
+    const firedUnder = queryClient.getQueryData<RemoteLens>(lensKey(repoPath));
     let url: string;
     try {
       url = await transferIssue.mutateAsync({ number, destination });
@@ -586,10 +590,11 @@ export function RemoteIssueView({
     );
     setTransferOpen(false);
     // The issue no longer lives in this repo; clear the now-stale view.
-    deselectIfStillHere();
+    deselectIfStillHere(firedUnder);
   }
 
   async function confirmDelete() {
+    const firedUnder = queryClient.getQueryData<RemoteLens>(lensKey(repoPath));
     try {
       await deleteIssue.mutateAsync(number);
     } catch (e) {
@@ -599,7 +604,7 @@ export function RemoteIssueView({
     }
     toast.success(`Deleted #${number}`);
     setDeleteOpen(false);
-    deselectIfStillHere();
+    deselectIfStillHere(firedUnder);
   }
 
   /** `wasPinned` comes from the render the click landed on: the refetch that

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -771,6 +771,17 @@ function IssueLinksSection({
     selectIssue({ kind: "remote", id: String(n) });
   }
 
+  async function link(target: number) {
+    try {
+      await linkIssue.mutateAsync({ number, targetNumber: target });
+    } catch {
+      // useLinkIssue toasts at the mutation level, so a second report here
+      // would double up.
+      return;
+    }
+    setAdding(false);
+  }
+
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2">
@@ -823,12 +834,7 @@ function IssueLinksSection({
               exclude={exclude}
               pending={linkIssue.isPending}
               lens={lens}
-              onPick={(target) =>
-                linkIssue.mutate(
-                  { number, targetNumber: target },
-                  { onSuccess: () => setAdding(false) },
-                )
-              }
+              onPick={(target) => void link(target)}
             />
           </div>
           <Button variant="ghost" size="xs" onClick={() => setAdding(false)}>

--- a/src/features/issues/RepoJiraDialog.tsx
+++ b/src/features/issues/RepoJiraDialog.tsx
@@ -224,32 +224,31 @@ export function RepoJiraDialog({
     existingLink.siteHost !== siteHost ||
     existingLink.projectKey !== project?.key;
 
-  function doSave() {
+  async function doSave() {
     if (!project) return;
-    save.mutate(
-      {
+    try {
+      await save.mutateAsync({
         siteHost,
         projectKey: project.key,
         projectName: project.name || project.key,
-      },
-      {
-        onSuccess: () => {
-          toast.success(`Linked ${project.key}`);
-          onOpenChange(false);
-        },
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(`Linked ${project.key}`);
+    onOpenChange(false);
   }
 
-  function doUnlink() {
-    clear.mutate(undefined, {
-      onSuccess: () => {
-        toast.success("Jira project unlinked");
-        onOpenChange(false);
-      },
-      onError: toastError,
-    });
+  async function doUnlink() {
+    try {
+      await clear.mutateAsync(undefined);
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success("Jira project unlinked");
+    onOpenChange(false);
   }
 
   const showCredentialFields =
@@ -457,7 +456,7 @@ export function RepoJiraDialog({
               size="sm"
               className="mr-auto text-destructive"
               disabled={clear.isPending}
-              onClick={doUnlink}
+              onClick={() => void doUnlink()}
               title="Remove this repository's Jira link (keeps your saved credential)"
             >
               <LinkBreakIcon data-icon="inline-start" />
@@ -477,7 +476,7 @@ export function RepoJiraDialog({
                   ? undefined
                   : "No changes to save")
             }
-            onClick={doSave}
+            onClick={() => void doSave()}
           >
             Save
           </DisabledReasonButton>

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -11,10 +11,10 @@ import { useUiStore } from "@/lib/stores/ui";
 
 /**
  * Offers the in-app reconnect (and a copyable `gh auth refresh -s <scope>`) when
- * the active gh token is a classic OAuth/PAT token missing every scope in
- * `coveredBy` (default: `scope` alone). Renders nothing when any covering scope
- * is present, or for a fine-grained/App token (those have no readable scopes and
- * can't be refreshed this way) — so it never nags about a non-problem.
+ * the active gh token is a classic OAuth/PAT token missing `scope` and every
+ * scope in `coveredBy`. Renders nothing when any of them is present, or for a
+ * fine-grained/App token (those have no readable scopes and can't be refreshed
+ * this way) — so it never nags about a non-problem.
  */
 export function ScopeRefreshHint({
   scope,
@@ -23,15 +23,14 @@ export function ScopeRefreshHint({
 }: {
   scope: string;
   action: string;
-  /** Scopes that each satisfy the need on their own — the hint hides when ANY
-   *  is present (a broader scope can cover the named one). Defaults to `scope`
-   *  alone. */
+  /** Additional scopes that each satisfy the need on their own (a broader
+   *  scope can cover the named one) — `scope` is always included. */
   coveredBy?: string[];
 }) {
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
-  const satisfied = (coveredBy ?? [scope]).some((s) =>
+  const satisfied = [scope, ...(coveredBy ?? [])].some((s) =>
     scopes.data?.scopes.includes(s),
   );
   if (!scopes.data?.classic || satisfied) return null;

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -19,14 +19,22 @@ import { useUiStore } from "@/lib/stores/ui";
 export function ScopeRefreshHint({
   scope,
   action,
+  coveredBy,
 }: {
   scope: string;
   action: string;
+  /** Scopes that each satisfy the need on their own — the hint hides when ANY
+   *  is present (a broader scope can cover the named one). Defaults to `scope`
+   *  alone. */
+  coveredBy?: string[];
 }) {
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
-  if (!scopes.data?.classic || scopes.data.scopes.includes(scope)) return null;
+  const satisfied = (coveredBy ?? [scope]).some((s) =>
+    scopes.data?.scopes.includes(s),
+  );
+  if (!scopes.data?.classic || satisfied) return null;
   // A host outside the reconnect grammar never reaches a copyable command string
   // (shell-syntax injection via a crafted remote) — only the command block is
   // suppressed: the explanation and the button stay, and the button's flow

--- a/src/features/repo-settings/ScopeRefreshHint.tsx
+++ b/src/features/repo-settings/ScopeRefreshHint.tsx
@@ -11,10 +11,10 @@ import { useUiStore } from "@/lib/stores/ui";
 
 /**
  * Offers the in-app reconnect (and a copyable `gh auth refresh -s <scope>`) when
- * the active gh token is a classic OAuth/PAT token missing `scope`. Renders
- * nothing when the scope is present, or for a fine-grained/App token (those have
- * no readable scopes and can't be refreshed this way) — so it never nags about a
- * non-problem.
+ * the active gh token is a classic OAuth/PAT token missing every scope in
+ * `coveredBy` (default: `scope` alone). Renders nothing when any covering scope
+ * is present, or for a fine-grained/App token (those have no readable scopes and
+ * can't be refreshed this way) — so it never nags about a non-problem.
  */
 export function ScopeRefreshHint({
   scope,

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -59,7 +59,7 @@ import {
   useRepoStatus,
   useTagList,
 } from "@/lib/git/queries";
-import type { CommitSummary } from "@/lib/git/types";
+import type { CommitSummary, GeneratedNotes } from "@/lib/git/types";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useAiEnabled } from "@/lib/settings/queries";
@@ -221,25 +221,27 @@ export function CreateReleaseDialog({
 
   const busyGenerating = githubNotes.isPending || aiNotes.generating;
 
-  function generateFromGithub() {
+  // Awaited like the submit above: react-query drops per-call callbacks once the
+  // observer loses listeners, and this dialog's host panel hides with its tab
+  // while generation is still in flight.
+  async function generateFromGithub() {
     if (!tagTrimmed) return;
-    githubNotes.mutate(
-      {
+    let gen: GeneratedNotes;
+    try {
+      gen = await githubNotes.mutateAsync({
         tag: tagTrimmed,
         target: showTarget ? target.trim() : "",
         previousTag: effectivePreviousTag,
-      },
-      {
-        onSuccess: (gen) => {
-          if (gen.body) form.setFieldValue("notes", gen.body);
-          if (gen.name && !form.getFieldValue("title").trim()) {
-            form.setFieldValue("title", gen.name);
-          }
-          notesEditorRef.current?.showPreview();
-        },
-        onError: toastError,
-      },
-    );
+      });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    if (gen.body) form.setFieldValue("notes", gen.body);
+    if (gen.name && !form.getFieldValue("title").trim()) {
+      form.setFieldValue("title", gen.name);
+    }
+    notesEditorRef.current?.showPreview();
   }
 
   function generateWithAi() {
@@ -475,7 +477,9 @@ export function CreateReleaseDialog({
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="min-w-56">
                         {!isGitLab && (
-                          <DropdownMenuItem onClick={generateFromGithub}>
+                          <DropdownMenuItem
+                            onClick={() => void generateFromGithub()}
+                          >
                             From GitHub (commits & PRs)
                           </DropdownMenuItem>
                         )}

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -163,7 +163,9 @@ export function CreateReleaseDialog({
           action: { label: "View", onClick: () => openUrl(url) },
         });
         onOpenChange(false);
-        selectTag({ tag });
+        // Adopt the new release's tag only while this repo is still on screen —
+        // the create can settle after a repo switch.
+        if (useUiStore.getState().repoPath === repoPath) selectTag({ tag });
       } catch (e) {
         toastError(e);
       }
@@ -226,10 +228,11 @@ export function CreateReleaseDialog({
   // while generation is still in flight.
   async function generateFromGithub() {
     if (!tagTrimmed) return;
+    const requestedFor = tagTrimmed;
     let gen: GeneratedNotes;
     try {
       gen = await githubNotes.mutateAsync({
-        tag: tagTrimmed,
+        tag: requestedFor,
         target: showTarget ? target.trim() : "",
         previousTag: effectivePreviousTag,
       });
@@ -237,6 +240,9 @@ export function CreateReleaseDialog({
       toastError(e);
       return;
     }
+    // The response belongs to the tag it was requested for — a reseeded or
+    // retyped form is another release, and stale notes must not touch it.
+    if (form.getFieldValue("tag").trim() !== requestedFor) return;
     if (gen.body) form.setFieldValue("notes", gen.body);
     if (gen.name && !form.getFieldValue("title").trim()) {
       form.setFieldValue("title", gen.name);

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -249,6 +249,14 @@ export function TagDetailView({
     toast.success(`Pushed ${tag}`);
   }
 
+  // `selectTag` is global — deselect only while THIS tag in THIS repo is still
+  // the live selection (a delete can settle after the user switched away).
+  function deselectIfStillHere() {
+    const live = useUiStore.getState();
+    if (live.repoPath === repoPath && live.selectedTag?.tag === tag)
+      selectTag(null);
+  }
+
   async function onDeleteTag() {
     try {
       await deleteTag.mutateAsync({ name: tag, onRemote: deleteTagRemote });
@@ -259,7 +267,7 @@ export function TagDetailView({
     }
     toast.success(`Deleted ${tag}`);
     setDeleteTagOpen(false);
-    selectTag(null);
+    deselectIfStillHere();
   }
 
   // ── Release view ───────────────────────────────────────────────────────────
@@ -369,7 +377,7 @@ export function TagDetailView({
       }
       toast.success("Release deleted");
       setDeleteOpen(false);
-      selectTag(null);
+      deselectIfStillHere();
     };
 
     return (

--- a/src/features/tags/TagDetailView.tsx
+++ b/src/features/tags/TagDetailView.tsx
@@ -164,13 +164,19 @@ export function TagDetailView({
     );
   }
 
+  // Every mutation below awaits its continuation: react-query drops per-call
+  // callbacks once the observer loses listeners, and this whole view hides with
+  // its <Activity> tab while a write is still in flight.
   async function onUpload() {
     const file = await openDialog({ multiple: false });
     if (typeof file !== "string") return;
-    uploadAsset.mutate(
-      { tag, filePath: file },
-      { onSuccess: () => toast.success("Asset uploaded"), onError },
-    );
+    try {
+      await uploadAsset.mutateAsync({ tag, filePath: file });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Asset uploaded");
   }
 
   async function onDownload(assetName: string) {
@@ -179,10 +185,13 @@ export function TagDetailView({
     if (relStale) return;
     const dir = await openDialog({ directory: true });
     if (typeof dir !== "string") return;
-    downloadAsset.mutate(
-      { tag, assetName, dir },
-      { onSuccess: () => toast.success(`Downloaded ${assetName}`), onError },
-    );
+    try {
+      await downloadAsset.mutateAsync({ tag, assetName, dir });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(`Downloaded ${assetName}`);
   }
 
   // Shared by both provider arms, which differ in what is actually lost: GitHub's
@@ -201,10 +210,13 @@ export function TagDetailView({
       confirmVariant: "destructive",
     });
     if (!ok) return;
-    deleteAsset.mutate(
-      { tag, assetName },
-      { onSuccess: () => toast.success("Asset deleted"), onError },
-    );
+    try {
+      await deleteAsset.mutateAsync({ tag, assetName });
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success("Asset deleted");
   }
 
   // Checking out a tag detaches HEAD exactly as checking out its commit does, so
@@ -218,10 +230,36 @@ export function TagDetailView({
       .getState()
       .ask(checkoutDetachedConfirm("tag", tag));
     if (!ok) return;
-    checkout.mutate(target, {
-      onSuccess: () => toast.success(checkoutTagSuccessToast(tag)),
-      onError,
-    });
+    try {
+      await checkout.mutateAsync(target);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(checkoutTagSuccessToast(tag));
+  }
+
+  async function onPushTag() {
+    try {
+      await pushTag.mutateAsync(tag);
+    } catch (e) {
+      onError(e);
+      return;
+    }
+    toast.success(`Pushed ${tag}`);
+  }
+
+  async function onDeleteTag() {
+    try {
+      await deleteTag.mutateAsync({ name: tag, onRemote: deleteTagRemote });
+    } catch (e) {
+      onError(e);
+      setDeleteTagOpen(false);
+      return;
+    }
+    toast.success(`Deleted ${tag}`);
+    setDeleteTagOpen(false);
+    selectTag(null);
   }
 
   // ── Release view ───────────────────────────────────────────────────────────
@@ -237,6 +275,103 @@ export function TagDetailView({
     // (nothing armed) stays dismissible exactly as it always was.
     const savePending = editRelease.isPending || syncUpdaterNotes.isPending;
     const saveLatched = syncArmed && savePending;
+
+    // Arrow consts, not declarations: only an expression created after the
+    // narrowing keeps `rel` non-nullable inside the closure.
+    const onPublish = async () => {
+      // `prerelease` rides the rendered release's flag, so a stale one would
+      // really flip the new release's state on the forge.
+      if (relStale) return;
+      try {
+        await editRelease.mutateAsync({
+          tag,
+          title: "",
+          notes: "",
+          prerelease: rel.isPrerelease,
+          draft: false,
+          // Omit --latest so GitHub applies its default (a newly published
+          // stable release becomes Latest, like the web UI). A draft's isLatest
+          // is structurally false — sending it here was the bug that stripped
+          // Latest on publish.
+          latest: undefined,
+        });
+      } catch (e) {
+        onError(e);
+        return;
+      }
+      toast.success("Published");
+    };
+
+    const saveEdit = async () => {
+      // `draft`/`latest` below are read off the rendered release at submit
+      // time, so a switch behind the open dialog holds the save.
+      if (relStale) return;
+      // Empty notes leave the body untouched (the edit skips `--notes`), so
+      // there's nothing to carry into the manifest either.
+      const syncManifest =
+        canSyncUpdater && editSyncUpdater && !!editNotes.trim();
+      setSyncArmed(syncManifest);
+      try {
+        await editRelease.mutateAsync({
+          tag,
+          title: editTitle.trim(),
+          notes: editNotes,
+          prerelease: editPrerelease,
+          draft: rel.isDraft,
+          // Only round-trip Latest for published releases (real user intent on
+          // an eligible release). A draft can't be Latest, so omit the flag and
+          // let GitHub decide on publish.
+          latest: rel.isDraft ? undefined : editLatest,
+        });
+      } catch (e) {
+        // The capture dies with the save it was taken for — phase 1 failing
+        // means no phase 2 will ever consume it.
+        setSyncArmed(false);
+        onError(e);
+        return;
+      }
+      if (!syncManifest) {
+        setSyncArmed(false);
+        toast.success("Release updated");
+        setEditOpen(false);
+        return;
+      }
+      // The body edit has already landed, so a manifest failure is partial
+      // state, not a failed save: close and disclose it — re-submitting would
+      // only repeat the edit.
+      try {
+        await syncUpdaterNotes.mutateAsync({ tag, notes: editNotes.trim() });
+      } catch (err) {
+        setSyncArmed(false);
+        // Which stage failed decides what recovery is possible — only a failed
+        // upload leaves a parked copy — so the summary stays arm-neutral and the
+        // backend's own text (carried into Details by toastError) names the specifics.
+        toastError(
+          new Error(
+            `Release updated, but the updater manifest may not have been.\n\n${presentError(err).fullText}`,
+          ),
+        );
+        setEditOpen(false);
+        return;
+      }
+      setSyncArmed(false);
+      toast.success("Release updated");
+      setEditOpen(false);
+    };
+
+    const onDeleteRelease = async () => {
+      try {
+        await deleteRelease.mutateAsync({ tag, cleanupTag });
+      } catch (e) {
+        onError(e);
+        setDeleteOpen(false);
+        return;
+      }
+      toast.success("Release deleted");
+      setDeleteOpen(false);
+      selectTag(null);
+    };
+
     return (
       <div className="flex h-full flex-col" aria-busy={Boolean(staleDim)}>
         <header className="space-y-2 border-b px-4 py-3">
@@ -256,29 +391,7 @@ export function TagDetailView({
                     size="xs"
                     disabled={editRelease.isPending || writeBlocked || relStale}
                     reason={blockReason}
-                    onClick={() => {
-                      // `prerelease` rides the rendered release's flag, so a stale
-                      // one would really flip the new release's state on the forge.
-                      if (relStale) return;
-                      editRelease.mutate(
-                        {
-                          tag,
-                          title: "",
-                          notes: "",
-                          prerelease: rel.isPrerelease,
-                          draft: false,
-                          // Omit --latest so GitHub applies its default (a newly
-                          // published stable release becomes Latest, like the web UI).
-                          // A draft's isLatest is structurally false — sending it here
-                          // was the bug that stripped Latest on publish.
-                          latest: undefined,
-                        },
-                        {
-                          onSuccess: () => toast.success("Published"),
-                          onError,
-                        },
-                      );
-                    }}
+                    onClick={() => void onPublish()}
                   >
                     Publish
                   </DisabledReasonButton>
@@ -479,69 +592,7 @@ export function TagDetailView({
               className="flex min-h-0 flex-1 flex-col gap-4"
               onSubmit={(e) => {
                 e.preventDefault();
-                // `draft`/`latest` below are read off the rendered release at
-                // submit time, so a switch behind the open dialog holds the save.
-                if (relStale) return;
-                // Empty notes leave the body untouched (the edit skips `--notes`),
-                // so there's nothing to carry into the manifest either.
-                const syncManifest =
-                  canSyncUpdater && editSyncUpdater && !!editNotes.trim();
-                setSyncArmed(syncManifest);
-                editRelease.mutate(
-                  {
-                    tag,
-                    title: editTitle.trim(),
-                    notes: editNotes,
-                    prerelease: editPrerelease,
-                    draft: rel.isDraft,
-                    // Only round-trip Latest for published releases (real user intent
-                    // on an eligible release). A draft can't be Latest, so omit the flag
-                    // and let GitHub decide on publish.
-                    latest: rel.isDraft ? undefined : editLatest,
-                  },
-                  {
-                    onSuccess: () => {
-                      if (!syncManifest) {
-                        setSyncArmed(false);
-                        toast.success("Release updated");
-                        setEditOpen(false);
-                        return;
-                      }
-                      // The body edit has already landed, so a manifest failure is
-                      // partial state, not a failed save: close and disclose it —
-                      // re-submitting would only repeat the edit.
-                      syncUpdaterNotes.mutate(
-                        { tag, notes: editNotes.trim() },
-                        {
-                          onSuccess: () => {
-                            setSyncArmed(false);
-                            toast.success("Release updated");
-                            setEditOpen(false);
-                          },
-                          onError: (err) => {
-                            setSyncArmed(false);
-                            // Which stage failed decides what recovery is possible —
-                            // only a failed upload leaves a parked copy — so the
-                            // summary stays arm-neutral and the backend's own text
-                            // (carried into Details by toastError) names the specifics.
-                            toastError(
-                              new Error(
-                                `Release updated, but the updater manifest may not have been.\n\n${presentError(err).fullText}`,
-                              ),
-                            );
-                            setEditOpen(false);
-                          },
-                        },
-                      );
-                    },
-                    // The capture dies with the save it was taken for — phase 1
-                    // failing means no phase 2 will ever consume it.
-                    onError: (e) => {
-                      setSyncArmed(false);
-                      onError(e);
-                    },
-                  },
-                );
+                void saveEdit();
               }}
             >
               <DialogHeader>
@@ -682,22 +733,7 @@ export function TagDetailView({
                 variant="destructive"
                 disabled={deleteRelease.isPending || relStale}
                 reason={blockReason}
-                onClick={() =>
-                  deleteRelease.mutate(
-                    { tag, cleanupTag },
-                    {
-                      onSuccess: () => {
-                        toast.success("Release deleted");
-                        setDeleteOpen(false);
-                        selectTag(null);
-                      },
-                      onError: (e) => {
-                        onError(e);
-                        setDeleteOpen(false);
-                      },
-                    },
-                  )
-                }
+                onClick={() => void onDeleteRelease()}
               >
                 {deleteRelease.isPending && (
                   <Spinner data-icon="inline-start" />
@@ -770,12 +806,7 @@ export function TagDetailView({
           variant="outline"
           size="sm"
           disabled={pushTag.isPending}
-          onClick={() =>
-            pushTag.mutate(tag, {
-              onSuccess: () => toast.success(`Pushed ${tag}`),
-              onError,
-            })
-          }
+          onClick={() => void onPushTag()}
         >
           Push tag
         </Button>
@@ -821,22 +852,7 @@ export function TagDetailView({
             <Button
               variant="destructive"
               disabled={deleteTag.isPending}
-              onClick={() =>
-                deleteTag.mutate(
-                  { name: tag, onRemote: deleteTagRemote },
-                  {
-                    onSuccess: () => {
-                      toast.success(`Deleted ${tag}`);
-                      setDeleteTagOpen(false);
-                      selectTag(null);
-                    },
-                    onError: (e) => {
-                      onError(e);
-                      setDeleteTagOpen(false);
-                    },
-                  },
-                )
-              }
+              onClick={() => void onDeleteTag()}
             >
               {deleteTag.isPending && <Spinner data-icon="inline-start" />}
               Delete

--- a/src/features/tags/TagsPanel.tsx
+++ b/src/features/tags/TagsPanel.tsx
@@ -136,7 +136,9 @@ export function TagsPanel({ repoPath }: { repoPath: string }) {
     toast.success(`Created tag ${name}`);
     setNewTagOpen(false);
     setNewTagName("");
-    selectTag({ tag: name });
+    // `selectTag` is global — a repo switch mid-create must not adopt this
+    // tag into the other repo's selection.
+    if (useUiStore.getState().repoPath === repoPath) selectTag({ tag: name });
   }
 
   return (

--- a/src/features/tags/TagsPanel.tsx
+++ b/src/features/tags/TagsPanel.tsx
@@ -122,21 +122,21 @@ export function TagsPanel({ repoPath }: { repoPath: string }) {
     rowKey: (t) => t.id,
   });
 
-  function createNewTag() {
+  // Awaited, not per-call callbacks: a panel hidden mid-create (repo-tab switch)
+  // drops react-query's callbacks, and with them the selection onto the new tag.
+  async function createNewTag() {
     const name = newTagName.trim();
     if (!name || !headOid) return;
-    createTag.mutate(
-      { name, hash: headOid },
-      {
-        onSuccess: () => {
-          toast.success(`Created tag ${name}`);
-          setNewTagOpen(false);
-          setNewTagName("");
-          selectTag({ tag: name });
-        },
-        onError: toastError,
-      },
-    );
+    try {
+      await createTag.mutateAsync({ name, hash: headOid });
+    } catch (e) {
+      toastError(e);
+      return;
+    }
+    toast.success(`Created tag ${name}`);
+    setNewTagOpen(false);
+    setNewTagName("");
+    selectTag({ tag: name });
   }
 
   return (
@@ -256,7 +256,7 @@ export function TagsPanel({ repoPath }: { repoPath: string }) {
             className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
-              createNewTag();
+              void createNewTag();
             }}
           >
             <DialogHeader>


### PR DESCRIPTION
React Query drops per-call `onSuccess`/`onError` callbacks once a mutation observer loses its listeners, so any write that settled after its host unmounted — an `<Activity>` tab hide on a repo-tab switch, a dialog closing mid-flight — landed on the server but silently lost its toast, draft clear, dialog close, or navigation. This converts the remaining issue, discussion, tag, and history surfaces to awaited `mutateAsync` continuations, extends the banned-pattern ratchet to cover those trees, and adds an in-app reconnect path for GitHub sign-ins whose classic scopes can't write discussions.

### Mutation continuations (`mutateAsync`)

- Rewrites every per-call-callback site in `src/features/discussions/DiscussionView.tsx` (comment/reply submit, comment edit, hide/unhide, mark-answer, lock, upvote, reaction) to `await mutateAsync` with `try`/`catch` around `onError`; fire-and-forget toggles use `void …mutateAsync(…).catch(onError)`.
- Same conversion across the issues tree: `RemoteIssueView.tsx` (close/reopen with riding draft, comment edit, hide/unhide, reactions, transfer), `JiraIssueView.tsx` (status transitions, assignee, priority, labels, comment edit/delete), `LocalIssueView.tsx` (`setStatus`, new `deleteIssue`), `IssueRelations.tsx` (`pickExisting`, new `addDependency`/`removeDependency`), `IssueDevelopment.tsx` (`submitBranch`), `RemoteIssueViewParts.tsx` (new `link`), `RepoJiraDialog.tsx` (`doSave`/`doUnlink`), and `JiraIssueSidebar.tsx` (due date).
- Tags: `TagDetailView.tsx` (asset upload/download/delete, checkout, new `onPushTag`/`onDeleteTag`, plus `onPublish`/`saveEdit` as arrow consts so the narrowed `rel` stays non-nullable in the closure), `TagsPanel.tsx` (`createNewTag`), and `CreateReleaseDialog.tsx` (`generateFromGithub`).
- History: `HistoryPanel.tsx` (`undoLast` now reads commit details *before* the undo, checkout/revert/cherry-pick, new `pushTagToOrigin`), `CommitDetailView.tsx` (checkout/revert/cherry-pick), and `HistoryDialogs.tsx` (`DeleteTagDialog`, `ResetCommitDialog`, `CherryPickOntoDialog` each gain a `run()` that closes the dialog on both paths).
- Call sites move to `onClick={() => void fn()}` / `void fn()` so the handlers stay sync-typed.
- Adds stale-selection guards where a write can settle after the user moved on: `deselectIfStillHere` in `RemoteIssueView.tsx` and the live-store check in `LocalIssueView.tsx` both verify `repoPath` and the selected issue before clearing the selection.

### Discussion write-scope reconnect

- `ScopeRefreshHint` (`src/features/repo-settings/ScopeRefreshHint.tsx`) gains an optional `coveredBy` prop so a broader scope can satisfy the requirement; the hint hides when *any* listed scope is present.
- Surfaces the hint before a write can fail, in `DiscussionsPanel.tsx` (under the filter row, gated on `listEnabled`), `CreateDiscussionDialog.tsx`, and the thread — all with `coveredBy={["repo", "write:discussion"]}`.
- `src-tauri/src/github/discussion.rs` trims `DISCUSSION_SCOPE_HINT` to a plain sentence (the UI now owns the reconnect path) and adds unit tests covering both match arms of `map_scope_error` plus pass-through of unrelated `Gh`/`InvalidArgument` failures.

### Ratchet and docs

- `scripts/check-banned-patterns.mjs` extends the per-call-callback check to `src/features/issues/`, `history/`, `discussions/`, and `tags/`, rewrites the rationale comment to list what remains unconverted, and allowlists `LocalIssueView.tsx` and `RemoteIssueViewParts.tsx` (single-arg writes with nothing to drop).
- `src/features/help/content.ts` documents the discussions scope hint and reconnect offer.
- Changelog fragments: `changelog.d/fixed-issue-discussion-tag-history-continuations.md` and `changelog.d/changed-discussion-scope-reconnect.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reconnect or refresh guidance when GitHub discussion permissions are insufficient, available in discussion lists, creation dialogs, and threads.
  * Added guidance explaining how to create issues from discussions and resolve discussion permission issues.

* **Bug Fixes**
  * Improved reliability for issue, discussion, tag, and history actions when switching tabs or closing dialogs during operations.
  * Dialogs, drafts, selections, views, and success/error notifications now update more consistently after actions complete.
  * Prevented completed actions from affecting a different repository or item after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->