### PR TITLE
feat(mywork,github): add a cross-repo My work inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,16 +953,16 @@ review via its subscription login. The full list is under
 - **Integrations**: open in any editor or terminal (auto-detected, point at
   any executable, or set a full custom command with a `{path}` placeholder),
   and tunable OS notifications for PR activity, checks, and CI runs.
-- **My work**: a cross-repo inbox of every open **GitHub** pull request and
-  issue that involves you (authored, assigned, mentioned, commented on, or
-  awaiting your review), newest first, so what's waiting on you is one screen
-  away instead of one repository at a time. Open it from the welcome screen or
-  the command palette (*My work*), narrow it with **All / Pull requests /
-  Issues** tabs and a filter box that takes arrow keys and Enter, and press
-  Enter on a row: an item from a repository you've added to GitDesktop usually
-  opens right in the app, and the ↗ marks the rows that will open on GitHub
-  instead. Read-only, with a **Refresh** in the header and a right-click menu
-  for *Open on GitHub* / *Copy link*.
+- **My work**: a cross-repo inbox of your open **GitHub** pull requests and
+  issues (authored, assigned, mentioned, commented on, or awaiting your
+  review), newest first, so what's waiting on you is one screen away instead
+  of one repository at a time. Open it from the welcome screen or the command
+  palette (*My work*), narrow it with **All / Pull requests / Issues** tabs and
+  a filter box that takes arrow keys and Enter, and press Enter on a row: an
+  item from a repository you've added to GitDesktop usually opens right in the
+  app, and the ↗ marks the rows that will open on GitHub instead. Read-only,
+  with a **Refresh** in the header and a right-click menu for *Open on GitHub* /
+  *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/README.md
+++ b/README.md
@@ -954,14 +954,15 @@ review via its subscription login. The full list is under
   any executable, or set a full custom command with a `{path}` placeholder),
   and tunable OS notifications for PR activity, checks, and CI runs.
 - **My work**: a cross-repo inbox of every open **GitHub** pull request and
-  issue that involves you (authored, assigned, mentioned, or awaiting your
-  review), newest first, so what's waiting on you is one screen away instead
-  of one repository at a time. Open it from the welcome screen or the command
-  palette (*My work*), narrow it with **All / Pull requests / Issues** tabs and
-  a filter box that takes arrow keys and Enter, and press Enter on a row: an
-  item from a repository you've added to GitDesktop opens right in the app, and
-  the rest open on GitHub (marked with a ↗). Read-only, with a **Refresh** in
-  the header and a right-click menu for *Open on GitHub* / *Copy link*.
+  issue that involves you (authored, assigned, mentioned, commented on, or
+  awaiting your review), newest first, so what's waiting on you is one screen
+  away instead of one repository at a time. Open it from the welcome screen or
+  the command palette (*My work*), narrow it with **All / Pull requests /
+  Issues** tabs and a filter box that takes arrow keys and Enter, and press
+  Enter on a row: an item from a repository you've added to GitDesktop usually
+  opens right in the app, and the ↗ marks the rows that will open on GitHub
+  instead. Read-only, with a **Refresh** in the header and a right-click menu
+  for *Open on GitHub* / *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/README.md
+++ b/README.md
@@ -953,6 +953,15 @@ review via its subscription login. The full list is under
 - **Integrations**: open in any editor or terminal (auto-detected, point at
   any executable, or set a full custom command with a `{path}` placeholder),
   and tunable OS notifications for PR activity, checks, and CI runs.
+- **My work**: a cross-repo inbox of every open **GitHub** pull request and
+  issue that involves you (authored, assigned, mentioned, or awaiting your
+  review), newest first, so what's waiting on you is one screen away instead
+  of one repository at a time. Open it from the welcome screen or the command
+  palette (*My work*), narrow it with **All / Pull requests / Issues** tabs and
+  a filter box that takes arrow keys and Enter, and press Enter on a row: an
+  item from a repository you've added to GitDesktop opens right in the app, and
+  the rest open on GitHub (marked with a ↗). Read-only, with a **Refresh** in
+  the header and a right-click menu for *Open on GitHub* / *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -1,0 +1,7 @@
+- **My work.** A cross-repo inbox of every open GitHub pull request and issue
+  that involves you (authored, assigned, mentioned, or awaiting your review),
+  newest first, so what's waiting on you is one screen away instead of one
+  repository at a time. Filter to pull requests or issues, or type to narrow by
+  title, repository, or number, then press Enter: an item from a repository
+  you've added to GitDesktop opens in the app, and the rest open on GitHub.
+  Reach it from the welcome screen or the command palette (*My work*).

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -1,7 +1,8 @@
 - **My work.** A cross-repo inbox of every open GitHub pull request and issue
-  that involves you (authored, assigned, mentioned, or awaiting your review),
-  newest first, so what's waiting on you is one screen away instead of one
-  repository at a time. Filter to pull requests or issues, or type to narrow by
-  title, repository, or number, then press Enter: an item from a repository
-  you've added to GitDesktop opens in the app, and the rest open on GitHub.
-  Reach it from the welcome screen or the command palette (*My work*).
+  that involves you: anything you authored, were assigned, were mentioned in, or
+  commented on, plus anything awaiting your review. Newest first, so what's
+  waiting on you is one screen away instead of one repository at a time. Filter
+  to pull requests or issues, or type to narrow by title, repository, or number.
+  Press Enter on a row and an item from a repository you've added to GitDesktop
+  usually opens in the app; the ↗ marks the rows that will open on GitHub
+  instead. Reach it from the welcome screen or the command palette (*My work*).

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -1,8 +1,8 @@
-- **My work.** A cross-repo inbox of every open GitHub pull request and issue
-  that involves you: anything you authored, were assigned, were mentioned in, or
-  commented on, plus anything awaiting your review. Newest first, so what's
-  waiting on you is one screen away instead of one repository at a time. Filter
-  to pull requests or issues, or type to narrow by title, repository, or number.
+- **My work.** A cross-repo inbox of your open GitHub pull requests and issues:
+  anything you authored, were assigned, were mentioned in, or commented on, plus
+  anything awaiting your review. Newest first, so what's waiting on you is one
+  screen away instead of one repository at a time. Filter to pull requests or
+  issues, or type to narrow by title, repository, or number.
   Press Enter on a row and an item from a repository you've added to GitDesktop
   usually opens in the app; the ↗ marks the rows that will open on GitHub
   instead. Reach it from the welcome screen or the command palette (*My work*).

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -372,6 +372,13 @@ export const capabilities: Capability[] = [
   {
     group: "Repository & workspace",
     label:
+      "My work — every open GitHub PR and issue involving you, across every repo, newest first",
+    ai: false,
+    highlight: true,
+  },
+  {
+    group: "Repository & workspace",
+    label:
       "Update a fork from its upstream — fetch, then fast-forward or merge",
   },
   {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -372,7 +372,7 @@ export const capabilities: Capability[] = [
   {
     group: "Repository & workspace",
     label:
-      "My work — every open GitHub PR and issue involving you, across every repo, newest first",
+      "My work — your open GitHub PRs and issues, across every repo, newest first",
     ai: false,
     highlight: true,
   },

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -924,6 +924,27 @@ pub async fn forge_owned_namespaces(provider: Provider) -> AppResult<Vec<String>
     }
 }
 
+/// Every open pull request and issue involving the signed-in user, across all the
+/// repos they can see — the "My work" inbox's single cross-repo read. Account-scoped
+/// (no repo path), so it dispatches on an explicit `provider` like the clone browser.
+///
+/// GitHub only for now: the other arms error rather than returning an empty list, so
+/// a caller can't read "not wired up" as "you have no open work".
+#[tauri::command]
+pub async fn forge_my_work(
+    provider: Provider,
+) -> AppResult<Vec<crate::github::my_work::MyWorkItem>> {
+    match provider {
+        Provider::GitHub => crate::github::my_work::my_work().await,
+        Provider::GitLab => Err(AppError::InvalidArgument(
+            "My work isn't supported for GitLab yet.".into(),
+        )),
+        Provider::Bitbucket => Err(AppError::InvalidArgument(
+            "My work isn't supported for Bitbucket yet.".into(),
+        )),
+    }
+}
+
 // ── Explore: repo search / fork-by-name / star / README / provider features ────
 // Account-scoped (no repo path) — Explore browses arbitrary repos across a provider,
 // so each command dispatches on an explicit `provider` argument. The frontend
@@ -4665,6 +4686,19 @@ mod tests {
         let zero_page =
             forge_search_repos(Provider::GitHub, "rust".into(), "best".into(), 0).await;
         assert!(matches!(zero_page, Err(AppError::InvalidArgument(_))));
+    }
+
+    /// The unsupported arms must fail typed, before any CLI spawn — this test
+    /// would hang or shell out if either arm fell through to the gh path.
+    #[tokio::test]
+    async fn my_work_refuses_the_unimplemented_providers() {
+        for provider in [Provider::GitLab, Provider::Bitbucket] {
+            let refused = forge_my_work(provider).await;
+            assert!(
+                matches!(refused, Err(AppError::InvalidArgument(_))),
+                "{provider:?} should be refused, got {refused:?}",
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -7,6 +7,7 @@ pub mod insights;
 pub mod issue;
 pub mod lifecycle;
 pub mod mcp_search;
+pub mod my_work;
 pub mod pages;
 pub mod pr;
 pub mod project;

--- a/src-tauri/src/github/my_work.rs
+++ b/src-tauri/src/github/my_work.rs
@@ -87,6 +87,8 @@ const MY_WORK_FIELDS: &str = "number,title,isPullRequest,repository,updatedAt,ur
 
 /// The whole page this surface fetches, per leg and after the merge. There is no
 /// pagination, so this is also the point where the inbox silently truncates.
+/// `MY_WORK_LIMIT` in `src/features/mywork/mywork-utils.ts` hand-mirrors this
+/// number to decide when to show the cap note, so the two must change together.
 const MY_WORK_LIMIT: usize = 200;
 
 /// Leg 1. GitHub's `involves:` is author OR assignee OR mentions OR commenter —

--- a/src-tauri/src/github/my_work.rs
+++ b/src-tauri/src/github/my_work.rs
@@ -1,0 +1,302 @@
+//! The cross-repo "My work" inbox: every open pull request and issue involving
+//! the signed-in GitHub user, in one call.
+//!
+//! Shells `gh search issues`, so it rides the user's gh CLI auth and never
+//! handles a token. Account-scoped — no repo path — because the whole point is
+//! the items that live OUTSIDE the checked-out repo.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+use crate::github::runner::{run_gh, GH_NETWORK_TIMEOUT};
+
+/// One open pull request or issue in the inbox, flattened for the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MyWorkItem {
+    /// A repo-scoped counter, so it stays JS-number-safe as a `u64` — the
+    /// string-over-IPC rule targets snowflake ids, which these aren't.
+    pub number: u64,
+    pub title: String,
+    pub is_pull_request: bool,
+    /// `owner/name` exactly as GitHub reports it; the split halves follow.
+    pub repo_full_name: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    /// Parsed from `url`, so Enterprise items carry their own host. Empty when
+    /// the URL has no parseable authority (modelled absence, never a guess).
+    pub host: String,
+    pub url: String,
+    /// ISO-8601 as gh emits it; the frontend validates before formatting.
+    pub updated_at: String,
+    pub author_login: Option<String>,
+}
+
+/// The `repository` object on a search hit. gh emits `name` and `nameWithOwner`
+/// here; both stay optional because the intake shape is untrusted.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhRepoRef {
+    #[serde(default)]
+    name_with_owner: Option<String>,
+}
+
+/// The `author` object on a search hit. gh also emits `id`, `type`, and a
+/// snake_case `is_bot` alongside `login`; unknown fields are ignored.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhAuthorRef {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+/// One raw `gh search issues --json …` hit. Every field is optional so a hit
+/// that omits one still deserializes and can be judged by [`item_from_intake`];
+/// this intake shape is deliberately separate from the outgoing [`MyWorkItem`].
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhSearchItem {
+    #[serde(default)]
+    number: Option<u64>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    is_pull_request: Option<bool>,
+    #[serde(default)]
+    repository: Option<GhRepoRef>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    author: Option<GhAuthorRef>,
+}
+
+/// The inbox query. `--involves=@me` is the one predicate covering authored,
+/// assigned, mentioned, and review-requested; `--limit 200` is the whole page
+/// this surface fetches (no pagination).
+const MY_WORK_ARGS: &[&str] = &[
+    "search",
+    "issues",
+    "--include-prs",
+    "--involves=@me",
+    "--state=open",
+    "--limit",
+    "200",
+    "--json",
+    "number,title,isPullRequest,repository,updatedAt,url,author",
+];
+
+/// Narrow one intake hit to a wire item, or `None` when it can't address
+/// anything: a hit without number, title, url, or a splittable `owner/name` has
+/// no usable link, so it is dropped rather than rendered broken.
+fn item_from_intake(raw: GhSearchItem) -> Option<MyWorkItem> {
+    let number = raw.number?;
+    let title = raw.title.filter(|t| !t.is_empty())?;
+    let url = raw.url.filter(|u| !u.is_empty())?;
+    let repo_full_name = raw
+        .repository
+        .and_then(|r| r.name_with_owner)
+        .filter(|n| !n.is_empty())?;
+    let (owner, name) = repo_full_name.split_once('/')?;
+    if owner.is_empty() || name.is_empty() {
+        return None;
+    }
+    let repo_owner = owner.to_string();
+    let repo_name = name.to_string();
+    // The shared remote-URL host parser, so Enterprise hosts and IPv6 literals
+    // are spelled the same here as everywhere else in the app.
+    let host = crate::forge::remote_host(&url).unwrap_or_default();
+    Some(MyWorkItem {
+        number,
+        title,
+        is_pull_request: raw.is_pull_request.unwrap_or(false),
+        repo_full_name,
+        repo_owner,
+        repo_name,
+        host,
+        url,
+        updated_at: raw.updated_at.unwrap_or_default(),
+        author_login: raw.author.and_then(|a| a.login).filter(|l| !l.is_empty()),
+    })
+}
+
+/// Parse `gh search issues --json …` stdout into wire items. Per-hit tolerance:
+/// each element is deserialized on its own so one malformed hit is skipped
+/// rather than sinking the batch. A top-level parse failure IS an error —
+/// an empty inbox and unreadable output must not look alike to the caller.
+fn parse_my_work(stdout: &str) -> AppResult<Vec<MyWorkItem>> {
+    let raw: Vec<Value> = serde_json::from_str(stdout)
+        .map_err(|e| AppError::Gh(format!("could not parse your GitHub work items: {e}")))?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value::<GhSearchItem>(v).ok())
+        .filter_map(item_from_intake)
+        .collect())
+}
+
+/// Every open pull request and issue involving the signed-in GitHub user,
+/// across every repo they can see.
+pub async fn my_work() -> AppResult<Vec<MyWorkItem>> {
+    let out = run_gh(None, MY_WORK_ARGS, GH_NETWORK_TIMEOUT).await?;
+    parse_my_work(&out.stdout_lossy())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_my_work, MY_WORK_ARGS};
+    use serde_json::{json, Value};
+
+    /// A real `gh search issues --include-prs --involves=@me --state=open
+    /// --limit 3 --json …` response (gh 2.x), structure byte-faithful; the
+    /// third-party author logins are stand-ins.
+    const GH_FIXTURE: &str = r#"[{"author":{"id":"U_kgDODHf_mg","is_bot":false,"login":"octo-cat","type":"User","url":"https://github.com/octo-cat"},"isPullRequest":true,"number":309,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"feat(settings): accent colour and UI font appearance","updatedAt":"2026-09-05T23:21:02Z","url":"https://github.com/theBGuy/GitDesktop/pull/309"},{"author":{"id":"MDM6Qm90NDk2OTkzMzM=","is_bot":false,"login":"dependabot[bot]","type":"Bot","url":"https://github.com/apps/dependabot"},"isPullRequest":true,"number":300,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"chore(deps): bump astro from 6.4.8 to 7.1.6","updatedAt":"2026-09-04T15:30:38Z","url":"https://github.com/theBGuy/GitDesktop/pull/300"},{"author":{"id":"MDQ6VXNlcjY4Nzc1OTU=","is_bot":false,"login":"octo-dev","type":"User","url":"https://github.com/octo-dev"},"isPullRequest":false,"number":262,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"feat: Markdown preview view for md files present in diffs","updatedAt":"2026-09-05T07:06:45Z","url":"https://github.com/theBGuy/GitDesktop/issues/262"}]"#;
+
+    #[test]
+    fn args_carry_the_whole_inbox_query() {
+        assert!(MY_WORK_ARGS.starts_with(&["search", "issues"]));
+        for flag in ["--include-prs", "--involves=@me", "--state=open"] {
+            assert!(MY_WORK_ARGS.contains(&flag), "missing {flag}");
+        }
+        assert!(
+            MY_WORK_ARGS.contains(&"number,title,isPullRequest,repository,updatedAt,url,author")
+        );
+    }
+
+    /// The frontend mirrors this wire shape field-for-field, so the serialized
+    /// key set is pinned here rather than trusted to the `rename_all` attribute.
+    #[test]
+    fn fixture_serializes_to_the_camel_case_wire_shape() {
+        let items = parse_my_work(GH_FIXTURE).unwrap();
+        assert_eq!(items.len(), 3);
+
+        let wire = serde_json::to_value(&items[0]).unwrap();
+        let obj = wire.as_object().unwrap();
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "authorLogin",
+                "host",
+                "isPullRequest",
+                "number",
+                "repoFullName",
+                "repoName",
+                "repoOwner",
+                "title",
+                "updatedAt",
+                "url",
+            ]
+        );
+        assert_eq!(
+            wire,
+            json!({
+                "number": 309,
+                "title": "feat(settings): accent colour and UI font appearance",
+                "isPullRequest": true,
+                "repoFullName": "theBGuy/GitDesktop",
+                "repoOwner": "theBGuy",
+                "repoName": "GitDesktop",
+                "host": "github.com",
+                "url": "https://github.com/theBGuy/GitDesktop/pull/309",
+                "updatedAt": "2026-09-05T23:21:02Z",
+                "authorLogin": "octo-cat",
+            })
+        );
+
+        // An issue keeps `isPullRequest: false`, and a bracketed bot login rides
+        // through unchanged.
+        assert!(!items[2].is_pull_request);
+        assert_eq!(items[1].author_login.as_deref(), Some("dependabot[bot]"));
+    }
+
+    #[test]
+    fn my_work_derives_owner_name_and_host() {
+        let raw = json!([
+            // A dotted owner is a legal GitHub login and must survive the split.
+            {
+                "number": 1, "title": "dotted", "isPullRequest": false,
+                "repository": {"nameWithOwner": "my.org/repo"},
+                "url": "https://github.com/my.org/repo/issues/1",
+                "updatedAt": "2026-01-01T00:00:00Z", "author": {"login": "a"}
+            },
+            // Enterprise: the host comes from the item URL, not a constant.
+            {
+                "number": 2, "title": "enterprise", "isPullRequest": true,
+                "repository": {"nameWithOwner": "acme/tools"},
+                "url": "https://github.acme.com:8443/acme/tools/pull/2",
+                "updatedAt": "2026-01-02T00:00:00Z", "author": {"login": "b"}
+            },
+        ])
+        .to_string();
+        let items = parse_my_work(&raw).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].repo_owner, "my.org");
+        assert_eq!(items[0].repo_name, "repo");
+        assert_eq!(items[0].host, "github.com");
+        assert_eq!(items[1].repo_owner, "acme");
+        assert_eq!(items[1].repo_name, "tools");
+        assert_eq!(items[1].host, "github.acme.com");
+    }
+
+    #[test]
+    fn my_work_drops_unaddressable_hits_without_sinking_the_batch() {
+        let good = json!({
+            "number": 7, "title": "keeper", "isPullRequest": true,
+            "repository": {"nameWithOwner": "octo/repo"},
+            "url": "https://github.com/octo/repo/pull/7",
+            "updatedAt": "2026-01-01T00:00:00Z", "author": {"login": "octo"}
+        });
+        let drops = [
+            // No `/` in nameWithOwner: nothing to address the repo with.
+            json!({"number": 1, "title": "t", "repository": {"nameWithOwner": "noslash"},
+                   "url": "https://github.com/x/y/issues/1"}),
+            json!({"number": 2, "title": "t", "repository": {"nameWithOwner": ""},
+                   "url": "https://github.com/x/y/issues/2"}),
+            json!({"number": 3, "title": "t", "url": "https://github.com/x/y/issues/3"}),
+            // Missing number / title / url.
+            json!({"title": "t", "repository": {"nameWithOwner": "x/y"},
+                   "url": "https://github.com/x/y/issues/4"}),
+            json!({"number": 5, "repository": {"nameWithOwner": "x/y"},
+                   "url": "https://github.com/x/y/issues/5"}),
+            json!({"number": 6, "title": "t", "repository": {"nameWithOwner": "x/y"}}),
+            // A field of the wrong type sinks only its own hit.
+            json!({"number": "eight", "title": "t", "repository": {"nameWithOwner": "x/y"},
+                   "url": "https://github.com/x/y/issues/8"}),
+        ];
+
+        for drop in &drops {
+            let batch = Value::Array(vec![drop.clone(), good.clone()]);
+            let items = parse_my_work(&batch.to_string()).unwrap();
+            assert_eq!(items.len(), 1, "should have dropped only {drop}");
+            assert_eq!(items[0].number, 7);
+        }
+    }
+
+    #[test]
+    fn my_work_models_a_missing_author_as_absent() {
+        // A ghost author and no `updatedAt` — neither is required to address the
+        // item, so both degrade instead of dropping the hit.
+        let raw = json!([{
+            "number": 1, "title": "ghost", "isPullRequest": false,
+            "repository": {"nameWithOwner": "octo/repo"},
+            "url": "https://github.com/octo/repo/issues/1",
+            "author": null
+        }])
+        .to_string();
+        let items = parse_my_work(&raw).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].author_login, None);
+        // Absent, not a fabricated timestamp.
+        assert_eq!(items[0].updated_at, "");
+    }
+
+    #[test]
+    fn my_work_distinguishes_an_empty_inbox_from_unreadable_output() {
+        assert!(parse_my_work("[]").unwrap().is_empty());
+        assert!(parse_my_work("not json").is_err());
+        assert!(parse_my_work("{\"items\":[]}").is_err());
+    }
+}

--- a/src-tauri/src/github/my_work.rs
+++ b/src-tauri/src/github/my_work.rs
@@ -1,9 +1,15 @@
 //! The cross-repo "My work" inbox: every open pull request and issue involving
 //! the signed-in GitHub user, in one call.
 //!
-//! Shells `gh search issues`, so it rides the user's gh CLI auth and never
-//! handles a token. Account-scoped — no repo path — because the whole point is
-//! the items that live OUTSIDE the checked-out repo.
+//! Shells `gh search issues` and `gh search prs`, so it rides the user's gh CLI
+//! auth and never handles a token. Account-scoped — no repo path — because the
+//! whole point is the items that live OUTSIDE the checked-out repo.
+//!
+//! Two queries, because GitHub's `involves:` qualifier does NOT cover
+//! review-requested (see [`INVOLVES_ARGS`]); their results are merged into one
+//! page by [`merge_my_work`].
+
+use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -34,7 +40,8 @@ pub struct MyWorkItem {
 }
 
 /// The `repository` object on a search hit. gh emits `name` and `nameWithOwner`
-/// here; both stay optional because the intake shape is untrusted.
+/// here; only the latter is taken (both wire halves split from it). Optional
+/// because the intake shape is untrusted.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhRepoRef {
@@ -51,9 +58,10 @@ struct GhAuthorRef {
     login: Option<String>,
 }
 
-/// One raw `gh search issues --json …` hit. Every field is optional so a hit
-/// that omits one still deserializes and can be judged by [`item_from_intake`];
-/// this intake shape is deliberately separate from the outgoing [`MyWorkItem`].
+/// One raw `gh search … --json` hit. Every field is optional so a hit that omits
+/// one still deserializes and can be judged by [`item_from_intake`]; a
+/// wrong-TYPED field fails the hit's own deserialize and drops it. This intake
+/// shape is deliberately separate from the outgoing [`MyWorkItem`].
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhSearchItem {
@@ -73,10 +81,22 @@ struct GhSearchItem {
     author: Option<GhAuthorRef>,
 }
 
-/// The inbox query. `--involves=@me` is the one predicate covering authored,
-/// assigned, mentioned, and review-requested; `--limit 200` is the whole page
-/// this surface fetches (no pagination).
-const MY_WORK_ARGS: &[&str] = &[
+/// The `--json` field set both legs request; identical so the two parse through
+/// the same intake shape.
+const MY_WORK_FIELDS: &str = "number,title,isPullRequest,repository,updatedAt,url,author";
+
+/// The whole page this surface fetches, per leg and after the merge. There is no
+/// pagination, so this is also the point where the inbox silently truncates.
+const MY_WORK_LIMIT: usize = 200;
+
+/// Leg 1. GitHub's `involves:` is author OR assignee OR mentions OR commenter —
+/// it does NOT cover review-requested, which is a separate qualifier
+/// ([`REVIEW_REQUESTED_ARGS`] is the leg that adds it).
+///
+/// `--sort updated --order desc` is required, not cosmetic: gh defaults to
+/// best-match, so a relevance-ranked `--limit 200` would drop recent items for
+/// accounts with more than 200 open hits.
+const INVOLVES_ARGS: &[&str] = &[
     "search",
     "issues",
     "--include-prs",
@@ -84,14 +104,41 @@ const MY_WORK_ARGS: &[&str] = &[
     "--state=open",
     "--limit",
     "200",
+    "--sort",
+    "updated",
+    "--order",
+    "desc",
     "--json",
-    "number,title,isPullRequest,repository,updatedAt,url,author",
+    MY_WORK_FIELDS,
+];
+
+/// Leg 2: the pull requests awaiting the user's review, which leg 1 cannot see.
+/// Every hit here is a PR by construction — `gh search prs` cannot return an
+/// issue — which is what [`my_work`] passes as this leg's `is_pull_request`
+/// default.
+const REVIEW_REQUESTED_ARGS: &[&str] = &[
+    "search",
+    "prs",
+    "--review-requested=@me",
+    "--state=open",
+    "--limit",
+    "200",
+    "--sort",
+    "updated",
+    "--order",
+    "desc",
+    "--json",
+    MY_WORK_FIELDS,
 ];
 
 /// Narrow one intake hit to a wire item, or `None` when it can't address
 /// anything: a hit without number, title, url, or a splittable `owner/name` has
 /// no usable link, so it is dropped rather than rendered broken.
-fn item_from_intake(raw: GhSearchItem) -> Option<MyWorkItem> {
+///
+/// `default_is_pull_request` applies only when gh omits the field: the
+/// review-requested leg queries `gh search prs`, where every hit is a PR, so a
+/// blanket `false` there would file the whole leg as issues.
+fn item_from_intake(raw: GhSearchItem, default_is_pull_request: bool) -> Option<MyWorkItem> {
     let number = raw.number?;
     let title = raw.title.filter(|t| !t.is_empty())?;
     let url = raw.url.filter(|u| !u.is_empty())?;
@@ -111,7 +158,7 @@ fn item_from_intake(raw: GhSearchItem) -> Option<MyWorkItem> {
     Some(MyWorkItem {
         number,
         title,
-        is_pull_request: raw.is_pull_request.unwrap_or(false),
+        is_pull_request: raw.is_pull_request.unwrap_or(default_is_pull_request),
         repo_full_name,
         repo_owner,
         repo_name,
@@ -122,30 +169,62 @@ fn item_from_intake(raw: GhSearchItem) -> Option<MyWorkItem> {
     })
 }
 
-/// Parse `gh search issues --json …` stdout into wire items. Per-hit tolerance:
-/// each element is deserialized on its own so one malformed hit is skipped
-/// rather than sinking the batch. A top-level parse failure IS an error —
+/// Parse one leg's `gh search … --json` stdout into wire items. Per-hit
+/// tolerance: each element is deserialized on its own so one malformed hit is
+/// skipped rather than sinking the batch. A top-level parse failure IS an error —
 /// an empty inbox and unreadable output must not look alike to the caller.
-fn parse_my_work(stdout: &str) -> AppResult<Vec<MyWorkItem>> {
+fn parse_my_work(stdout: &str, default_is_pull_request: bool) -> AppResult<Vec<MyWorkItem>> {
     let raw: Vec<Value> = serde_json::from_str(stdout)
         .map_err(|e| AppError::Gh(format!("could not parse your GitHub work items: {e}")))?;
     Ok(raw
         .into_iter()
         .filter_map(|v| serde_json::from_value::<GhSearchItem>(v).ok())
-        .filter_map(item_from_intake)
+        .filter_map(|raw| item_from_intake(raw, default_is_pull_request))
         .collect())
 }
 
+/// Merge the two legs into one page: dedupe by URL (a PR can be both involving
+/// and review-requested), newest first, truncated to [`MY_WORK_LIMIT`] so the
+/// wire contract stays one page however much the union overshoots.
+///
+/// The sort is a plain string compare because gh emits `updatedAt` as
+/// Z-suffixed RFC 3339 — fixed width, one offset, so lexical order IS
+/// chronological order. An item with no timestamp sorts last rather than
+/// claiming to be the newest.
+fn merge_my_work(involves: Vec<MyWorkItem>, review_requested: Vec<MyWorkItem>) -> Vec<MyWorkItem> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut merged: Vec<MyWorkItem> = Vec::new();
+    for item in involves.into_iter().chain(review_requested) {
+        if seen.insert(item.url.clone()) {
+            merged.push(item);
+        }
+    }
+    merged.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    merged.truncate(MY_WORK_LIMIT);
+    merged
+}
+
 /// Every open pull request and issue involving the signed-in GitHub user,
-/// across every repo they can see.
+/// across every repo they can see, plus the ones awaiting their review.
+///
+/// Sequential rather than concurrent: two `gh` spawns keep the failure mode
+/// simple, and either leg failing fails the call rather than half-filling the
+/// inbox.
 pub async fn my_work() -> AppResult<Vec<MyWorkItem>> {
-    let out = run_gh(None, MY_WORK_ARGS, GH_NETWORK_TIMEOUT).await?;
-    parse_my_work(&out.stdout_lossy())
+    let involves = run_gh(None, INVOLVES_ARGS, GH_NETWORK_TIMEOUT).await?;
+    let involves = parse_my_work(&involves.stdout_lossy(), false)?;
+    let review_requested = run_gh(None, REVIEW_REQUESTED_ARGS, GH_NETWORK_TIMEOUT).await?;
+    // Leg 2 is `gh search prs`: an omitted `isPullRequest` still means PR.
+    let review_requested = parse_my_work(&review_requested.stdout_lossy(), true)?;
+    Ok(merge_my_work(involves, review_requested))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_my_work, MY_WORK_ARGS};
+    use super::{
+        merge_my_work, parse_my_work, INVOLVES_ARGS, MY_WORK_FIELDS, MY_WORK_LIMIT,
+        REVIEW_REQUESTED_ARGS,
+    };
     use serde_json::{json, Value};
 
     /// A real `gh search issues --include-prs --involves=@me --state=open
@@ -153,22 +232,48 @@ mod tests {
     /// third-party author logins are stand-ins.
     const GH_FIXTURE: &str = r#"[{"author":{"id":"U_kgDODHf_mg","is_bot":false,"login":"octo-cat","type":"User","url":"https://github.com/octo-cat"},"isPullRequest":true,"number":309,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"feat(settings): accent colour and UI font appearance","updatedAt":"2026-09-05T23:21:02Z","url":"https://github.com/theBGuy/GitDesktop/pull/309"},{"author":{"id":"MDM6Qm90NDk2OTkzMzM=","is_bot":false,"login":"dependabot[bot]","type":"Bot","url":"https://github.com/apps/dependabot"},"isPullRequest":true,"number":300,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"chore(deps): bump astro from 6.4.8 to 7.1.6","updatedAt":"2026-09-04T15:30:38Z","url":"https://github.com/theBGuy/GitDesktop/pull/300"},{"author":{"id":"MDQ6VXNlcjY4Nzc1OTU=","is_bot":false,"login":"octo-dev","type":"User","url":"https://github.com/octo-dev"},"isPullRequest":false,"number":262,"repository":{"name":"GitDesktop","nameWithOwner":"theBGuy/GitDesktop"},"title":"feat: Markdown preview view for md files present in diffs","updatedAt":"2026-09-05T07:06:45Z","url":"https://github.com/theBGuy/GitDesktop/issues/262"}]"#;
 
+    /// Both legs are pinned here because each carries a correctness constraint,
+    /// not just a preference: without `--sort updated`, gh's best-match default
+    /// makes `--limit 200` a relevance subset that can omit recent items.
     #[test]
     fn args_carry_the_whole_inbox_query() {
-        assert!(MY_WORK_ARGS.starts_with(&["search", "issues"]));
+        assert!(INVOLVES_ARGS.starts_with(&["search", "issues"]));
         for flag in ["--include-prs", "--involves=@me", "--state=open"] {
-            assert!(MY_WORK_ARGS.contains(&flag), "missing {flag}");
+            assert!(INVOLVES_ARGS.contains(&flag), "involves leg missing {flag}");
         }
-        assert!(
-            MY_WORK_ARGS.contains(&"number,title,isPullRequest,repository,updatedAt,url,author")
-        );
+
+        // `involves:` doesn't cover review-requested, so the second leg exists.
+        assert!(REVIEW_REQUESTED_ARGS.starts_with(&["search", "prs"]));
+        assert!(REVIEW_REQUESTED_ARGS.contains(&"--review-requested=@me"));
+        assert!(REVIEW_REQUESTED_ARGS.contains(&"--state=open"));
+        // `--include-prs` is an issues-search flag; `gh search prs` rejects it.
+        assert!(!REVIEW_REQUESTED_ARGS.contains(&"--include-prs"));
+
+        let limit = MY_WORK_LIMIT.to_string();
+        for args in [INVOLVES_ARGS, REVIEW_REQUESTED_ARGS] {
+            let has_pair = |pair: &[&str; 2]| args.windows(2).any(|w| w == pair.as_slice());
+            assert!(
+                args.contains(&MY_WORK_FIELDS),
+                "{args:?} lost the field set"
+            );
+            // Newest-first, or the limit truncates by relevance instead of age.
+            assert!(
+                has_pair(&["--sort", "updated"]),
+                "{args:?} lost --sort updated"
+            );
+            assert!(has_pair(&["--order", "desc"]), "{args:?} lost --order desc");
+            assert!(
+                has_pair(&["--limit", limit.as_str()]),
+                "{args:?} limit must match MY_WORK_LIMIT",
+            );
+        }
     }
 
     /// The frontend mirrors this wire shape field-for-field, so the serialized
     /// key set is pinned here rather than trusted to the `rename_all` attribute.
     #[test]
     fn fixture_serializes_to_the_camel_case_wire_shape() {
-        let items = parse_my_work(GH_FIXTURE).unwrap();
+        let items = parse_my_work(GH_FIXTURE, false).unwrap();
         assert_eq!(items.len(), 3);
 
         let wire = serde_json::to_value(&items[0]).unwrap();
@@ -231,7 +336,7 @@ mod tests {
             },
         ])
         .to_string();
-        let items = parse_my_work(&raw).unwrap();
+        let items = parse_my_work(&raw, false).unwrap();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].repo_owner, "my.org");
         assert_eq!(items[0].repo_name, "repo");
@@ -269,7 +374,7 @@ mod tests {
 
         for drop in &drops {
             let batch = Value::Array(vec![drop.clone(), good.clone()]);
-            let items = parse_my_work(&batch.to_string()).unwrap();
+            let items = parse_my_work(&batch.to_string(), false).unwrap();
             assert_eq!(items.len(), 1, "should have dropped only {drop}");
             assert_eq!(items[0].number, 7);
         }
@@ -286,7 +391,7 @@ mod tests {
             "author": null
         }])
         .to_string();
-        let items = parse_my_work(&raw).unwrap();
+        let items = parse_my_work(&raw, false).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].author_login, None);
         // Absent, not a fabricated timestamp.
@@ -295,8 +400,118 @@ mod tests {
 
     #[test]
     fn my_work_distinguishes_an_empty_inbox_from_unreadable_output() {
-        assert!(parse_my_work("[]").unwrap().is_empty());
-        assert!(parse_my_work("not json").is_err());
-        assert!(parse_my_work("{\"items\":[]}").is_err());
+        assert!(parse_my_work("[]", false).unwrap().is_empty());
+        assert!(parse_my_work("not json", false).is_err());
+        assert!(parse_my_work("{\"items\":[]}", false).is_err());
+    }
+
+    /// `gh search prs` hits are PRs by construction, so an omitted
+    /// `isPullRequest` on that leg must NOT fall back to "issue" — that would
+    /// file every review-requested PR under the wrong kind.
+    #[test]
+    fn my_work_classifies_the_review_requested_leg_as_pull_requests() {
+        let raw = json!([
+            // gh 2.94.0 does emit `isPullRequest` on `gh search prs` (measured),
+            // so the leg default is a belt-and-braces path — pin both.
+            {"number": 1, "title": "explicit", "isPullRequest": true,
+             "repository": {"nameWithOwner": "octo/repo"},
+             "url": "https://github.com/octo/repo/pull/1",
+             "updatedAt": "2026-01-01T00:00:00Z"},
+            {"number": 2, "title": "omitted",
+             "repository": {"nameWithOwner": "octo/repo"},
+             "url": "https://github.com/octo/repo/pull/2",
+             "updatedAt": "2026-01-02T00:00:00Z"},
+        ])
+        .to_string();
+
+        let review_leg = parse_my_work(&raw, true).unwrap();
+        assert!(
+            review_leg.iter().all(|i| i.is_pull_request),
+            "{review_leg:?}"
+        );
+
+        // The involves leg keeps the opposite default: there an omitted flag
+        // really can mean an issue.
+        let involves_leg = parse_my_work(&raw, false).unwrap();
+        assert!(involves_leg[0].is_pull_request);
+        assert!(!involves_leg[1].is_pull_request);
+    }
+
+    #[test]
+    fn merge_dedupes_by_url_and_orders_newest_first() {
+        let item = |n: u64, url: &str, updated: &str| {
+            let raw = json!([{
+                "number": n, "title": "t", "isPullRequest": true,
+                "repository": {"nameWithOwner": "octo/repo"},
+                "url": url, "updatedAt": updated
+            }])
+            .to_string();
+            parse_my_work(&raw, true).unwrap().pop().unwrap()
+        };
+
+        let shared = "https://github.com/octo/repo/pull/300";
+        let involves = vec![
+            item(
+                309,
+                "https://github.com/octo/repo/pull/309",
+                "2026-09-05T23:21:02Z",
+            ),
+            item(300, shared, "2026-09-04T15:30:38Z"),
+        ];
+        // #300 is in BOTH legs (review-requested AND involving) — the real
+        // overlap observed against gh; #2 is review-requested only, the whole
+        // reason the second leg exists.
+        let review_requested = vec![
+            item(300, shared, "2026-09-04T15:30:38Z"),
+            item(
+                2,
+                "https://github.com/octo/other/pull/2",
+                "2026-09-06T00:00:00Z",
+            ),
+        ];
+
+        let merged = merge_my_work(involves, review_requested);
+        assert_eq!(merged.len(), 3, "the shared URL should appear once");
+        assert_eq!(
+            merged.iter().map(|i| i.number).collect::<Vec<_>>(),
+            [2, 309, 300],
+            "merged page must be newest-first ACROSS both legs",
+        );
+        assert_eq!(merged.iter().filter(|i| i.url == shared).count(), 1);
+    }
+
+    /// The union can overshoot the per-leg limit, so the merge is where the wire
+    /// contract's one-page promise is actually kept.
+    #[test]
+    fn merge_truncates_the_union_to_one_page() {
+        let leg = |prefix: &str, count: usize, base: u32| {
+            let raw: Vec<Value> = (0..count)
+                .map(|i| {
+                    json!({
+                        "number": i + 1, "title": "t", "isPullRequest": true,
+                        "repository": {"nameWithOwner": "octo/repo"},
+                        "url": format!("https://github.com/octo/{prefix}/pull/{i}"),
+                        // Descending within the leg, and the `a` leg is newer.
+                        "updatedAt": format!("2026-{base:02}-01T00:{:02}:00Z", 59 - i % 60),
+                    })
+                })
+                .collect();
+            parse_my_work(&Value::Array(raw).to_string(), true).unwrap()
+        };
+
+        let merged = merge_my_work(leg("a", MY_WORK_LIMIT, 9), leg("b", MY_WORK_LIMIT, 1));
+        assert_eq!(
+            merged.len(),
+            MY_WORK_LIMIT,
+            "400 distinct hits must cap at 200"
+        );
+        // Truncation keeps the NEWEST page, not the first leg wholesale.
+        assert!(
+            merged
+                .windows(2)
+                .all(|w| w[0].updated_at >= w[1].updated_at),
+            "truncated page must still be newest-first",
+        );
+        assert_eq!(merged[0].updated_at, "2026-09-01T00:59:00Z");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -355,6 +355,7 @@ pub fn run() {
             forge::jira_worklog_delete,
             forge::forge_list_repos,
             forge::forge_owned_namespaces,
+            forge::forge_my_work,
             forge::forge_clone,
             forge::forge_search_repos,
             forge::forge_fork_repo,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useMacAppMenu } from "@/features/app-menu/useMacAppMenu";
 import { AutomationResultDialog } from "@/features/automations/AutomationResultDialog";
 import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
+import { MyWorkScreen } from "@/features/mywork/MyWorkScreen";
 import { RepositoryView } from "@/features/repository/RepositoryView";
 import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { SettingsScreen } from "@/features/settings/SettingsScreen";
@@ -45,6 +46,7 @@ function App() {
   const openMcpBrowse = useUiStore((s) => s.openMcpBrowse);
   const openHelp = useUiStore((s) => s.openHelp);
   const openExplore = useUiStore((s) => s.openExplore);
+  const openMyWork = useUiStore((s) => s.openMyWork);
   const toggleActivity = useUiStore((s) => s.toggleActivity);
   const gitInstalled = useGitInstalled();
   const queryClient = useQueryClient();
@@ -188,6 +190,7 @@ function App() {
   useHotkeyAction("browse-mcp-registry", openMcpBrowse, !settings.data?.hideAi);
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("open-explore", openExplore);
+  useHotkeyAction("open-my-work", openMyWork);
   useHotkeyAction("toggle-notifications", toggleActivity);
   useHotkeyAction("show-shortcuts", () => setShortcutsOpen(true));
   useHotkeyAction("command-palette", () => setPaletteOpen(true));
@@ -245,6 +248,7 @@ function App() {
         {view === "settings" && <SettingsScreen />}
         {view === "help" && <HelpScreen />}
         {view === "explore" && <ExploreScreen />}
+        {view === "mywork" && <MyWorkScreen />}
         {/* A thin activity strip for the headerless screens (the repo view uses
             its in-header dock instead); only present while a review runs. */}
         <ActivityStrip />

--- a/src/components/list-row-skeleton.tsx
+++ b/src/components/list-row-skeleton.tsx
@@ -8,12 +8,19 @@ import { cn } from "@/lib/utils";
  * `indent` (the default) lines after the first sit where icon-led rows put
  * their meta lines (≈ their `pl-4`/`pl-5`); lists whose lines share one left
  * edge (avatar-column or chip-led) pass `indent={false}`.
- * `lines` must match the real row's line count (2 = issue / commit / tag /
- * finding rows, 3 = PR / workflow-run / Jira / discussion rows).
+ * `lines` must match the real row's line count (1 = single-line rows such as the
+ * work inbox, 2 = issue / commit / tag / finding rows, 3 = PR / workflow-run /
+ * Jira / discussion rows); `indent` is moot at 1, which has no later lines.
  * Callers render `ListRowSkeletons` instead — it wraps this one with the busy
  * announcement a loading region owes readers.
  */
-function ListRowSkeleton({ lines, indent }: { lines: 2 | 3; indent: boolean }) {
+function ListRowSkeleton({
+  lines,
+  indent,
+}: {
+  lines: 1 | 2 | 3;
+  indent: boolean;
+}) {
   return (
     <div className="border-b px-3 py-2">
       {/* Index key: a fixed static list that never reorders. */}
@@ -38,7 +45,7 @@ export function ListRowSkeletons({
   indent = true,
 }: {
   rows: number;
-  lines: 2 | 3;
+  lines: 1 | 2 | 3;
   name: string;
   indent?: boolean;
 }) {

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -250,6 +250,59 @@ From here:
 > **Settings → Accounts**, rather than empty results.`,
   },
   {
+    id: "my-work",
+    label: "My work",
+    body: `# My work
+
+**My work** is a cross-repo inbox: every open pull request and issue on GitHub that
+involves you, newest first, without opening a repository to go looking. Open it from
+the **My work** button on the welcome screen, or from the command palette (*My work*).
+**Back** in the header, or Esc, returns you to whatever you were on.
+
+*Involves you* is GitHub's own lens: anything you **authored**, are **assigned** to,
+were **mentioned** in, or have had a **review requested** on. The search covers every
+repository your GitHub account can see, so items from repos you've never cloned sit
+alongside the ones you have. GitHub only for now.
+
+## Reading the list
+
+Each row is a single line: a pull-request or issue glyph, the item's number, its
+title, the repository it lives in, and when it last changed. The number beside the
+title in the header is how many items came back, and each tab carries its own count.
+
+Rows are ordered by **most recently updated**. The view fetches one page of up to
+**200** items; when it comes back that full, a note at the bottom reminds you the
+feed may not be the whole picture.
+
+## Narrowing and opening
+
+Three tabs pick the slice: **All**, **Pull requests**, and **Issues**. The **filter
+box** beside them matches on **title**, **repository**, or **number** (\`#123\`, or
+just the digits) as you type, filtering what's already loaded rather than searching
+again.
+
+The keyboard flow lives in that box: **↑ / ↓** move the highlight through the visible
+rows and **Enter** opens the highlighted one, so you can type, arrow, and open without
+leaving it. Clicking a row does the same thing.
+
+Where a row opens depends on whether you have its repository. An item from a
+repository you've added to GitDesktop opens **in the app**: GitDesktop switches to
+that repository and lands on the pull request or issue. Everything else opens **on
+GitHub in your browser**, and those rows carry a **↗** so you can tell which is which
+before you press Enter. The inbox itself changes nothing — it finds the item and
+hands you to the place where you can act on it.
+
+**Right-click** a row for **Open on GitHub** and **Copy link**.
+
+## Keeping it current
+
+**Refresh** in the header re-runs the search and spins while the fetch is in flight.
+
+GitHub features here ride the GitHub CLI (\`gh\`), so if it isn't installed or signed
+in, the screen says which and points at \`gh auth login\`, with **Retry** once it is.
+See *Getting started* for the sign-in options.`,
+  },
+  {
     id: "repo-settings",
     label: "Repository settings",
     body: `# Repository settings

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -254,9 +254,9 @@ From here:
     label: "My work",
     body: `# My work
 
-**My work** is a cross-repo inbox: every open pull request and issue on GitHub that
-involves you, newest first, without opening a repository to go looking. Open it from
-the **My work** button on the welcome screen, or from the command palette (*My work*).
+**My work** is a cross-repo inbox: your open pull requests and issues on GitHub,
+newest first, without opening a repository to go looking. Open it from the **My work**
+button on the welcome screen, or from the command palette (*My work*).
 **Back** in the header, or Esc, closes the inbox and returns you to the screen
 underneath.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -257,12 +257,13 @@ From here:
 **My work** is a cross-repo inbox: every open pull request and issue on GitHub that
 involves you, newest first, without opening a repository to go looking. Open it from
 the **My work** button on the welcome screen, or from the command palette (*My work*).
-**Back** in the header, or Esc, returns you to whatever you were on.
+**Back** in the header, or Esc, closes the inbox and returns you to the screen
+underneath.
 
-*Involves you* is GitHub's own lens: anything you **authored**, are **assigned** to,
-were **mentioned** in, or have had a **review requested** on. The search covers every
-repository your GitHub account can see, so items from repos you've never cloned sit
-alongside the ones you have. GitHub only for now.
+It gathers anything you **authored**, are **assigned** to, were **mentioned** in, or
+**commented on**, together with anything **awaiting your review**. The search covers
+every repository your GitHub account can see, so items from repos you've never cloned
+sit alongside the ones you have. GitHub only for now.
 
 ## Reading the list
 
@@ -270,9 +271,11 @@ Each row is a single line: a pull-request or issue glyph, the item's number, its
 title, the repository it lives in, and when it last changed. The number beside the
 title in the header is how many items came back, and each tab carries its own count.
 
-Rows are ordered by **most recently updated**. The view fetches one page of up to
-**200** items; when it comes back that full, a note at the bottom reminds you the
-feed may not be the whole picture.
+Rows are ordered by **most recently updated**. The search fetches a single page of
+results, so a big inbox won't arrive whole. When the page comes back full, a note
+says so at the bottom: *This view fetches one page of results. Filter to narrow the
+list.* You'll see it under the rows, and under **No items match** as well, since a
+filter that finds nothing is when an item off the page matters most.
 
 ## Narrowing and opening
 
@@ -285,12 +288,15 @@ The keyboard flow lives in that box: **↑ / ↓** move the highlight through th
 rows and **Enter** opens the highlighted one, so you can type, arrow, and open without
 leaving it. Clicking a row does the same thing.
 
-Where a row opens depends on whether you have its repository. An item from a
-repository you've added to GitDesktop opens **in the app**: GitDesktop switches to
-that repository and lands on the pull request or issue. Everything else opens **on
-GitHub in your browser**, and those rows carry a **↗** so you can tell which is which
-before you press Enter. The inbox itself changes nothing — it finds the item and
-hands you to the place where you can act on it.
+Where a row opens depends on whether GitDesktop recognizes its repository as one of
+yours. An item from a repository you've added usually opens **in the app**: GitDesktop
+switches to that repository and lands on the pull request or issue. Everything else
+opens **on GitHub in your browser**. The match reads each repo's resolved owner and
+host, so one you added moments ago, or cloned into a folder named something else, can
+still go to the browser. The **↗** on a row is the signal to trust: it marks every row
+that opens on GitHub, so you know which you're getting before you press Enter. The
+inbox itself changes nothing: it finds the item and hands you to the place where you
+can act on it.
 
 **Right-click** a row for **Open on GitHub** and **Copy link**.
 
@@ -298,9 +304,9 @@ hands you to the place where you can act on it.
 
 **Refresh** in the header re-runs the search and spins while the fetch is in flight.
 
-GitHub features here ride the GitHub CLI (\`gh\`), so if it isn't installed or signed
-in, the screen says which and points at \`gh auth login\`, with **Retry** once it is.
-See *Getting started* for the sign-in options.`,
+GitHub features here ride the GitHub CLI (\`gh\`). When it's missing, the screen names
+that and points at \`gh auth login\`; anything else that goes wrong shows the underlying
+error. Either way there's a **Retry**. See *Getting started* for the sign-in options.`,
   },
   {
     id: "repo-settings",

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -1,0 +1,523 @@
+import {
+  ArrowLeftIcon,
+  ArrowSquareOutIcon,
+  ArrowsClockwiseIcon,
+  CircleDashedIcon,
+  GitPullRequestIcon,
+} from "@phosphor-icons/react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { clipTitleFromText } from "@/lib/clip-title";
+import { copyText } from "@/lib/clipboard";
+import { suppressContextMenu } from "@/lib/context-menu";
+import { useMyWork } from "@/lib/git/queries";
+import type { MyWorkItem } from "@/lib/git/types";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import type { RecentRepo } from "@/lib/settings/api";
+import { useSettings } from "@/lib/settings/queries";
+import { useUiStore } from "@/lib/stores/ui";
+import { errorMessage, isAppError } from "@/lib/tauri/invoke";
+import { parseableDate } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import {
+  filterMyWork,
+  MY_WORK_LIMIT,
+  MY_WORK_LISTBOX_ID,
+  type MyWorkTab,
+  matchLocalRepo,
+  myWorkOptionId,
+  sortMyWork,
+} from "./mywork-utils";
+
+/** Stable empty default, so a settings read that hasn't landed doesn't hand a
+ *  fresh array to every render. */
+const NO_RECENTS: RecentRepo[] = [];
+
+/**
+ * The cross-repo work inbox — every open GitHub pull request and issue
+ * involving you, newest first, without switching repositories to find them.
+ * Read-only: Enter (or a click) navigates, to the repo when it's cloned locally
+ * and to the browser when it isn't. Palette-reachable and launched from the
+ * Welcome screen; Back / Esc return to the previous view.
+ */
+export function MyWorkScreen() {
+  const closeMyWork = useUiStore((s) => s.closeMyWork);
+  const openPr = useUiStore((s) => s.openPr);
+  const openIssue = useUiStore((s) => s.openIssue);
+  const [tab, setTab] = useState<MyWorkTab>("all");
+  const [filter, setFilter] = useState("");
+  // The active row is tracked by URL (unique per item) rather than by index, so
+  // a filter change can't silently retarget the selection to a different item.
+  const [activeUrl, setActiveUrl] = useState<string | null>(null);
+
+  // GitHub-only in this slice: the backend refuses the other providers outright,
+  // so there is no provider axis to offer.
+  const work = useMyWork("github", true);
+  const settings = useSettings();
+  const recents = settings.data?.recentRepos ?? NO_RECENTS;
+
+  const items = sortMyWork(work.data ?? []);
+  const prCount = items.filter((i) => i.isPullRequest).length;
+  const visible = filterMyWork(items, tab, filter);
+  // Derived, never stored: a row the filter has hidden simply stops being
+  // active, and arrow keys restart from the ends of the new visible set.
+  const activeIndex = visible.findIndex((i) => i.url === activeUrl);
+  const activeId =
+    activeIndex >= 0 ? myWorkOptionId(visible[activeIndex].url) : undefined;
+
+  // Esc closes the inbox. Guarded so Base UI popups (which mark the event
+  // consumed) get first claim; an effect event reads the latest closeMyWork.
+  const onEscape = useEffectEvent(() => closeMyWork());
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !e.defaultPrevented) onEscape();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Every navigation goes through an atomic navigator: an openRepo followed by a
+  // select would pair the new repo with the old selection, because the
+  // view-transition callback that carries the selection is deferred.
+  function openItem(item: MyWorkItem) {
+    const match = matchLocalRepo(item, recents);
+    if (!match) {
+      openUrl(item.url);
+      return;
+    }
+    if (item.isPullRequest) {
+      openPr({
+        kind: "remote",
+        repoPath: match.path,
+        repoName: match.name,
+        ref: String(item.number),
+        section: null,
+      });
+    } else {
+      openIssue({
+        repoPath: match.path,
+        repoName: match.name,
+        number: item.number,
+      });
+    }
+  }
+
+  // Arrow keys from the filter input move the selection through the visible
+  // rows and Enter opens it, so a keyboard user goes type → arrows → Enter
+  // without ever leaving the input.
+  const onInputArrow = listKeyboardNav({
+    items: visible,
+    activeIndex,
+    onActivate: (item) => setActiveUrl(item.url),
+  });
+  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      const item = visible[activeIndex];
+      if (!item) return;
+      e.preventDefault();
+      openItem(item);
+      return;
+    }
+    onInputArrow(e);
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="flex items-center gap-2 border-b px-3 py-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Back"
+          onClick={closeMyWork}
+        >
+          <ArrowLeftIcon />
+        </Button>
+        <span className="text-sm font-medium">My work</span>
+        {work.isSuccess && (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {items.length}
+          </span>
+        )}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="ml-auto"
+          aria-label="Refresh"
+          title="Refresh"
+          disabled={work.isFetching}
+          onClick={() => work.refetch()}
+        >
+          {work.isFetching ? <Spinner /> : <ArrowsClockwiseIcon />}
+        </Button>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as MyWorkTab)}>
+          <TabsList>
+            <TabsTrigger value="all">
+              All
+              <Count n={items.length} />
+            </TabsTrigger>
+            <TabsTrigger value="prs">
+              Pull requests
+              <Count n={prCount} />
+            </TabsTrigger>
+            <TabsTrigger value="issues">
+              Issues
+              <Count n={items.length - prCount} />
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={onInputKeyDown}
+          placeholder="Filter by title, repository, or number"
+          aria-label="Filter your work"
+          role="combobox"
+          aria-expanded={visible.length > 0}
+          aria-controls={MY_WORK_LISTBOX_ID}
+          aria-autocomplete="list"
+          aria-activedescendant={activeId}
+          className="h-8 min-w-40 flex-1"
+        />
+      </div>
+
+      <MyWorkBody
+        work={work}
+        items={items}
+        visible={visible}
+        activeIndex={activeIndex}
+        recents={recents}
+        onSelect={setActiveUrl}
+        onOpen={openItem}
+      />
+    </div>
+  );
+}
+
+/** The body's state machine: loading → error → empty → filtered-empty → list.
+ *  Split from the shell so the virtualizer below only ever mounts with rows. */
+function MyWorkBody({
+  work,
+  items,
+  visible,
+  activeIndex,
+  recents,
+  onSelect,
+  onOpen,
+}: {
+  work: ReturnType<typeof useMyWork>;
+  items: MyWorkItem[];
+  visible: MyWorkItem[];
+  activeIndex: number;
+  recents: readonly RecentRepo[];
+  onSelect: (url: string) => void;
+  onOpen: (item: MyWorkItem) => void;
+}) {
+  if (work.isPending) {
+    return <ListRowSkeletons rows={8} lines={1} name="your work" />;
+  }
+  if (work.isError) {
+    return <MyWorkError error={work.error} onRetry={() => work.refetch()} />;
+  }
+  if (items.length === 0) {
+    return (
+      <QuietLine>
+        Nothing on GitHub involves you right now. This searches every repo
+        you're involved in, not just local ones.
+      </QuietLine>
+    );
+  }
+  if (visible.length === 0) {
+    return <QuietLine>No items match.</QuietLine>;
+  }
+  return (
+    <MyWorkList
+      items={visible}
+      activeIndex={activeIndex}
+      recents={recents}
+      onSelect={onSelect}
+      onOpen={onOpen}
+      // A heuristic, not a count: the backend drops unaddressable hits, so a
+      // truncated page that lost one arrives short and reads as uncapped. It
+      // errs only toward staying quiet, which is why the note states the
+      // constraint rather than a number.
+      capped={items.length >= MY_WORK_LIMIT}
+    />
+  );
+}
+
+/** The virtualized row list, plus one shared context menu for the whole list
+ *  (capture phase records the row before the menu opens). */
+function MyWorkList({
+  items,
+  activeIndex,
+  recents,
+  onSelect,
+  onOpen,
+  capped,
+}: {
+  items: MyWorkItem[];
+  activeIndex: number;
+  recents: readonly RecentRepo[];
+  onSelect: (url: string) => void;
+  onOpen: (item: MyWorkItem) => void;
+  capped: boolean;
+}) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [menuItem, setMenuItem] = useState<MyWorkItem | null>(null);
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 33,
+    overscan: 12,
+  });
+
+  // Keep the keyboard-selected row in view. Keyed on the selection alone: a
+  // re-scroll on any list change would fight the user's own scrolling on every
+  // unrelated re-render (the shared clock ticks these rows every 30s).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when the selection moves
+  useEffect(() => {
+    if (activeIndex >= 0) {
+      virtualizer.scrollToIndex(activeIndex, { align: "auto" });
+    }
+  }, [activeIndex]);
+
+  // A right-click on blank space hits no row — suppress the menu rather than
+  // show an empty popup.
+  function onContextMenu(e: ReactMouseEvent) {
+    const url = (e.target as HTMLElement)
+      .closest("[data-my-work-url]")
+      ?.getAttribute("data-my-work-url");
+    const item = url ? items.find((i) => i.url === url) : undefined;
+    if (item) {
+      setMenuItem(item);
+    } else {
+      setMenuItem(null);
+      suppressContextMenu(e);
+    }
+  }
+
+  const activeUrl = activeIndex >= 0 ? items[activeIndex].url : undefined;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ContextMenu>
+        {/* The scroll element keeps its own ref rather than riding the Trigger's
+            render prop — the virtualizer needs that node, and a merged-ref miss
+            would leave the list unmeasured and blank. */}
+        <ContextMenuTrigger
+          render={
+            <div
+              onContextMenuCapture={onContextMenu}
+              className="flex min-h-0 flex-1 flex-col"
+            />
+          }
+        >
+          {/* Arrow-key navigation lives on the filter Input (combobox pattern),
+              so the listbox itself is not a Tab stop — a pure a11y container. */}
+          <div
+            ref={parentRef}
+            className="min-h-0 flex-1 overflow-y-auto"
+            role="listbox"
+            id={MY_WORK_LISTBOX_ID}
+            aria-label="Your work"
+            aria-activedescendant={
+              activeUrl ? myWorkOptionId(activeUrl) : undefined
+            }
+          >
+            <div
+              className="relative w-full"
+              style={{ height: `${virtualizer.getTotalSize()}px` }}
+            >
+              {virtualizer.getVirtualItems().map((v) => {
+                const item = items[v.index];
+                return (
+                  <div
+                    key={v.key}
+                    data-index={v.index}
+                    ref={virtualizer.measureElement}
+                    // Presentation wrapper so the virtualizer's positioning div
+                    // doesn't sit between the listbox and its options.
+                    role="presentation"
+                    className="absolute top-0 left-0 w-full"
+                    style={{ transform: `translateY(${v.start}px)` }}
+                  >
+                    <MyWorkRow
+                      item={item}
+                      local={matchLocalRepo(item, recents) !== null}
+                      active={v.index === activeIndex}
+                      onSelect={onSelect}
+                      onOpen={onOpen}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="min-w-44">
+          {menuItem && (
+            <>
+              <ContextMenuItem onClick={() => openUrl(menuItem.url)}>
+                Open on GitHub
+              </ContextMenuItem>
+              <ContextMenuItem
+                onClick={() => copyText(menuItem.url, "Link copied")}
+              >
+                Copy link
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+      {capped && (
+        <p className="px-3 py-2 text-center text-[11px] text-muted-foreground">
+          This view fetches one page of results. Filter to narrow the list.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** One inbox row — a `role="option"` in the listbox. Single line: type glyph,
+ *  number, title, repository, and when it last moved. */
+function MyWorkRow({
+  item,
+  local,
+  active,
+  onSelect,
+  onOpen,
+}: {
+  item: MyWorkItem;
+  local: boolean;
+  active: boolean;
+  onSelect: (url: string) => void;
+  onOpen: (item: MyWorkItem) => void;
+}) {
+  const Icon = item.isPullRequest ? GitPullRequestIcon : CircleDashedIcon;
+  const typeLabel = item.isPullRequest ? "Pull request" : "Issue";
+  const browserLabel = `Opens on ${item.host || "GitHub"} — not a local repository`;
+  return (
+    <button
+      type="button"
+      id={myWorkOptionId(item.url)}
+      data-my-work-url={item.url}
+      role="option"
+      aria-selected={active}
+      onClick={() => {
+        onSelect(item.url);
+        onOpen(item);
+      }}
+      className={cn(
+        "flex w-full items-center gap-2 border-b px-3 py-2 text-left text-xs",
+        active ? "bg-accent text-accent-foreground" : "hover:bg-muted/60",
+      )}
+    >
+      {/* role="img" prunes the glyph's own markup, so the label is what carries
+          the PR-vs-issue distinction to readers — never the shape alone. */}
+      <span
+        role="img"
+        aria-label={typeLabel}
+        title={typeLabel}
+        className="flex shrink-0 items-center text-muted-foreground"
+      >
+        <Icon className="size-3.5" aria-hidden />
+      </span>
+      <span className="shrink-0 tabular-nums text-muted-foreground">
+        #{item.number}
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate"
+        onMouseEnter={clipTitleFromText}
+      >
+        {item.title}
+      </span>
+      <span
+        className="max-w-56 shrink-0 truncate text-muted-foreground"
+        onMouseEnter={clipTitleFromText}
+      >
+        {item.repoFullName}
+      </span>
+      {!local && (
+        <span
+          role="img"
+          aria-label={browserLabel}
+          title={browserLabel}
+          className="flex shrink-0 items-center text-muted-foreground"
+        >
+          <ArrowSquareOutIcon className="size-3" aria-hidden />
+        </span>
+      )}
+      {parseableDate(item.updatedAt) && (
+        <span className="shrink-0 text-muted-foreground">
+          <RelativeTime date={item.updatedAt} />
+        </span>
+      )}
+    </button>
+  );
+}
+
+function Count({ n }: { n: number }) {
+  return (
+    <span className="ml-1.5 text-[10px] tabular-nums text-muted-foreground">
+      {n}
+    </span>
+  );
+}
+
+function QuietLine({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="flex flex-1 items-center justify-center p-6 text-center text-xs text-muted-foreground">
+      <span className="max-w-sm">{children}</span>
+    </p>
+  );
+}
+
+/** The two failure branches: gh missing (the fixable one, named) or anything
+ *  else, both offering a retry. */
+function MyWorkError({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry: () => void;
+}) {
+  const cliMissing = isAppError(error) && error.kind === "ghNotFound";
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+      <p className="text-xs font-medium">
+        {cliMissing ? "GitHub CLI (gh) not found" : "Couldn't load your work"}
+      </p>
+      <p className="max-w-xs text-xs text-muted-foreground">
+        {cliMissing
+          ? "Install the GitHub CLI (gh) and run gh auth login to see your pull requests and issues here."
+          : errorMessage(error)}
+      </p>
+      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -33,7 +33,7 @@ import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { suppressContextMenu } from "@/lib/context-menu";
 import { validateRepo } from "@/lib/git/api";
-import { useMyWork } from "@/lib/git/queries";
+import { useForgeMyWork } from "@/lib/git/queries";
 import type { MyWorkItem } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { applyRepoLens } from "@/lib/repo-lens/queries";
@@ -42,6 +42,7 @@ import { useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage, isAppError } from "@/lib/tauri/invoke";
 import { parseableDate } from "@/lib/time";
+import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
   filterMyWork,
@@ -76,10 +77,12 @@ export function MyWorkScreen() {
 
   // GitHub-only in this slice: the backend refuses the other providers outright,
   // so there is no provider axis to offer.
-  const work = useMyWork("github", true);
+  const work = useForgeMyWork("github", true);
   const settings = useSettings();
   const recents = settings.data?.recentRepos ?? NO_RECENTS;
   const queryClient = useQueryClient();
+  // Generation counter for openItem's validate await — see its guard below.
+  const openGenRef = useRef(0);
 
   const items = sortMyWork(work.data ?? []);
   const prCount = items.filter((i) => i.isPullRequest).length;
@@ -113,13 +116,27 @@ export function MyWorkScreen() {
     // Recents rows outlive deleted and moved clones, so prove the path is still
     // a repo before navigating; the browser fallback keeps the row a working
     // link while the toast names the stale path (repair lives in the repo list).
+    // This await makes both continuations stale-able: a superseding open or a
+    // view change must strand them, or a late navigation stomps the newer action
+    // or yanks the user back. View is read live — the ref dies with the screen.
+    const gen = ++openGenRef.current;
+    const superseded = () =>
+      gen !== openGenRef.current || useUiStore.getState().view !== "mywork";
     try {
       await validateRepo(match.path);
-    } catch {
+    } catch (e) {
+      if (superseded()) return;
       openUrl(item.url);
-      toast.error(`${match.path} is no longer a git repository.`);
+      // Only a real notARepo earns the stale-path sentence — a missing CLI or an
+      // IPC failure would be misdescribed by it, so it takes the generic toast.
+      if (isAppError(e) && e.kind === "notARepo") {
+        toast.error(`${match.path} is no longer a git repository.`);
+      } else {
+        toastError(e);
+      }
       return;
     }
+    if (superseded()) return;
     // Land under the origin lens (matchLocalRepo matched the ORIGIN slug): a fork
     // sitting on "upstream" resolves this number against the parent repo. The lens
     // write is session-only. Clears are safe: an unchanged lens short-circuits
@@ -259,7 +276,7 @@ function MyWorkBody({
   onSelect,
   onOpen,
 }: {
-  work: ReturnType<typeof useMyWork>;
+  work: ReturnType<typeof useForgeMyWork>;
   items: MyWorkItem[];
   visible: MyWorkItem[];
   activeIndex: number;

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -108,6 +108,13 @@ export function MyWorkScreen() {
   // select would pair the new repo with the old selection, because the
   // view-transition callback that carries the selection is deferred.
   async function openItem(item: MyWorkItem) {
+    // Claim the generation before any early return, so EVERY open — including
+    // the browser arm, which never awaits — supersedes a pending one; a stale
+    // continuation must strand rather than stomp the newer action or yank the
+    // user back. View is read live: the ref dies with the screen, the risk doesn't.
+    const gen = ++openGenRef.current;
+    const superseded = () =>
+      gen !== openGenRef.current || useUiStore.getState().view !== "mywork";
     const match = matchLocalRepo(item, recents);
     if (!match) {
       openUrl(item.url);
@@ -116,12 +123,6 @@ export function MyWorkScreen() {
     // Recents rows outlive deleted and moved clones, so prove the path is still
     // a repo before navigating; the browser fallback keeps the row a working
     // link while the toast names the stale path (repair lives in the repo list).
-    // This await makes both continuations stale-able: a superseding open or a
-    // view change must strand them, or a late navigation stomps the newer action
-    // or yanks the user back. View is read live — the ref dies with the screen.
-    const gen = ++openGenRef.current;
-    const superseded = () =>
-      gen !== openGenRef.current || useUiStore.getState().view !== "mywork";
     try {
       await validateRepo(match.path);
     } catch (e) {

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -16,6 +16,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
@@ -31,6 +32,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { suppressContextMenu } from "@/lib/context-menu";
+import { validateRepo } from "@/lib/git/api";
 import { useMyWork } from "@/lib/git/queries";
 import type { MyWorkItem } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
@@ -102,18 +104,29 @@ export function MyWorkScreen() {
   // Every navigation goes through an atomic navigator: an openRepo followed by a
   // select would pair the new repo with the old selection, because the
   // view-transition callback that carries the selection is deferred.
-  function openItem(item: MyWorkItem) {
+  async function openItem(item: MyWorkItem) {
     const match = matchLocalRepo(item, recents);
     if (!match) {
       openUrl(item.url);
       return;
     }
-    // matchLocalRepo matched the ORIGIN slug, so land under the origin lens — a
-    // fork sitting on "upstream" resolves this number against the parent repo.
-    // Session-only (navigation isn't a lens choice); the call selects the item.
+    // Recents rows outlive deleted and moved clones, so prove the path is still
+    // a repo before navigating; the browser fallback keeps the row a working
+    // link while the toast names the stale path (repair lives in the repo list).
+    try {
+      await validateRepo(match.path);
+    } catch {
+      openUrl(item.url);
+      toast.error(`${match.path} is no longer a git repository.`);
+      return;
+    }
+    // Land under the origin lens (matchLocalRepo matched the ORIGIN slug): a fork
+    // sitting on "upstream" resolves this number against the parent repo. The lens
+    // write is session-only. Clears are safe: an unchanged lens short-circuits
+    // before them, and a real flip drops old-lens siblings before the landing set.
     const applyLens = () =>
       applyRepoLens(queryClient, match.path, "origin", {
-        clearSelections: false,
+        clearSelections: true,
         persist: false,
       });
     if (item.isPullRequest) {
@@ -151,7 +164,7 @@ export function MyWorkScreen() {
       const item = visible[activeIndex];
       if (!item) return;
       e.preventDefault();
-      openItem(item);
+      void openItem(item);
       return;
     }
     onInputArrow(e);
@@ -212,7 +225,10 @@ export function MyWorkScreen() {
           aria-label="Filter your work"
           role="combobox"
           aria-expanded={visible.length > 0}
-          aria-controls={MY_WORK_LISTBOX_ID}
+          // Same predicate as aria-expanded: the listbox only mounts in the list
+          // branch, so pointing at its id from any other state would reference a
+          // node that isn't there.
+          aria-controls={visible.length > 0 ? MY_WORK_LISTBOX_ID : undefined}
           aria-autocomplete="list"
           aria-activedescendant={activeId}
           className="h-8 min-w-40 flex-1"
@@ -226,7 +242,7 @@ export function MyWorkScreen() {
         activeIndex={activeIndex}
         recents={recents}
         onSelect={setActiveUrl}
-        onOpen={openItem}
+        onOpen={(item) => void openItem(item)}
       />
     </div>
   );

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -5,6 +5,7 @@ import {
   CircleDashedIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
@@ -33,6 +34,7 @@ import { suppressContextMenu } from "@/lib/context-menu";
 import { useMyWork } from "@/lib/git/queries";
 import type { MyWorkItem } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { applyRepoLens } from "@/lib/repo-lens/queries";
 import type { RecentRepo } from "@/lib/settings/api";
 import { useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -75,6 +77,7 @@ export function MyWorkScreen() {
   const work = useMyWork("github", true);
   const settings = useSettings();
   const recents = settings.data?.recentRepos ?? NO_RECENTS;
+  const queryClient = useQueryClient();
 
   const items = sortMyWork(work.data ?? []);
   const prCount = items.filter((i) => i.isPullRequest).length;
@@ -105,6 +108,14 @@ export function MyWorkScreen() {
       openUrl(item.url);
       return;
     }
+    // matchLocalRepo matched the ORIGIN slug, so land under the origin lens — a
+    // fork sitting on "upstream" resolves this number against the parent repo.
+    // Session-only (navigation isn't a lens choice); the call selects the item.
+    const applyLens = () =>
+      applyRepoLens(queryClient, match.path, "origin", {
+        clearSelections: false,
+        persist: false,
+      });
     if (item.isPullRequest) {
       openPr({
         kind: "remote",
@@ -112,12 +123,17 @@ export function MyWorkScreen() {
         repoName: match.name,
         ref: String(item.number),
         section: null,
+        // Inside the navigator's view-transition callback, so the lens and the
+        // selection reach the same commit; applied here it would land a render
+        // early and fetch the new lens against the OLD number.
+        beforeSelect: applyLens,
       });
     } else {
       openIssue({
         repoPath: match.path,
         repoName: match.name,
         number: item.number,
+        beforeSelect: applyLens,
       });
     }
   }
@@ -249,22 +265,31 @@ function MyWorkBody({
       </QuietLine>
     );
   }
+  // A heuristic, not a count: the backend drops unaddressable hits, so a
+  // truncated page that lost one arrives short and reads as uncapped. It errs
+  // only toward staying quiet, which is why the note states the constraint
+  // rather than a number. Shown under the filtered-empty branch too — filtering
+  // to nothing is when an off-page item matters most.
+  const capped = items.length >= MY_WORK_LIMIT;
   if (visible.length === 0) {
-    return <QuietLine>No items match.</QuietLine>;
+    return (
+      <>
+        <QuietLine>No items match.</QuietLine>
+        {capped && <CapNote />}
+      </>
+    );
   }
   return (
-    <MyWorkList
-      items={visible}
-      activeIndex={activeIndex}
-      recents={recents}
-      onSelect={onSelect}
-      onOpen={onOpen}
-      // A heuristic, not a count: the backend drops unaddressable hits, so a
-      // truncated page that lost one arrives short and reads as uncapped. It
-      // errs only toward staying quiet, which is why the note states the
-      // constraint rather than a number.
-      capped={items.length >= MY_WORK_LIMIT}
-    />
+    <>
+      <MyWorkList
+        items={visible}
+        activeIndex={activeIndex}
+        recents={recents}
+        onSelect={onSelect}
+        onOpen={onOpen}
+      />
+      {capped && <CapNote />}
+    </>
   );
 }
 
@@ -276,14 +301,12 @@ function MyWorkList({
   recents,
   onSelect,
   onOpen,
-  capped,
 }: {
   items: MyWorkItem[];
   activeIndex: number;
   recents: readonly RecentRepo[];
   onSelect: (url: string) => void;
   onOpen: (item: MyWorkItem) => void;
-  capped: boolean;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [menuItem, setMenuItem] = useState<MyWorkItem | null>(null);
@@ -392,12 +415,17 @@ function MyWorkList({
           )}
         </ContextMenuContent>
       </ContextMenu>
-      {capped && (
-        <p className="px-3 py-2 text-center text-[11px] text-muted-foreground">
-          This view fetches one page of results. Filter to narrow the list.
-        </p>
-      )}
     </div>
+  );
+}
+
+/** The one-page-of-results note. Rendered by the body, not the list, so it
+ *  survives a filter that matches nothing. */
+function CapNote() {
+  return (
+    <p className="px-3 py-2 text-center text-[11px] text-muted-foreground">
+      This view fetches one page of results. Filter to narrow the list.
+    </p>
   );
 }
 

--- a/src/features/mywork/mywork-utils.ts
+++ b/src/features/mywork/mywork-utils.ts
@@ -6,10 +6,10 @@ export type MyWorkTab = "all" | "prs" | "issues";
 
 /** The backend's page cap (each search leg's `--limit` and the merged page's
  *  truncation) — mirrors `MY_WORK_LIMIT` in `src-tauri/src/github/my_work.rs`;
- *  the two must change together. A full page is the signal the feed MAY be truncated, never a
- *  count of what exists: unaddressable hits are dropped server-side, so a
- *  truncated page can arrive short and read as complete — which is why the
- *  note states the constraint, not a number. */
+ *  the two must change together. A full page is the signal the feed MAY be
+ *  truncated, never a count of what exists: unaddressable hits are dropped
+ *  server-side, so a truncated page can arrive short and read as complete —
+ *  which is why the note states the constraint, not a number. */
 export const MY_WORK_LIMIT = 200;
 
 export const MY_WORK_LISTBOX_ID = "my-work-listbox";

--- a/src/features/mywork/mywork-utils.ts
+++ b/src/features/mywork/mywork-utils.ts
@@ -5,7 +5,8 @@ import type { RecentRepo } from "@/lib/settings/api";
 export type MyWorkTab = "all" | "prs" | "issues";
 
 /** The backend's page cap (each search leg's `--limit` and the merged page's
- *  truncation). A full page is the signal the feed MAY be truncated, never a
+ *  truncation) — mirrors `MY_WORK_LIMIT` in `src-tauri/src/github/my_work.rs`;
+ *  the two must change together. A full page is the signal the feed MAY be truncated, never a
  *  count of what exists: unaddressable hits are dropped server-side, so a
  *  truncated page can arrive short and read as complete — which is why the
  *  note states the constraint, not a number. */

--- a/src/features/mywork/mywork-utils.ts
+++ b/src/features/mywork/mywork-utils.ts
@@ -4,8 +4,11 @@ import type { RecentRepo } from "@/lib/settings/api";
 /** Which slice of the inbox the tab strip is showing. */
 export type MyWorkTab = "all" | "prs" | "issues";
 
-/** The backend's `gh search issues --limit`; a full page means the feed is
- *  truncated, which the list says out loud rather than implying more. */
+/** The backend's page cap (each search leg's `--limit` and the merged page's
+ *  truncation). A full page is the signal the feed MAY be truncated, never a
+ *  count of what exists: unaddressable hits are dropped server-side, so a
+ *  truncated page can arrive short and read as complete — which is why the
+ *  note states the constraint, not a number. */
 export const MY_WORK_LIMIT = 200;
 
 export const MY_WORK_LISTBOX_ID = "my-work-listbox";

--- a/src/features/mywork/mywork-utils.ts
+++ b/src/features/mywork/mywork-utils.ts
@@ -1,0 +1,82 @@
+import type { MyWorkItem } from "@/lib/git/types";
+import type { RecentRepo } from "@/lib/settings/api";
+
+/** Which slice of the inbox the tab strip is showing. */
+export type MyWorkTab = "all" | "prs" | "issues";
+
+/** The backend's `gh search issues --limit`; a full page means the feed is
+ *  truncated, which the list says out loud rather than implying more. */
+export const MY_WORK_LIMIT = 200;
+
+export const MY_WORK_LISTBOX_ID = "my-work-listbox";
+
+/** Stable DOM id per row, so the filter input's aria-activedescendant can point
+ *  at the keyboard-highlighted option. The item URL is unique per item. */
+export const myWorkOptionId = (url: string) =>
+  `my-work-${url.replace(/[^\w-]/g, "_")}`;
+
+/**
+ * A recent repository that looks like this item's, or null. `RecentRepo.name`
+ * is the checkout's FOLDER basename, not the remote's repo name, so this is a
+ * heuristic in both directions: a clone in a renamed folder (or a worktree)
+ * never matches and opens in the browser, and a folder that happens to be named
+ * after a different repo of the same owner can match wrongly. `owner`/`host`
+ * resolve in the background, so a recent missing either never matches, as does
+ * an item whose URL had no parseable authority (empty host).
+ */
+export function matchLocalRepo(
+  item: MyWorkItem,
+  recents: readonly RecentRepo[],
+): RecentRepo | null {
+  const host = item.host.toLowerCase();
+  const owner = item.repoOwner.toLowerCase();
+  const name = item.repoName.toLowerCase();
+  if (!host || !owner || !name) return null;
+  return (
+    recents.find(
+      (r) =>
+        !!r.host &&
+        !!r.owner &&
+        r.host.toLowerCase() === host &&
+        r.owner.toLowerCase() === owner &&
+        r.name.toLowerCase() === name,
+    ) ?? null
+  );
+}
+
+/**
+ * Newest first by `updatedAt`. Forge timestamps are untrusted, so an
+ * unparseable date sorts to the bottom rather than landing wherever a NaN
+ * comparison drops it.
+ */
+export function sortMyWork(items: readonly MyWorkItem[]): MyWorkItem[] {
+  return items.toSorted((a, b) => {
+    const at = Date.parse(a.updatedAt);
+    const bt = Date.parse(b.updatedAt);
+    const aOk = !Number.isNaN(at);
+    const bOk = !Number.isNaN(bt);
+    if (aOk !== bOk) return aOk ? -1 : 1;
+    if (!aOk) return 0;
+    return bt - at;
+  });
+}
+
+/** The rows a tab + filter leave visible. Client-side over already-loaded data,
+ *  so no debounce: every keystroke re-filters an array, never the network. */
+export function filterMyWork(
+  items: readonly MyWorkItem[],
+  tab: MyWorkTab,
+  query: string,
+): MyWorkItem[] {
+  const q = query.trim().toLowerCase();
+  return items.filter((item) => {
+    if (tab === "prs" && !item.isPullRequest) return false;
+    if (tab === "issues" && item.isPullRequest) return false;
+    if (!q) return true;
+    return (
+      item.title.toLowerCase().includes(q) ||
+      item.repoFullName.toLowerCase().includes(q) ||
+      `#${item.number}`.includes(q)
+    );
+  });
+}

--- a/src/features/plan/PlanIssueButton.tsx
+++ b/src/features/plan/PlanIssueButton.tsx
@@ -28,9 +28,14 @@ export function PlanIssueButton({
       size="xs"
       title="Plan an implementation for this issue with a read-only agent"
       onClick={() => {
+        // The seed is keyed to the repo it was raised in, so read the live one
+        // rather than take it as a prop (this button renders deep inside issue
+        // views). No repo open = no Agent surface to seed.
+        const repoPath = useUiStore.getState().repoPath;
+        if (!repoPath) return;
         // Show the activation Plan composer, seeded from this issue.
         clearAgentSelection();
-        setPendingPlanSeed({ issueTitle: title, issueBody: body });
+        setPendingPlanSeed({ repoPath, issueTitle: title, issueBody: body });
         setRepoTab("agent");
       }}
     >

--- a/src/features/plan/PlanView.tsx
+++ b/src/features/plan/PlanView.tsx
@@ -285,7 +285,11 @@ function PlanResult({ run, repoPath }: { run: PlanRun; repoPath: string }) {
   // Reopen the composer seeded from this plan to tweak the goal and try again —
   // dropping this result (the new attempt is its own run).
   const replan = () => {
-    setPendingPlanSeed(run.seed ?? { goal: run.origin?.goal ?? "" });
+    // repoPath last: a run persisted before the seed carried one has none.
+    setPendingPlanSeed({
+      ...(run.seed ?? { goal: run.origin?.goal ?? "" }),
+      repoPath,
+    });
     remove(run.id);
   };
 

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -35,6 +35,10 @@ export interface PlanDraft {
 
 /** Prefill for the plan composer — a free-form goal and/or an existing issue. */
 export interface PlanSeed {
+  /** The repo this seed was raised in. The Agent tab lives under `<Activity>`, so
+   *  an unconsumed seed outlives a repo switch — the consumer matches on this
+   *  rather than prefilling another repo's composer. */
+  repoPath: string;
   goal?: string;
   issueTitle?: string | null;
   issueBody?: string | null;
@@ -48,8 +52,11 @@ export interface PlanSeed {
   contextPack?: ContextPack;
 }
 
+/** A seed as recorded on its run — `repoPath` is absent on runs persisted before
+ *  the repo axis existed, so readers of a rehydrated seed must handle its absence. */
+export type StoredPlanSeed = Omit<PlanSeed, "repoPath"> & { repoPath?: string };
+
 export interface GenerateArgs extends PlanSeed {
-  repoPath: string;
   /** Planning needs repo-aware reads, which only the CLI agents have. */
   agent: AgentKind;
   model: string;
@@ -83,7 +90,7 @@ export interface PlanRun {
   /** The original prompt, for the sidebar row + the result header. */
   origin: { goal: string; issueTitle: string | null } | null;
   /** The seed this run was started from, so "Re-plan" can reopen the composer. */
-  seed: PlanSeed | null;
+  seed: StoredPlanSeed | null;
   generating: boolean;
   /** The user stopped this run mid-turn (Stop). Idle but restartable; tells the
    *  result view to offer Restart instead of treating partial output as a draft. */
@@ -430,6 +437,7 @@ export const usePlanStore = create<PlanState>((set, get) => {
         nativeSessionId: null,
         origin: args.origin ?? { goal, issueTitle: issueTitle ?? null },
         seed: {
+          repoPath: args.repoPath,
           goal: args.goal,
           issueTitle: args.issueTitle,
           issueBody: args.issueBody,

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -430,6 +430,7 @@ function ResearchResult({ run }: { run: ResearchRun }) {
     // seed still lands and the activation surface consumes it whenever it next shows.
     if (agentSelectionUnchanged(selectionAtClick)) clearAgentSelection();
     setPendingPlanSeed({
+      repoPath: cur.repoPath,
       issueTitle: cur.report.title,
       // The distilled brief, or the raw whole-session assembly as a fallback.
       issueBody: brief ?? assembleSessionReport(cur),

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -66,12 +66,21 @@ export interface ResearchHistoryTurn {
  *  hotkey). Going deeper on a brainstorm happens by switching the persona
  *  mid-session in the follow-up composer, not by seeding a separate run. */
 export interface ResearchSeed {
+  /** The repo this seed was raised in. The Agent tab lives under `<Activity>`, so
+   *  an unconsumed seed outlives a repo switch — the consumer matches on this
+   *  rather than prefilling another repo's composer. */
+  repoPath: string;
   topic?: string;
   depth?: ResearchDepth;
 }
 
+/** A seed as recorded on its run — `repoPath` is absent on runs persisted before
+ *  the repo axis existed, so readers of a rehydrated seed must handle its absence. */
+export type StoredResearchSeed = Omit<ResearchSeed, "repoPath"> & {
+  repoPath?: string;
+};
+
 export interface ResearchGenerateArgs extends ResearchSeed {
-  repoPath: string;
   /** Which CLI runs the research — each uses its own native web tools. */
   agent: AgentKind;
   model: string;
@@ -101,7 +110,7 @@ export interface ResearchRun {
   /** The original topic + persona, for the sidebar row + canvas header. */
   origin: { topic: string; depth: ResearchDepth } | null;
   /** The seed this run was started from, so a re-run can reopen the composer. */
-  seed: ResearchSeed | null;
+  seed: StoredResearchSeed | null;
   /** Completed earlier turns, oldest first — shown above the current turn so the
    *  whole research session stays visible (the current turn is the fields below). */
   history?: ResearchHistoryTurn[];
@@ -502,7 +511,7 @@ export const useResearchStore = create<ResearchState>((set, get) => {
         sessionId: crypto.randomUUID(),
         nativeSessionId: null,
         origin: { topic: args.topic, depth: args.depth },
-        seed: { topic: args.topic, depth: args.depth },
+        seed: { repoPath: args.repoPath, topic: args.topic, depth: args.depth },
         history: [],
         currentPrompt: "",
         generating: true,

--- a/src/features/sessions/SessionActivation.tsx
+++ b/src/features/sessions/SessionActivation.tsx
@@ -31,6 +31,17 @@ export function SessionActivation({ repoPath }: { repoPath: string }) {
   // its fields from the new seed.
   const [seedNonce, setSeedNonce] = useState(0);
 
+  // Repo switches don't remount this surface (RepositoryView + SessionActivation
+  // both mount unkeyed), so a consumed seed's snapshot would submit repo A's
+  // content under repo B. Reset in render — an effect paints A's fields first.
+  const [prevRepoPath, setPrevRepoPath] = useState(repoPath);
+  if (prevRepoPath !== repoPath) {
+    setPrevRepoPath(repoPath);
+    setPlanSeed(null);
+    setResearchSeed(null);
+    setSeedNonce((n) => n + 1);
+  }
+
   const pendingTask = useSessionsStore((s) => s.pendingTask);
   const pendingPlanSeed = usePlanStore((s) => s.pendingPlanSeed);
   const setPendingPlanSeed = usePlanStore((s) => s.setPendingPlanSeed);

--- a/src/features/sessions/SessionActivation.tsx
+++ b/src/features/sessions/SessionActivation.tsx
@@ -48,21 +48,26 @@ export function SessionActivation({ repoPath }: { repoPath: string }) {
   // research run switches to (and seeds) the Plan composer. Snapshot the seed
   // locally so it survives clearing the store.
   useEffect(() => {
-    if (!pendingPlanSeed) return;
+    // A seed raised in another repo stays put, uncleared: this surface lives under
+    // <Activity>, so a seed set before a repo switch reaches us in the new repo and
+    // would prefill its composer with the old repo's work.
+    if (!pendingPlanSeed || pendingPlanSeed.repoPath !== repoPath) return;
     setMode("plan");
     setPlanSeed(pendingPlanSeed);
     setSeedNonce((n) => n + 1);
     setPendingPlanSeed(null);
-  }, [pendingPlanSeed, setPendingPlanSeed]);
+  }, [pendingPlanSeed, setPendingPlanSeed, repoPath]);
 
   // The agent-research hotkey switches to (and seeds) the Research composer.
   useEffect(() => {
-    if (!pendingResearchSeed) return;
+    // Repo-gated like the plan seed above.
+    if (!pendingResearchSeed || pendingResearchSeed.repoPath !== repoPath)
+      return;
     setMode("research");
     setResearchSeed(pendingResearchSeed);
     setSeedNonce((n) => n + 1);
     setPendingResearchSeed(null);
-  }, [pendingResearchSeed, setPendingResearchSeed]);
+  }, [pendingResearchSeed, setPendingResearchSeed, repoPath]);
 
   return (
     <div className="flex h-full flex-col">

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -284,6 +284,7 @@ function ResearchMenuItems({
     // leave their view alone; the pending seed still lands and is consumed later.
     if (agentSelectionUnchanged(selectionAtClick)) clearAgentSelection();
     usePlanStore.getState().setPendingPlanSeed({
+      repoPath: cur.repoPath,
       issueTitle: cur.report.title,
       issueBody: brief ?? assembleSessionReport(cur),
       originResearchId: run.id,
@@ -544,11 +545,11 @@ export function SessionList({ repoPath }: { repoPath: string }) {
   const newSession = () => clearAgentSelection();
   const openPlanComposer = () => {
     clearAgentSelection();
-    setPendingPlanSeed({});
+    setPendingPlanSeed({ repoPath });
   };
   const openResearchComposer = () => {
     clearAgentSelection();
-    setPendingResearchSeed({});
+    setPendingResearchSeed({ repoPath });
   };
   useHotkeyAction("agent-new-session", newSession);
   useHotkeyAction("agent-plan", openPlanComposer);

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -6,6 +6,7 @@ import {
   GearIcon,
   GitForkIcon,
   QuestionIcon,
+  TrayIcon,
 } from "@phosphor-icons/react";
 import { BrandMark } from "@/components/BrandMark";
 import { Button } from "@/components/ui/button";
@@ -26,6 +27,7 @@ export function WelcomeScreen() {
   const openSettings = useUiStore((s) => s.openSettings);
   const openHelp = useUiStore((s) => s.openHelp);
   const openExplore = useUiStore((s) => s.openExplore);
+  const openMyWork = useUiStore((s) => s.openMyWork);
   const settings = useSettings();
   const saveSettings = useSaveSettings();
   const aiEnabled = useAiEnabled();
@@ -78,6 +80,13 @@ export function WelcomeScreen() {
       icon: CompassIcon,
       variant: "outline",
       onClick: openExplore,
+    },
+    {
+      id: "open-my-work",
+      label: "My work",
+      icon: TrayIcon,
+      variant: "outline",
+      onClick: openMyWork,
     },
   ];
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -95,6 +95,7 @@ import type {
   IssueType,
   MergePreview,
   Milestone,
+  MyWorkItem,
   OpLogEntry,
   OrphanedStash,
   PagesInfo,
@@ -1502,6 +1503,12 @@ export const forgeListRepos = (provider: ForgeProvider) =>
  *  list. */
 export const forgeOwnedNamespaces = (provider: ForgeProvider) =>
   invoke<string[]>("forge_owned_namespaces", { provider });
+
+/** The viewer's work items across every repository on a provider — the cross-repo
+ *  inbox's one fetch. Provider-scoped rather than repo-scoped: each row names the
+ *  repository it came from. */
+export const forgeMyWork = (provider: ForgeProvider) =>
+  invoke<MyWorkItem[]>("forge_my_work", { provider });
 
 // ── Explore: search / browse / fork / star / README ──────────────────────────
 //

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3231,6 +3231,19 @@ export function useForgeOwnedNamespaces(
   });
 }
 
+/** The viewer's work items across every repository on a provider, for the
+ *  cross-repo inbox. The key carries no host/account axis, same as
+ *  `["forge-repos", provider]` — one ambient account per provider today. */
+export function useMyWork(provider: ForgeProvider, enabled: boolean) {
+  return useQuery({
+    queryKey: ["forge-my-work", provider] as const,
+    queryFn: () => api.forgeMyWork(provider),
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 // ── Explore: search / browse / fork / star / README ──────────────────────────
 
 /** What a provider supports and has built — the Explore surface's gate for the

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3234,7 +3234,7 @@ export function useForgeOwnedNamespaces(
 /** The viewer's work items across every repository on a provider, for the
  *  cross-repo inbox. The key carries no host/account axis, same as
  *  `["forge-repos", provider]` — one ambient account per provider today. */
-export function useMyWork(provider: ForgeProvider, enabled: boolean) {
+export function useForgeMyWork(provider: ForgeProvider, enabled: boolean) {
   return useQuery({
     queryKey: ["forge-my-work", provider] as const,
     queryFn: () => api.forgeMyWork(provider),

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -655,6 +655,22 @@ export interface ForgeProviderFeatures {
   implemented: ForgeImplemented;
 }
 
+/** One row of the cross-repo work inbox: the wire shape of `forge_my_work`.
+ *  Items come from the provider, not a local repo, so each carries its own
+ *  `host` + `repoFullName` — the only identity a row has to navigate by. */
+export interface MyWorkItem {
+  number: number;
+  title: string;
+  isPullRequest: boolean;
+  repoFullName: string;
+  repoOwner: string;
+  repoName: string;
+  host: string;
+  url: string;
+  updatedAt: string;
+  authorLogin?: string | null;
+}
+
 export interface GhAccount {
   /** The host this account is signed in to ("github.com" or an Enterprise
    *  server). Accounts are grouped by host and switched per host. */

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -59,6 +59,12 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "open-my-work",
+    label: "My work",
+    category: "Application",
+    defaultBinding: null,
+  },
+  {
     id: "open-mcp-servers-settings",
     label: "MCP server settings",
     category: "Application",

--- a/src/lib/repo-lens/queries.ts
+++ b/src/lib/repo-lens/queries.ts
@@ -81,11 +81,14 @@ export function useRepoLens(repo: string): RemoteLens {
  * ["repo", …] subtree, so no repo mutation's invalidation can refetch it back
  * to the stored value.
  *
- * `clearSelections` is false for a navigation that selects its own PR right
- * after (clearing would fight it) and true for the switcher, whose whole point
- * is to drop a selection minted under the old lens. It rides the cache
- * short-circuit: a re-select of the lens already showing must not drop the
- * user's selection.
+ * `clearSelections` drops any REMOTE PR/issue selection, and only when the
+ * lens actually flips — it rides the cache short-circuit, so re-applying the
+ * lens already showing never touches the user's selection. Pass true whenever
+ * a sibling selection minted under the old lens would outlive the flip: the
+ * switcher, and any navigation whose own selection lands after this call
+ * (openPr/openIssue run `beforeSelect` inside the navigator's transition
+ * callback, before its set(), so the clear can't fight the landing). False
+ * only where nothing re-selects afterwards.
  */
 export function applyRepoLens(
   queryClient: QueryClient,

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,7 +3,13 @@ import type { CommitAuthor, RemoteLens, RepoInfo } from "@/lib/git/types";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { startViewTransition } from "@/lib/view-transition";
 
-export type AppView = "welcome" | "repo" | "settings" | "help" | "explore";
+export type AppView =
+  | "welcome"
+  | "repo"
+  | "settings"
+  | "help"
+  | "explore"
+  | "mywork";
 export type RepoTab =
   | "changes"
   | "history"
@@ -155,6 +161,7 @@ const CROSS_REPO_RESET: Partial<UiState> = {
   selectedIssue: null,
   selectedDiscussion: null,
   pendingIssueDraft: null,
+  pendingCreate: null,
   selectedRunId: null,
   selectedFinding: null,
   findingsLimits: DEFAULT_FINDINGS_LIMITS,
@@ -217,8 +224,9 @@ function isEmptyDraft(d: CommitDraft): boolean {
 
 interface UiState {
   view: AppView;
-  /** Underlying view to return to when an overlay (settings, help, explore) closes. */
-  previousView: Exclude<AppView, "settings" | "help" | "explore">;
+  /** Underlying view to return to when an overlay (settings, help, explore, my
+   *  work) closes. */
+  previousView: Exclude<AppView, "settings" | "help" | "explore" | "mywork">;
   /** Settings section to jump to when opening Settings; null = leave as-is.
    *  Consumed (and cleared) by SettingsScreen once applied. */
   settingsTarget: SettingsTarget | null;
@@ -275,7 +283,7 @@ interface UiState {
   } | null;
   /** A create dialog requested from the palette / a New menu; the owning panel
    *  opens its dialog when this matches its kind, then clears it. Survives the
-   *  tab switch requestCreate performs. */
+   *  tab switch requestCreate performs, but not a repo switch (CROSS_REPO_RESET). */
   pendingCreate: CreateKind | null;
   /** The hoisted "create local PR" dialog: null = closed; an object = open, with
    *  optional branch seeds. Lives at RepositoryView level (outside the tab
@@ -354,6 +362,19 @@ interface UiState {
      *  fetching a pair the user never selected. */
     beforeSelect?: () => void;
   }) => void;
+  /** Open a repo (if not already open) and select one of its issues — the
+   *  cross-repo path the work inbox navigates by. ONE atomic update: a repo
+   *  switch landing apart from its selection pairs the new repo with the old
+   *  selection, and fetches an issue the user never picked. */
+  openIssue: (target: {
+    repoPath: string;
+    repoName: string;
+    number: number;
+    /** Store-external state this navigation depends on, run inside the SAME
+     *  view-transition callback as the selection (openPr's field of the same
+     *  name carries the full rationale). */
+    beforeSelect?: () => void;
+  }) => void;
   /** Open a repo (if not already) and land on a workflow run in the Actions tab —
    *  used by a notification's click-through. Atomic, like openPr. */
   openRun: (target: {
@@ -388,6 +409,8 @@ interface UiState {
   closeHelp: () => void;
   openExplore: () => void;
   closeExplore: () => void;
+  openMyWork: () => void;
+  closeMyWork: () => void;
   setRepoTab: (tab: RepoTab) => void;
   setCompareBranch: (branch: string | null) => void;
   selectPr: (pr: SelectedPr | null) => void;
@@ -588,6 +611,23 @@ export const useUiStore = create<UiState>()((set, get) => {
           pendingReviewId: target.reviewId ?? null,
         });
       }),
+    openIssue: (target) =>
+      startViewTransition(() => {
+        target.beforeSelect?.();
+        const switchingRepo = get().repoPath !== target.repoPath;
+        set({
+          view: "repo",
+          previousView: "repo",
+          repoPath: target.repoPath,
+          repoName: target.repoName,
+          repoTab: "issues",
+          // Switching repos clears the rest the way openRepo does; the issue
+          // comes AFTER the spread so the reset can't null the very selection
+          // this navigation is landing on.
+          ...(switchingRepo ? CROSS_REPO_RESET : {}),
+          selectedIssue: { kind: "remote", id: String(target.number) },
+        });
+      }),
     openRun: (target) =>
       startViewTransition(() => {
         const switchingRepo = get().repoPath !== target.repoPath;
@@ -652,7 +692,10 @@ export const useUiStore = create<UiState>()((set, get) => {
           settingsTarget: target ?? null,
           // Keep the underlying view when opening from another overlay.
           previousView:
-            view === "settings" || view === "help" || view === "explore"
+            view === "settings" ||
+            view === "help" ||
+            view === "explore" ||
+            view === "mywork"
               ? get().previousView
               : view,
         });
@@ -668,7 +711,10 @@ export const useUiStore = create<UiState>()((set, get) => {
           settingsTarget: "mcp-servers",
           mcpBrowseOpen: true,
           previousView:
-            view === "settings" || view === "help" || view === "explore"
+            view === "settings" ||
+            view === "help" ||
+            view === "explore" ||
+            view === "mywork"
               ? get().previousView
               : view,
         });
@@ -698,7 +744,10 @@ export const useUiStore = create<UiState>()((set, get) => {
         set({
           view: "help",
           previousView:
-            view === "settings" || view === "help" || view === "explore"
+            view === "settings" ||
+            view === "help" ||
+            view === "explore" ||
+            view === "mywork"
               ? get().previousView
               : view,
         });
@@ -713,12 +762,33 @@ export const useUiStore = create<UiState>()((set, get) => {
           // Keep the underlying view when opening Explore from another overlay,
           // so closing Explore returns to what was really underneath.
           previousView:
-            view === "settings" || view === "help" || view === "explore"
+            view === "settings" ||
+            view === "help" ||
+            view === "explore" ||
+            view === "mywork"
               ? get().previousView
               : view,
         });
       }),
     closeExplore: () =>
+      startViewTransition(() => set({ view: get().previousView })),
+    openMyWork: () =>
+      startViewTransition(() => {
+        const { view } = get();
+        set({
+          view: "mywork",
+          // Keep the underlying view when opening My work from another overlay,
+          // so closing it returns to what was really underneath.
+          previousView:
+            view === "settings" ||
+            view === "help" ||
+            view === "explore" ||
+            view === "mywork"
+              ? get().previousView
+              : view,
+        });
+      }),
+    closeMyWork: () =>
       startViewTransition(() => set({ view: get().previousView })),
     selectFile: (file) => set({ selectedFile: file }),
     setCommitDraft: (title, body) =>

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -10,6 +10,23 @@ export type AppView =
   | "help"
   | "explore"
   | "mywork";
+/** The views that can sit UNDER an overlay — where closing one returns to. */
+type NonOverlayView = "welcome" | "repo";
+/** Views that overlay a real screen. Derived from {@link AppView}, and
+ *  `OVERLAY_VIEWS` below is exhaustive over it, so a new AppView member stops
+ *  compiling until it is classified as one or the other. */
+type OverlayView = Exclude<AppView, NonOverlayView>;
+const OVERLAY_VIEWS: Record<OverlayView, true> = {
+  settings: true,
+  help: true,
+  explore: true,
+  mywork: true,
+};
+/** A type predicate rather than a boolean: the else branch has to narrow to
+ *  {@link NonOverlayView} for the `previousView` writes to type-check at all. */
+function isOverlayView(v: AppView): v is OverlayView {
+  return v in OVERLAY_VIEWS;
+}
 export type RepoTab =
   | "changes"
   | "history"
@@ -226,7 +243,7 @@ interface UiState {
   view: AppView;
   /** Underlying view to return to when an overlay (settings, help, explore, my
    *  work) closes. */
-  previousView: Exclude<AppView, "settings" | "help" | "explore" | "mywork">;
+  previousView: NonOverlayView;
   /** Settings section to jump to when opening Settings; null = leave as-is.
    *  Consumed (and cleared) by SettingsScreen once applied. */
   settingsTarget: SettingsTarget | null;
@@ -690,14 +707,7 @@ export const useUiStore = create<UiState>()((set, get) => {
         set({
           view: "settings",
           settingsTarget: target ?? null,
-          // Keep the underlying view when opening from another overlay.
-          previousView:
-            view === "settings" ||
-            view === "help" ||
-            view === "explore" ||
-            view === "mywork"
-              ? get().previousView
-              : view,
+          previousView: isOverlayView(view) ? get().previousView : view,
         });
       }),
     clearSettingsTarget: () => set({ settingsTarget: null }),
@@ -710,13 +720,7 @@ export const useUiStore = create<UiState>()((set, get) => {
           view: "settings",
           settingsTarget: "mcp-servers",
           mcpBrowseOpen: true,
-          previousView:
-            view === "settings" ||
-            view === "help" ||
-            view === "explore" ||
-            view === "mywork"
-              ? get().previousView
-              : view,
+          previousView: isOverlayView(view) ? get().previousView : view,
         });
       }),
     setMcpBrowseOpen: (open) => set({ mcpBrowseOpen: open }),
@@ -743,13 +747,7 @@ export const useUiStore = create<UiState>()((set, get) => {
         const { view } = get();
         set({
           view: "help",
-          previousView:
-            view === "settings" ||
-            view === "help" ||
-            view === "explore" ||
-            view === "mywork"
-              ? get().previousView
-              : view,
+          previousView: isOverlayView(view) ? get().previousView : view,
         });
       }),
     closeHelp: () =>
@@ -759,15 +757,7 @@ export const useUiStore = create<UiState>()((set, get) => {
         const { view } = get();
         set({
           view: "explore",
-          // Keep the underlying view when opening Explore from another overlay,
-          // so closing Explore returns to what was really underneath.
-          previousView:
-            view === "settings" ||
-            view === "help" ||
-            view === "explore" ||
-            view === "mywork"
-              ? get().previousView
-              : view,
+          previousView: isOverlayView(view) ? get().previousView : view,
         });
       }),
     closeExplore: () =>
@@ -777,15 +767,7 @@ export const useUiStore = create<UiState>()((set, get) => {
         const { view } = get();
         set({
           view: "mywork",
-          // Keep the underlying view when opening My work from another overlay,
-          // so closing it returns to what was really underneath.
-          previousView:
-            view === "settings" ||
-            view === "help" ||
-            view === "explore" ||
-            view === "mywork"
-              ? get().previousView
-              : view,
+          previousView: isOverlayView(view) ? get().previousView : view,
         });
       }),
     closeMyWork: () =>


### PR DESCRIPTION
Adds **My work**, a cross-repo inbox listing every open GitHub pull request and issue that involves the signed-in user (authored, assigned, mentioned, or review-requested), newest first, so what's waiting on you is one screen away instead of one repository at a time. The list is read-only: pressing Enter on a row hands you to the place where you can act on it, opening in-app when the repository is already in GitDesktop and in the browser otherwise.

### Backend

- Adds `src-tauri/src/github/my_work.rs`: shells `gh search issues --include-prs --involves=@me --state=open --limit 200` through `run_gh`, so it rides the user's gh CLI auth and never handles a token. A separate intake shape (`GhSearchItem`) is narrowed to the wire `MyWorkItem` by `item_from_intake`, which drops hits that can't address anything (no number/title/url/`owner/name`) and derives `host` from the item URL via `crate::forge::remote_host` so Enterprise items carry their own host.
- `parse_my_work` deserializes per hit, so one malformed element is skipped rather than sinking the batch, while a top-level parse failure stays an error — an empty inbox and unreadable output must not look alike.
- Adds the `forge_my_work` command in `src-tauri/src/forge/mod.rs`, dispatching on an explicit `provider` like the other account-scoped commands; the GitLab and Bitbucket arms return `InvalidArgument` rather than an empty list so "not wired up" can't read as "no open work". Registered in `src-tauri/src/lib.rs`, module declared in `src-tauri/src/github/mod.rs`.
- Rust tests cover the query args, the camelCase wire shape against a byte-faithful gh fixture, owner/name/host derivation (dotted owners, Enterprise host with port), per-hit drops, absent author/timestamp modelled as absent, and the empty-vs-unreadable distinction; `my_work_refuses_the_unimplemented_providers` pins that the unsupported arms fail before any CLI spawn.

### My work screen

- Adds `src/features/mywork/MyWorkScreen.tsx`: header with item count and a Refresh button, **All / Pull requests / Issues** tabs with per-tab counts, and a filter input wired as a combobox — ↑/↓ move the highlight through visible rows and Enter opens, so the whole flow stays in the input. Rows are virtualized (`useVirtualizer`) inside a `role="listbox"`, with `aria-activedescendant` pointing at the highlighted option and the selected row scrolled into view.
- Selection is tracked by item URL rather than index, so a filter change can't retarget it to a different item; the active index is derived from the visible set.
- Row rendering carries the PR-vs-issue distinction in an `aria-label` rather than the glyph alone, marks browser-bound rows with a `↗` plus a label naming the host, and shows relative time only when `updatedAt` parses. A shared context menu offers *Open on GitHub* and *Copy link*, suppressing the popup on blank space.
- Body states are split into `MyWorkBody` (loading skeletons → error → empty → filtered-empty → list), with the error branch naming the fixable case (`ghNotFound`) and pointing at `gh auth login`, and a note when the page comes back at the fetch limit.
- Adds `src/features/mywork/mywork-utils.ts` with `sortMyWork` (unparseable dates sort last instead of landing wherever a NaN comparison drops them), `filterMyWork` (title / repository / `#number`, client-side over loaded data), `matchLocalRepo` (host + owner + name against `recentRepos`, documented as a heuristic in both directions), `myWorkOptionId`, and `MY_WORK_LIMIT`.

### Wiring and navigation

- `src/lib/stores/ui.ts` gains the `"mywork"` view, `openMyWork`/`closeMyWork` (preserving `previousView` when opened from another overlay, alongside settings/help/explore), and a new atomic `openIssue` navigator that lands the repo switch, `CROSS_REPO_RESET`, and the issue selection in one update so a new repo can't be paired with the old selection. Also adds `pendingCreate` to `CROSS_REPO_RESET`.
- Registers the `open-my-work` action in `src/lib/hotkeys/registry.ts` (palette-reachable, no default binding), routes the view and hotkey in `src/App.tsx`, and adds a **My work** button to `src/features/welcome/WelcomeScreen.tsx`.
- Adds `forgeMyWork` in `src/lib/git/api.ts`, the `useMyWork` query in `src/lib/git/queries.ts` (60s `staleTime`, `retry: false`), and the `MyWorkItem` type in `src/lib/git/types.ts`.
- `src/components/list-row-skeleton.tsx` accepts `lines={1}` for single-line rows like these, with the doc comment updated.

### Plan / research seeds gain a repo axis

Navigating between repositories from the inbox makes an unconsumed composer seed outliving a repo switch reachable, since the Agent tab lives under `<Activity>`:

- `PlanSeed` and `ResearchSeed` now carry `repoPath` (`src/features/plan/store.ts`, `src/features/research/store.ts`), with `StoredPlanSeed`/`StoredResearchSeed` keeping it optional for runs persisted before the field existed.
- `src/features/sessions/SessionActivation.tsx` consumes a pending seed only when its `repoPath` matches the mounted repo, leaving another repo's seed in place rather than prefilling the wrong composer.
- Callers updated to supply it: `PlanIssueButton.tsx` (reads the live `repoPath` and no-ops without one), `PlanView.tsx` re-plan, `ResearchView.tsx`, and `SessionList.tsx`.

### Documentation

- `README.md`: a **My work** bullet under Features.
- `site/src/data/capabilities.ts`: a highlighted, non-AI capability under *Repository & workspace*.
- `src/features/help/content.ts`: a new **My work** guide section covering the involves-you lens, row anatomy, tabs and filtering, the keyboard flow, in-app vs browser opening, the context menu, Refresh, and the gh requirement.
- `changelog.d/added-my-work-inbox.md`: the Added fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a read-only **My work** inbox for your open GitHub pull requests and issues across repositories.
  - Filter by type or text, sort by recent activity, refresh results, navigate with the keyboard, and open or copy links.
  - Open matching items in the app when available, or in GitHub otherwise.
  - Access the inbox from the welcome screen or command palette.
  - Added related help and capability documentation.

- **Bug Fixes**
  - Plan and research handoffs now remain associated with the correct repository when switching repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->