### PR TITLE
docs(delegate,agents): add the codex implementer arm and AGENTS.md

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -36,12 +36,13 @@ machine, proceed without it).
 
 - **Git is a whitelist, not a deny-list.** The ONLY git commands you may run
   are read-only inspection: `git --no-pager diff`, `git --no-pager status`,
-  `git --no-pager log`, `git --no-pager show`, `git branch --list`. Every
-  other git invocation is forbidden — anything that writes state, including
-  commit, add/stage, checkout, reset, stash, rm, clean, push, pull, fetch,
-  merge, rebase, tag, branch create/delete, worktree, remote, and config. The
-  user commits their own work; a past agent that broke this wiped `.gitignore`
-  and corrupted their working state.
+  `git --no-pager log`, `git --no-pager show`, `git branch --list` — each may
+  be prefixed with `-C <path>` to address a task worktree. Every other git
+  invocation is forbidden — anything that writes state, including commit,
+  add/stage, checkout, reset, stash, rm, clean, push, pull, fetch, merge,
+  rebase, tag, branch create/delete, worktree, remote, and config. The user
+  commits their own work; a past agent that broke this wiped `.gitignore` and
+  corrupted their working state.
 - **Stay inside the spec's file scope.** If the right fix requires touching a
   file the spec didn't put in scope, stop and report that back instead of
   expanding scope yourself — the orchestrator may have another package
@@ -82,6 +83,8 @@ machine, proceed without it).
    changes; `cargo test --manifest-path src-tauri/Cargo.toml` and
    `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` when
    Rust changed; `cd site && pnpm build` when the marketing site changed.
+   Working in a task worktree, run each from that tree — `cd <worktree>`
+   first, and `cargo … --manifest-path <worktree>/src-tauri/Cargo.toml`.
    These are allowlisted in `.claude/settings.local.json` — run them, don't
    ask. Fix what they surface; never report a check you didn't run. Quote
    failures verbatim; summarize each passing check in one line (replaying
@@ -94,14 +97,19 @@ machine, proceed without it).
    ./src/ ./site/`): it mutates every file under `src/` and `site/`, including
    the user's parallel uncommitted work and sibling packages — an out-of-scope
    write no matter who runs it. Tree-wide, verify with the check-only
-   `pnpm exec biome check ./src/`. If a full-tree rewrite happened anyway,
-   report exactly which out-of-scope files changed — don't revert files you
-   don't own.
+   `pnpm exec biome check ./src/` — but in a fresh task worktree that form
+   false-fails on CRLF for files nobody edited, so judge your own files with
+   the per-file LF-copy `biome ci` gate (gd-conventions) instead. If a
+   full-tree rewrite happened anyway, report exactly which out-of-scope files
+   changed — don't revert files you don't own.
 4. **Sweep before reporting:** `git --no-pager status`. The working tree may
    legitimately contain the user's parallel WIP and sibling packages — you are
    accounting for YOUR footprint only: every file you touched is intended and
    in scope, and no file you created is unaccounted for. Do not investigate or
-   "clean up" changes you didn't make.
+   "clean up" changes you didn't make. When the dispatch prompt names a task
+   worktree, run this sweep and your verification commands in THAT tree
+   (`git -C <worktree> --no-pager status`); a check run from the main checkout
+   reports on code you never touched.
 
 ## Report format (your final message — it goes to the orchestrator, not the user)
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -50,7 +50,8 @@ machine, proceed without it).
 - **Do the work yourself.** Never spawn subagents or re-delegate from inside a
   package; the orchestration layer above you owns decomposition.
 - **No scratch files in the repo.** Temporary experiments go in the session
-  scratchpad or `C:/temp`.
+  scratchpad or `C:/temp`. (One exception: the LF-copy gate's `__cigate__<name>`
+  sibling, deleted after the check.)
 
 ## Working style
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -16,8 +16,10 @@ skills:
 
 You are the **designated implementation agent** for the GitDesktop repo. The
 orchestrator (the main conversation) owns architecture and planning; you own
-turning one written work-package spec into working, verified code. You are the
-one agent sanctioned to create and edit files inside this repository — the user
+turning one written work-package spec into working, verified code. You and the
+experimental codex implementer arm are the two agents sanctioned to create and
+edit files inside this repository (that arm's dispatch rules live in
+`.claude/skills/delegate/references/codex-implementer.md`) — the user
 authorized this path explicitly. That trust is conditional on the boundaries
 below.
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -16,10 +16,11 @@ skills:
 
 You are the **designated implementation agent** for the GitDesktop repo. The
 orchestrator (the main conversation) owns architecture and planning; you own
-turning one written work-package spec into working, verified code. You and the
-experimental codex implementer arm are the two agents sanctioned to create and
-edit files inside this repository (that arm's dispatch rules live in
-`.claude/skills/delegate/references/codex-implementer.md`) — the user
+turning one written work-package spec into working, verified code. You are one
+of two agents sanctioned to create and edit files inside this repository; the
+other is the experimental codex implementer arm, when /delegate dispatches it
+into a linked task worktree where the sandbox confines it
+(`.claude/skills/delegate/references/codex-implementer.md`) — the user
 authorized this path explicitly. That trust is conditional on the boundaries
 below.
 

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -41,26 +41,36 @@ redirection into any path, no piping into files, no in-place editors.
 the review — fresh-eyes verification by one agent is the point of this role,
 and fan-out from inside it multiplies cost without adding coverage.
 
-**Git is a whitelist:** the ONLY git commands you may run are
-`git --no-pager diff`, `git --no-pager status`, `git --no-pager log`,
-`git --no-pager show`, `git branch --list`. Every other git invocation is
-forbidden — anything that writes state, including commit, add/stage, checkout,
-reset, stash, rm, clean, push, pull, fetch, merge, rebase, tag, branch
-create/delete, worktree, remote, and config.
+**Git is a whitelist:** the ONLY git commands you may run are `git --no-pager
+diff`, `git --no-pager status`, `git --no-pager log`, `git --no-pager show`,
+`git branch --list` — each may be prefixed with `-C <path>` to address a task
+worktree. Every other git invocation is forbidden — anything that writes state,
+including commit, add/stage, checkout, reset, stash, rm, clean, push, pull,
+fetch, merge, rebase, tag, branch create/delete, worktree, remote, and config.
 
 **Verification commands — check-only forms only.** `pnpm lint` runs
 `biome check --write ./src/ ./site/` and REWRITES source files; never run it.
 Allowed:
 
 ```sh
-pnpm exec tsc -b                       # typecheck, no source mutation
-pnpm exec biome check ./src/           # lint/format check WITHOUT --write
-cargo test --manifest-path src-tauri/Cargo.toml
-cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+# <worktree> = the tree your dispatch prompt names; omit the cd when reviewing
+# the main checkout.
+cd <worktree> && pnpm exec tsc -b            # typecheck, no source mutation
+cd <worktree> && pnpm exec biome check <the package's own files>
+cargo test --manifest-path <worktree>/src-tauri/Cargo.toml
+cargo clippy --manifest-path <worktree>/src-tauri/Cargo.toml -- -D warnings
 ```
 
 (These may emit gitignored build artifacts like `target/` — that is the one
 tolerated form of file creation. Nothing else.)
+
+**Formatting in a fresh worktree is unverifiable from here, and that is the
+finding.** A checkout lands CRLF, so a tree-wide `biome check` false-fails on
+files nobody touched — scope the check to the package's own files instead. The
+trustworthy gate is the per-file LF-copy `biome ci` form, and building an LF
+copy is file creation, which this role bans absolutely. Say in your report that
+tree-wide formatting went unverified and why; never create the copy, never run
+any `--write` form.
 
 ## Review protocol
 
@@ -76,8 +86,13 @@ implementation agent's (related area, same feature) — do not report the user's
 unrelated WIP as findings.
 
 Your dispatch prompt names the tree to review; run the read-only git commands
-against it (`git -C <worktree> --no-pager diff`). For a codex package it also
-names the codex `-o` report file, which stands in for the agent report.
+against it (`git -C <worktree> --no-pager diff`) and every verification command
+from that tree too — `cd <worktree>` before `pnpm exec tsc -b` or the scoped
+`biome check`, and point cargo at `<worktree>/src-tauri/Cargo.toml`. A worktree
+carries its own `node_modules` and needs its own `pnpm install` (delegate
+SKILL.md's Environment notes); a check run from the main checkout green-lights
+code you never reviewed. For a codex package the prompt also names the codex
+`-o` report file, which stands in for the agent report.
 
 1. **Correctness first.** Trace the changed code paths against concrete
    inputs: boundaries, first/last/empty, error paths, concurrent or mid-flight

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -93,9 +93,10 @@ from the main checkout green-lights code you never reviewed. A worktree carries
 its own `node_modules`, and if that tree has none, the typecheck and lint simply
 cannot run from this role — say so in the what-this-review-cannot-see list.
 Never run `pnpm install` yourself: it creates files, which this charter bans,
-and worktree setup is the orchestrator's job (delegate SKILL.md's Environment
-notes). For a codex package the prompt also names the codex `-o` report file,
-which stands in for the agent report.
+and worktree setup is not this role's — the orchestrator arranges it with the
+user (delegate SKILL.md's Phase 3 codex rules and Environment notes). For a
+codex package the prompt also names the codex `-o` report file, which stands
+in for the agent report.
 
 1. **Correctness first.** Trace the changed code paths against concrete
    inputs: boundaries, first/last/empty, error paths, concurrent or mid-flight

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -53,8 +53,8 @@ fetch, merge, rebase, tag, branch create/delete, worktree, remote, and config.
 Allowed:
 
 ```sh
-# <worktree> = the tree your dispatch prompt names; omit the cd when reviewing
-# the main checkout.
+# <worktree> = the tree your dispatch prompt names. Reviewing the main
+# checkout, drop the cd and the <worktree>/ prefix on --manifest-path.
 cd <worktree> && pnpm exec tsc -b            # typecheck, no source mutation
 cd <worktree> && pnpm exec biome check <the package's own files>
 cargo test --manifest-path <worktree>/src-tauri/Cargo.toml
@@ -88,11 +88,14 @@ unrelated WIP as findings.
 Your dispatch prompt names the tree to review; run the read-only git commands
 against it (`git -C <worktree> --no-pager diff`) and every verification command
 from that tree too — `cd <worktree>` before `pnpm exec tsc -b` or the scoped
-`biome check`, and point cargo at `<worktree>/src-tauri/Cargo.toml`. A worktree
-carries its own `node_modules` and needs its own `pnpm install` (delegate
-SKILL.md's Environment notes); a check run from the main checkout green-lights
-code you never reviewed. For a codex package the prompt also names the codex
-`-o` report file, which stands in for the agent report.
+`biome check`, and point cargo at `<worktree>/src-tauri/Cargo.toml`; a check run
+from the main checkout green-lights code you never reviewed. A worktree carries
+its own `node_modules`, and if that tree has none, the typecheck and lint simply
+cannot run from this role — say so in the what-this-review-cannot-see list.
+Never run `pnpm install` yourself: it creates files, which this charter bans,
+and worktree setup is the orchestrator's job (delegate SKILL.md's Environment
+notes). For a codex package the prompt also names the codex `-o` report file,
+which stands in for the agent report.
 
 1. **Correctness first.** Trace the changed code paths against concrete
    inputs: boundaries, first/last/empty, error paths, concurrent or mid-flight

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -16,10 +16,11 @@ skills:
 ---
 
 You are the **verification gate** for delegated implementation work in the
-GitDesktop repo. An implementer agent has just executed a work-package spec;
-your job is to find what's wrong with the result before the user sees it. You
-have fresh eyes and no attachment to the implementation — use that. Assume the
-diff contains at least one problem and go looking for it.
+GitDesktop repo. An implementation agent (the Opus `implementer` or the codex
+implementer arm) has just executed a work-package spec; your job is to find
+what's wrong with the result before the user sees it. You have fresh eyes and
+no attachment to the implementation — use that. Assume the diff contains at
+least one problem and go looking for it.
 
 The gd-conventions playbook should be preloaded into your context (frontmatter
 `skills:`). If you don't see it, Read
@@ -64,15 +65,19 @@ tolerated form of file creation. Nothing else.)
 ## Review protocol
 
 Work from the actual diff (`git --no-pager diff` plus reading the touched
-files in full), not from the implementer's report — the report tells you where
-to look, the code tells you what's true.
+files in full), not from the implementation agent's report — the report tells
+you where to look, the code tells you what's true.
 
 **Attribution first.** The working tree may contain the user's parallel
 uncommitted work and sibling packages alongside the package under review. Use
-the spec's file scope and the implementer's reported file list to attribute
-changes; review those. Flag out-of-scope changes as scope creep only when
-they're plausibly the implementer's (related area, same feature) — do not
-report the user's unrelated WIP as findings.
+the spec's file scope and the reported file list to attribute changes; review
+those. Flag out-of-scope changes as scope creep only when they're plausibly the
+implementation agent's (related area, same feature) — do not report the user's
+unrelated WIP as findings.
+
+Your dispatch prompt names the tree to review; run the read-only git commands
+against it (`git -C <worktree> --no-pager diff`). For a codex package it also
+names the codex `-o` report file, which stands in for the agent report.
 
 1. **Correctness first.** Trace the changed code paths against concrete
    inputs: boundaries, first/last/empty, error paths, concurrent or mid-flight

--- a/.claude/rules/git-safety.md
+++ b/.claude/rules/git-safety.md
@@ -3,8 +3,8 @@
 > Excerpted from `.claude/skills/gd-conventions/SKILL.md` (the canonical playbook — the
 > conventions-sync rule updates every file that states the changed rule, wherever it is
 > restated: this excerpt, the repo `AGENTS.md`, the agent definitions, and any carrier
-> added later. `scripts/check-rule-mirrors.mjs` holds the current list for the git
-> whitelist). Consult that skill before writing any code here.
+> added later). `scripts/check-rule-mirrors.mjs` holds the current list for the git
+> whitelist. Consult that skill before writing any code here.
 
 1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log / show` and
    `git branch --list`, each optionally prefixed with `-C <path>` to address a task
@@ -13,8 +13,9 @@
    config — is forbidden, even "just to test". The user commits their own work,
    possibly in parallel with your session.
 2. **No stray files.** Create only what your task calls for. Scratch files go in the
-   session scratchpad or `C:/temp`, never the repo. (One exception: the LF-copy
-   gate's `__cigate__<name>` sibling, deleted after the check.)
+   session scratchpad or `C:/temp`, never the repo. (One exception, for runs that may
+   create files: the LF-copy gate's `__cigate__<name>` sibling, deleted after the
+   check — reviewers never create it; see rule 7.)
 3. **Don't edit `src/components/ui/`** — vendored primitives; fix at the call site. That
    folder's `README.md` inventories sanctioned local modifications.
 4. **Never repo-wide `cargo fmt`** in `src-tauri`. New files only: `rustfmt <that file>`.

--- a/.claude/rules/git-safety.md
+++ b/.claude/rules/git-safety.md
@@ -13,7 +13,8 @@
    config — is forbidden, even "just to test". The user commits their own work,
    possibly in parallel with your session.
 2. **No stray files.** Create only what your task calls for. Scratch files go in the
-   session scratchpad or `C:/temp`, never the repo.
+   session scratchpad or `C:/temp`, never the repo. (One exception: the LF-copy
+   gate's `__cigate__<name>` sibling, deleted after the check.)
 3. **Don't edit `src/components/ui/`** — vendored primitives; fix at the call site. That
    folder's `README.md` inventories sanctioned local modifications.
 4. **Never repo-wide `cargo fmt`** in `src-tauri`. New files only: `rustfmt <that file>`.

--- a/.claude/rules/git-safety.md
+++ b/.claude/rules/git-safety.md
@@ -1,14 +1,17 @@
 # Hard safety rules (always loaded — violations have destroyed user state before)
 
 > Excerpted from `.claude/skills/gd-conventions/SKILL.md` (the canonical playbook — the
-> conventions-sync rule updates all THREE copies: the playbook, this excerpt, and the
-> repo `AGENTS.md`). Consult that skill before writing any code here.
+> conventions-sync rule updates every file that states the changed rule, wherever it is
+> restated: this excerpt, the repo `AGENTS.md`, the agent definitions, and any carrier
+> added later. `scripts/check-rule-mirrors.mjs` holds the current list for the git
+> whitelist). Consult that skill before writing any code here.
 
 1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log / show` and
-   `git branch --list`. Everything else — commit, add/stage, checkout, reset, stash, rm,
-   clean, push, pull, fetch, merge, rebase, tag, branch create/delete, worktree, remote,
-   config — is forbidden, even "just to test". The user commits their own work, possibly
-   in parallel with your session.
+   `git branch --list`, each optionally prefixed with `-C <path>` to address a task
+   worktree. Everything else — commit, add/stage, checkout, reset, stash, rm, clean,
+   push, pull, fetch, merge, rebase, tag, branch create/delete, worktree, remote,
+   config — is forbidden, even "just to test". The user commits their own work,
+   possibly in parallel with your session.
 2. **No stray files.** Create only what your task calls for. Scratch files go in the
    session scratchpad or `C:/temp`, never the repo.
 3. **Don't edit `src/components/ui/`** — vendored primitives; fix at the call site. That
@@ -19,5 +22,9 @@
 6. **`gd/session/*` branches are filtered from every branch surface** and never deleted —
    the user dogfoods agent sessions on them; deleting one breaks Resume.
 7. **`pnpm lint` is a rewrite, not a check** (`biome check --write` over `src/` AND
-   `site/`). Check form: `pnpm exec biome check ./src/`. Reviewers never run any
-   `--write` form.
+   `site/`). Check form: `pnpm exec biome check ./src/`. In a task worktree that check
+   false-fails on CRLF, so the remedy splits by role. WRITERS: use the per-file LF-copy
+   `biome ci` gate (gd-conventions), or whatever the spec's Verification field names.
+   REVIEWERS: run the check-only form scoped to the package's own files, and in a fresh
+   worktree treat tree-wide formatting as unverifiable and report it as such — never
+   create files (an LF copy is a file), never any `--write` form.

--- a/.claude/rules/git-safety.md
+++ b/.claude/rules/git-safety.md
@@ -3,8 +3,9 @@
 > Excerpted from `.claude/skills/gd-conventions/SKILL.md` (the canonical playbook — the
 > conventions-sync rule updates every file that states the changed rule, wherever it is
 > restated: this excerpt, the repo `AGENTS.md`, the agent definitions, and any carrier
-> added later). `scripts/check-rule-mirrors.mjs` holds the current list for the git
-> whitelist. Consult that skill before writing any code here.
+> added later). `scripts/check-rule-mirrors.mjs` holds the gated list for the git
+> whitelist (the codex spec preamble restates it condensed, synced by hand). Consult
+> that skill before writing any code here.
 
 1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log / show` and
    `git branch --list`, each optionally prefixed with `-C <path>` to address a task

--- a/.claude/rules/git-safety.md
+++ b/.claude/rules/git-safety.md
@@ -1,7 +1,8 @@
 # Hard safety rules (always loaded — violations have destroyed user state before)
 
 > Excerpted from `.claude/skills/gd-conventions/SKILL.md` (the canonical playbook — the
-> conventions-sync rule updates BOTH). Consult that skill before writing any code here.
+> conventions-sync rule updates all THREE copies: the playbook, this excerpt, and the
+> repo `AGENTS.md`). Consult that skill before writing any code here.
 
 1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log / show` and
    `git branch --list`. Everything else — commit, add/stage, checkout, reset, stash, rm,

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -3,21 +3,23 @@ name: delegate
 description: >-
   Orchestrate delegated implementation in GitDesktop — the main model (Fable
   or Opus) architects, plans, and integrates; Opus subagents implement and
-  review. Gated to Fable/Opus orchestrators (Sonnet and smaller work inline
-  instead). Use whenever the user asks to delegate, fan out, or
-  parallelize implementation work, says "have opus build/implement X", or hands
-  over a well-scoped multi-file feature that should be built by subagents
-  rather than inline. Also applies when resuming a partially delegated feature.
+  review, with an experimental codex implementer lane alongside. Gated to
+  Fable/Opus orchestrators (Sonnet and smaller work inline instead). Use
+  whenever the user asks to delegate, fan out, or parallelize implementation
+  work, says "have opus build/implement X", or hands over a well-scoped
+  multi-file feature that should be built by subagents rather than inline.
+  Also applies when resuming a partially delegated feature.
 argument-hint: "[task description]"
 ---
 
-# /delegate — Fable or Opus orchestrates, Opus implements
+# /delegate — Fable or Opus orchestrates, Opus (or the codex arm) implements
 
 The division of labor: **you** (the main conversation) own architecture,
 decomposition, dispatch, integration, and everything the user sees. The
-**`implementer`** agent (Opus) turns written work-package specs into code; it and
-the experimental **codex implementer arm** (`gpt-6-astra` via `codex exec` — see
-`references/codex-implementer.md`) are the two sanctioned writers in this repo. The
+**`implementer`** agent (Opus) turns written work-package specs into code; it
+and the experimental **codex implementer arm** (`gpt-6-astra` via `codex exec`)
+are the two sanctioned writers in this repo — the codex arm is sandbox-confined
+to linked task worktrees (see `references/codex-implementer.md`). The
 **`spec-reviewer`** agent (Opus, read-only) adversarially checks the result.
 
 ## Phase 0 — Gate & ground
@@ -67,9 +69,9 @@ Research with read-only fan-outs when needed: `Explore` for codebase
 questions, `Plan` for competing strategies, Workflow for bigger read-only
 sweeps (see Workflows below). Every research/review agent prompt must state:
 **strictly read-only — no file writes, no git mutations, no test files.** The
-`implementer` agent is the sole exception to the *file-write* rule, and only
-when executing a spec; the no-git-mutation rule has no exceptions, for any
-agent, ever.
+two sanctioned writers (the `implementer` agent and the codex implementer arm)
+are the only exceptions to the *file-write* rule, each only when executing a
+spec; the no-git-mutation rule has no exceptions, for any agent, ever.
 
 Then write one **work-package spec** per package. Keep specs tight — they are
 replayed into both the implementer's and reviewer's contexts — but never
@@ -132,10 +134,17 @@ measured sandbox behavior, and the spec preamble live there. The hard rules:
 
 - **Linked task worktrees only** — the sandbox git-block does not exist in the
   main checkout, where `.git` sits inside the workspace root.
+- **Never pass `--add-dir` pointing at the main repo** — that is the one way to
+  defeat the confinement from an otherwise correct dispatch.
 - Feed the preamble + spec through **stdin** (heredoc), never argv.
 - Set `-c model_reasoning_effort` explicitly; the default is `none`.
 - Capture the `session id:` line from the run header.
 - Fix rounds go through `codex exec resume (session-id)`, not a fresh dispatch.
+- Network is off under `workspace-write`: dependencies must already be
+  installed when the worktree is set up.
+- The Phase 0 baseline and the Phase 5 footprint sweep run **in the task
+  worktree** (`git -C <worktree> status`). A feature split across Opus and codex
+  packages colocates in ONE worktree so the sweep sees every package's files.
 
 ## Phase 4 — Verify (never skip; never trust the report alone)
 
@@ -161,8 +170,9 @@ measured sandbox behavior, and the spec preamble live there. The hard rules:
    contract, API, or design. Disclose every such fix in the report and re-run
    the package's verification. Anything beyond trivial still round-trips to
    the owning implementer; this never loosens the no-git-mutation rule.
-6. **Codex packages get the identical treatment** — spec-reviewer or
-   orchestrator review, plus the integration checks in the main loop; its `-o`
+6. **Codex packages always get a `spec-reviewer` pass** while the arm is
+   experimental (lite-mode orchestrator self-review stays available for Opus
+   packages only), plus the integration checks in the main loop. Its `-o`
    report file is the analogue of an agent report and earns the same skepticism.
 
 ## Phase 5 — Close out

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -15,8 +15,9 @@ argument-hint: "[task description]"
 
 The division of labor: **you** (the main conversation) own architecture,
 decomposition, dispatch, integration, and everything the user sees. The
-**`implementer`** agent (Opus) turns written work-package specs into code —
-it is the only agent sanctioned to write files in this repo. The
+**`implementer`** agent (Opus) turns written work-package specs into code; it and
+the experimental **codex implementer arm** (`gpt-6-astra` via `codex exec` — see
+`references/codex-implementer.md`) are the two sanctioned writers in this repo. The
 **`spec-reviewer`** agent (Opus, read-only) adversarially checks the result.
 
 ## Phase 0 — Gate & ground
@@ -124,6 +125,18 @@ it is a design-time question.
 - Iterate with the SAME agent via SendMessage (it keeps its context) — don't
   spawn a fresh implementer to fix its own package.
 
+### Codex implementer arm (experimental)
+
+Routing a package to codex? Follow `references/codex-implementer.md` — recipe,
+measured sandbox behavior, and the spec preamble live there. The hard rules:
+
+- **Linked task worktrees only** — the sandbox git-block does not exist in the
+  main checkout, where `.git` sits inside the workspace root.
+- Feed the preamble + spec through **stdin** (heredoc), never argv.
+- Set `-c model_reasoning_effort` explicitly; the default is `none`.
+- Capture the `session id:` line from the run header.
+- Fix rounds go through `codex exec resume (session-id)`, not a fresh dispatch.
+
 ## Phase 4 — Verify (never skip; never trust the report alone)
 
 1. **Full mode:** one whole-feature `spec-reviewer` given ALL the specs +
@@ -148,6 +161,9 @@ it is a design-time question.
    contract, API, or design. Disclose every such fix in the report and re-run
    the package's verification. Anything beyond trivial still round-trips to
    the owning implementer; this never loosens the no-git-mutation rule.
+6. **Codex packages get the identical treatment** — spec-reviewer or
+   orchestrator review, plus the integration checks in the main loop; its `-o`
+   report file is the analogue of an agent report and earns the same skepticism.
 
 ## Phase 5 — Close out
 

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -44,7 +44,8 @@ to linked task worktrees (see `references/codex-implementer.md`). The
   (if the user is researching or thinking out loud, produce plans instead —
   standing feedback).
 - `git --no-pager status` — record the baseline. **Never skip this**; the
-  Phase 5 footprint sweep depends on it.
+  Phase 5 footprint sweep depends on it. (Codex or colocated worktree packages:
+  take the baseline in the task worktree — Phase 3.)
 - If the task shapes or polishes UI, run the `impeccable` skill BEFORE
   decomposing — its confirmed brief becomes part of the spec (standing
   feedback; an AskUserQuestion round is not a substitute).
@@ -56,7 +57,8 @@ Review is never skipped; **who reviews scales.** Each avoided agent session is
 
 - **Lite mode** — single package, few files: ONE implementer + your own
   orchestrator-review of the diff + one integration build. No Explore
-  grounding when you already know the area; no separate reviewer.
+  grounding when you already know the area; no separate reviewer. (Codex
+  packages are never lite-mode — Phase 4 item 6.)
 - **Full mode** — genuinely multi-file, parallelizable work: packages +
   spec-reviewer(s), everything below.
 - Threshold is conservative: orchestrator self-review loses the fresh-eyes
@@ -70,8 +72,9 @@ questions, `Plan` for competing strategies, Workflow for bigger read-only
 sweeps (see Workflows below). Every research/review agent prompt must state:
 **strictly read-only — no file writes, no git mutations, no test files.** The
 two sanctioned writers (the `implementer` agent and the codex implementer arm)
-are the only exceptions to the *file-write* rule, each only when executing a
-spec; the no-git-mutation rule has no exceptions, for any agent, ever.
+are the only agent-side exceptions to the *file-write* rule, each only when
+executing a spec — you keep the Phase 4 trivial-fix carve-out. The
+no-git-mutation rule has no exceptions, for any agent, ever.
 
 Then write one **work-package spec** per package. Keep specs tight — they are
 replayed into both the implementer's and reviewer's contexts — but never
@@ -81,7 +84,7 @@ skill's `references/orchestrator.md` — its spec-shaping checklist and Sonnet
 stage-prompt scaffolding compensate for the dispatched models' documented
 failure modes.
 
-```
+```text
 ## Package: <name>
 Objective: <one paragraph — what and why>
 Files in scope: <explicit list; the implementer must not touch others>
@@ -134,17 +137,29 @@ measured sandbox behavior, and the spec preamble live there. The hard rules:
 
 - **Linked task worktrees only** — the sandbox git-block does not exist in the
   main checkout, where `.git` sits inside the workspace root.
-- **Never pass `--add-dir` pointing at the main repo** — that is the one way to
-  defeat the confinement from an otherwise correct dispatch.
+- **Never pass `--add-dir` pointing at the main repo** — one way to defeat the
+  confinement from an otherwise correct dispatch; a resume that drops `-s` is
+  the other.
 - Feed the preamble + spec through **stdin** (heredoc), never argv.
 - Set `-c model_reasoning_effort` explicitly; the default is `none`.
 - Capture the `session id:` line from the run header.
-- Fix rounds go through `codex exec resume (session-id)`, not a fresh dispatch.
-- Network is off under `workspace-write`: dependencies must already be
-  installed when the worktree is set up.
+- Fix rounds go through `codex exec resume (session-id)` from inside the
+  worktree (`cd <worktree> && codex exec resume …` — `resume` has no `--cd`),
+  not a fresh dispatch.
+- **Repeat every flag the dispatch form carries on each resume** — `-m`, `-o`,
+  `-s workspace-write`, `-c model_reasoning_effort`, and the network pin
+  `-c sandbox_workspace_write.network_access=false`. Unspecified flags fall
+  back to the machine config (measured: a dropped `-m` resumed as the config
+  default), so a dropped `-s` can silently change the sandbox — read the run
+  header's sandbox line before trusting it.
+- Network is off under `workspace-write` by default AND pinned off by
+  `-c sandbox_workspace_write.network_access=false` on every invocation, since
+  a machine profile can enable it; dependencies must already be installed when
+  the worktree is set up.
 - The Phase 0 baseline and the Phase 5 footprint sweep run **in the task
-  worktree** (`git -C <worktree> status`). A feature split across Opus and codex
-  packages colocates in ONE worktree so the sweep sees every package's files.
+  worktree** (`git -C <worktree> --no-pager status`). A feature split across
+  Opus and codex packages colocates in ONE worktree so the sweep sees every
+  package's files.
 
 ## Phase 4 — Verify (never skip; never trust the report alone)
 
@@ -160,10 +175,13 @@ measured sandbox behavior, and the spec preamble live there. The hard rules:
    green doesn't guarantee the merged working tree is green.
 3. UI work: dogfood live via the `drive-ui` skill — edge cases (first/last/
    empty, boundaries) and visual polish, before declaring done.
-4. **Batch fix rounds:** collect ALL findings for a package into ONE
-   SendMessage to the owning implementer (every extra round replays the
-   agent's whole context — ~100k tokens even for a one-line diff). Re-review
-   = the delta + prior findings only, not the full protocol again.
+4. **Batch fix rounds:** collect ALL findings for a package into ONE message
+   to the owning agent (every extra round replays its whole context — ~100k
+   tokens even for a one-line diff). Re-review = the delta + prior findings
+   only, not the full protocol again. The delivery path follows the dispatch
+   path: an Opus package takes one SendMessage; a codex package takes one
+   stdin message via `cd (worktree) && codex exec resume (session-id)` with
+   the flags repeated — SendMessage reaches Agent-tool dispatches only.
 5. **Trivial-fix exception (user-authorized 2026-07-02):** the orchestrator
    may apply a trivial fix directly instead of a fix round — ≤ ~3 lines,
    confirmed by the spec-reviewer or by live validation, and changing no
@@ -181,6 +199,7 @@ measured sandbox behavior, and the spec preamble live there. The hard rules:
 - Footprint sweep: `git --no-pager status` against the Phase 0 baseline —
   every difference is accounted for by a package or the user's own parallel
   work; nothing stray, nothing staged, no probe/scratch files left behind.
+  (Codex or colocated worktree packages: sweep the task worktree — Phase 3.)
 - Report to the user: outcome first, then per-package summary, verification
   results verbatim, and open concerns. **Never commit — the user commits.**
 

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -135,6 +135,12 @@ it is a design-time question.
 Routing a package to codex? Follow `references/codex-implementer.md` — recipe,
 measured sandbox behavior, and the spec preamble live there. The hard rules:
 
+- **The worktree is a prerequisite, and only the user can create it.** Codex
+  routing needs a linked task worktree with `pnpm install` already run (the
+  sandbox has no network, so a run cannot install anything). `git worktree` is
+  off every agent whitelist, so ASK the user to create it before you dispatch,
+  and take the Phase 0 baseline in it once it exists.
+
 - **Linked task worktrees only** — the sandbox git-block does not exist in the
   main checkout, where `.git` sits inside the workspace root.
 - **Never pass `--add-dir` pointing at the main repo** — one way to defeat the

--- a/.claude/skills/delegate/references/codex-implementer.md
+++ b/.claude/skills/delegate/references/codex-implementer.md
@@ -1,0 +1,173 @@
+# Codex implementer arm (experimental)
+
+**Status:** experimental, owner-ratified 2026-09-06. The codex CLI
+(`codex-cli` 0.153.3) driving **`gpt-6-astra`** is a second sanctioned writer in
+this repo alongside the Opus `implementer` agent — nothing else about /delegate
+changes. Codex packages get the same work-package spec, the same
+`spec-reviewer` (Opus) pass, and the same orchestrator integration gates as
+Opus packages. The arm exists because the codex reviewer-lane pilot showed
+classes astra finds well; treat every dispatch as evidence for or against
+keeping it.
+
+## Routing — which packages go to codex
+
+- Astra's proven niche from the reviewer-lane pilot: **platform/encoding/parser
+  and reachability-regime classes on fresh surfaces.** Start it on
+  self-contained packages — pure-logic Rust, wire/serde shapes, scripts, test
+  fixtures, CI plumbing.
+- **Opus keeps idiom-dense React/UI packages.** The repo-idiom playbooks
+  (`gd-conventions`, the frontend rules) are preloaded into the Opus agents and
+  reach codex only through cold file reads, so idiom drift is the expected
+  failure mode there.
+- **The first codex dispatch of any adoption phase doubles as the smoke test** —
+  smallest package first, before anything depends on the lane working.
+
+## Astra behavior notes (OpenAI model guidance, fetched 2026-09-06)
+
+- **Asks for clarification more readily than prior GPT models.** Headless `exec`
+  has nobody to answer, which is why the preamble grants authorization up front
+  and says to decide and note. OpenAI's recommended counter-phrasing: "You don't
+  need user permission for reversible tasks, read-only actions, reviews or
+  fixes, or anything for which authorization is provided earlier in the
+  session."
+- **Over-verifies small changes.** The official calibration line:
+  "Do not write tests for reversible, low-impact changes that mirror the implementation".
+  The spec's Verification field is authoritative — run exactly that list.
+- **More sensitive to instruction files** (`AGENTS.md`, skill files) than prior
+  models: every rule it reads gets enforced hard, so rules stay short, accurate,
+  and non-vague —
+  "A short, accurate AGENTS.md is more useful than a long file full of vague rules".
+  Audit wording changes to either file with that in mind.
+- **Reasoning effort** runs low / medium / high / xhigh: low for well-scoped
+  mechanical packages, high as the implementer-package default, xhigh for long
+  reasoning-heavy ones — the routing shape /delegate already uses for Opus
+  effort.
+- **Default output is verbose and markdown-heavy**, hence the plain-prose report
+  line in the preamble.
+- **Reader-facing copy:** OpenAI's guidance discourages contrastive framing and
+  stock phrases, converging with this repo's reader-facing-prose rules in
+  `CLAUDE.md`. The repo rules still govern and still get swept.
+
+Sources:
+
+- https://developers.openai.com/api/docs/guides/latest-model
+- https://learn.chatgpt.com/guides/best-practices
+
+## Dispatch recipe
+
+Prompt goes in over **stdin**, never argv: argv is capped near 32 KB and the
+`.cmd` shim mangles newline-containing arguments. `cd` into the task worktree
+first, then (one command; continuations are for the page width):
+
+```sh
+codex exec --cd . -m gpt-6-astra -s workspace-write \
+  -c model_reasoning_effort="high" \
+  -o (scratchpad)/(package)-report.md - <<'EOF'
+... preamble + spec ...
+EOF
+```
+
+- `(scratchpad)` is the session scratchpad directory and `(package)` the package
+  name — the report file never lands in the repo.
+- **Set `-c model_reasoning_effort` on every dispatch.** The default prints
+  `none` in the run header.
+- The run header also prints a **`session id:`** line. Capture it — it is the
+  only handle on the session.
+- `--output-schema (file)` exists for typed reports. Available, **not yet
+  validated here**; the markdown report via `-o` is the current path.
+
+## Fix rounds
+
+Batch all findings for a package into one message and resume the same session.
+The message goes in over stdin exactly like the dispatch, for the same
+argv-cap reason — batched findings are long:
+
+```sh
+codex exec resume (session-id) - <<'EOF'
+... batched findings ...
+EOF
+```
+
+`--last` is safe only while a single codex session is in flight; with more than
+one, resume by id. Measured: a resumed session retained knowledge of files it
+had created earlier without re-reading them, and the AGENTS.md instruction
+persisted across the resume.
+
+Resume re-runs the trust / git-repo check rather than inheriting
+`--skip-git-repo-check` from the original invocation, so resuming outside a git
+repo fails with:
+
+```
+Not inside a trusted directory and --skip-git-repo-check was not specified.
+```
+
+Irrelevant for task worktrees, which are git repos — but don't misread it as a
+broken session while smoke-testing in a scratch directory.
+
+## Measured sandbox behavior (2026-09-05, linked worktree)
+
+- File writes inside the worktree **succeed**. Git **reads** (`status`, `log`,
+  `diff`) work.
+- `git add` and `git commit` are **denied**, with:
+
+  ```
+  fatal: Unable to create '(main-repo)/.git/worktrees/(wt)/index.lock': Permission denied
+  ```
+
+  A linked worktree's real git dir lives outside the workspace root, so the
+  sandbox blocks the write the index lock needs.
+- **HARD RULE: dispatch codex only in linked task worktrees, never in the main
+  checkout.** There `.git` sits inside the workspace root and git mutations
+  would be permitted — the block above is what keeps the no-git-mutation rule
+  enforced rather than merely stated. For the same reason, never pass
+  `--add-dir` pointing at the main repo.
+- **Network is off** under `workspace-write`: `pnpm install` fails, so
+  dependencies must be pre-installed when the worktree is set up (already the
+  /delegate pattern).
+- The sandbox may emit benign Permission-denied warnings while reading
+  out-of-workspace config (measured on `~/.config/git/ignore`). Not findings.
+- `AGENTS.md` at the workspace root is auto-read by codex (measured with a
+  marker token), which is why the repo ships one.
+- The machine may layer a global `~/.codex/AGENTS.md` under the repo one: codex
+  loads both, and the more specific file takes precedence — the repo `AGENTS.md`
+  wins any conflict, the global one only fills machine-wide gaps. This machine's
+  exposes the owner's scoped rules as pointers into `C:\Users\Evan\.claude\rules\`,
+  and the sandbox permits reading those files (both probed 2026-09-06), so the
+  repo file need not duplicate machine-global rules.
+
+## Operational dependency and watch items
+
+- Runs consume the owner's ChatGPT subscription. A run that dies on expired auth
+  must be **flagged for `codex login`**, never silently skipped or retried into
+  the void.
+- Implementer-length runs are untested against plan limits — the free tier once
+  died mid-review on a 26-file diff. Watch for truncated or missing reports on
+  long packages and report the suspicion.
+
+## Preamble — paste above every codex spec
+
+```
+You are executing one work-package spec in a linked task worktree of
+GitDesktop. Binding context, in order: AGENTS.md (auto-loaded), CLAUDE.md, and
+.claude/skills/gd-conventions/SKILL.md — read the latter two before writing
+anything.
+
+- Stay strictly inside the spec's "Files in scope". A spec conflict, or a fix
+  that needs another file, is reported back — never improvised around. Nobody
+  can answer questions mid-run, so for in-scope implementation choices (naming,
+  placement, minor idiom) pick a reasonable option and note it in the report;
+  you do not need permission for work the spec already authorizes.
+- Make the smallest change that satisfies the acceptance criteria.
+- No scratch or temp files inside the repo.
+- Git mutations are forbidden and sandbox-blocked; read-only git only
+  (diff / status / log / show, branch --list).
+- A Permission-denied on a path outside the workspace is an environment limit:
+  report it and continue.
+- Lint only your own files: pnpm exec biome check --write (files). NEVER
+  pnpm lint — it rewrites all of src/ and site/.
+- Run exactly the spec's Verification commands and quote any failure verbatim.
+  Do not invent broader test scaffolding for small, reversible changes.
+- Your final message is the report: Outcome (one sentence) / Changes (per file)
+  / Verification (each command with its actual result) / Deviations & concerns.
+  Write it in plain prose sentences — no tables, no decorative formatting.
+```

--- a/.claude/skills/delegate/references/codex-implementer.md
+++ b/.claude/skills/delegate/references/codex-implementer.md
@@ -38,10 +38,10 @@ keeping it.
   and non-vague —
   "A short, accurate AGENTS.md is more useful than a long file full of vague rules".
   Audit wording changes to either file with that in mind.
-- **Reasoning effort** runs low / medium / high / xhigh: low for well-scoped
-  mechanical packages, high as the implementer-package default, xhigh for long
-  reasoning-heavy ones — the routing shape /delegate already uses for Opus
-  effort.
+- **Reasoning effort** runs none (the default — never leave it) / low / medium /
+  high / xhigh: low for well-scoped mechanical packages, high as the
+  implementer-package default, xhigh for long reasoning-heavy ones — the routing
+  shape /delegate already uses for Opus effort.
 - **Default output is verbose and markdown-heavy**, hence the plain-prose report
   line in the preamble.
 - **Reader-facing copy:** OpenAI's guidance discourages contrastive framing and
@@ -70,6 +70,7 @@ Then, one command (continuations are for the page width):
 ```sh
 codex exec --cd (task-worktree-path) -m gpt-6-astra -s workspace-write \
   -c model_reasoning_effort="high" \
+  -c sandbox_workspace_write.network_access=false \
   -o (scratchpad)/(package)-report.md - <<'EOF'
 ... preamble + spec ...
 EOF
@@ -94,30 +95,40 @@ The message goes in over stdin exactly like the dispatch, for the same
 argv-cap reason — batched findings are long:
 
 ```sh
-codex exec resume (session-id) -m gpt-6-astra -s workspace-write \
+cd (task-worktree-path) && codex exec resume (session-id) \
+  -m gpt-6-astra -s workspace-write \
   -c model_reasoning_effort="high" \
+  -c sandbox_workspace_write.network_access=false \
   -o (scratchpad)/(package)-fix1-report.md - <<'EOF'
 ... batched findings ...
 EOF
 ```
 
-**Repeat `-m`, `-c model_reasoning_effort`, `-s`, and `-o` on every resume** —
-flags do not reliably carry over. Measured: a session dispatched without `-m`
-resumed as the config's default model at its configured effort, so a resume can
-silently run a different model than the dispatch did. Resume prints the full run
-header (model, effort, sandbox, session id); read it as the truth for what the
-run actually used.
+**`resume` has no `--cd` flag** — it roots at the shell's cwd, so every resume
+runs from inside the worktree in one Bash-tool command, as above. Read the
+resume header's workdir line as the per-run check that it rooted where you
+meant.
+
+**Repeat every flag the dispatch form carries on each resume** — the pin
+`-c sandbox_workspace_write.network_access=false` included, alongside `-m`,
+`-o`, `-s`, and `-c model_reasoning_effort`. Flags do not reliably carry over.
+Measured: a session dispatched without `-m` resumed as the config's default
+model at its configured effort, so a resume can silently run a different model
+than the dispatch did. Resume prints the full run header (model, effort,
+sandbox, session id); read it as the truth for what the run actually used.
 
 `--last` is safe only while a single codex session is in flight; with more than
-one, resume by id. Measured: a resumed session retained knowledge of files it
-had created earlier without re-reading them, and the AGENTS.md instruction
-persisted across the resume.
+one, resume by id. The session listing is cwd-filtered by default (`--all`
+disables the filter), so a `--last` issued from the right worktree cwd already
+scopes to that worktree's sessions — one more reason the `cd` matters. Measured:
+a resumed session retained knowledge of files it had created earlier without
+re-reading them, and the AGENTS.md instruction persisted across the resume.
 
 Resume re-runs the trust / git-repo check rather than inheriting
 `--skip-git-repo-check` from the original invocation, so resuming outside a git
 repo fails with:
 
-```
+```text
 Not inside a trusted directory and --skip-git-repo-check was not specified.
 ```
 
@@ -132,7 +143,7 @@ broken session while smoke-testing in a scratch directory.
   `git commit`, `git checkout -- (file)`, `git rm --cached (file)`, and
   `git stash push`, each on the out-of-workspace index lock:
 
-  ```
+  ```text
   fatal: Unable to create '(main-repo)/.git/worktrees/(wt)/index.lock': Permission denied
   ```
 
@@ -148,9 +159,11 @@ broken session while smoke-testing in a scratch directory.
   enforced rather than merely stated for the git-dir-writing subset; every other
   mutation — `git clean` being the measured counterexample — rests on the policy
   alone. For the same reason, never pass `--add-dir` pointing at the main repo.
-- **Network is off** under `workspace-write`: `pnpm install` fails, so
-  dependencies must be pre-installed when the worktree is set up (already the
-  /delegate pattern).
+- **Network is off** under `workspace-write` by default, and pinned off
+  explicitly by the forms above — a machine profile can turn it on
+  (`sandbox_workspace_write.network_access=true`), which is why the flag rides
+  every invocation. With it off, `pnpm install` fails, so dependencies must be
+  pre-installed when the worktree is set up (already the /delegate pattern).
 - The sandbox may emit benign Permission-denied warnings while reading
   out-of-workspace config (measured on `~/.config/git/ignore`). Not findings.
 - `AGENTS.md` at the workspace root is auto-read by codex (measured with a
@@ -165,8 +178,9 @@ broken session while smoke-testing in a scratch directory.
 ## Run lifecycle
 
 - **A killed or timed-out run leaves partial edits.** Diagnose with
-  `git -C (worktree) status` and `git -C (worktree) diff` before resuming or
-  redispatching; a half-applied package looks like a fresh one to the next run.
+  `git -C (worktree) --no-pager status` and `git -C (worktree) --no-pager diff`
+  before resuming or redispatching; a half-applied package looks like a fresh
+  one to the next run.
 - **Windows kills don't tree-kill.** Kill the codex node process and verify it
   is gone before treating the worktree as free.
 - **One codex session per worktree at a time** — concurrent sessions share the
@@ -185,7 +199,7 @@ broken session while smoke-testing in a scratch directory.
 
 ## Preamble — paste above every codex spec
 
-```
+```text
 You are executing one work-package spec in a linked task worktree of
 GitDesktop. Binding context, in order: AGENTS.md (auto-loaded), CLAUDE.md, and
 .claude/skills/gd-conventions/SKILL.md — read the latter two before writing
@@ -198,8 +212,8 @@ anything.
   you do not need permission for work the spec already authorizes.
 - Make the smallest change that satisfies the acceptance criteria.
 - No scratch or temp files inside the repo.
-- Git mutations are forbidden and sandbox-blocked; read-only git only
-  (diff / status / log / show, branch --list).
+- Git mutations are forbidden; the sandbox additionally blocks the git-dir
+  writers. Read-only git only (diff / status / log / show, branch --list).
 - A Permission-denied on a path outside the workspace is an environment limit:
   report it and continue.
 - Lint-fix only the files you touched, using the command the spec's

--- a/.claude/skills/delegate/references/codex-implementer.md
+++ b/.claude/skills/delegate/references/codex-implementer.md
@@ -211,7 +211,9 @@ anything.
   placement, minor idiom) pick a reasonable option and note it in the report;
   you do not need permission for work the spec already authorizes.
 - Make the smallest change that satisfies the acceptance criteria.
-- No scratch or temp files inside the repo.
+- No scratch or temp files inside the repo. The one exception is the LF-copy
+  biome ci gate: its __cigate__<name> sibling is sanctioned for the length of
+  the check, and you delete it afterwards.
 - Git mutations are forbidden; the sandbox additionally blocks the git-dir
   writers. Read-only git only (diff / status / log / show, branch --list).
 - A Permission-denied on a path outside the workspace is an environment limit:

--- a/.claude/skills/delegate/references/codex-implementer.md
+++ b/.claude/skills/delegate/references/codex-implementer.md
@@ -56,17 +56,28 @@ Sources:
 ## Dispatch recipe
 
 Prompt goes in over **stdin**, never argv: argv is capped near 32 KB and the
-`.cmd` shim mangles newline-containing arguments. `cd` into the task worktree
-first, then (one command; continuations are for the page width):
+`.cmd` shim mangles newline-containing arguments. The heredoc forms on this page
+are POSIX shell — on this Windows machine run them through the Bash tool, never
+PowerShell.
+
+**Assert the workspace root before dispatching:**
+`(task-worktree-path)/.git` must be a **file** (the `gitdir:` pointer that marks
+a linked worktree). A `.git` **directory** means the root is main-checkout
+shaped — abort the dispatch rather than fix the flags.
+
+Then, one command (continuations are for the page width):
 
 ```sh
-codex exec --cd . -m gpt-6-astra -s workspace-write \
+codex exec --cd (task-worktree-path) -m gpt-6-astra -s workspace-write \
   -c model_reasoning_effort="high" \
   -o (scratchpad)/(package)-report.md - <<'EOF'
 ... preamble + spec ...
 EOF
 ```
 
+- **`--cd` takes an absolute path.** A relative `--cd` resolves against the
+  shell's cwd, and a run rooted at the main checkout has `.git` inside its
+  workspace, where the sandbox permits git mutations.
 - `(scratchpad)` is the session scratchpad directory and `(package)` the package
   name — the report file never lands in the repo.
 - **Set `-c model_reasoning_effort` on every dispatch.** The default prints
@@ -83,10 +94,19 @@ The message goes in over stdin exactly like the dispatch, for the same
 argv-cap reason — batched findings are long:
 
 ```sh
-codex exec resume (session-id) - <<'EOF'
+codex exec resume (session-id) -m gpt-6-astra -s workspace-write \
+  -c model_reasoning_effort="high" \
+  -o (scratchpad)/(package)-fix1-report.md - <<'EOF'
 ... batched findings ...
 EOF
 ```
+
+**Repeat `-m`, `-c model_reasoning_effort`, `-s`, and `-o` on every resume** —
+flags do not reliably carry over. Measured: a session dispatched without `-m`
+resumed as the config's default model at its configured effort, so a resume can
+silently run a different model than the dispatch did. Resume prints the full run
+header (model, effort, sandbox, session id); read it as the truth for what the
+run actually used.
 
 `--last` is safe only while a single codex session is in flight; with more than
 one, resume by id. Measured: a resumed session retained knowledge of files it
@@ -108,7 +128,9 @@ broken session while smoke-testing in a scratch directory.
 
 - File writes inside the worktree **succeed**. Git **reads** (`status`, `log`,
   `diff`) work.
-- `git add` and `git commit` are **denied**, with:
+- **Commands that write the git dir are denied.** Measured blocked: `git add`,
+  `git commit`, `git checkout -- (file)`, `git rm --cached (file)`, and
+  `git stash push`, each on the out-of-workspace index lock:
 
   ```
   fatal: Unable to create '(main-repo)/.git/worktrees/(wt)/index.lock': Permission denied
@@ -116,11 +138,16 @@ broken session while smoke-testing in a scratch directory.
 
   A linked worktree's real git dir lives outside the workspace root, so the
   sandbox blocks the write the index lock needs.
+- **Commands that touch only worktree files are not denied.** Measured
+  permitted: `git clean -n` and `git clean -fd` — the `-fd` run deleted the
+  probe's untracked file, with only benign config-read warnings. So the sandbox
+  is no guard for untracked WIP; the no-git-mutation policy is.
 - **HARD RULE: dispatch codex only in linked task worktrees, never in the main
-  checkout.** There `.git` sits inside the workspace root and git mutations
-  would be permitted — the block above is what keeps the no-git-mutation rule
-  enforced rather than merely stated. For the same reason, never pass
-  `--add-dir` pointing at the main repo.
+  checkout.** There `.git` sits inside the workspace root and even the git-dir
+  writes would be permitted. That block is what keeps the no-git-mutation rule
+  enforced rather than merely stated for the git-dir-writing subset; every other
+  mutation — `git clean` being the measured counterexample — rests on the policy
+  alone. For the same reason, never pass `--add-dir` pointing at the main repo.
 - **Network is off** under `workspace-write`: `pnpm install` fails, so
   dependencies must be pre-installed when the worktree is set up (already the
   /delegate pattern).
@@ -128,18 +155,30 @@ broken session while smoke-testing in a scratch directory.
   out-of-workspace config (measured on `~/.config/git/ignore`). Not findings.
 - `AGENTS.md` at the workspace root is auto-read by codex (measured with a
   marker token), which is why the repo ships one.
-- The machine may layer a global `~/.codex/AGENTS.md` under the repo one: codex
+- A machine may layer a global `~/.codex/AGENTS.md` under the repo one: codex
   loads both, and the more specific file takes precedence — the repo `AGENTS.md`
-  wins any conflict, the global one only fills machine-wide gaps. This machine's
-  exposes the owner's scoped rules as pointers into `C:\Users\Evan\.claude\rules\`,
-  and the sandbox permits reading those files (both probed 2026-09-06), so the
-  repo file need not duplicate machine-global rules.
+  wins any conflict, the global one only fills machine-wide gaps. The owner's
+  machine has one, exposing user-global rule files as pointers, and the
+  sandbox permits reading them (both probed 2026-09-06), so the repo file need
+  not duplicate machine-global rules.
 
-## Operational dependency and watch items
+## Run lifecycle
 
+- **A killed or timed-out run leaves partial edits.** Diagnose with
+  `git -C (worktree) status` and `git -C (worktree) diff` before resuming or
+  redispatching; a half-applied package looks like a fresh one to the next run.
+- **Windows kills don't tree-kill.** Kill the codex node process and verify it
+  is gone before treating the worktree as free.
+- **One codex session per worktree at a time** — concurrent sessions share the
+  working tree and overwrite each other's edits.
+- Resume by the captured session id. `--last` is only safe while a single
+  session is in flight.
 - Runs consume the owner's ChatGPT subscription. A run that dies on expired auth
   must be **flagged for `codex login`**, never silently skipped or retried into
   the void.
+
+## Watch items
+
 - Implementer-length runs are untested against plan limits — the free tier once
   died mid-review on a 26-file diff. Watch for truncated or missing reports on
   long packages and report the suspicion.
@@ -163,8 +202,11 @@ anything.
   (diff / status / log / show, branch --list).
 - A Permission-denied on a path outside the workspace is an environment limit:
   report it and continue.
-- Lint only your own files: pnpm exec biome check --write (files). NEVER
-  pnpm lint — it rewrites all of src/ and site/.
+- Lint-fix only the files you touched, using the command the spec's
+  Verification field names. NEVER pnpm lint — it rewrites all of src/ and
+  site/. In a fresh worktree, never judge formatting from a tree-wide check:
+  the CRLF checkout false-fails files you never edited. The trustworthy form is
+  the LF-copy biome ci gate the spec names for each ts/tsx you edit.
 - Run exactly the spec's Verification commands and quote any failure verbatim.
   Do not invent broader test scaffolding for small, reversible changes.
 - Your final message is the report: Outcome (one sentence) / Changes (per file)

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -20,7 +20,8 @@ Where this file and generic best practice disagree, this file wins.
    past subagent's stray commit wiped `.gitignore` and broke the app.
 2. **No stray files.** Create only what your task calls for. Scratch files go
    in the session scratchpad or `C:/temp`, never the repo; destructive
-   experiments happen in a throwaway repo under `C:/temp`.
+   experiments happen in a throwaway repo under `C:/temp`. (One exception: the
+   LF-copy gate's `__cigate__<name>` sibling, deleted after the check.)
 3. **Don't edit `src/components/ui/`** — vendored shadcn/Base UI primitives.
    Fix at the feature/call-site level. That folder's `README.md` inventories
    the sanctioned local modifications (a re-vendor silently reverts them);

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -12,11 +12,12 @@ Where this file and generic best practice disagree, this file wins.
 ## Hard rules (violations have destroyed user state before)
 
 1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log /
-   show` and `git branch --list`. Everything else — commit, add/stage,
-   checkout, reset, stash, rm, clean, push, pull, fetch, merge, rebase, tag,
-   branch create/delete, worktree, remote, config — is forbidden, even "just
-   to test". The user commits their own work, possibly in parallel with your
-   session; a past subagent's stray commit wiped `.gitignore` and broke the app.
+   show` and `git branch --list`, each optionally prefixed with `-C <path>` to
+   address a task worktree. Everything else — commit, add/stage, checkout,
+   reset, stash, rm, clean, push, pull, fetch, merge, rebase, tag, branch
+   create/delete, worktree, remote, config — is forbidden, even "just to test".
+   The user commits their own work, possibly in parallel with your session; a
+   past subagent's stray commit wiped `.gitignore` and broke the app.
 2. **No stray files.** Create only what your task calls for. Scratch files go
    in the session scratchpad or `C:/temp`, never the repo; destructive
    experiments happen in a throwaway repo under `C:/temp`.
@@ -430,8 +431,11 @@ mentions when a feature ships.
   the count with a named home. Never leave the Nth instance for a later PR.
 - **Conventions-sync:** a change that builds a reusable primitive adds its line
   to THIS file in the same change (the docs-sync rule, applied to idioms). A
-  change to a hard rule also updates its two mirrors: the always-loaded excerpt
-  `.claude/rules/git-safety.md` and the repo `AGENTS.md`.
+  change to a hard rule also updates every file that states that rule, wherever
+  it is restated — the always-loaded excerpt `.claude/rules/git-safety.md`, the
+  repo `AGENTS.md`, the agent definitions, and any carrier added later;
+  `scripts/check-rule-mirrors.mjs` holds the current list for the git
+  whitelist and fails when one drifts.
 
 ## Definition of done
 

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -20,8 +20,10 @@ Where this file and generic best practice disagree, this file wins.
    past subagent's stray commit wiped `.gitignore` and broke the app.
 2. **No stray files.** Create only what your task calls for. Scratch files go
    in the session scratchpad or `C:/temp`, never the repo; destructive
-   experiments happen in a throwaway repo under `C:/temp`. (One exception: the
-   LF-copy gate's `__cigate__<name>` sibling, deleted after the check.)
+   experiments happen in a throwaway repo under `C:/temp`. (One exception, for
+   runs that may create files: the LF-copy gate's `__cigate__<name>` sibling,
+   deleted after the check — reviewers never create it, per the `--write` rule
+   below.)
 3. **Don't edit `src/components/ui/`** — vendored shadcn/Base UI primitives.
    Fix at the feature/call-site level. That folder's `README.md` inventories
    the sanctioned local modifications (a re-vendor silently reverts them);
@@ -436,7 +438,7 @@ mentions when a feature ships.
   it is restated — the always-loaded excerpt `.claude/rules/git-safety.md`, the
   repo `AGENTS.md`, the agent definitions, and any carrier added later;
   `scripts/check-rule-mirrors.mjs` holds the current list for the git
-  whitelist and fails when one drifts.
+  whitelist and fails when a carrier drops the rule's core.
 
 ## Definition of done
 

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -429,7 +429,9 @@ mentions when a feature ships.
   grep its class immediately — fix every sibling in the same batch, or record
   the count with a named home. Never leave the Nth instance for a later PR.
 - **Conventions-sync:** a change that builds a reusable primitive adds its line
-  to THIS file in the same change (the docs-sync rule, applied to idioms).
+  to THIS file in the same change (the docs-sync rule, applied to idioms). A
+  change to a hard rule also updates its two mirrors: the always-loaded excerpt
+  `.claude/rules/git-safety.md` and the repo `AGENTS.md`.
 
 ## Definition of done
 

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -22,8 +22,7 @@ Where this file and generic best practice disagree, this file wins.
    in the session scratchpad or `C:/temp`, never the repo; destructive
    experiments happen in a throwaway repo under `C:/temp`. (One exception, for
    runs that may create files: the LF-copy gate's `__cigate__<name>` sibling,
-   deleted after the check — reviewers never create it, per the `--write` rule
-   below.)
+   deleted after the check — reviewers never create it: the LF copy is a file.)
 3. **Don't edit `src/components/ui/`** — vendored shadcn/Base UI primitives.
    Fix at the feature/call-site level. That folder's `README.md` inventories
    the sanctioned local modifications (a re-vendor silently reverts them);
@@ -437,8 +436,9 @@ mentions when a feature ships.
   change to a hard rule also updates every file that states that rule, wherever
   it is restated — the always-loaded excerpt `.claude/rules/git-safety.md`, the
   repo `AGENTS.md`, the agent definitions, and any carrier added later;
-  `scripts/check-rule-mirrors.mjs` holds the current list for the git
-  whitelist and fails when a carrier drops the rule's core.
+  `scripts/check-rule-mirrors.mjs` holds the gated list for the git whitelist
+  and fails when a carrier drops the rule's core (the codex spec preamble
+  restates it condensed, synced by hand).
 
 ## Definition of done
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 jobs:
-  # BLOCKING. The three scripts are Node-stdlib-only by design, so this job
+  # BLOCKING. The four scripts are Node-stdlib-only by design, so this job
   # needs no install step and stays a seconds-long gate on every PR.
   guards:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
           node-version: 24
 
       # One step per script so a failure names its own check in the UI. The same
-      # three scripts plus the self-tests below run locally via package.json's
+      # four scripts plus the self-tests below run locally via package.json's
       # `checks` alias — a new guard is added in BOTH places.
       - name: Banned frontend patterns
         run: node scripts/check-banned-patterns.mjs
@@ -55,6 +55,9 @@ jobs:
 
       - name: IPC surface drift
         run: node scripts/check-dead-surface.mjs
+
+      - name: Rule-mirror drift
+        run: node scripts/check-rule-mirrors.mjs
 
       # Negative controls for the scanners themselves — their worst failure is a
       # silent fail-open, so the fixtures that prove each predicate still fires

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — GitDesktop
+
+GitDesktop is an AI-native, keyboard-first Git desktop client (Tauri 2 +
+React 19) with an Astro marketing site in `site/`. Every agent run rooted at this
+repo auto-loads this file whatever its role, so it carries repo context and hard
+boundaries only.
+
+## Binding context — read before substantive work
+
+`CLAUDE.md` and `.claude/skills/gd-conventions/SKILL.md` are the binding agent
+context: the standing brief and the repo playbook of conventions and gotchas.
+`CONTRIBUTING.md` holds the human conventions, `PRODUCT.md` the product intent.
+
+## Hard boundaries
+
+- **Git is a whitelist.** Permitted: `git --no-pager diff`, `git --no-pager
+  status`, `git --no-pager log`, `git --no-pager show`, `git branch --list`.
+  Every state-mutating git command — commit, add/stage, checkout, reset, stash,
+  rm, clean, push, pull, fetch, merge, rebase, tag, branch create/delete,
+  worktree, remote, config — is forbidden, even "just to test": the user commits
+  their own work, possibly in parallel with this run.
+  `.claude/rules/git-safety.md` is the authoritative list; read it in the tree.
+- In a task worktree the sandbox denies those mutations at the filesystem layer
+  as well. A denial there is the policy working, not an obstacle to route around.
+- **Never edit `src/components/ui/`** — vendored shadcn/Base UI primitives; fix
+  at the feature or call site (that folder's `README.md` inventories the
+  sanctioned local deltas).
+- **No tree-wide rewrites.** `pnpm lint` is `biome check --write` over `src/`
+  AND `site/` — a rewrite, not a check; the check form is `pnpm exec biome check
+  ./src/`. Never run repo-wide `cargo fmt` in `src-tauri`; `rustfmt <file>` on
+  individual new files only.
+- **No scratch or temp files inside the repo** — working files belong in the
+  session scratchpad or `C:/temp`.
+
+## Verification commands
+
+- `pnpm build` — typecheck plus frontend bundle. Plain `tsc --noEmit` is a no-op
+  in this repo; only `tsc -b` (or `pnpm build`) typechecks.
+- `cargo test --manifest-path src-tauri/Cargo.toml`
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
+- `cd site && pnpm build` — the marketing site.
+
+## When the run was given a task spec
+
+Stay strictly inside its stated file scope: a spec that looks wrong, or a fix
+that would need a file the spec did not list, is reported back rather than
+improvised around. A Permission-denied on a path outside the workspace is an
+environment limit — report it, don't work around it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS.md — GitDesktop
 
 GitDesktop is an AI-native, keyboard-first Git desktop client (Tauri 2 +
-React 19) with an Astro marketing site in `site/`. Every agent run rooted at this
-repo auto-loads this file whatever its role, so it carries repo context and hard
+React 19) with an Astro marketing site in `site/`. Codex and other agents that
+follow the AGENTS.md convention auto-load this file whatever their role (Claude
+sessions load `CLAUDE.md` instead), so it carries repo context and hard
 boundaries only.
 
 ## Binding context — read before substantive work
@@ -19,9 +20,20 @@ context: the standing brief and the repo playbook of conventions and gotchas.
   rm, clean, push, pull, fetch, merge, rebase, tag, branch create/delete,
   worktree, remote, config — is forbidden, even "just to test": the user commits
   their own work, possibly in parallel with this run.
-  `.claude/rules/git-safety.md` is the authoritative list; read it in the tree.
-- In a task worktree the sandbox denies those mutations at the filesystem layer
-  as well. A denial there is the policy working, not an obstacle to route around.
+  `.claude/skills/gd-conventions/SKILL.md` is the canonical playbook and
+  `.claude/rules/git-safety.md` its always-loaded excerpt; read either in the
+  tree.
+- In a task worktree the sandbox additionally denies the git commands that write
+  the git dir (measured on add, commit, checkout, rm, stash), and a denial there
+  is the policy working, not an obstacle to route around. Commands touching only
+  worktree files (`git clean`, for one) are **not** blocked, so the whitelist
+  above is the only thing protecting them.
+- **Repo files are written only when the run is executing a delegated
+  work-package spec** (the two sanctioned writer lanes, described in CLAUDE.md's
+  delegated-implementation section). A run handed no spec treats the repo as
+  read-only.
+- **Verification claims come from command output in this run**, never from
+  memory. Quote failures verbatim.
 - **Never edit `src/components/ui/`** — vendored shadcn/Base UI primitives; fix
   at the feature or call site (that folder's `README.md` inventories the
   sanctioned local deltas).
@@ -36,6 +48,8 @@ context: the standing brief and the repo playbook of conventions and gotchas.
 
 - `pnpm build` — typecheck plus frontend bundle. Plain `tsc --noEmit` is a no-op
   in this repo; only `tsc -b` (or `pnpm build`) typechecks.
+- `pnpm run checks` — the repo guard scripts CI runs (banned patterns, Rust
+  invariants, dead surface, script tests).
 - `cargo test --manifest-path src-tauri/Cargo.toml`
 - `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
 - `cd site && pnpm build` — the marketing site.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ context: the standing brief and the repo playbook of conventions and gotchas.
 ## Hard boundaries
 
 - **Git is a whitelist.** Permitted: `git --no-pager diff`, `git --no-pager
-  status`, `git --no-pager log`, `git --no-pager show`, `git branch --list`.
+  status`, `git --no-pager log`, `git --no-pager show`, `git branch --list` —
+  each may be prefixed with `-C <path>` to address a task worktree.
   Every state-mutating git command — commit, add/stage, checkout, reset, stash,
   rm, clean, push, pull, fetch, merge, rebase, tag, branch create/delete,
   worktree, remote, config — is forbidden, even "just to test": the user commits
@@ -29,9 +30,9 @@ context: the standing brief and the repo playbook of conventions and gotchas.
   worktree files (`git clean`, for one) are **not** blocked, so the whitelist
   above is the only thing protecting them.
 - **Repo files are written only when the run is executing a delegated
-  work-package spec** (the two sanctioned writer lanes, described in CLAUDE.md's
-  delegated-implementation section). A run handed no spec treats the repo as
-  read-only.
+  work-package spec** (CLAUDE.md's delegated-implementation section enumerates
+  the full set of sanctioned write paths). A run handed no spec treats the repo
+  as read-only.
 - **Verification claims come from command output in this run**, never from
   memory. Quote failures verbatim.
 - **Never edit `src/components/ui/`** — vendored shadcn/Base UI primitives; fix
@@ -39,8 +40,10 @@ context: the standing brief and the repo playbook of conventions and gotchas.
   sanctioned local deltas).
 - **No tree-wide rewrites.** `pnpm lint` is `biome check --write` over `src/`
   AND `site/` — a rewrite, not a check; the check form is `pnpm exec biome check
-  ./src/`. Never run repo-wide `cargo fmt` in `src-tauri`; `rustfmt <file>` on
-  individual new files only.
+  ./src/`. In a task worktree even that tree-wide check false-fails on CRLF, so
+  the trustworthy gate is the per-file LF-copy `biome ci` form (gd-conventions),
+  or whatever the spec's Verification field names. Never run repo-wide
+  `cargo fmt` in `src-tauri`; `rustfmt <file>` on individual new files only.
 - **No scratch or temp files inside the repo** — working files belong in the
   session scratchpad or `C:/temp`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,14 +45,17 @@ context: the standing brief and the repo playbook of conventions and gotchas.
   or whatever the spec's Verification field names. Never run repo-wide
   `cargo fmt` in `src-tauri`; `rustfmt <file>` on individual new files only.
 - **No scratch or temp files inside the repo** — working files belong in the
-  session scratchpad or `C:/temp`.
+  session scratchpad or `C:/temp`. The one sanctioned exception: a run that may
+  create files judges formatting with the per-file LF-copy `biome ci` gate,
+  whose `__cigate__<name>` sibling lives beside the original for the length of
+  the check and is deleted after. A read-only run creates nothing and reports
+  tree-wide formatting as unverified instead.
 
 ## Verification commands
 
 - `pnpm build` — typecheck plus frontend bundle. Plain `tsc --noEmit` is a no-op
   in this repo; only `tsc -b` (or `pnpm build`) typechecks.
-- `pnpm run checks` — the repo guard scripts CI runs (banned patterns, Rust
-  invariants, dead surface, script tests).
+- `pnpm run checks` — the repo guard scripts CI runs.
 - `cargo test --manifest-path src-tauri/Cargo.toml`
 - `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
 - `cd site && pnpm build` — the marketing site.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,16 +187,16 @@ For multi-file implementation work, prefer the `/delegate` workflow
 (`.claude/skills/delegate/SKILL.md`): the main conversation architects and
 writes work-package specs; the `implementer` agent (Opus,
 `.claude/agents/implementer.md`) executes them; the read-only `spec-reviewer`
-agent verifies. **/delegate requires Fable as the main conversation model**
-(the agents themselves are pinned to Opus regardless) — non-Fable sessions
-work inline instead. Both agents preload the `gd-conventions` skill — the repo
-playbook of hard rules and gotchas (`.claude/skills/gd-conventions/SKILL.md`).
-Three write paths are sanctioned in this repo: the `implementer` agent
-executing a spec; the experimental codex arm when /delegate dispatches one,
-sandbox-confined to a task worktree
+agent verifies. **/delegate requires a Fable- or Opus-family main
+conversation model** (the agents themselves are pinned to Opus regardless) —
+Sonnet and smaller work inline instead. Both agents preload the
+`gd-conventions` skill — the repo playbook of hard rules and gotchas
+(`.claude/skills/gd-conventions/SKILL.md`). Three write paths are sanctioned
+in this repo: the `implementer` agent executing a spec; the experimental
+codex arm when /delegate dispatches one, sandbox-confined to a task worktree
 (`.claude/skills/delegate/references/codex-implementer.md`); and the
 orchestrator for trivial ≤ ~3-line reviewer/live-confirmed fixes during a
-/delegate run (see the skill's Phase 4); every other spawned agent is
+/delegate run (see the skill's Phase 4). Every other spawned agent is
 strictly read-only, and **no agent ever commits or mutates git state — the
 user commits their own work.** (This section addresses the main
 conversation: if you are a dispatched subagent working a package, do your

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,12 +191,13 @@ agent verifies. **/delegate requires Fable as the main conversation model**
 (the agents themselves are pinned to Opus regardless) — non-Fable sessions
 work inline instead. Both agents preload the `gd-conventions` skill — the repo
 playbook of hard rules and gotchas (`.claude/skills/gd-conventions/SKILL.md`).
-Only `implementer` may write files in this repo — plus the experimental codex
-implementer arm when /delegate dispatches one, sandbox-confined to a task worktree
-(`.claude/skills/delegate/references/codex-implementer.md`), and the orchestrator
-for trivial ≤ ~3-line reviewer/live-confirmed fixes during a /delegate run (see
-the skill's Phase 4); every other spawned agent is strictly read-only, and
-**no agent ever commits or mutates git state — the user commits their own
-work.** (This section addresses the main conversation:
-if you are a dispatched subagent working a package, do your package — never
-re-delegate or spawn further agents.)
+Three write paths are sanctioned in this repo: the `implementer` agent
+executing a spec; the experimental codex arm when /delegate dispatches one,
+sandbox-confined to a task worktree
+(`.claude/skills/delegate/references/codex-implementer.md`); and the
+orchestrator for trivial ≤ ~3-line reviewer/live-confirmed fixes during a
+/delegate run (see the skill's Phase 4); every other spawned agent is
+strictly read-only, and **no agent ever commits or mutates git state — the
+user commits their own work.** (This section addresses the main
+conversation: if you are a dispatched subagent working a package, do your
+package — never re-delegate or spawn further agents.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,8 +191,10 @@ agent verifies. **/delegate requires Fable as the main conversation model**
 (the agents themselves are pinned to Opus regardless) — non-Fable sessions
 work inline instead. Both agents preload the `gd-conventions` skill — the repo
 playbook of hard rules and gotchas (`.claude/skills/gd-conventions/SKILL.md`).
-Only `implementer` may write files in this repo — plus the orchestrator for
-trivial ≤ ~3-line reviewer/live-confirmed fixes during a /delegate run (see
+Only `implementer` may write files in this repo — plus the experimental codex
+implementer arm when /delegate dispatches one, sandbox-confined to a task worktree
+(`.claude/skills/delegate/references/codex-implementer.md`), and the orchestrator
+for trivial ≤ ~3-line reviewer/live-confirmed fixes during a /delegate run (see
 the skill's Phase 4); every other spawned agent is strictly read-only, and
 **no agent ever commits or mutates git state — the user commits their own
 work.** (This section addresses the main conversation:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "biome check --write ./src/ ./site/",
-    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs && node --test \"scripts/*.test.mjs\"",
+    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs && node scripts/check-rule-mirrors.mjs && node --test \"scripts/*.test.mjs\"",
     "preview": "vite preview",
     "changelog": "node scripts/changelog-draft.mjs",
     "changelog:preview": "node scripts/changelog-draft.mjs --preview",

--- a/scripts/check-rule-mirrors.mjs
+++ b/scripts/check-rule-mirrors.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Drift gate for the git-whitelist hard rule, which lives in FIVE carriers by
+// design — the canonical playbook, its always-loaded excerpt, the repo
+// AGENTS.md that agents outside Claude auto-load, and the two agent definitions
+// that restate it as their own charter. Two review findings in one round came
+// from a rule changing in one carrier and not the others, so the class ships
+// its guard: each carrier must still state the whitelist's core.
+//
+// PRESENCE, not equality: the copies word the rule differently on purpose (one
+// is a numbered hard rule, one a bullet, one prose for a different audience),
+// so verbatim comparison would fail on every legitimate edit. Each sentinel is
+// the smallest phrase whose ABSENCE means a carrier lost the rule.
+//
+// Matching runs over whitespace-NORMALIZED text: every carrier hand-wraps at a
+// different width, so a line break inside a sentinel phrase would otherwise
+// read as a missing rule.
+//
+// Run: node scripts/check-rule-mirrors.mjs
+// Test seam: GD_RULE_MIRROR_ROOT points the check at a copy of the tree (used
+// for the negative control — a mutated copy must go red).
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Every file that states the git-whitelist rule. */
+export const CARRIERS = [
+  ".claude/skills/gd-conventions/SKILL.md",
+  ".claude/rules/git-safety.md",
+  "AGENTS.md",
+  ".claude/agents/implementer.md",
+  ".claude/agents/spec-reviewer.md",
+];
+
+/**
+ * Each sentinel names what its absence would mean, and carries the fix a
+ * reader needs — never just "pattern not found".
+ */
+export const SENTINELS = [
+  {
+    name: "read-only git forms",
+    pattern: /git --no-pager diff/,
+    fix: "state the permitted read-only forms, starting `git --no-pager diff`",
+  },
+  {
+    name: "branch --list allowance",
+    pattern: /git branch --list/,
+    fix: "keep `git branch --list` in the permitted set",
+  },
+  {
+    name: "forbidden catchall",
+    pattern:
+      /(everything else|every other git invocation|every state-mutating git command)[\s\S]{0,300}?is forbidden/i,
+    fix: "keep the catchall sentence that forbids every other git invocation",
+  },
+  {
+    name: "-C worktree sanction",
+    pattern: /-C <path>[^.]{0,40}task worktree/i,
+    fix: "sanction the `-C <path>` form so worktree-scoped commands stay legal",
+  },
+];
+
+export const normalize = (text) => text.replace(/\s+/g, " ");
+
+/** Sentinels a carrier's text no longer satisfies. */
+export function missingSentinels(text, sentinels = SENTINELS) {
+  const flat = normalize(text);
+  return sentinels.filter((s) => !s.pattern.test(flat));
+}
+
+function main() {
+  const root = process.env.GD_RULE_MIRROR_ROOT
+    ? resolve(process.env.GD_RULE_MIRROR_ROOT)
+    : REPO_ROOT;
+
+  let failed = false;
+  for (const carrier of CARRIERS) {
+    let text;
+    try {
+      text = readFileSync(join(root, carrier), "utf8");
+    } catch (err) {
+      failed = true;
+      process.stderr.write(`rule-mirrors: FAIL — cannot read ${carrier}\n`);
+      process.stderr.write(`    ${err.message}\n`);
+      continue;
+    }
+    const missing = missingSentinels(text);
+    if (missing.length === 0) {
+      process.stdout.write(
+        `rule-mirrors: OK ${carrier} (${SENTINELS.length} sentinels)\n`,
+      );
+      continue;
+    }
+    failed = true;
+    process.stderr.write(
+      `rule-mirrors: FAIL ${carrier} (${missing.length} of ${SENTINELS.length} sentinels missing)\n`,
+    );
+    for (const s of missing) {
+      process.stderr.write(`  missing: ${s.name}\n`);
+      process.stderr.write(`    ${s.fix}\n`);
+    }
+  }
+
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // finding the failure is about on a CI runner.
+  process.exitCode = failed ? 1 : 0;
+}
+
+// Main-module detection by PATH comparison, not `import.meta.main`: that form
+// only exists from node 24.2 and fails SILENTLY on older runtimes (the gate
+// reads `if (undefined)` and exits 0 having checked nothing).
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-rule-mirrors.mjs
+++ b/scripts/check-rule-mirrors.mjs
@@ -5,6 +5,10 @@
 // that restate it as their own charter. Two review findings in one round came
 // from a rule changing in one carrier and not the others, so the class ships
 // its guard: each carrier must still state the whitelist's core.
+// A sixth statement — the codex spec preamble in
+// .claude/skills/delegate/references/codex-implementer.md — is deliberately
+// condensed for a prompt and is NOT sentinel-matchable, so it stays out of
+// CARRIERS and is kept in sync by hand; trimming it never trips this gate.
 //
 // PRESENCE, not equality: the copies word the rule differently on purpose (one
 // is a numbered hard rule, one a bullet, one prose for a different audience),
@@ -54,10 +58,13 @@ export const SENTINELS = [
     name: "forbidden catchall",
     // The lookahead is the point: a carrier that keeps the sentence and then
     // carves an exception out of it ("is forbidden, except …") has lost the
-    // rule as surely as one that deleted it.
+    // rule as surely as one that deleted it. Its scope is narrow, though — it
+    // sees an exception qualifier immediately following "is forbidden", so
+    // differently-phrased carve-outs ("with one exception:", "— save for")
+    // still pass.
     pattern:
       /(everything else|every other git invocation|every state-mutating git command)[\s\S]{0,300}?is forbidden(?!\s*(?:,|;|—|-)?\s*(?:except|but|unless)\b)/i,
-    fix: "keep the catchall sentence that forbids every other git invocation",
+    fix: "keep the catchall sentence forbidding every other git invocation, with no except/but/unless clause carved out of it",
   },
   {
     name: "-C worktree sanction",

--- a/scripts/check-rule-mirrors.mjs
+++ b/scripts/check-rule-mirrors.mjs
@@ -52,8 +52,11 @@ export const SENTINELS = [
   },
   {
     name: "forbidden catchall",
+    // The lookahead is the point: a carrier that keeps the sentence and then
+    // carves an exception out of it ("is forbidden, except …") has lost the
+    // rule as surely as one that deleted it.
     pattern:
-      /(everything else|every other git invocation|every state-mutating git command)[\s\S]{0,300}?is forbidden/i,
+      /(everything else|every other git invocation|every state-mutating git command)[\s\S]{0,300}?is forbidden(?!\s*(?:,|;|—|-)?\s*(?:except|but|unless)\b)/i,
     fix: "keep the catchall sentence that forbids every other git invocation",
   },
   {

--- a/scripts/check-rule-mirrors.mjs
+++ b/scripts/check-rule-mirrors.mjs
@@ -16,8 +16,10 @@
 // read as a missing rule.
 //
 // Run: node scripts/check-rule-mirrors.mjs
-// Test seam: GD_RULE_MIRROR_ROOT points the check at a copy of the tree (used
-// for the negative control — a mutated copy must go red).
+// GD_RULE_MIRROR_ROOT points the check at a copy of the tree, for an ad-hoc
+// negative control by hand: copy the carriers, mutate one, watch it go red.
+// The committed controls live in scripts/checks.test.mjs and drive
+// `missingSentinels` in memory, touching no disk.
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1,4 +1,4 @@
-// Negative controls for the three guard scanners. Their worst failure mode is
+// Negative controls for the four guard scanners. Their worst failure mode is
 // silent fail-open — a pattern that stops matching still prints "OK" — so every
 // predicate keeps a fixture that MUST hit and a fixture that must not. The
 // scripts export their predicates and gate their CLI body on a main-module path
@@ -22,6 +22,7 @@ import {
   parseRegistered,
   staleAllowlistEntries as staleCommandEntries,
 } from "./check-dead-surface.mjs";
+import { missingSentinels } from "./check-rule-mirrors.mjs";
 import {
   checkCompareEndpoints,
   checkRefspecTemplates,
@@ -1759,4 +1760,38 @@ test("invoke matching survives nested generics and wrapped calls", () => {
     "git_branch_tips",
     "git_status",
   ]);
+});
+
+// ----------------------------------------------------------- check-rule-mirrors
+
+// Both fixtures wrap their sentences the way the real carriers do — the `-C`
+// clause and the `is / forbidden` catchall each straddle a line break. That is
+// deliberate: if the whitespace normalization ever came out, the passing
+// fixture would read as a carrier missing two sentinels, so these cases pin the
+// normalization as much as the patterns.
+const carrierStatingTheRule = [
+  "1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log /",
+  "   show` and `git branch --list`, each optionally prefixed with `-C <path>`",
+  "   to address a task worktree. Everything else — commit, add/stage, stash,",
+  "   push, worktree, config — is",
+  '   forbidden, even "just to test". The user commits their own work.',
+].join("\n");
+
+test("a carrier that still states the whole rule satisfies every sentinel", () => {
+  assert.deepEqual(missingSentinels(carrierStatingTheRule), []);
+});
+
+test("a carrier that drops the line-wrapped catchall is caught", () => {
+  // The dangerous direction: the whitelist forms are still listed, so the file
+  // LOOKS like it carries the rule — only the sentence forbidding everything
+  // else is gone, which is exactly the drift a reader would not notice.
+  const softened = carrierStatingTheRule.replace(
+    ["   push, worktree, config — is", "   forbidden, even"].join("\n"),
+    "   push, worktree, config — are discouraged, except",
+  );
+  assert.notEqual(softened, carrierStatingTheRule);
+  assert.deepEqual(
+    missingSentinels(softened).map((s) => s.name),
+    ["forbidden catchall"],
+  );
 });

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1799,6 +1799,23 @@ test("a carrier that drops the line-wrapped catchall is caught", () => {
   );
 });
 
+test("a carrier that carves an exception into the catchall is caught", () => {
+  // Worse than deleting the sentence, because the sentence is still there to
+  // read: the rule is stated and then unstated in the same breath.
+  const excepted = carrierStatingTheRule.replace(
+    [
+      "   push, worktree, config — is",
+      '   forbidden, even "just to test".',
+    ].join("\n"),
+    "   push, worktree, config — is forbidden, except git commit.",
+  );
+  assert.notEqual(excepted, carrierStatingTheRule);
+  assert.deepEqual(
+    missingSentinels(excepted).map((s) => s.name),
+    ["forbidden catchall"],
+  );
+});
+
 test("a carrier that drops the -C sanction is caught", () => {
   // Losing this clause is what makes a worktree-scoped command read as
   // forbidden to an agent honoring its own charter.

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -9,7 +9,10 @@
 // Node's stdlib test runner and node: imports only, no dev dependency, so the
 // CI `guards` job runs `node --test "scripts/*.test.mjs"` with no install step.
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   CHECKS,
@@ -22,7 +25,7 @@ import {
   parseRegistered,
   staleAllowlistEntries as staleCommandEntries,
 } from "./check-dead-surface.mjs";
-import { missingSentinels } from "./check-rule-mirrors.mjs";
+import { CARRIERS, missingSentinels } from "./check-rule-mirrors.mjs";
 import {
   checkCompareEndpoints,
   checkRefspecTemplates,
@@ -1794,4 +1797,58 @@ test("a carrier that drops the line-wrapped catchall is caught", () => {
     missingSentinels(softened).map((s) => s.name),
     ["forbidden catchall"],
   );
+});
+
+test("a carrier that drops the -C sanction is caught", () => {
+  // Losing this clause is what makes a worktree-scoped command read as
+  // forbidden to an agent honoring its own charter.
+  const unscoped = carrierStatingTheRule.replace(
+    [
+      "   show` and `git branch --list`, each optionally prefixed with `-C <path>`",
+      "   to address a task worktree. Everything else",
+    ].join("\n"),
+    "   show` and `git branch --list`. Everything else",
+  );
+  assert.notEqual(unscoped, carrierStatingTheRule);
+  assert.deepEqual(
+    missingSentinels(unscoped).map((s) => s.name),
+    ["-C worktree sanction"],
+  );
+});
+
+test("a carrier that drops the branch --list allowance is caught", () => {
+  const withoutBranch = carrierStatingTheRule.replace(
+    "` and `git branch --list`,",
+    "`,",
+  );
+  assert.notEqual(withoutBranch, carrierStatingTheRule);
+  assert.deepEqual(
+    missingSentinels(withoutBranch).map((s) => s.name),
+    ["branch --list allowance"],
+  );
+});
+
+test("a carrier that drops the read-only forms list is caught", () => {
+  const withoutForms = carrierStatingTheRule.replace(
+    [
+      "1. **Git is a whitelist.** Permitted: `git --no-pager diff / status / log /",
+      "   show`",
+    ].join("\n"),
+    "1. **Git is a whitelist.** Permitted: the read-only inspection forms",
+  );
+  assert.notEqual(withoutForms, carrierStatingTheRule);
+  assert.deepEqual(
+    missingSentinels(withoutForms).map((s) => s.name),
+    ["read-only git forms"],
+  );
+});
+
+test("every carrier path the gate checks exists on disk", () => {
+  // The sentinels only fire on a file the gate can read: a carrier renamed or
+  // moved without updating CARRIERS would otherwise fail as "cannot read" in
+  // CI long after the rename landed.
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  for (const carrier of CARRIERS) {
+    assert.ok(existsSync(join(root, carrier)), `missing carrier: ${carrier}`);
+  }
 });


### PR DESCRIPTION
Sanctions a second implementation writer for the `/delegate` workflow: the codex CLI driving `gpt-6-astra`, confined to linked task worktrees where the sandbox denies git-dir-writing mutations at the filesystem layer. Adds a repo-root `AGENTS.md` so codex-rooted runs auto-load repo context and hard boundaries, and threads the "two sanctioned writers" wording through every place that previously claimed `implementer` was the only one. Documentation and agent config only — no app code changes.

### Codex implementer arm

- Adds `.claude/skills/delegate/references/codex-implementer.md`, the full recipe for the arm: routing guidance (self-contained Rust/wire/script/CI packages to codex, idiom-dense React/UI packages stay with Opus), astra behavior notes with their OpenAI sources, the stdin-heredoc `codex exec` dispatch form with an absolute `--cd` and a linked-worktree assertion, fix rounds via `codex exec resume` repeating the dispatch flags, measured sandbox behavior, a run-lifecycle section, and the spec preamble to paste above every codex spec.
- Records the measured sandbox findings that scope the lane's guarantees: writes inside the worktree succeed and git reads work; commands that write the git dir (`add`, `commit`, `checkout -- <file>`, `rm --cached`, `stash push`) fail on the out-of-workspace `index.lock`, while commands touching only worktree files (`git clean`, measured) are not blocked — so the sandbox enforces the git-dir-writing subset and the no-git-mutation policy covers the rest. Hence the hard rules: dispatch only in linked task worktrees, never pass `--add-dir` at the main repo. Also documents that network is off under `workspace-write`, that `AGENTS.md` is auto-read, and how a global `~/.codex/AGENTS.md` layers under the repo one (the repo file wins conflicts).
- Updates `.claude/skills/delegate/SKILL.md`: the division-of-labor paragraph and Phase 1 both name the two sanctioned writers, the "Codex implementer arm (experimental)" subsection in Phase 3 carries the hard rules (worktrees only, no `--add-dir` at the main repo, stdin not argv, explicit `-c model_reasoning_effort` since the default is `none`, capture the `session id:` line, resume rather than re-dispatch, network off, worktree-scoped baseline and footprint sweep), and Phase 4 item 6 requires a `spec-reviewer` pass on every codex package while the arm is experimental, with its `-o` report file earning the same skepticism as an agent report.
- Updates `.claude/agents/implementer.md`, `.claude/agents/spec-reviewer.md` (the reviewer now covers both implementation agents and knows about worktree pointers and the codex report file), and the delegated-implementation section of `CLAUDE.md`, which now enumerates the three sanctioned write paths affirmatively. None of these edits loosen the no-git-mutation rule.

### Repo-root AGENTS.md

- Adds `AGENTS.md`, scoped to repo context and hard boundaries since codex and other AGENTS.md-convention runs rooted here auto-load it regardless of role (Claude sessions load `CLAUDE.md` instead). It points at the binding context (`CLAUDE.md`, `.claude/skills/gd-conventions/SKILL.md`, `CONTRIBUTING.md`, `PRODUCT.md`) and restates only the hard boundaries.
- Restates the git whitelist with `.claude/skills/gd-conventions/SKILL.md` as the canonical playbook (`.claude/rules/git-safety.md` is its always-loaded excerpt; the conventions-sync note in both now names `AGENTS.md` as the third synced copy), frames a sandbox denial as the policy working, states the write-default (repo files are written only when executing a delegated work-package spec; a run handed no spec treats the repo as read-only), requires verification claims to come from command output in the current run, bans edits to `src/components/ui/`, and rules out tree-wide rewrites (`pnpm lint` is `biome check --write` over `src/` and `site/`; the check form is `pnpm exec biome check ./src/`; never repo-wide `cargo fmt` in `src-tauri`).
- Lists the verification commands (including `pnpm run checks`) with the `tsc -b` caveat that plain `tsc --noEmit` is a no-op here, plus the spec-scope rule for runs handed a task spec.

No changelog fragment: the diff touches neither `src/` nor `src-tauri/`, so it has no user-facing effect and the `fragment` check passes in its no-fragment-required path (it fires on `src/` and `src-tauri/` changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance for Git safety, file-editing boundaries, worktree verification, and task scope.
  * Documented the experimental Codex implementation workflow, including delegation, sandboxing, session handling, and review requirements.
  * Clarified implementation and specification-review responsibilities.
  * Updated convention-sync guidance to keep documented rules aligned.

* **Quality**
  * Added automated detection for drift among synchronized repository rules.
  * Expanded rule-validation tests and integrated the checks into standard quality workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->