### PR TITLE
feat(mywork,github): open pull requests in the worktree holding them

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,7 +964,8 @@ review via its subscription login. The full list is under
   request usually lands in the **worktree** its head branch is checked out in,
   so you arrive in the checkout the work lives in. Read-only, with a
   **Refresh** in the header and a right-click menu for *Open in main workspace*
-  (on a local pull request) / *Open on GitHub* / *Copy link*.
+  (on a pull request from a repository you've added) / *Open on GitHub* /
+  *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/README.md
+++ b/README.md
@@ -960,9 +960,11 @@ review via its subscription login. The full list is under
   palette (*My work*), narrow it with **All / Pull requests / Issues** tabs and
   a filter box that takes arrow keys and Enter, and press Enter on a row: an
   item from a repository you've added to GitDesktop usually opens right in the
-  app, and the ↗ marks the rows that will open on GitHub instead. Read-only,
-  with a **Refresh** in the header and a right-click menu for *Open on GitHub* /
-  *Copy link*.
+  app, and the ↗ marks the rows that will open on GitHub instead. A pull
+  request usually lands in the **worktree** its head branch is checked out in,
+  so you arrive in the checkout the work lives in. Read-only, with a
+  **Refresh** in the header and a right-click menu for *Open in main workspace*
+  (on a local pull request) / *Open on GitHub* / *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/README.md
+++ b/README.md
@@ -956,8 +956,9 @@ review via its subscription login. The full list is under
 - **My work**: a cross-repo inbox of your open **GitHub** pull requests and
   issues (authored, assigned, mentioned, commented on, or awaiting your
   review), newest first, so what's waiting on you is one screen away instead
-  of one repository at a time. Open it from the welcome screen or the command
-  palette (*My work*), narrow it with **All / Pull requests / Issues** tabs and
+  of one repository at a time. Open it with `Ctrl`/`⌘`+`Shift`+`M`, from the
+  welcome screen, or from the command palette (*My work*), narrow it with
+  **All / Pull requests / Issues** tabs and
   a filter box that takes arrow keys and Enter, and press Enter on a row: an
   item from a repository you've added to GitDesktop usually opens right in the
   app, and the ↗ marks the rows that will open on GitHub instead. A pull

--- a/README.md
+++ b/README.md
@@ -958,15 +958,14 @@ review via its subscription login. The full list is under
   review), newest first, so what's waiting on you is one screen away instead
   of one repository at a time. Open it with `Ctrl`/`⌘`+`Shift`+`M`, from the
   welcome screen, or from the command palette (*My work*), narrow it with
-  **All / Pull requests / Issues** tabs and
-  a filter box that takes arrow keys and Enter, and press Enter on a row: an
-  item from a repository you've added to GitDesktop usually opens right in the
-  app, and the ↗ marks the rows that will open on GitHub instead. A pull
-  request usually lands in the **worktree** its head branch is checked out in,
-  so you arrive in the checkout the work lives in. Read-only, with a
-  **Refresh** in the header and a right-click menu for *Open in main workspace*
-  (on a pull request from a repository you've added) / *Open on GitHub* /
-  *Copy link*.
+  **All / Pull requests / Issues** tabs and a filter box that takes arrow keys
+  and Enter, and press Enter on a row: an item from a repository you've added
+  to GitDesktop usually opens right in the app, and the ↗ marks the rows that
+  will open on GitHub instead. A pull request usually lands in the **worktree**
+  its head branch is checked out in, so you arrive in the checkout the work
+  lives in. Read-only, with a **Refresh** in the header and a right-click menu
+  for *Open in main workspace* (on a pull request from a repository you've
+  added) / *Open on GitHub* / *Copy link*.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -8,4 +8,5 @@
   instead. A pull request usually lands in the worktree its head branch is
   checked out in, so you arrive in the checkout the work lives in, and
   *Open in main workspace* on the row's right-click menu skips that. Reach it
-  from the welcome screen or the command palette (*My work*).
+  with its shortcut, from the welcome screen, or from the command palette
+  (*My work*).

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -8,5 +8,5 @@
   instead. A pull request usually lands in the worktree its head branch is
   checked out in, so you arrive in the checkout the work lives in, and
   *Open in main workspace* on the row's right-click menu skips that. Reach it
-  with its shortcut, from the welcome screen, or from the command palette
-  (*My work*).
+  with `Ctrl`/`⌘`+`Shift`+`M`, from the welcome screen, or from the command
+  palette (*My work*).

--- a/changelog.d/added-my-work-inbox.md
+++ b/changelog.d/added-my-work-inbox.md
@@ -5,4 +5,7 @@
   issues, or type to narrow by title, repository, or number.
   Press Enter on a row and an item from a repository you've added to GitDesktop
   usually opens in the app; the ↗ marks the rows that will open on GitHub
-  instead. Reach it from the welcome screen or the command palette (*My work*).
+  instead. A pull request usually lands in the worktree its head branch is
+  checked out in, so you arrive in the checkout the work lives in, and
+  *Open in main workspace* on the row's right-click menu skips that. Reach it
+  from the welcome screen or the command palette (*My work*).

--- a/changelog.d/fixed-combobox-a11y.md
+++ b/changelog.d/fixed-combobox-a11y.md
@@ -1,0 +1,4 @@
+- **Explore repositories** reads cleanly with a screen reader: the search box
+  announces the highlighted result on its own, references the results list only
+  while that list is on screen, and Tab moves past the results rather than
+  stepping through them.

--- a/changelog.d/fixed-combobox-a11y.md
+++ b/changelog.d/fixed-combobox-a11y.md
@@ -1,4 +1,3 @@
 - **Explore repositories** reads cleanly with a screen reader: the search box
-  announces the highlighted result on its own, references the results list only
-  while that list is on screen, and Tab moves past the results rather than
-  stepping through them.
+  references the results list only while that list is on screen, and Tab moves
+  past the results rather than stepping through them.

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -933,7 +933,7 @@ pub async fn forge_owned_namespaces(provider: Provider) -> AppResult<Vec<String>
 #[tauri::command]
 pub async fn forge_my_work(
     provider: Provider,
-) -> AppResult<Vec<crate::github::my_work::MyWorkItem>> {
+) -> AppResult<crate::github::my_work::MyWorkPage> {
     match provider {
         Provider::GitHub => crate::github::my_work::my_work().await,
         Provider::GitLab => Err(AppError::InvalidArgument(

--- a/src-tauri/src/git/repo.rs
+++ b/src-tauri/src/git/repo.rs
@@ -24,12 +24,17 @@ pub struct RepoOwner {
     /// there's no host or it's unrecognized (the UI labels those GitHub,
     /// matching the backend's gh-authoritative routing).
     pub provider: Option<String>,
+    /// The repo name as the `origin` remote spells it (e.g. "GitDesktop") — the
+    /// REMOTE identity, unlike `RepoInfo.name`, which is the checkout's folder
+    /// basename and can differ (a renamed clone, a worktree directory). `None`
+    /// when there's no origin remote or its URL doesn't parse.
+    pub repo_name: Option<String>,
 }
 
-/// Owner segment + host of a git remote URL — handles
+/// Owner segment + host + repo name of a git remote URL — handles
 /// `https://host/owner/repo(.git)` and scp-style `git@host:owner/repo(.git)`.
-/// None if it can't be parsed.
-fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
+/// None per component if it can't be parsed.
+fn parse_owner_host(url: &str) -> (Option<String>, Option<String>, Option<String>) {
     let url = url.trim().trim_end_matches('/');
     let url = url.strip_suffix(".git").unwrap_or(url);
     // Split into host and the `owner/repo` path (scheme or scp form).
@@ -37,7 +42,7 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
         let rest = &url[idx + 3..];
         match rest.split_once('/') {
             Some((h, p)) => (h, p),
-            None => return (None, None),
+            None => return (None, None, None),
         }
     } else if let Some(colon) = url.rfind(':') {
         // A Windows drive-path remote (`C:\path\to\repo`, `C:/path/to/repo`)
@@ -46,12 +51,12 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
         // persist a bogus host ("c") + owner ("to") onto RecentRepo.
         let head = &url[..colon];
         if head.len() == 1 && head.as_bytes()[0].is_ascii_alphabetic() {
-            return (None, None);
+            return (None, None, None);
         }
         let host = head.rsplit('@').next().unwrap_or(head);
         (host, &url[colon + 1..])
     } else {
-        return (None, None);
+        return (None, None, None);
     };
     // Strip credentials and a port from the host.
     let host = host.rsplit('@').next().unwrap_or(host);
@@ -69,10 +74,12 @@ fn parse_owner_host(url: &str) -> (Option<String>, Option<String>) {
     };
     let host = host.to_ascii_lowercase();
     let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-    // owner is the segment immediately before the repo name.
+    // owner is the segment immediately before the repo name; a single-segment
+    // path carries neither, so both take the same guard.
     let owner = (segs.len() >= 2).then(|| segs[segs.len() - 2].to_string());
+    let repo_name = (segs.len() >= 2).then(|| segs[segs.len() - 1].to_string());
     let host = (!host.is_empty()).then_some(host);
-    (owner, host)
+    (owner, host, repo_name)
 }
 
 /// Resolves the owner + host + provider for each repo path (from its `origin`
@@ -83,7 +90,7 @@ pub async fn git_repo_owners(repo_paths: Vec<String>) -> AppResult<Vec<RepoOwner
     let glab_hosts = crate::forge::glab::known_hosts().await;
     let mut out = Vec::with_capacity(repo_paths.len());
     for path in repo_paths {
-        let (owner, host) = match run_git_raw(
+        let (owner, host, repo_name) = match run_git_raw(
             Some(&path),
             &["remote", "get-url", "origin"],
             DEFAULT_TIMEOUT,
@@ -91,7 +98,7 @@ pub async fn git_repo_owners(repo_paths: Vec<String>) -> AppResult<Vec<RepoOwner
         .await
         {
             Ok(res) if res.code == 0 => parse_owner_host(res.stdout_lossy().trim()),
-            _ => (None, None),
+            _ => (None, None, None),
         };
         let provider = host
             .as_deref()
@@ -102,6 +109,7 @@ pub async fn git_repo_owners(repo_paths: Vec<String>) -> AppResult<Vec<RepoOwner
             owner,
             host,
             provider,
+            repo_name,
         });
     }
     Ok(out)
@@ -463,29 +471,68 @@ mod clone_dir_tests {
 
 #[cfg(test)]
 mod owner_tests {
-    use super::parse_owner_host;
+    use super::{parse_owner_host, RepoOwner};
 
     #[test]
-    fn parses_owner_and_host_from_common_remote_forms() {
+    fn parses_owner_host_and_repo_name_from_common_remote_forms() {
         assert_eq!(
             parse_owner_host("https://github.com/octocat/repo.git"),
-            (Some("octocat".into()), Some("github.com".into()))
+            (
+                Some("octocat".into()),
+                Some("github.com".into()),
+                Some("repo".into())
+            )
+        );
+        // Without the `.git` suffix, and with a trailing slash — both trimmed
+        // before the segments are cut, so the name never carries either.
+        assert_eq!(
+            parse_owner_host("https://github.com/octocat/repo"),
+            (
+                Some("octocat".into()),
+                Some("github.com".into()),
+                Some("repo".into())
+            )
+        );
+        assert_eq!(
+            parse_owner_host("https://github.com/octocat/repo.git/"),
+            (
+                Some("octocat".into()),
+                Some("github.com".into()),
+                Some("repo".into())
+            )
         );
         assert_eq!(
             parse_owner_host("git@gitlab.com:group/repo.git"),
-            (Some("group".into()), Some("gitlab.com".into()))
+            (
+                Some("group".into()),
+                Some("gitlab.com".into()),
+                Some("repo".into())
+            )
         );
         // Subgroups: the owner is the segment before the repo name.
         assert_eq!(
             parse_owner_host("https://gitlab.com/group/sub/repo"),
-            (Some("sub".into()), Some("gitlab.com".into()))
+            (
+                Some("sub".into()),
+                Some("gitlab.com".into()),
+                Some("repo".into())
+            )
         );
         // Credentials + port strip from the host.
         assert_eq!(
             parse_owner_host("https://user@gitlab.acme.com:8443/g/r.git"),
-            (Some("g".into()), Some("gitlab.acme.com".into()))
+            (
+                Some("g".into()),
+                Some("gitlab.acme.com".into()),
+                Some("r".into())
+            )
         );
-        assert_eq!(parse_owner_host("not-a-url"), (None, None));
+        assert_eq!(parse_owner_host("not-a-url"), (None, None, None));
+        // A single-segment path addresses no repo: neither owner nor name.
+        assert_eq!(
+            parse_owner_host("https://github.com/repo.git"),
+            (None, Some("github.com".into()), None)
+        );
     }
 
     #[test]
@@ -494,31 +541,62 @@ mod owner_tests {
         // provider routing compares two different strings for the same instance.
         assert_eq!(
             parse_owner_host("https://[2001:DB8::1]:8443/owner/repo.git"),
-            (Some("owner".into()), Some("[2001:db8::1]".into()))
+            (
+                Some("owner".into()),
+                Some("[2001:db8::1]".into()),
+                Some("repo".into())
+            )
         );
         // scp form: `rfind(':')` lands past the address, on the path separator.
         assert_eq!(
             parse_owner_host("git@[2001:db8::1]:owner/repo.git"),
-            (Some("owner".into()), Some("[2001:db8::1]".into()))
+            (
+                Some("owner".into()),
+                Some("[2001:db8::1]".into()),
+                Some("repo".into())
+            )
         );
         // A malformed bracket is no host at all — the path still parses.
         assert_eq!(
             parse_owner_host("https://[2001:db8::1/owner/repo"),
-            (Some("owner".into()), None)
+            (Some("owner".into()), None, Some("repo".into()))
         );
         // Nor is a span followed by something that isn't a port.
         assert_eq!(
             parse_owner_host("https://[2001:db8::1]junk/owner/repo"),
-            (Some("owner".into()), None)
+            (Some("owner".into()), None, Some("repo".into()))
         );
     }
 
     #[test]
-    fn windows_drive_path_remotes_have_no_owner_or_host() {
+    fn windows_drive_path_remotes_have_no_owner_host_or_repo_name() {
         // A local-path origin (backslash or forward-slash form) must not be
         // misparsed as scp-style `host:owner/repo`.
-        assert_eq!(parse_owner_host(r"C:\path\to\repo"), (None, None));
-        assert_eq!(parse_owner_host("C:/path/to/repo"), (None, None));
-        assert_eq!(parse_owner_host("c:/x/y"), (None, None));
+        assert_eq!(parse_owner_host(r"C:\path\to\repo"), (None, None, None));
+        assert_eq!(parse_owner_host("C:/path/to/repo"), (None, None, None));
+        assert_eq!(parse_owner_host("c:/x/y"), (None, None, None));
+    }
+
+    /// The frontend matches inbox rows to local clones on `repoName`, so the
+    /// wire key set is pinned here rather than trusted to `rename_all`.
+    #[test]
+    fn repo_owner_serializes_to_the_camel_case_wire_shape() {
+        let wire = serde_json::to_value(RepoOwner {
+            path: "C:/repos/GitDesktop".into(),
+            owner: Some("theBGuy".into()),
+            host: Some("github.com".into()),
+            provider: Some("github".into()),
+            repo_name: Some("GitDesktop".into()),
+        })
+        .unwrap();
+        let mut keys: Vec<&str> = wire
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["host", "owner", "path", "provider", "repoName"]);
+        assert_eq!(wire.get("repoName").and_then(|v| v.as_str()), Some("GitDesktop"));
     }
 }

--- a/src-tauri/src/github/my_work.rs
+++ b/src-tauri/src/github/my_work.rs
@@ -591,6 +591,11 @@ mod tests {
             "a leg that came back full may have had more"
         );
 
+        // The review-requested leg's cap is its own truncation event — the
+        // disjunction's second arm must hold without the first.
+        let b_capped = merge_my_work(empty(), leg("b", MY_WORK_LIMIT, 1));
+        assert!(b_capped.truncated, "either leg's full page reports the cap");
+
         // One short of the cap, gh returned everything it had.
         let under = merge_my_work(leg("a", MY_WORK_LIMIT - 1, 9), empty());
         assert_eq!(under.items.len(), MY_WORK_LIMIT - 1);

--- a/src-tauri/src/github/my_work.rs
+++ b/src-tauri/src/github/my_work.rs
@@ -86,9 +86,9 @@ struct GhSearchItem {
 const MY_WORK_FIELDS: &str = "number,title,isPullRequest,repository,updatedAt,url,author";
 
 /// The whole page this surface fetches, per leg and after the merge. There is no
-/// pagination, so this is also the point where the inbox silently truncates.
-/// `MY_WORK_LIMIT` in `src/features/mywork/mywork-utils.ts` hand-mirrors this
-/// number to decide when to show the cap note, so the two must change together.
+/// pagination, so this is also the point where the inbox truncates — the wire
+/// envelope's `truncated` flag reports that to the frontend, so the number
+/// itself is not mirrored there and can change on its own.
 const MY_WORK_LIMIT: usize = 200;
 
 /// Leg 1. GitHub's `involves:` is author OR assignee OR mentions OR commenter —
@@ -171,39 +171,75 @@ fn item_from_intake(raw: GhSearchItem, default_is_pull_request: bool) -> Option<
     })
 }
 
+/// One leg's parsed result: its wire items, plus how many elements gh actually
+/// returned. The raw count is the leg's own truncation signal and cannot be
+/// recovered from `items` — dropped hits ([`item_from_intake`]) already shrank
+/// that.
+struct MyWorkLeg {
+    items: Vec<MyWorkItem>,
+    raw_len: usize,
+}
+
 /// Parse one leg's `gh search … --json` stdout into wire items. Per-hit
 /// tolerance: each element is deserialized on its own so one malformed hit is
 /// skipped rather than sinking the batch. A top-level parse failure IS an error —
 /// an empty inbox and unreadable output must not look alike to the caller.
-fn parse_my_work(stdout: &str, default_is_pull_request: bool) -> AppResult<Vec<MyWorkItem>> {
+fn parse_my_work(stdout: &str, default_is_pull_request: bool) -> AppResult<MyWorkLeg> {
     let raw: Vec<Value> = serde_json::from_str(stdout)
         .map_err(|e| AppError::Gh(format!("could not parse your GitHub work items: {e}")))?;
-    Ok(raw
-        .into_iter()
-        .filter_map(|v| serde_json::from_value::<GhSearchItem>(v).ok())
-        .filter_map(|raw| item_from_intake(raw, default_is_pull_request))
-        .collect())
+    let raw_len = raw.len();
+    Ok(MyWorkLeg {
+        items: raw
+            .into_iter()
+            .filter_map(|v| serde_json::from_value::<GhSearchItem>(v).ok())
+            .filter_map(|raw| item_from_intake(raw, default_is_pull_request))
+            .collect(),
+        raw_len,
+    })
+}
+
+/// One page of the inbox, and whether anything was left off it: `truncated` is
+/// true when either search leg hit its own server-side cap or the merged union
+/// overshot the page — so it can be true on a page that arrives short.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MyWorkPage {
+    pub items: Vec<MyWorkItem>,
+    pub truncated: bool,
 }
 
 /// Merge the two legs into one page: dedupe by URL (a PR can be both involving
 /// and review-requested), newest first, truncated to [`MY_WORK_LIMIT`] so the
 /// wire contract stays one page however much the union overshoots.
 ///
+/// A leg that came back with as many elements as it ASKED for is itself a
+/// truncation: gh may have had more, and the page can still land short of the
+/// limit once dedupe and dropped hits take their cut, so the union's length
+/// alone can't see it. The reverse error — a leg holding exactly the limit with
+/// nothing more on the server — reports a cap that isn't there, and that is the
+/// safe direction: an inbox that hides items must never look complete.
+///
 /// The sort is a plain string compare because gh emits `updatedAt` as
 /// Z-suffixed RFC 3339 — fixed width, one offset, so lexical order IS
 /// chronological order. An item with no timestamp sorts last rather than
 /// claiming to be the newest.
-fn merge_my_work(involves: Vec<MyWorkItem>, review_requested: Vec<MyWorkItem>) -> Vec<MyWorkItem> {
+fn merge_my_work(involves: MyWorkLeg, review_requested: MyWorkLeg) -> MyWorkPage {
+    let leg_capped =
+        involves.raw_len >= MY_WORK_LIMIT || review_requested.raw_len >= MY_WORK_LIMIT;
     let mut seen: HashSet<String> = HashSet::new();
     let mut merged: Vec<MyWorkItem> = Vec::new();
-    for item in involves.into_iter().chain(review_requested) {
+    for item in involves.items.into_iter().chain(review_requested.items) {
         if seen.insert(item.url.clone()) {
             merged.push(item);
         }
     }
     merged.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    let truncated = leg_capped || merged.len() > MY_WORK_LIMIT;
     merged.truncate(MY_WORK_LIMIT);
-    merged
+    MyWorkPage {
+        items: merged,
+        truncated,
+    }
 }
 
 /// Every open pull request and issue involving the signed-in GitHub user,
@@ -212,7 +248,7 @@ fn merge_my_work(involves: Vec<MyWorkItem>, review_requested: Vec<MyWorkItem>) -
 /// Sequential rather than concurrent: two `gh` spawns keep the failure mode
 /// simple, and either leg failing fails the call rather than half-filling the
 /// inbox.
-pub async fn my_work() -> AppResult<Vec<MyWorkItem>> {
+pub async fn my_work() -> AppResult<MyWorkPage> {
     let involves = run_gh(None, INVOLVES_ARGS, GH_NETWORK_TIMEOUT).await?;
     let involves = parse_my_work(&involves.stdout_lossy(), false)?;
     let review_requested = run_gh(None, REVIEW_REQUESTED_ARGS, GH_NETWORK_TIMEOUT).await?;
@@ -224,8 +260,8 @@ pub async fn my_work() -> AppResult<Vec<MyWorkItem>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        merge_my_work, parse_my_work, INVOLVES_ARGS, MY_WORK_FIELDS, MY_WORK_LIMIT,
-        REVIEW_REQUESTED_ARGS,
+        merge_my_work, parse_my_work, MyWorkItem, MyWorkLeg, MyWorkPage, INVOLVES_ARGS,
+        MY_WORK_FIELDS, MY_WORK_LIMIT, REVIEW_REQUESTED_ARGS,
     };
     use serde_json::{json, Value};
 
@@ -275,7 +311,7 @@ mod tests {
     /// key set is pinned here rather than trusted to the `rename_all` attribute.
     #[test]
     fn fixture_serializes_to_the_camel_case_wire_shape() {
-        let items = parse_my_work(GH_FIXTURE, false).unwrap();
+        let items = parse_my_work(GH_FIXTURE, false).unwrap().items;
         assert_eq!(items.len(), 3);
 
         let wire = serde_json::to_value(&items[0]).unwrap();
@@ -317,6 +353,24 @@ mod tests {
         // through unchanged.
         assert!(!items[2].is_pull_request);
         assert_eq!(items[1].author_login.as_deref(), Some("dependabot[bot]"));
+
+        // The items ride inside the page envelope, whose own two keys the
+        // frontend reads by name.
+        let page = serde_json::to_value(MyWorkPage {
+            items,
+            truncated: true,
+        })
+        .unwrap();
+        let mut page_keys: Vec<&str> = page
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        page_keys.sort_unstable();
+        assert_eq!(page_keys, ["items", "truncated"]);
+        assert_eq!(page.get("truncated").and_then(Value::as_bool), Some(true));
+        assert_eq!(page.pointer("/items/0"), Some(&wire));
     }
 
     #[test]
@@ -338,7 +392,7 @@ mod tests {
             },
         ])
         .to_string();
-        let items = parse_my_work(&raw, false).unwrap();
+        let items = parse_my_work(&raw, false).unwrap().items;
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].repo_owner, "my.org");
         assert_eq!(items[0].repo_name, "repo");
@@ -376,7 +430,7 @@ mod tests {
 
         for drop in &drops {
             let batch = Value::Array(vec![drop.clone(), good.clone()]);
-            let items = parse_my_work(&batch.to_string(), false).unwrap();
+            let items = parse_my_work(&batch.to_string(), false).unwrap().items;
             assert_eq!(items.len(), 1, "should have dropped only {drop}");
             assert_eq!(items[0].number, 7);
         }
@@ -393,7 +447,7 @@ mod tests {
             "author": null
         }])
         .to_string();
-        let items = parse_my_work(&raw, false).unwrap();
+        let items = parse_my_work(&raw, false).unwrap().items;
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].author_login, None);
         // Absent, not a fabricated timestamp.
@@ -402,7 +456,9 @@ mod tests {
 
     #[test]
     fn my_work_distinguishes_an_empty_inbox_from_unreadable_output() {
-        assert!(parse_my_work("[]", false).unwrap().is_empty());
+        let empty = parse_my_work("[]", false).unwrap();
+        assert!(empty.items.is_empty());
+        assert_eq!(empty.raw_len, 0);
         assert!(parse_my_work("not json", false).is_err());
         assert!(parse_my_work("{\"items\":[]}", false).is_err());
     }
@@ -426,7 +482,7 @@ mod tests {
         ])
         .to_string();
 
-        let review_leg = parse_my_work(&raw, true).unwrap();
+        let review_leg = parse_my_work(&raw, true).unwrap().items;
         assert!(
             review_leg.iter().all(|i| i.is_pull_request),
             "{review_leg:?}"
@@ -434,7 +490,7 @@ mod tests {
 
         // The involves leg keeps the opposite default: there an omitted flag
         // really can mean an issue.
-        let involves_leg = parse_my_work(&raw, false).unwrap();
+        let involves_leg = parse_my_work(&raw, false).unwrap().items;
         assert!(involves_leg[0].is_pull_request);
         assert!(!involves_leg[1].is_pull_request);
     }
@@ -448,7 +504,7 @@ mod tests {
                 "url": url, "updatedAt": updated
             }])
             .to_string();
-            parse_my_work(&raw, true).unwrap().pop().unwrap()
+            parse_my_work(&raw, true).unwrap().items.pop().unwrap()
         };
 
         let shared = "https://github.com/octo/repo/pull/300";
@@ -472,14 +528,21 @@ mod tests {
             ),
         ];
 
-        let merged = merge_my_work(involves, review_requested);
-        assert_eq!(merged.len(), 3, "the shared URL should appear once");
+        // Neither leg came near its cap, so nothing here is truncation.
+        let leg = |items: Vec<MyWorkItem>| MyWorkLeg {
+            raw_len: items.len(),
+            items,
+        };
+        let page = merge_my_work(leg(involves), leg(review_requested));
+        assert_eq!(page.items.len(), 3, "the shared URL should appear once");
         assert_eq!(
-            merged.iter().map(|i| i.number).collect::<Vec<_>>(),
+            page.items.iter().map(|i| i.number).collect::<Vec<_>>(),
             [2, 309, 300],
             "merged page must be newest-first ACROSS both legs",
         );
-        assert_eq!(merged.iter().filter(|i| i.url == shared).count(), 1);
+        assert_eq!(page.items.iter().filter(|i| i.url == shared).count(), 1);
+        // A union well under the cap is the whole inbox.
+        assert!(!page.truncated);
     }
 
     /// The union can overshoot the per-leg limit, so the merge is where the wire
@@ -500,20 +563,67 @@ mod tests {
                 .collect();
             parse_my_work(&Value::Array(raw).to_string(), true).unwrap()
         };
+        let empty = || parse_my_work("[]", true).unwrap();
 
-        let merged = merge_my_work(leg("a", MY_WORK_LIMIT, 9), leg("b", MY_WORK_LIMIT, 1));
+        let page = merge_my_work(leg("a", MY_WORK_LIMIT, 9), leg("b", MY_WORK_LIMIT, 1));
         assert_eq!(
-            merged.len(),
+            page.items.len(),
             MY_WORK_LIMIT,
             "400 distinct hits must cap at 200"
         );
+        assert!(page.truncated, "an over-limit union must report truncation");
         // Truncation keeps the NEWEST page, not the first leg wholesale.
         assert!(
-            merged
+            page.items
                 .windows(2)
                 .all(|w| w[0].updated_at >= w[1].updated_at),
             "truncated page must still be newest-first",
         );
-        assert_eq!(merged[0].updated_at, "2026-09-01T00:59:00Z");
+        assert_eq!(page.items[0].updated_at, "2026-09-01T00:59:00Z");
+
+        // A leg that filled its own `--limit` IS the truncation event, even
+        // though the page lands exactly on the cap and never overshoots it —
+        // gh had no way to tell us what it left behind.
+        let at_limit = merge_my_work(leg("a", MY_WORK_LIMIT, 9), empty());
+        assert_eq!(at_limit.items.len(), MY_WORK_LIMIT);
+        assert!(
+            at_limit.truncated,
+            "a leg that came back full may have had more"
+        );
+
+        // One short of the cap, gh returned everything it had.
+        let under = merge_my_work(leg("a", MY_WORK_LIMIT - 1, 9), empty());
+        assert_eq!(under.items.len(), MY_WORK_LIMIT - 1);
+        assert!(!under.truncated);
+    }
+
+    /// The reachable arm the union's length can never see: a leg fills its cap,
+    /// dropped hits shrink it below the limit, and the merged page arrives short
+    /// while items are still missing from the server.
+    #[test]
+    fn merge_reports_a_capped_leg_whose_page_arrives_short() {
+        let mut raw: Vec<Value> = (0..MY_WORK_LIMIT - 5)
+            .map(|i| {
+                json!({
+                    "number": i + 1, "title": "t", "isPullRequest": true,
+                    "repository": {"nameWithOwner": "octo/repo"},
+                    "url": format!("https://github.com/octo/repo/pull/{i}"),
+                    "updatedAt": "2026-09-01T00:00:00Z",
+                })
+            })
+            .collect();
+        // Five unaddressable hits: gh still counted them against the limit.
+        raw.extend((0..5).map(|_| json!({"number": 1, "title": "t"})));
+        assert_eq!(raw.len(), MY_WORK_LIMIT);
+
+        let capped = parse_my_work(&Value::Array(raw).to_string(), true).unwrap();
+        assert_eq!(capped.items.len(), MY_WORK_LIMIT - 5, "five hits dropped");
+
+        let page = merge_my_work(capped, parse_my_work("[]", true).unwrap());
+        assert_eq!(page.items.len(), MY_WORK_LIMIT - 5);
+        assert!(
+            page.truncated,
+            "a short page from a capped leg still hides items"
+        );
     }
 }

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2453,8 +2453,14 @@ fn parse_pr_url_repo(url: &str) -> AppResult<(String, String, String)> {
                 .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
     };
     // The host reaches `--hostname <host>` argv at both callers, so it takes the
-    // same flag-injection guard as the path segments.
-    if sep != "pull" || host.starts_with('-') || !valid_seg(owner) || !valid_seg(name) {
+    // shared authority gate (charset — `remote_host` lets `=`/`;`/`$`/spaces
+    // through) plus the `-`-prefix arm the gate's charset admits.
+    if sep != "pull"
+        || !crate::forge::is_safe_authority(&host)
+        || host.starts_with('-')
+        || !valid_seg(owner)
+        || !valid_seg(name)
+    {
         return Err(AppError::InvalidArgument(format!(
             "could not parse owner/repo from PR url: {url}"
         )));
@@ -7436,8 +7442,10 @@ mod tests {
             parse_pr_url_repo("https://GitHub.COM/biomejs/biome/pull/1").unwrap();
         assert_eq!(host, "github.com");
 
-        // A `-`-led host would ride the `--hostname` argv slot → Err.
+        // A `-`-led host would ride the `--hostname` argv slot → Err, and a host
+        // outside the authority charset (which `remote_host` passes through) → Err.
         assert!(parse_pr_url_repo("-evil.com/biomejs/biome/pull/1").is_err());
+        assert!(parse_pr_url_repo("https://evil;host.com/biomejs/biome/pull/1").is_err());
 
         // Malformed / non-PR urls → Err.
         assert!(parse_pr_url_repo("https://github.com/biomejs/biome/issues/1").is_err());

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -39,25 +39,15 @@ struct RepoView {
 }
 
 /// The host of a repo URL like `https://github.acme.com/owner/repo` →
-/// `github.acme.com`. None when it isn't an http(s)-style URL. Tolerates an
-/// optional `user@` prefix and `:port` suffix. A bracketed IPv6 literal keeps its
-/// brackets, matching `remote_host`'s spelling; a malformed bracket is no host.
+/// `github.acme.com`, lowercased. `None` when there's no parseable host.
+///
+/// Delegates to [`crate::forge::remote_host`] so this module's host spelling can't
+/// drift from the one the rest of the app persists, gates and routes on — both
+/// callers compare the result (against `gh auth status` hosts, and against the
+/// `github.com` default that decides whether `--hostname` is passed), and two
+/// spellings of one host compare unequal.
 fn host_from_url(url: &str) -> Option<String> {
-    let after = url.split_once("://").map(|(_, rest)| rest)?;
-    let authority = after.split('/').next().unwrap_or("");
-    let host = authority.rsplit('@').next().unwrap_or(authority);
-    let host = if host.starts_with('[') {
-        let (span, suffix) = crate::forge::bracketed_split(host)?;
-        // A `:`-led suffix rides the port slot and is dropped, like the bare arm drops
-        // it; any other suffix is no host.
-        if !suffix.is_empty() && !suffix.starts_with(':') {
-            return None;
-        }
-        span
-    } else {
-        host.split(':').next().unwrap_or(host)
-    };
-    (!host.is_empty()).then(|| host.to_string())
+    crate::forge::remote_host(url)
 }
 
 /// Probes the GitHub CLI: present on PATH, logged in, and pointing at a
@@ -2438,8 +2428,11 @@ fn rollup_state_to_ci(state: Option<&str>) -> String {
 /// Parse `(host, owner, name)` from a PR html url. The url is the empirical truth
 /// for which repo the PR numbers belong to — on a fork the PR list resolves to the
 /// PARENT while origin is the fork, so the repo must NOT be re-derived from the
-/// checkout. Strict: two valid segments immediately followed by `/pull/`, and a
-/// `-`-prefixed segment is rejected (flag-injection guard).
+/// checkout. Strict on the PATH: two valid segments immediately followed by
+/// `/pull/`, and a `-`-prefixed segment is rejected (flag-injection guard). The
+/// HOST is only as strict as [`host_from_url`]'s shared parser, which takes
+/// scheme-less and scp-form input, so the `/pull/` check is what actually admits
+/// a url here.
 fn parse_pr_url_repo(url: &str) -> AppResult<(String, String, String)> {
     let host = host_from_url(url)
         .ok_or_else(|| AppError::InvalidArgument(format!("not a PR url: {url}")))?;
@@ -2899,6 +2892,74 @@ pub async fn gh_pr_poll(repo_path: String) -> AppResult<Vec<PrPollInfo>> {
         })
         .filter(|p| p.number > 0)
         .collect())
+}
+
+/// Where one PR's head branch lives.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrHeadRef {
+    pub head_ref_name: String,
+    /// "owner/name" of the PR's HEAD repository — lets a consumer tell a
+    /// same-repo branch from a fork's identically-named branch. `""` when the
+    /// provider can't supply it (GitHub nulls `headRepository` once the head
+    /// fork is deleted).
+    pub head_repo_full_name: String,
+}
+
+/// One PR's head projection, addressed BY NUMBER rather than read out of
+/// [`pr_poll_query`]'s 30-PR window — a PR older than that window is invisible
+/// to the poll, and this answer has to hold for any PR the user can name.
+/// Separate from its caller so a test can assert what it asks for.
+fn pr_head_ref_query(owner: &str, name: &str, number: u64) -> String {
+    // `number` is a u64 — digits only, so it embeds without a validator; the
+    // owner/name embeds are validated by the caller.
+    format!(
+        r#"query{{ repository(owner:"{owner}", name:"{name}"){{ pullRequest(number:{number}){{ headRefName headRepository{{ nameWithOwner }} }} }} }}"#
+    )
+}
+
+/// Read the head projection out of the GraphQL envelope. Every absence — a null
+/// `headRepository`, a PR GitHub didn't return at all — maps to `""` rather than
+/// an error: the caller's question is "which repo is this branch on", and
+/// "unknown" is a usable answer where a failed call is not.
+fn pr_head_ref_from_value(value: &serde_json::Value) -> PrHeadRef {
+    let str_at = |p: &str| {
+        value
+            .pointer(p)
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    PrHeadRef {
+        head_ref_name: str_at("/data/repository/pullRequest/headRefName"),
+        head_repo_full_name: str_at("/data/repository/pullRequest/headRepository/nameWithOwner"),
+    }
+}
+
+/// The head branch of ONE pull request, plus the repo that branch lives in.
+///
+/// Pins the origin slug like [`gh_pr_poll`]: an unpinned `gh repo view` on a fork
+/// with an `upstream` remote auto-resolves to the PARENT, which would answer for
+/// the upstream's PR of the same number.
+#[tauri::command]
+pub async fn gh_pr_head_ref(repo_path: String, number: u64) -> AppResult<PrHeadRef> {
+    let slug = crate::github::gh_origin_slug(&repo_path).await?;
+    let Some((owner, name)) = slug.split_once('/') else {
+        return Err(AppError::Gh("could not determine the repository owner".into()));
+    };
+    validate_graphql_embed(owner, "repository owner")?;
+    validate_graphql_embed(name, "repository name")?;
+
+    let query = pr_head_ref_query(owner, name, number);
+    let out = run_gh(
+        Some(&repo_path),
+        &["api", "graphql", "-f", &format!("query={query}")],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await?;
+    let value: serde_json::Value = serde_json::from_str(&out.stdout_lossy())
+        .map_err(|e| AppError::Gh(format!("could not parse the PR head ref: {e}")))?;
+    Ok(pr_head_ref_from_value(&value))
 }
 
 /// Adds/removes labels on a PR via GraphQL mutations. `labelable_id` is the
@@ -5964,7 +6025,8 @@ mod tests {
         flatten_slurped_pages, fork_head_identity, gh_api_error_message,
         gh_pr_discard_pending_review, host_from_url,
         is_diff_too_large, is_object_id, map_timeline_node, parse_actions_run_job,
-        parse_auth_accounts, parse_pr_url_repo, parse_publish_owners, pr_edit_args, pr_poll_query,
+        parse_auth_accounts, parse_pr_url_repo, parse_publish_owners, pr_edit_args,
+        pr_head_ref_from_value, pr_head_ref_query, pr_poll_query,
         pull_stack_ref,
         real_check_time,
         real_time_or_empty, reconstruct_pr_diff, reject_upstream_create_metadata,
@@ -7027,6 +7089,73 @@ mod tests {
         );
     }
 
+    /// Both fields are the whole point of the call — a dropped `headRepository`
+    /// leaves a fork's PR indistinguishable from a same-repo one sharing the
+    /// branch name, and reads as "unknown" rather than as an error.
+    #[test]
+    fn head_ref_query_selects_the_branch_and_its_repo() {
+        let q = pr_head_ref_query("owner", "repo", 42);
+        // Addressed by number, not by a recently-updated window.
+        assert!(q.contains("pullRequest(number:42)"), "got: {q}");
+        assert!(q.contains(" headRefName "), "got: {q}");
+        assert!(q.contains("headRepository{ nameWithOwner }"), "got: {q}");
+        assert!(q.contains(r#"repository(owner:"owner", name:"repo")"#), "got: {q}");
+    }
+
+    #[test]
+    fn head_ref_maps_a_null_head_repository_to_empty() {
+        let full = serde_json::json!({"data": {"repository": {"pullRequest": {
+            "headRefName": "feat/x",
+            "headRepository": {"nameWithOwner": "contrib/proj"}
+        }}}});
+        let head = pr_head_ref_from_value(&full);
+        assert_eq!(head.head_ref_name, "feat/x");
+        assert_eq!(head.head_repo_full_name, "contrib/proj");
+
+        // A deleted head fork nulls `headRepository` — "" (unknown), not an error.
+        let deleted_fork = serde_json::json!({"data": {"repository": {"pullRequest": {
+            "headRefName": "feat/x", "headRepository": serde_json::Value::Null
+        }}}});
+        let head = pr_head_ref_from_value(&deleted_fork);
+        assert_eq!(head.head_ref_name, "feat/x");
+        assert_eq!(head.head_repo_full_name, "");
+
+        // A PR GitHub didn't return at all degrades the same way, both fields.
+        let missing = serde_json::json!({"data": {"repository": {"pullRequest": serde_json::Value::Null}}});
+        let head = pr_head_ref_from_value(&missing);
+        assert_eq!(head.head_ref_name, "");
+        assert_eq!(head.head_repo_full_name, "");
+
+        // And so does an envelope carrying only errors.
+        let errors = serde_json::json!({"errors": [{"message": "Could not resolve to a Repository"}]});
+        let head = pr_head_ref_from_value(&errors);
+        assert_eq!(head.head_ref_name, "");
+        assert_eq!(head.head_repo_full_name, "");
+    }
+
+    /// The command's payload is read key-by-key in TypeScript, where a rename
+    /// reads as `undefined` and silently disables the resolution it feeds.
+    #[test]
+    fn head_ref_serializes_camel_case_wire_names() {
+        let v = serde_json::to_value(pr_head_ref_from_value(&serde_json::json!({
+            "data": {"repository": {"pullRequest": {
+                "headRefName": "topic", "headRepository": {"nameWithOwner": "contrib/repo"}
+            }}}
+        })))
+        .expect("PrHeadRef serializes");
+        assert_eq!(
+            v.get("headRefName").and_then(|x| x.as_str()),
+            Some("topic")
+        );
+        assert_eq!(
+            v.get("headRepoFullName").and_then(|x| x.as_str()),
+            Some("contrib/repo")
+        );
+        let mut keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["headRefName", "headRepoFullName"]);
+    }
+
     /// The poll payload is read field-by-field in TypeScript, where a renamed or
     /// dropped key reads as `undefined` and silently disables a notification
     /// branch. Pin the wire names the frontend keys on; the struct literal makes a
@@ -7299,10 +7428,20 @@ mod tests {
         assert_eq!(owner, "biomejs");
         assert_eq!(name, "biome");
 
+        // A mixed-case host folds down, so the `github.com` default check (which
+        // decides whether `--hostname` is passed to gh) recognizes it.
+        let (host, _, _) =
+            parse_pr_url_repo("https://GitHub.COM/biomejs/biome/pull/1").unwrap();
+        assert_eq!(host, "github.com");
+
         // Malformed / non-PR urls → Err.
         assert!(parse_pr_url_repo("https://github.com/biomejs/biome/issues/1").is_err());
         assert!(parse_pr_url_repo("https://github.com/onlyowner/pull/1").is_err());
         assert!(parse_pr_url_repo("not a url").is_err());
+        // The shared host parser accepts scp form, but this one still won't: the
+        // `/pull/` segment check is what makes a url a PR url.
+        assert!(parse_pr_url_repo("git@github.com:owner/repo.git").is_err());
+        assert!(parse_pr_url_repo("git@github.com:owner/repo/pull/1").is_err());
         // Empty string → Err (no host, no segments).
         assert!(parse_pr_url_repo("").is_err());
         // A `-`-prefixed segment (flag-injection guard) → Err.
@@ -7531,8 +7670,19 @@ mod tests {
             host_from_url("https://user@github.acme.com:8443/owner/repo").as_deref(),
             Some("github.acme.com")
         );
-        // Not an http(s)-style URL → no host.
-        assert_eq!(host_from_url("git@github.com:owner/repo.git"), None);
+        // Case folds, so a host read off a URL compares equal to the same host
+        // spelled by `gh auth status` or by the `github.com` default check.
+        assert_eq!(
+            host_from_url("https://GitHub.Acme.COM/owner/repo").as_deref(),
+            Some("github.acme.com")
+        );
+        // scp form yields the bare host — that `:` is a path separator. The
+        // shared parser accepts it; `parse_pr_url_repo` still rejects such a URL
+        // on its own `/pull/` check.
+        assert_eq!(
+            host_from_url("git@github.com:owner/repo.git").as_deref(),
+            Some("github.com")
+        );
         // A bracketed IPv6 literal survives whole, with or without a port.
         assert_eq!(
             host_from_url("https://[2001:db8::1]:8443/o/r").as_deref(),

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -2452,7 +2452,9 @@ fn parse_pr_url_repo(url: &str) -> AppResult<(String, String, String)> {
             && s.chars()
                 .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
     };
-    if sep != "pull" || !valid_seg(owner) || !valid_seg(name) {
+    // The host reaches `--hostname <host>` argv at both callers, so it takes the
+    // same flag-injection guard as the path segments.
+    if sep != "pull" || host.starts_with('-') || !valid_seg(owner) || !valid_seg(name) {
         return Err(AppError::InvalidArgument(format!(
             "could not parse owner/repo from PR url: {url}"
         )));
@@ -7433,6 +7435,9 @@ mod tests {
         let (host, _, _) =
             parse_pr_url_repo("https://GitHub.COM/biomejs/biome/pull/1").unwrap();
         assert_eq!(host, "github.com");
+
+        // A `-`-led host would ride the `--hostname` argv slot → Err.
+        assert!(parse_pr_url_repo("-evil.com/biomejs/biome/pull/1").is_err());
 
         // Malformed / non-PR urls → Err.
         assert!(parse_pr_url_repo("https://github.com/biomejs/biome/issues/1").is_err());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -543,6 +543,7 @@ pub fn run() {
             github::pr::gh_pr_minimize_comment,
             github::pr::gh_pr_unminimize_comment,
             github::pr::gh_pr_discard_pending_review,
+            github::pr::gh_pr_head_ref,
             github::pr::gh_pr_update_branch,
             github::pr::gh_pr_base_divergence,
             github::pr::gh_pr_checkout,

--- a/src/features/explore/ExploreResultRow.tsx
+++ b/src/features/explore/ExploreResultRow.tsx
@@ -38,6 +38,9 @@ export function ExploreResultRow({
       // Selection rides aria-activedescendant on the search input, which keeps
       // focus; a row in the tab order would be a second way to reach the list.
       tabIndex={-1}
+      // tabIndex alone doesn't stop a click from focusing the row, which would
+      // strand the input's arrow/Enter navigation; click activation still fires.
+      onMouseDown={(e) => e.preventDefault()}
       onClick={() => onSelect(repo)}
       className={cn(
         "flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs",

--- a/src/features/explore/ExploreResultRow.tsx
+++ b/src/features/explore/ExploreResultRow.tsx
@@ -35,6 +35,9 @@ export function ExploreResultRow({
       id={exploreOptionId(repo.fullName)}
       role="option"
       aria-selected={active}
+      // Selection rides aria-activedescendant on the search input, which keeps
+      // focus; a row in the tab order would be a second way to reach the list.
+      tabIndex={-1}
       onClick={() => onSelect(repo)}
       className={cn(
         "flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs",

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -182,7 +182,10 @@ export function ExploreScreen() {
           aria-label="Search repositories"
           role="combobox"
           aria-expanded={flatRepos.length > 0}
-          aria-controls={EXPLORE_LISTBOX_ID}
+          // Same predicate as aria-expanded: the listbox only mounts in the
+          // results branch, so pointing at its id from the loading / error /
+          // empty states would reference a node that isn't there.
+          aria-controls={flatRepos.length > 0 ? EXPLORE_LISTBOX_ID : undefined}
           aria-autocomplete="list"
           aria-activedescendant={
             selected ? exploreOptionId(selected.fullName) : undefined
@@ -460,9 +463,6 @@ function ResultsList({
         role="listbox"
         id={EXPLORE_LISTBOX_ID}
         aria-label="Search results"
-        aria-activedescendant={
-          selected ? exploreOptionId(selected.fullName) : undefined
-        }
       >
         <div
           className="relative w-full"

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -187,8 +187,13 @@ export function ExploreScreen() {
           // empty states would reference a node that isn't there.
           aria-controls={flatRepos.length > 0 ? EXPLORE_LISTBOX_ID : undefined}
           aria-autocomplete="list"
+          // The id has to exist in the mounted list: `selected` outlives a query
+          // / mode / sort change (it resets only on a provider switch), so gate
+          // on membership instead of pointing at a row that is no longer there.
           aria-activedescendant={
-            selected ? exploreOptionId(selected.fullName) : undefined
+            selected && flatRepos.some((r) => r.fullName === selected.fullName)
+              ? exploreOptionId(selected.fullName)
+              : undefined
           }
           className="h-8 min-w-40 flex-1"
         />

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -272,9 +272,9 @@ title, the repository it lives in, and when it last changed. The number beside t
 title in the header is how many items came back, and each tab carries its own count.
 
 Rows are ordered by **most recently updated**. The search fetches a single page of
-results, so a big inbox won't arrive whole. When the page comes back full, a note
-says so at the bottom: *This view fetches one page of results. Filter to narrow the
-list.* You'll see it under the rows, and under **No items match** as well, since a
+results, so a big inbox won't arrive whole. When there may be more than the page holds,
+a note says so at the bottom: *This view fetches one page of results. Filter to narrow
+the list.* You'll see it under the rows, and under **No items match** as well, since a
 filter that finds nothing is when an item off the page matters most.
 
 ## Narrowing and opening
@@ -291,14 +291,26 @@ leaving it. Clicking a row does the same thing.
 Where a row opens depends on whether GitDesktop recognizes its repository as one of
 yours. An item from a repository you've added usually opens **in the app**: GitDesktop
 switches to that repository and lands on the pull request or issue. Everything else
-opens **on GitHub in your browser**. The match reads each repo's resolved owner and
-host, so one you added moments ago, or cloned into a folder named something else, can
-still go to the browser. The **↗** on a row is the signal to trust: it marks every row
-that opens on GitHub, so you know which you're getting before you press Enter. The
-inbox itself changes nothing: it finds the item and hands you to the place where you
-can act on it.
+opens **on GitHub in your browser**. The match reads each repo's resolved owner, host,
+and the name its remote spells, so a clone sitting in a folder you renamed still counts
+as yours once GitDesktop has looked at it; one you added moments ago, before any of that
+is resolved, can still go to the browser. The **↗** on a row is the signal to trust: it
+marks every row that opens on GitHub, so you know which you're getting before you press
+Enter. The inbox itself changes nothing: it finds the item and hands you to the place
+where you can act on it.
 
-**Right-click** a row for **Open on GitHub** and **Copy link**.
+A pull request usually lands where its branch already is. When one of the repository's
+worktrees has that pull request's head branch checked out, GitDesktop opens it there
+rather than in the main workspace, so you arrive in the checkout the work lives in.
+Confirming the branch really belongs to that pull request takes a quick background
+check, and whatever it can't confirm opens the main workspace as before: a pull
+request from a fork, a branch that isn't checked out anywhere, a slow network. A row
+shows a small spinner while that check is still running. Issues skip the check
+entirely and open in the repository as before.
+
+**Right-click** a row for **Open on GitHub** and **Copy link**; on a pull request from a
+repository you've added, **Open in main workspace** heads the menu and skips the
+worktree for that one open.
 
 ## Keeping it current
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -310,7 +310,8 @@ entirely and open in the repository as before.
 
 **Right-click** a row for **Open on GitHub** and **Copy link**; on a pull request from a
 repository you've added, **Open in main workspace** heads the menu and skips the
-worktree for that one open.
+worktree for that one open. **Shift + Enter** (or Shift-click) does the same from
+the keyboard.
 
 ## Keeping it current
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -303,15 +303,15 @@ A pull request usually lands where its branch already is. When one of the reposi
 worktrees has that pull request's head branch checked out, GitDesktop opens it there
 rather than in the main workspace, so you arrive in the checkout the work lives in.
 Confirming the branch really belongs to that pull request takes a quick background
-check, and whatever it can't confirm opens the main workspace as before: a pull
+check, and whatever it can't confirm opens the repository as before: a pull
 request from a fork, a branch that isn't checked out anywhere, a slow network. A row
 shows a small spinner while that check is still running. Issues skip the check
 entirely and open in the repository as before.
 
-**Right-click** a row for **Open on GitHub** and **Copy link**; on a pull request from a
-repository you've added, **Open in main workspace** heads the menu and skips the
-worktree for that one open. **Shift + Enter** (or Shift-click) does the same from
-the keyboard.
+{{Secondaryclick}} a row for **Open on GitHub** and **Copy link**; on a pull request
+from a repository you've added, **Open in main workspace** heads the menu and skips
+the worktree for that one open. {{key:shift+enter}} does the same from the keyboard,
+Shift-click from the pointer.
 
 ## Keeping it current
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -255,8 +255,9 @@ From here:
     body: `# My work
 
 **My work** is a cross-repo inbox: your open pull requests and issues on GitHub,
-newest first, without opening a repository to go looking. Open it from the **My work**
-button on the welcome screen, or from the command palette (*My work*).
+newest first, without opening a repository to go looking. Open it with
+{{kbd:open-my-work}}, from the **My work** button on the welcome screen, or from the
+command palette (*My work*).
 **Back** in the header, or Esc, closes the inbox and returns you to the screen
 underneath.
 
@@ -303,10 +304,10 @@ A pull request usually lands where its branch already is. When one of the reposi
 worktrees has that pull request's head branch checked out, GitDesktop opens it there
 rather than in the main workspace, so you arrive in the checkout the work lives in.
 Confirming the branch really belongs to that pull request takes a quick background
-check, and whatever it can't confirm opens the repository as before: a pull
+check, and whatever it can't confirm opens the main workspace instead: a pull
 request from a fork, a branch that isn't checked out anywhere, a slow network. A row
-shows a small spinner while that check is still running. Issues skip the check
-entirely and open in the repository as before.
+shows a small spinner while that check is still running. Issues skip the branch
+check and open in the main workspace.
 
 {{Secondaryclick}} a row for **Open on GitHub** and **Copy link**; on a pull request
 from a repository you've added, **Open in main workspace** heads the menu and skips

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -306,13 +306,14 @@ rather than in the main workspace, so you arrive in the checkout the work lives 
 Confirming the branch really belongs to that pull request takes a quick background
 check, and whatever it can't confirm opens the main workspace instead: a pull
 request from a fork, a branch that isn't checked out anywhere, a slow network. A row
-shows a small spinner while that check is still running. Issues skip the branch
-check and open in the main workspace.
+shows a small spinner while GitDesktop works out where to open it. Issues skip the
+branch check and open in the main workspace.
 
 {{Secondaryclick}} a row for **Open on GitHub** and **Copy link**; on a pull request
 from a repository you've added, **Open in main workspace** heads the menu and skips
-the worktree for that one open. {{key:shift+enter}} does the same from the keyboard,
-Shift-click from the pointer.
+the worktree for that one open. The menu opens from the keyboard too, with
+{{key:shift+f10}} or the Menu key on the highlighted row. {{key:shift+enter}} opens
+the main workspace directly, Shift-click from the pointer.
 
 ## Keeping it current
 

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -3,6 +3,7 @@ import {
   ArrowSquareOutIcon,
   ArrowsClockwiseIcon,
   CircleDashedIcon,
+  CircleNotchIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -32,9 +33,11 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { suppressContextMenu } from "@/lib/context-menu";
-import { validateRepo } from "@/lib/git/api";
+import { ghPrHeadRef, validateRepo } from "@/lib/git/api";
+import { normPath } from "@/lib/git/path";
 import { useForgeMyWork } from "@/lib/git/queries";
-import type { MyWorkItem } from "@/lib/git/types";
+import type { MyWorkItem, PrHeadRef } from "@/lib/git/types";
+import { listUserWorktrees } from "@/lib/git/worktree";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { applyRepoLens } from "@/lib/repo-lens/queries";
 import type { RecentRepo } from "@/lib/settings/api";
@@ -46,7 +49,6 @@ import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
   filterMyWork,
-  MY_WORK_LIMIT,
   MY_WORK_LISTBOX_ID,
   type MyWorkTab,
   matchLocalRepo,
@@ -57,6 +59,85 @@ import {
 /** Stable empty default, so a settings read that hasn't landed doesn't hand a
  *  fresh array to every render. */
 const NO_RECENTS: RecentRepo[] = [];
+
+/** Total budget for resolving where to open a PR, across BOTH of its awaited
+ *  legs. Opening must stay a keypress-fast action, and the worktree list alone
+ *  can block for seconds behind git's prune. */
+const WORKTREE_RESOLVE_BUDGET_MS = 1500;
+
+/** Grace period before a resolving open lights its row, so a resolution that
+ *  answers quickly never flashes a spinner. */
+const PENDING_AFFORDANCE_MS = 300;
+
+/** Open generation. Module-scoped because MyWorkScreen unmounts on every view
+ *  change: against a component ref, a continuation from a previous mount would
+ *  compare with a fresh counter, pass its own supersede check, and navigate the
+ *  app by itself. Read only from handlers and continuations, never in render. */
+let openGen = 0;
+
+/** Resolves `work` against what's left of `deadline`, answering `fallback` on
+ *  both rejection and expiry — the caller treats slow and broken alike. */
+function withDeadline<T>(
+  work: Promise<T>,
+  deadline: number,
+  fallback: T,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    work.catch(() => fallback),
+    new Promise<T>((resolve) => {
+      timer = setTimeout(
+        () => resolve(fallback),
+        Math.max(0, deadline - Date.now()),
+      );
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * The checkout to open a PR in: a user worktree whose checked-out branch is
+ * provably this PR's head, else null for the repo's main checkout. Every
+ * unknown — a slow or failed leg, an unproven head, no matching branch — is a
+ * null, and one shared deadline bounds both awaited legs.
+ */
+async function resolveWorktreeTarget(
+  item: MyWorkItem,
+  repoPath: string,
+  superseded: () => boolean,
+): Promise<string | null> {
+  const deadline = Date.now() + WORKTREE_RESOLVE_BUDGET_MS;
+  const worktrees = await withDeadline(
+    listUserWorktrees(repoPath),
+    deadline,
+    [],
+  );
+  if (superseded()) return null;
+  // normPath for comparison only — git spells worktree paths with forward
+  // slashes where validate_repo hands back Windows separators.
+  const candidates = worktrees.filter(
+    (w) => w.branch !== "" && normPath(w.path) !== normPath(repoPath),
+  );
+  if (candidates.length === 0) return null;
+  const head = await withDeadline<PrHeadRef | null>(
+    ghPrHeadRef(repoPath, item.number),
+    deadline,
+    null,
+  );
+  if (superseded()) return null;
+  // A fork PR's head branch lives in a different repository, where that branch
+  // name routinely also exists locally — only a head slug matching this item's
+  // repo proves a local branch IS the PR's, so an empty or foreign slug falls
+  // back to the main checkout.
+  if (
+    !head ||
+    head.headRefName === "" ||
+    head.headRepoFullName.toLowerCase() !== item.repoFullName.toLowerCase()
+  ) {
+    return null;
+  }
+  // Exact compare: git branch names are case-sensitive.
+  return candidates.find((w) => w.branch === head.headRefName)?.path ?? null;
+}
 
 /**
  * The cross-repo work inbox — every open GitHub pull request and issue
@@ -74,6 +155,8 @@ export function MyWorkScreen() {
   // The active row is tracked by URL (unique per item) rather than by index, so
   // a filter change can't silently retarget the selection to a different item.
   const [activeUrl, setActiveUrl] = useState<string | null>(null);
+  // The row whose open is still resolving where to land, or null.
+  const [pendingOpenUrl, setPendingOpenUrl] = useState<string | null>(null);
 
   // GitHub-only in this slice: the backend refuses the other providers outright,
   // so there is no provider axis to offer.
@@ -81,10 +164,12 @@ export function MyWorkScreen() {
   const settings = useSettings();
   const recents = settings.data?.recentRepos ?? NO_RECENTS;
   const queryClient = useQueryClient();
-  // Generation counter for openItem's validate await — see its guard below.
-  const openGenRef = useRef(0);
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Which open generation lit the pending row, so an older open finishing late
+  // can't darken an affordance a newer one owns.
+  const pendingGenRef = useRef(0);
 
-  const items = sortMyWork(work.data ?? []);
+  const items = sortMyWork(work.data?.items ?? []);
   const prCount = items.filter((i) => i.isPullRequest).length;
   const visible = filterMyWork(items, tab, filter);
   // Derived, never stored: a row the filter has hidden simply stops being
@@ -104,17 +189,36 @@ export function MyWorkScreen() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  // openItem clears its own timer on every exit path; this catches an unmount
+  // while one is still armed — and retires the mount's continuations: a quick
+  // reopen restores view === "mywork", so the view guard alone can't see it.
+  useEffect(() => {
+    return () => {
+      openGen += 1;
+      if (pendingTimerRef.current !== null) {
+        clearTimeout(pendingTimerRef.current);
+      }
+    };
+  }, []);
+
   // Every navigation goes through an atomic navigator: an openRepo followed by a
   // select would pair the new repo with the old selection, because the
   // view-transition callback that carries the selection is deferred.
-  async function openItem(item: MyWorkItem) {
+  // `preferWorktree: false` is the context menu's escape hatch back to the main
+  // checkout; everything else lands where the branch actually is.
+  async function openItem(
+    item: MyWorkItem,
+    opts?: { preferWorktree?: boolean },
+  ) {
     // Claim the generation before any early return, so EVERY open — including
     // the browser arm, which never awaits — supersedes a pending one; a stale
     // continuation must strand rather than stomp the newer action or yank the
-    // user back. View is read live: the ref dies with the screen, the risk doesn't.
-    const gen = ++openGenRef.current;
+    // user back. The counter outlives the screen (this one unmounts on every
+    // view change), so a continuation from a previous mount stays superseded;
+    // the view is read live because the screen can be gone entirely.
+    const gen = ++openGen;
     const superseded = () =>
-      gen !== openGenRef.current || useUiStore.getState().view !== "mywork";
+      gen !== openGen || useUiStore.getState().view !== "mywork";
     const match = matchLocalRepo(item, recents);
     if (!match) {
       openUrl(item.url);
@@ -138,20 +242,68 @@ export function MyWorkScreen() {
       return;
     }
     if (superseded()) return;
+    // A PR's work lives wherever its head branch is checked out, so land there
+    // rather than in the main checkout the recents row names. Every unknown
+    // falls back to match.path, silently: nothing broke for the user.
+    let targetPath = match.path;
+    let targetName = match.name;
+    if (item.isPullRequest && (opts?.preferWorktree ?? true)) {
+      // Armed before the first await, not before the network leg: listing
+      // worktrees runs a prune that can block for seconds, and a freeze the row
+      // doesn't acknowledge reads as a dropped keypress. Held locally as well as
+      // on the ref — the ref is what an unmount can reach, but only this
+      // generation may clear its own timer out of it.
+      const timer = setTimeout(() => {
+        if (superseded()) return;
+        setPendingOpenUrl(item.url);
+      }, PENDING_AFFORDANCE_MS);
+      pendingTimerRef.current = timer;
+      // Ownership is claimed at ARM time, not fire time: a successor open must
+      // own the affordance from its first instant, or the superseded open's
+      // cleanup darkens a row the successor is still resolving.
+      pendingGenRef.current = gen;
+      try {
+        const worktreePath = await resolveWorktreeTarget(
+          item,
+          match.path,
+          superseded,
+        );
+        if (worktreePath) {
+          // git skips its prune while another process holds the worktree-admin
+          // lock, so a checkout deleted out-of-band can still be listed.
+          const info = await validateRepo(worktreePath);
+          if (superseded()) return;
+          targetPath = worktreePath;
+          targetName = info.name;
+        }
+      } catch {
+        // The worktree no longer validates — the main checkout still opens.
+      } finally {
+        clearTimeout(timer);
+        if (pendingTimerRef.current === timer) pendingTimerRef.current = null;
+        // Only the generation that owns the affordance may darken it.
+        if (pendingGenRef.current === gen) {
+          pendingGenRef.current = 0;
+          setPendingOpenUrl(null);
+        }
+      }
+      if (superseded()) return;
+    }
     // Land under the origin lens (matchLocalRepo matched the ORIGIN slug): a fork
-    // sitting on "upstream" resolves this number against the parent repo. The lens
-    // write is session-only. Clears are safe: an unchanged lens short-circuits
+    // sitting on "upstream" resolves this number against the parent repo. Keyed on
+    // the path actually navigated to, since a worktree carries its own lens. The
+    // lens write is session-only. Clears are safe: an unchanged lens short-circuits
     // before them, and a real flip drops old-lens siblings before the landing set.
     const applyLens = () =>
-      applyRepoLens(queryClient, match.path, "origin", {
+      applyRepoLens(queryClient, targetPath, "origin", {
         clearSelections: true,
         persist: false,
       });
     if (item.isPullRequest) {
       openPr({
         kind: "remote",
-        repoPath: match.path,
-        repoName: match.name,
+        repoPath: targetPath,
+        repoName: targetName,
         ref: String(item.number),
         section: null,
         // Inside the navigator's view-transition callback, so the lens and the
@@ -259,12 +411,16 @@ export function MyWorkScreen() {
         visible={visible}
         activeIndex={activeIndex}
         recents={recents}
+        pendingOpenUrl={pendingOpenUrl}
         onSelect={setActiveUrl}
-        onOpen={(item) => void openItem(item)}
+        onOpen={(item, opts) => void openItem(item, opts)}
       />
     </div>
   );
 }
+
+/** Opens an item, optionally overriding the worktree preference. */
+type OpenItem = (item: MyWorkItem, opts?: { preferWorktree?: boolean }) => void;
 
 /** The body's state machine: loading → error → empty → filtered-empty → list.
  *  Split from the shell so the virtualizer below only ever mounts with rows. */
@@ -274,6 +430,7 @@ function MyWorkBody({
   visible,
   activeIndex,
   recents,
+  pendingOpenUrl,
   onSelect,
   onOpen,
 }: {
@@ -282,8 +439,9 @@ function MyWorkBody({
   visible: MyWorkItem[];
   activeIndex: number;
   recents: readonly RecentRepo[];
+  pendingOpenUrl: string | null;
   onSelect: (url: string) => void;
-  onOpen: (item: MyWorkItem) => void;
+  onOpen: OpenItem;
 }) {
   if (work.isPending) {
     return <ListRowSkeletons rows={8} lines={1} name="your work" />;
@@ -299,12 +457,11 @@ function MyWorkBody({
       </QuietLine>
     );
   }
-  // A heuristic, not a count: the backend drops unaddressable hits, so a
-  // truncated page that lost one arrives short and reads as uncapped. It errs
-  // only toward staying quiet, which is why the note states the constraint
-  // rather than a number. Shown under the filtered-empty branch too — filtering
-  // to nothing is when an off-page item matters most.
-  const capped = items.length >= MY_WORK_LIMIT;
+  // Set server-side when a search leg hit its cap or the merged union overshot
+  // the page — leg caps count raw hits before unaddressable ones drop, so it
+  // stays true on a page that arrives short. Shown under the filtered-empty
+  // branch too: filtering to nothing is when an off-page item matters most.
+  const capped = work.data?.truncated ?? false;
   if (visible.length === 0) {
     return (
       <>
@@ -319,6 +476,7 @@ function MyWorkBody({
         items={visible}
         activeIndex={activeIndex}
         recents={recents}
+        pendingOpenUrl={pendingOpenUrl}
         onSelect={onSelect}
         onOpen={onOpen}
       />
@@ -333,14 +491,16 @@ function MyWorkList({
   items,
   activeIndex,
   recents,
+  pendingOpenUrl,
   onSelect,
   onOpen,
 }: {
   items: MyWorkItem[];
   activeIndex: number;
   recents: readonly RecentRepo[];
+  pendingOpenUrl: string | null;
   onSelect: (url: string) => void;
-  onOpen: (item: MyWorkItem) => void;
+  onOpen: OpenItem;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [menuItem, setMenuItem] = useState<MyWorkItem | null>(null);
@@ -376,8 +536,6 @@ function MyWorkList({
     }
   }
 
-  const activeUrl = activeIndex >= 0 ? items[activeIndex].url : undefined;
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <ContextMenu>
@@ -393,16 +551,15 @@ function MyWorkList({
           }
         >
           {/* Arrow-key navigation lives on the filter Input (combobox pattern),
-              so the listbox itself is not a Tab stop — a pure a11y container. */}
+              so the listbox itself is neither a Tab stop nor the owner of
+              aria-activedescendant — focus never leaves the input, and a second
+              copy here would be inert. A pure a11y container. */}
           <div
             ref={parentRef}
             className="min-h-0 flex-1 overflow-y-auto"
             role="listbox"
             id={MY_WORK_LISTBOX_ID}
             aria-label="Your work"
-            aria-activedescendant={
-              activeUrl ? myWorkOptionId(activeUrl) : undefined
-            }
           >
             <div
               className="relative w-full"
@@ -425,6 +582,7 @@ function MyWorkList({
                       item={item}
                       local={matchLocalRepo(item, recents) !== null}
                       active={v.index === activeIndex}
+                      pending={item.url === pendingOpenUrl}
                       onSelect={onSelect}
                       onOpen={onOpen}
                     />
@@ -437,6 +595,16 @@ function MyWorkList({
         <ContextMenuContent className="min-w-44">
           {menuItem && (
             <>
+              {/* The escape hatch from the worktree-aware default: only ever
+                  offered for a PR that resolves to a local repo at all. */}
+              {menuItem.isPullRequest &&
+                matchLocalRepo(menuItem, recents) !== null && (
+                  <ContextMenuItem
+                    onClick={() => onOpen(menuItem, { preferWorktree: false })}
+                  >
+                    Open in main workspace
+                  </ContextMenuItem>
+                )}
               <ContextMenuItem onClick={() => openUrl(menuItem.url)}>
                 Open on GitHub
               </ContextMenuItem>
@@ -469,14 +637,16 @@ function MyWorkRow({
   item,
   local,
   active,
+  pending,
   onSelect,
   onOpen,
 }: {
   item: MyWorkItem;
   local: boolean;
   active: boolean;
+  pending: boolean;
   onSelect: (url: string) => void;
-  onOpen: (item: MyWorkItem) => void;
+  onOpen: OpenItem;
 }) {
   const Icon = item.isPullRequest ? GitPullRequestIcon : CircleDashedIcon;
   const typeLabel = item.isPullRequest ? "Pull request" : "Issue";
@@ -488,6 +658,10 @@ function MyWorkRow({
       data-my-work-url={item.url}
       role="option"
       aria-selected={active}
+      aria-busy={pending}
+      // The combobox input owns focus and drives the selection, so an option
+      // must not also be a Tab stop.
+      tabIndex={-1}
       onClick={() => {
         onSelect(item.url);
         onOpen(item);
@@ -530,6 +704,14 @@ function MyWorkRow({
           className="flex shrink-0 items-center text-muted-foreground"
         >
           <ArrowSquareOutIcon className="size-3" aria-hidden />
+        </span>
+      )}
+      {pending && (
+        <span
+          className="flex shrink-0 items-center text-muted-foreground"
+          aria-hidden
+        >
+          <CircleNotchIcon className="size-3.5 animate-spin" />
         </span>
       )}
       {parseableDate(item.updatedAt) && (

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -581,18 +581,21 @@ function MyWorkBody({
   }
   // Set server-side when a search leg hit its cap or the merged union overshot
   // the page — leg caps count raw hits before unaddressable ones drop, so it
-  // stays true on a page that arrives short. Shown under the empty branches
-  // too: a page whose every hit was dropped must not read as "nothing exists".
+  // stays true on a page that arrives short. A capped EMPTY page carries its
+  // own sentence rather than CapNote: the note's filter advice has nothing to
+  // narrow, but the page must not read as "nothing exists".
   const capped = work.data?.truncated ?? false;
   if (items.length === 0) {
-    return (
-      <>
-        <QuietLine>
-          Nothing on GitHub involves you right now. This searches every repo
-          you're involved in, not just local ones.
-        </QuietLine>
-        {capped && <CapNote />}
-      </>
+    return capped ? (
+      <QuietLine>
+        GitHub returned results this view can't display. There may be more than
+        one page holds.
+      </QuietLine>
+    ) : (
+      <QuietLine>
+        Nothing on GitHub involves you right now. This searches every repo
+        you're involved in, not just local ones.
+      </QuietLine>
     );
   }
   if (visible.length === 0) {

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -180,7 +180,7 @@ async function branchWorktreeOf(
 const MENU_KEY_ANCHOR_INSET_PX = 12;
 
 /**
- * Opens a row's context menu from the keyboard, reporting whether it could.
+ * Opens a row's context menu from the keyboard.
  *
  * A real `contextmenu` event on the row is the only route: Base UI takes the
  * popup's anchor solely from such an event's coordinates (its trigger's handler
@@ -188,9 +188,9 @@ const MENU_KEY_ANCHOR_INSET_PX = 12;
  * close/unmount), and the list's own capture handler reads the row out of the
  * event target. Dispatching one drives both, exactly as a right-click does.
  */
-function openRowContextMenu(url: string): boolean {
+function openRowContextMenu(url: string): void {
   const row = document.getElementById(myWorkOptionId(url));
-  if (!row) return false;
+  if (!row) return;
   const rect = row.getBoundingClientRect();
   row.dispatchEvent(
     new MouseEvent("contextmenu", {
@@ -201,7 +201,6 @@ function openRowContextMenu(url: string): boolean {
       clientY: Math.round(rect.top + rect.height / 2),
     }),
   );
-  return true;
 }
 
 /**
@@ -580,19 +579,22 @@ function MyWorkBody({
   if (work.isError) {
     return <MyWorkError error={work.error} onRetry={() => work.refetch()} />;
   }
-  if (items.length === 0) {
-    return (
-      <QuietLine>
-        Nothing on GitHub involves you right now. This searches every repo
-        you're involved in, not just local ones.
-      </QuietLine>
-    );
-  }
   // Set server-side when a search leg hit its cap or the merged union overshot
   // the page — leg caps count raw hits before unaddressable ones drop, so it
-  // stays true on a page that arrives short. Shown under the filtered-empty
-  // branch too: filtering to nothing is when an off-page item matters most.
+  // stays true on a page that arrives short. Shown under the empty branches
+  // too: a page whose every hit was dropped must not read as "nothing exists".
   const capped = work.data?.truncated ?? false;
+  if (items.length === 0) {
+    return (
+      <>
+        <QuietLine>
+          Nothing on GitHub involves you right now. This searches every repo
+          you're involved in, not just local ones.
+        </QuietLine>
+        {capped && <CapNote />}
+      </>
+    );
+  }
   if (visible.length === 0) {
     return (
       <>

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -37,7 +37,7 @@ import { ghPrHeadRef, validateRepo } from "@/lib/git/api";
 import { normPath } from "@/lib/git/path";
 import { useForgeMyWork } from "@/lib/git/queries";
 import type { MyWorkItem, PrHeadRef, RepoInfo } from "@/lib/git/types";
-import { listUserWorktrees } from "@/lib/git/worktree";
+import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { applyRepoLens } from "@/lib/repo-lens/queries";
 import type { RecentRepo } from "@/lib/settings/api";
@@ -123,45 +123,34 @@ async function resolveTarget(
 /**
  * The repo's main worktree when `repoPath` is itself a linked one, else null.
  * A worktree opened through the folder picker lands in recents like any other
- * checkout, so the escape hatch can't assume its match is the main workspace.
+ * checkout, so a matched row can't be assumed to be the main workspace.
  */
-async function resolveMainWorktree(
+function mainWorktreeOf(
+  worktrees: UserWorktree[],
   repoPath: string,
-  deadline: number,
-): Promise<string | null> {
-  const worktrees = await withDeadline(
-    listUserWorktrees(repoPath),
-    deadline,
-    [],
-  );
+): string | null {
   const main = worktrees.find((w) => w.isMain);
+  // normPath for comparison only — git spells worktree paths with forward
+  // slashes where validate_repo hands back Windows separators.
   if (!main || normPath(main.path) === normPath(repoPath)) return null;
   return main.path;
 }
 
 /**
- * The checkout to open a PR in: a user worktree whose checked-out branch is
- * provably this PR's head, else null for the repo's main checkout. Every
- * unknown — a slow or failed leg, an unproven head, no matching branch — is a
- * null, and the caller's deadline bounds every awaited leg.
+ * The worktree whose checked-out branch is provably this PR's head, else null.
+ * Every unknown — a slow or failed head-ref read, an unproven head, no branch
+ * match — is a null, and the caller's deadline bounds the read. Candidates are
+ * not filtered against `repoPath`: a head branch checked out in the matched
+ * checkout itself is still the proven answer, and returning it is what keeps
+ * the main-workspace preference from pulling the user off their own branch.
  */
-async function resolveWorktreeTarget(
+async function branchWorktreeOf(
   item: MyWorkItem,
+  worktrees: UserWorktree[],
   repoPath: string,
   deadline: number,
-  superseded: () => boolean,
 ): Promise<string | null> {
-  const worktrees = await withDeadline(
-    listUserWorktrees(repoPath),
-    deadline,
-    [],
-  );
-  if (superseded()) return null;
-  // normPath for comparison only — git spells worktree paths with forward
-  // slashes where validate_repo hands back Windows separators.
-  const candidates = worktrees.filter(
-    (w) => w.branch !== "" && normPath(w.path) !== normPath(repoPath),
-  );
+  const candidates = worktrees.filter((w) => w.branch !== "");
   if (candidates.length === 0) return null;
   // A spent budget would race gh against a zero-length timeout and discard the
   // result — don't spawn the process at all.
@@ -171,11 +160,10 @@ async function resolveWorktreeTarget(
     deadline,
     null,
   );
-  if (superseded()) return null;
   // A fork PR's head branch lives in a different repository, where that branch
   // name routinely also exists locally — only a head slug matching this item's
   // repo proves a local branch IS the PR's, so an empty or foreign slug falls
-  // back to the main checkout.
+  // back to whatever the caller had chosen.
   if (
     !head ||
     head.headRefName === "" ||
@@ -185,6 +173,35 @@ async function resolveWorktreeTarget(
   }
   // Exact compare: git branch names are case-sensitive.
   return candidates.find((w) => w.branch === head.headRefName)?.path ?? null;
+}
+
+/** Inset from the row's leading edge for a keyboard-opened menu's anchor, so the
+ *  popup hangs beside the row rather than off the viewport edge. */
+const MENU_KEY_ANCHOR_INSET_PX = 12;
+
+/**
+ * Opens a row's context menu from the keyboard, reporting whether it could.
+ *
+ * A real `contextmenu` event on the row is the only route: Base UI takes the
+ * popup's anchor solely from such an event's coordinates (its trigger's handler
+ * is what calls `setAnchor`, and the public actions ref exposes only
+ * close/unmount), and the list's own capture handler reads the row out of the
+ * event target. Dispatching one drives both, exactly as a right-click does.
+ */
+function openRowContextMenu(url: string): boolean {
+  const row = document.getElementById(myWorkOptionId(url));
+  if (!row) return false;
+  const rect = row.getBoundingClientRect();
+  row.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: Math.round(rect.left + MENU_KEY_ANCHOR_INSET_PX),
+      clientY: Math.round(rect.top + rect.height / 2),
+    }),
+  );
+  return true;
 }
 
 /**
@@ -291,14 +308,13 @@ export function MyWorkScreen() {
       return;
     }
     if (superseded()) return;
-    // A PR's work lives wherever its head branch is checked out, so land there
-    // rather than in the main checkout the recents row names; the escape hatch
-    // resolves the other way, since the matched row can itself BE a worktree.
-    // Every unknown falls back to match.path, silently: nothing broke for the user.
+    // Where a local landing goes, in one rule: a matched row that is itself a
+    // linked worktree prefers its repo's main workspace, and a PROVEN PR head
+    // branch outranks that toward the worktree holding it. Every unknown stays
+    // on match.path, silently — nothing broke for the user.
     let targetPath = match.path;
     let targetName = match.name;
-    if (item.isPullRequest) {
-      const preferWorktree = opts?.preferWorktree ?? true;
+    {
       // Armed before the first await, not before the network leg: listing
       // worktrees runs a prune that can block for seconds, and a freeze the row
       // doesn't acknowledge reads as a dropped keypress. Held locally as well as
@@ -316,19 +332,65 @@ export function MyWorkScreen() {
       // One budget for the whole resolution, however many legs it takes.
       const deadline = Date.now() + WORKTREE_RESOLVE_BUDGET_MS;
       try {
-        const checkout = preferWorktree
-          ? await resolveWorktreeTarget(item, match.path, deadline, superseded)
-          : await resolveMainWorktree(match.path, deadline);
+        // Listed once and shared: both preferences read the same snapshot, and
+        // this is the leg that can block.
+        const worktrees = await withDeadline(
+          listUserWorktrees(match.path),
+          deadline,
+          [],
+        );
         if (superseded()) return;
-        if (checkout) {
+        // The fallback is resolved AND validated first, before the optional
+        // network leg can spend the budget on it: the semantics promise the main
+        // workspace whenever the branch is unconfirmed, so that promise must not
+        // depend on how slow the head-ref read turns out to be. Costs one local
+        // git call even when the branch goes on to win.
+        // Null when the matched row already IS the main workspace, so the
+        // ordinary main-clone open never re-validates or re-spells its path.
+        const mainPath = mainWorktreeOf(worktrees, match.path);
+        // Where the open lands if the branch is never looked up. Proving a head
+        // can only matter when some branch-bearing checkout sits somewhere ELSE
+        // than that: a single-checkout clone has nowhere to be redirected to, and
+        // the common open must stay keypress-instant rather than wait on a forge
+        // call whose every outcome is the path it already has.
+        const fallbackPath = mainPath ?? match.path;
+        const lookupCanMove = worktrees.some(
+          (w) => w.branch !== "" && normPath(w.path) !== normPath(fallbackPath),
+        );
+        let landing: { path: string; name: string } | null = null;
+        if (mainPath) {
           // git skips its prune while another process holds the worktree-admin
           // lock, so a checkout deleted out-of-band can still be listed.
-          const target = await resolveTarget(checkout, deadline);
+          landing = await resolveTarget(mainPath, deadline);
           if (superseded()) return;
-          if (target) {
-            targetPath = target.path;
-            targetName = target.name;
+        }
+        if (
+          lookupCanMove &&
+          item.isPullRequest &&
+          (opts?.preferWorktree ?? true)
+        ) {
+          const branch = await branchWorktreeOf(
+            item,
+            worktrees,
+            match.path,
+            deadline,
+          );
+          if (superseded()) return;
+          if (branch && normPath(branch) === normPath(match.path)) {
+            // The proven head is the matched checkout itself — stay on the
+            // user's own branch rather than moving them to the main workspace.
+            landing = null;
+          } else if (branch) {
+            const branchTarget = await resolveTarget(branch, deadline);
+            if (superseded()) return;
+            // A branch that won't validate keeps the main-workspace fallback
+            // rather than dropping back to the matched worktree.
+            if (branchTarget) landing = branchTarget;
           }
+        }
+        if (landing) {
+          targetPath = landing.path;
+          targetName = landing.name;
         }
       } finally {
         clearTimeout(timer);
@@ -365,8 +427,8 @@ export function MyWorkScreen() {
       });
     } else {
       openIssue({
-        repoPath: match.path,
-        repoName: match.name,
+        repoPath: targetPath,
+        repoName: targetName,
         number: item.number,
         beforeSelect: applyLens,
       });
@@ -389,6 +451,15 @@ export function MyWorkScreen() {
       if (!item) return;
       e.preventDefault();
       void openItem(item, { preferWorktree: !e.shiftKey });
+      return;
+    }
+    // The menu keys reach the row's context menu from here because focus never
+    // leaves this input: pressed on the input they would target it instead, and
+    // it sits outside the list's menu trigger, so the rows' only menu route is
+    // this one. Targets the active row, which the menu already acts on.
+    if (e.key === "ContextMenu" || (e.key === "F10" && e.shiftKey)) {
+      const item = visible[activeIndex];
+      if (item && openRowContextMenu(item.url)) e.preventDefault();
       return;
     }
     onInputArrow(e);
@@ -731,6 +802,10 @@ function MyWorkRow({
       // The combobox input owns focus and drives the selection, so an option
       // must not also be a Tab stop.
       tabIndex={-1}
+      // tabIndex alone doesn't stop a CLICK from focusing the button, which
+      // would move focus off the combobox input and kill arrow/Enter nav;
+      // suppressing mousedown's default keeps focus without affecting activation.
+      onMouseDown={(e) => e.preventDefault()}
       onClick={(e) => {
         onSelect(item.url);
         // Shift-click mirrors Shift+Enter: open the main workspace instead of

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -109,6 +109,9 @@ async function resolveTarget(
   path: string,
   deadline: number,
 ): Promise<{ path: string; name: string } | null> {
+  // A spent budget would race git against a zero-length timeout and discard the
+  // result — don't spawn the process at all.
+  if (Date.now() >= deadline) return null;
   const info = await withDeadline<RepoInfo | null>(
     validateRepo(path),
     deadline,
@@ -562,11 +565,20 @@ function MyWorkList({
     overscan: 12,
   });
 
+  // Armed by a right-click, consumed by the very next run of the align effect:
+  // the menu opens anchored to the cursor, so aligning the row it selected would
+  // slide the list out from under it.
+  const skipAlignRef = useRef(false);
+
   // Keep the keyboard-selected row in view. Keyed on the selection alone: a
   // re-scroll on any list change would fight the user's own scrolling on every
   // unrelated re-render (the shared clock ticks these rows every 30s).
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when the selection moves
   useEffect(() => {
+    if (skipAlignRef.current) {
+      skipAlignRef.current = false;
+      return;
+    }
     if (activeIndex >= 0) {
       virtualizer.scrollToIndex(activeIndex, { align: "auto" });
     }
@@ -582,7 +594,10 @@ function MyWorkList({
     if (item) {
       setMenuItem(item);
       // Move the highlight with the menu, so it can't act on a row other than
-      // the one aria-activedescendant is pointing at.
+      // the one aria-activedescendant is pointing at — but arm the skip only
+      // when the index will actually change, or the flag would outlive this
+      // click and swallow the next keyboard scroll.
+      if (item.url !== items[activeIndex]?.url) skipAlignRef.current = true;
       onSelect(item.url);
     } else {
       setMenuItem(null);

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -589,7 +589,7 @@ function MyWorkBody({
     return capped ? (
       <QuietLine>
         GitHub returned results this view can't display. There may be more than
-        one page holds.
+        this page holds.
       </QuietLine>
     ) : (
       <QuietLine>

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -438,8 +438,7 @@ export function MyWorkScreen() {
   // Arrow keys from the filter input move the selection through the visible
   // rows and Enter opens it, so a keyboard user goes type → arrows → Enter
   // without ever leaving the input. Shift+Enter is the keyboard route to the
-  // main workspace — focus never leaves the input, so the context menu that
-  // also offers it is unreachable without a pointer.
+  // main workspace.
   const onInputArrow = listKeyboardNav({
     items: visible,
     activeIndex,
@@ -459,7 +458,14 @@ export function MyWorkScreen() {
     // this one. Targets the active row, which the menu already acts on.
     if (e.key === "ContextMenu" || (e.key === "F10" && e.shiftKey)) {
       const item = visible[activeIndex];
-      if (item && openRowContextMenu(item.url)) e.preventDefault();
+      // Swallowed whenever a row is active, even if it scrolled out of the
+      // virtualizer and couldn't be found: the input's own edit menu is the
+      // wrong answer to a row-menu request. With no active row there is no row
+      // menu to ask for, so that menu stays reachable.
+      if (item) {
+        e.preventDefault();
+        openRowContextMenu(item.url);
+      }
       return;
     }
     onInputArrow(e);

--- a/src/features/mywork/MyWorkScreen.tsx
+++ b/src/features/mywork/MyWorkScreen.tsx
@@ -36,7 +36,7 @@ import { suppressContextMenu } from "@/lib/context-menu";
 import { ghPrHeadRef, validateRepo } from "@/lib/git/api";
 import { normPath } from "@/lib/git/path";
 import { useForgeMyWork } from "@/lib/git/queries";
-import type { MyWorkItem, PrHeadRef } from "@/lib/git/types";
+import type { MyWorkItem, PrHeadRef, RepoInfo } from "@/lib/git/types";
 import { listUserWorktrees } from "@/lib/git/worktree";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { applyRepoLens } from "@/lib/repo-lens/queries";
@@ -60,9 +60,12 @@ import {
  *  fresh array to every render. */
 const NO_RECENTS: RecentRepo[] = [];
 
-/** Total budget for resolving where to open a PR, across BOTH of its awaited
- *  legs. Opening must stay a keypress-fast action, and the worktree list alone
- *  can block for seconds behind git's prune. */
+/** Total budget for resolving where to open a PR, spanning EVERY awaited leg of
+ *  the resolution — the worktree list, the head-ref read, and the validate of
+ *  whatever checkout they point at. Opening must stay a keypress-fast action,
+ *  and any one leg can block for seconds (git's prune, a stalled network mount).
+ *  Legs that consume the whole budget leave nothing for the ones after them,
+ *  which fall back to the main checkout — the safe direction. */
 const WORKTREE_RESOLVE_BUDGET_MS = 1500;
 
 /** Grace period before a resolving open lights its row, so a resolution that
@@ -95,17 +98,56 @@ function withDeadline<T>(
 }
 
 /**
+ * A checkout's navigation target, or null when it can't be validated in time.
+ * `root` rather than the caller's path: git prints worktree paths with forward
+ * slashes while validate_repo answers the canonical spelling, and every
+ * repo-identity consumer (query keys, per-repo stores, the session lists'
+ * `s.repoPath === repoPath` filters) compares that form as a plain string — two
+ * spellings of one checkout would read as two different repos.
+ */
+async function resolveTarget(
+  path: string,
+  deadline: number,
+): Promise<{ path: string; name: string } | null> {
+  const info = await withDeadline<RepoInfo | null>(
+    validateRepo(path),
+    deadline,
+    null,
+  );
+  return info ? { path: info.root, name: info.name } : null;
+}
+
+/**
+ * The repo's main worktree when `repoPath` is itself a linked one, else null.
+ * A worktree opened through the folder picker lands in recents like any other
+ * checkout, so the escape hatch can't assume its match is the main workspace.
+ */
+async function resolveMainWorktree(
+  repoPath: string,
+  deadline: number,
+): Promise<string | null> {
+  const worktrees = await withDeadline(
+    listUserWorktrees(repoPath),
+    deadline,
+    [],
+  );
+  const main = worktrees.find((w) => w.isMain);
+  if (!main || normPath(main.path) === normPath(repoPath)) return null;
+  return main.path;
+}
+
+/**
  * The checkout to open a PR in: a user worktree whose checked-out branch is
  * provably this PR's head, else null for the repo's main checkout. Every
  * unknown — a slow or failed leg, an unproven head, no matching branch — is a
- * null, and one shared deadline bounds both awaited legs.
+ * null, and the caller's deadline bounds every awaited leg.
  */
 async function resolveWorktreeTarget(
   item: MyWorkItem,
   repoPath: string,
+  deadline: number,
   superseded: () => boolean,
 ): Promise<string | null> {
-  const deadline = Date.now() + WORKTREE_RESOLVE_BUDGET_MS;
   const worktrees = await withDeadline(
     listUserWorktrees(repoPath),
     deadline,
@@ -118,6 +160,9 @@ async function resolveWorktreeTarget(
     (w) => w.branch !== "" && normPath(w.path) !== normPath(repoPath),
   );
   if (candidates.length === 0) return null;
+  // A spent budget would race gh against a zero-length timeout and discard the
+  // result — don't spawn the process at all.
+  if (Date.now() >= deadline) return null;
   const head = await withDeadline<PrHeadRef | null>(
     ghPrHeadRef(repoPath, item.number),
     deadline,
@@ -204,8 +249,9 @@ export function MyWorkScreen() {
   // Every navigation goes through an atomic navigator: an openRepo followed by a
   // select would pair the new repo with the old selection, because the
   // view-transition callback that carries the selection is deferred.
-  // `preferWorktree: false` is the context menu's escape hatch back to the main
-  // checkout; everything else lands where the branch actually is.
+  // `preferWorktree: false` is the escape hatch back to the main workspace
+  // (Shift+Enter, shift-click, or the context menu); everything else lands where
+  // the branch actually is.
   async function openItem(
     item: MyWorkItem,
     opts?: { preferWorktree?: boolean },
@@ -243,11 +289,13 @@ export function MyWorkScreen() {
     }
     if (superseded()) return;
     // A PR's work lives wherever its head branch is checked out, so land there
-    // rather than in the main checkout the recents row names. Every unknown
-    // falls back to match.path, silently: nothing broke for the user.
+    // rather than in the main checkout the recents row names; the escape hatch
+    // resolves the other way, since the matched row can itself BE a worktree.
+    // Every unknown falls back to match.path, silently: nothing broke for the user.
     let targetPath = match.path;
     let targetName = match.name;
-    if (item.isPullRequest && (opts?.preferWorktree ?? true)) {
+    if (item.isPullRequest) {
+      const preferWorktree = opts?.preferWorktree ?? true;
       // Armed before the first await, not before the network leg: listing
       // worktrees runs a prune that can block for seconds, and a freeze the row
       // doesn't acknowledge reads as a dropped keypress. Held locally as well as
@@ -262,22 +310,23 @@ export function MyWorkScreen() {
       // own the affordance from its first instant, or the superseded open's
       // cleanup darkens a row the successor is still resolving.
       pendingGenRef.current = gen;
+      // One budget for the whole resolution, however many legs it takes.
+      const deadline = Date.now() + WORKTREE_RESOLVE_BUDGET_MS;
       try {
-        const worktreePath = await resolveWorktreeTarget(
-          item,
-          match.path,
-          superseded,
-        );
-        if (worktreePath) {
+        const checkout = preferWorktree
+          ? await resolveWorktreeTarget(item, match.path, deadline, superseded)
+          : await resolveMainWorktree(match.path, deadline);
+        if (superseded()) return;
+        if (checkout) {
           // git skips its prune while another process holds the worktree-admin
           // lock, so a checkout deleted out-of-band can still be listed.
-          const info = await validateRepo(worktreePath);
+          const target = await resolveTarget(checkout, deadline);
           if (superseded()) return;
-          targetPath = worktreePath;
-          targetName = info.name;
+          if (target) {
+            targetPath = target.path;
+            targetName = target.name;
+          }
         }
-      } catch {
-        // The worktree no longer validates — the main checkout still opens.
       } finally {
         clearTimeout(timer);
         if (pendingTimerRef.current === timer) pendingTimerRef.current = null;
@@ -323,7 +372,9 @@ export function MyWorkScreen() {
 
   // Arrow keys from the filter input move the selection through the visible
   // rows and Enter opens it, so a keyboard user goes type → arrows → Enter
-  // without ever leaving the input.
+  // without ever leaving the input. Shift+Enter is the keyboard route to the
+  // main workspace — focus never leaves the input, so the context menu that
+  // also offers it is unreachable without a pointer.
   const onInputArrow = listKeyboardNav({
     items: visible,
     activeIndex,
@@ -334,7 +385,7 @@ export function MyWorkScreen() {
       const item = visible[activeIndex];
       if (!item) return;
       e.preventDefault();
-      void openItem(item);
+      void openItem(item, { preferWorktree: !e.shiftKey });
       return;
     }
     onInputArrow(e);
@@ -530,6 +581,9 @@ function MyWorkList({
     const item = url ? items.find((i) => i.url === url) : undefined;
     if (item) {
       setMenuItem(item);
+      // Move the highlight with the menu, so it can't act on a row other than
+      // the one aria-activedescendant is pointing at.
+      onSelect(item.url);
     } else {
       setMenuItem(null);
       suppressContextMenu(e);
@@ -662,9 +716,11 @@ function MyWorkRow({
       // The combobox input owns focus and drives the selection, so an option
       // must not also be a Tab stop.
       tabIndex={-1}
-      onClick={() => {
+      onClick={(e) => {
         onSelect(item.url);
-        onOpen(item);
+        // Shift-click mirrors Shift+Enter: open the main workspace instead of
+        // the worktree holding the head branch.
+        onOpen(item, { preferWorktree: !e.shiftKey });
       }}
       className={cn(
         "flex w-full items-center gap-2 border-b px-3 py-2 text-left text-xs",

--- a/src/features/mywork/mywork-utils.ts
+++ b/src/features/mywork/mywork-utils.ts
@@ -4,14 +4,6 @@ import type { RecentRepo } from "@/lib/settings/api";
 /** Which slice of the inbox the tab strip is showing. */
 export type MyWorkTab = "all" | "prs" | "issues";
 
-/** The backend's page cap (each search leg's `--limit` and the merged page's
- *  truncation) — mirrors `MY_WORK_LIMIT` in `src-tauri/src/github/my_work.rs`;
- *  the two must change together. A full page is the signal the feed MAY be
- *  truncated, never a count of what exists: unaddressable hits are dropped
- *  server-side, so a truncated page can arrive short and read as complete —
- *  which is why the note states the constraint, not a number. */
-export const MY_WORK_LIMIT = 200;
-
 export const MY_WORK_LISTBOX_ID = "my-work-listbox";
 
 /** Stable DOM id per row, so the filter input's aria-activedescendant can point
@@ -20,13 +12,15 @@ export const myWorkOptionId = (url: string) =>
   `my-work-${url.replace(/[^\w-]/g, "_")}`;
 
 /**
- * A recent repository that looks like this item's, or null. `RecentRepo.name`
- * is the checkout's FOLDER basename, not the remote's repo name, so this is a
- * heuristic in both directions: a clone in a renamed folder (or a worktree)
- * never matches and opens in the browser, and a folder that happens to be named
- * after a different repo of the same owner can match wrongly. `owner`/`host`
- * resolve in the background, so a recent missing either never matches, as does
- * an item whose URL had no parseable authority (empty host).
+ * A recent repository that looks like this item's, or null. Matches on
+ * `RecentRepo.repoName` — the name the record's origin URL spells — so a clone
+ * in a renamed folder resolves exactly. Rows the owner probe hasn't touched yet
+ * carry no `repoName` and fall back to `name`, the FOLDER basename, which stays
+ * a heuristic in both directions: a renamed clone never matches and opens in the
+ * browser, and a folder named after a different repo of the same owner can match
+ * wrongly. `owner`/`host` resolve in the background, so a recent missing either
+ * never matches, as does an item whose URL had no parseable authority (empty
+ * host).
  */
 export function matchLocalRepo(
   item: MyWorkItem,
@@ -43,7 +37,7 @@ export function matchLocalRepo(
         !!r.owner &&
         r.host.toLowerCase() === host &&
         r.owner.toLowerCase() === owner &&
-        r.name.toLowerCase() === name,
+        (r.repoName ?? r.name).toLowerCase() === name,
     ) ?? null
   );
 }

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -162,8 +162,9 @@ export function RepoList({
   const providerOf = (r: RecentRepo): ForgeProvider | null =>
     resolveProvider(r, providerByPath, hostByPath);
 
-  // Backfill resolved owners + hosts + providers onto the recent records so the
-  // NEXT open groups (and labels its context menu) synchronously. Fires once
+  // Backfill resolved owners + hosts + providers + remote repo names onto the
+  // recent records so the NEXT open groups (and labels its context menu)
+  // synchronously, and remote-name matching works cold. Fires once
   // whenever a record's stored value is stale; the helper no-ops when nothing
   // changed, so its settings refetch doesn't loop.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mutateAsync() is stable; rerun only on resolved owners / records
@@ -175,7 +176,8 @@ export function RepoList({
       return (
         (o.owner || undefined) !== r?.owner ||
         (o.host || undefined) !== r?.host ||
-        (o.provider || undefined) !== r?.provider
+        (o.provider || undefined) !== r?.provider ||
+        (o.repoName || undefined) !== r?.repoName
       );
     });
     if (stale) void persistOwners.mutateAsync(resolved).catch(() => undefined);

--- a/src/features/repository/useRepoVisibilityProbe.ts
+++ b/src/features/repository/useRepoVisibilityProbe.ts
@@ -11,9 +11,10 @@ import { settingsKeys } from "@/lib/settings/queries";
 /**
  * Probe a repo's hosted visibility + fork provenance and persist it, returning the
  * fresh probe — or `null` when no provider resolves (remote removed/absent), which
- * clears every derived field so a stale badge clears. Owner/host/provider are
- * persisted here too, so a fresh clone shows its provider label, host, and fork
- * badge on the FIRST open, without a RepoList render backfilling them.
+ * clears every derived field so a stale badge clears. Owner/host/provider plus the
+ * remote's repo name are persisted here too, so a fresh clone shows its provider
+ * label, host, and fork badge on the FIRST open, without a RepoList render
+ * backfilling them.
  *
  * Shared by the ambient open-time probe below and the Danger zone's "Re-check fork
  * status", which therefore also heals the provider label after the user re-points
@@ -29,7 +30,7 @@ export async function probeAndPersistVisibility(
   const [owner] = await gitRepoOwners([repoPath]);
   if (!owner?.provider) {
     // Clearing the provider also clears visibility/isFork/forkParent (they can't
-    // outlive it) — all six derived fields in one write. `owner` is undefined when
+    // outlive it) — all seven derived fields in one write. `owner` is undefined when
     // gitRepoOwners returns no entry (no remote at all); the null-filled entry
     // still targets this path, so the clear lands.
     await persistRepoOwners([
@@ -38,6 +39,7 @@ export async function probeAndPersistVisibility(
         owner: owner?.owner ?? null,
         host: owner?.host ?? null,
         provider: null,
+        repoName: owner?.repoName ?? null,
       },
     ]);
     return null;

--- a/src/features/welcome/WelcomeScreen.tsx
+++ b/src/features/welcome/WelcomeScreen.tsx
@@ -74,19 +74,21 @@ export function WelcomeScreen() {
       variant: "outline",
       onClick: () => dispatchAction("new-repository"),
     },
-    {
-      id: "open-explore",
-      label: "Explore repositories",
-      icon: CompassIcon,
-      variant: "outline",
-      onClick: openExplore,
-    },
+    // My work sits with the shortcut-bearing actions above it; Explore, the
+    // least-frequent (discovery) action, anchors the bottom.
     {
       id: "open-my-work",
       label: "My work",
       icon: TrayIcon,
       variant: "outline",
       onClick: openMyWork,
+    },
+    {
+      id: "open-explore",
+      label: "Explore repositories",
+      icon: CompassIcon,
+      variant: "outline",
+      onClick: openExplore,
     },
   ];
 

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -95,13 +95,14 @@ import type {
   IssueType,
   MergePreview,
   Milestone,
-  MyWorkItem,
+  MyWorkPage,
   OpLogEntry,
   OrphanedStash,
   PagesInfo,
   PrBaseDivergence,
   PrCiStatus,
   PrDetails,
+  PrHeadRef,
   PrInfo,
   PrMergeability,
   PrMergeabilityState,
@@ -1508,7 +1509,7 @@ export const forgeOwnedNamespaces = (provider: ForgeProvider) =>
  *  inbox's one fetch. Provider-scoped rather than repo-scoped: each row names the
  *  repository it came from. */
 export const forgeMyWork = (provider: ForgeProvider) =>
-  invoke<MyWorkItem[]>("forge_my_work", { provider });
+  invoke<MyWorkPage>("forge_my_work", { provider });
 
 // ── Explore: search / browse / fork / star / README ──────────────────────────
 //
@@ -2807,6 +2808,11 @@ export const ghPrBaseDivergence = (
   lens: RemoteLens,
 ) =>
   invoke<PrBaseDivergence>("gh_pr_base_divergence", { repoPath, number, lens });
+
+/** Where one PR's head branch lives, by number. Targeted rather than a scan of
+ *  the poll list, so it answers for a PR outside the poll's window. */
+export const ghPrHeadRef = (repoPath: string, number: number) =>
+  invoke<PrHeadRef>("gh_pr_head_ref", { repoPath, number });
 
 /** The open fork PR whose head `branch` already contains, or null. Advisory —
  *  a forge outage answers null rather than failing. */

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3232,8 +3232,10 @@ export function useForgeOwnedNamespaces(
 }
 
 /** The viewer's work items across every repository on a provider, for the
- *  cross-repo inbox. The key carries no host/account axis, same as
- *  `["forge-repos", provider]` — one ambient account per provider today. */
+ *  cross-repo inbox. Resolves the whole `MyWorkPage` envelope, not a bare array,
+ *  so consumers can read its `truncated` flag. The key carries no host/account
+ *  axis, same as `["forge-repos", provider]` — one ambient account per provider
+ *  today. */
 export function useForgeMyWork(provider: ForgeProvider, enabled: boolean) {
   return useQuery({
     queryKey: ["forge-my-work", provider] as const,

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -127,6 +127,9 @@ export interface RepoOwner {
    *  including self-managed GitLab hosts glab is signed in to. Null when
    *  unrecognized — the UI labels those GitHub (gh stays authoritative). */
   provider: string | null;
+  /** Repo name as the origin URL spells it, which a renamed clone's folder
+   *  basename doesn't. Null when no remote resolves. */
+  repoName: string | null;
 }
 
 /** A git submodule and its state vs. the commit the parent records. */
@@ -562,6 +565,16 @@ export interface PrPollInfo {
   createdAt: string;
 }
 
+/** Where one PR's head branch lives — the targeted read behind opening a PR in
+ *  the worktree that has it checked out. Both fields are "" when unknown (a
+ *  deleted fork answers "" rather than failing), and a resolver must require
+ *  `headRepoFullName` to match the PR's own repo before trusting `headRefName`:
+ *  branch names collide freely across forks. */
+export interface PrHeadRef {
+  headRefName: string;
+  headRepoFullName: string;
+}
+
 export interface GhRepo {
   nameWithOwner: string;
   owner: string;
@@ -669,6 +682,15 @@ export interface MyWorkItem {
   url: string;
   updatedAt: string;
   authorLogin?: string | null;
+}
+
+/** One page of the work inbox. `truncated` is true when either search leg hit
+ *  its own server-side cap or the merged union overshot the page, so it can be
+ *  true on a page that arrives short — a leg's raw count is measured before
+ *  unaddressable hits are dropped. */
+export interface MyWorkPage {
+  items: MyWorkItem[];
+  truncated: boolean;
 }
 
 export interface GhAccount {

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -62,7 +62,10 @@ export const ACTIONS = [
     id: "open-my-work",
     label: "My work",
     category: "Application",
-    defaultBinding: null,
+    // mod+m would shadow macOS's native minimize (the listener preventDefaults
+    // registered chords), so the surface takes the shift layer with its opener
+    // siblings.
+    defaultBinding: "mod+shift+m",
   },
   {
     id: "open-mcp-servers-settings",

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -20,6 +20,11 @@ export interface RecentRepo {
   /** The origin remote's host (e.g. "gitlab.com"), stored alongside `owner` so
    *  the context menu names the right provider from the first frame. */
   host?: string;
+  /** Repo name as the origin URL spells it, as opposed to `name` — the
+   *  checkout's FOLDER basename, which a renamed clone spells differently.
+   *  Backfilled by the owner probe like `owner`/`host`, so it is absent until a
+   *  probe has touched the row, and an empty remote clears it. */
+  repoName?: string;
   /** The provider that host routes to ("github"/"gitlab"/"bitbucket") — resolved
    *  backend-side (it knows glab's self-managed hosts) and stored so labels are right from
    *  the first frame. Absent until first resolved. */
@@ -495,10 +500,10 @@ export function addRecentRepo(repo: {
 }
 
 /**
- * Stores resolved repo owners (+ hosts) onto the matching recent-repo records so the repo
- * list groups synchronously and the context menu names the right provider from the first
- * frame. Touches only records whose stored values changed (an empty remote clears them) —
- * a no-op write would loop with its own settings refetch.
+ * Stores resolved repo owners (+ hosts + remote repo names) onto the matching recent-repo
+ * records so the repo list groups synchronously and the context menu names the right
+ * provider from the first frame. Touches only records whose stored values changed (an empty
+ * remote clears them) — a no-op write would loop with its own settings refetch.
  *
  * Matched by worktree-stable identity ({@link repoIdentity}, git common dir), not raw
  * checkout path, so a probe from one checkout updates EVERY row for the same underlying
@@ -510,6 +515,7 @@ export function persistRepoOwners(
     owner: string | null;
     host: string | null;
     provider: string | null;
+    repoName: string | null;
   }[],
 ): Promise<void> {
   if (owners.length === 0) return Promise.resolve();
@@ -533,6 +539,7 @@ export function persistRepoOwners(
       const owner = resolved.owner || undefined;
       const host = resolved.host || undefined;
       const provider = resolved.provider || undefined;
+      const repoName = resolved.repoName || undefined;
       // Visibility and fork provenance come from the provider; when the provider is being
       // cleared (remote removed) they can't outlive it — drop them so no stale badge
       // lingers on a now-local-only repo.
@@ -543,13 +550,23 @@ export function persistRepoOwners(
         owner === r.owner &&
         host === r.host &&
         provider === r.provider &&
+        repoName === r.repoName &&
         visibility === r.visibility &&
         isFork === r.isFork &&
         forkParent === r.forkParent
       )
         return r;
       changed = true;
-      return { ...r, owner, host, provider, visibility, isFork, forkParent };
+      return {
+        ...r,
+        owner,
+        host,
+        provider,
+        repoName,
+        visibility,
+        isFork,
+        forkParent,
+      };
     });
     if (!changed) return;
     await saveSettings({ ...settings, recentRepos });

--- a/src/lib/settings/queries.ts
+++ b/src/lib/settings/queries.ts
@@ -171,6 +171,7 @@ export function usePersistRepoOwners() {
         owner: string | null;
         host: string | null;
         provider: string | null;
+        repoName: string | null;
       }[],
     ) => persistRepoOwners(owners),
     onSuccess: () =>


### PR DESCRIPTION
Opening a pull request from the **My work** inbox always landed in the repository's main checkout, even when the PR's branch was checked out in a worktree. This change resolves a PR to the worktree that actually holds its head branch, matches inbox rows to local clones by the name the remote spells (not the folder basename), moves the page-truncation signal to the backend so the frontend stops mirroring a constant, and cleans up combobox accessibility in Explore and the inbox.

### Worktree-aware opening

- Adds `resolveWorktreeTarget` in `src/features/mywork/MyWorkScreen.tsx`: lists the repo's user worktrees, then requires the PR's head repo slug to equal the item's own repo before trusting a branch-name match, so a fork PR whose branch name also exists locally falls back to the main checkout.
- Adds `withDeadline` plus a shared `WORKTREE_RESOLVE_BUDGET_MS` (1500ms) across both awaited legs; every unknown (rejection, expiry, unproven head, no matching branch) resolves to `null` and opens the main checkout silently.
- Promotes the open-generation counter from `openGenRef` to a module-scoped `openGen`, since the screen unmounts on every view change and a continuation from a previous mount would otherwise pass its own supersede check against a fresh counter. An unmount effect bumps the generation and clears any armed timer.
- Re-validates the resolved worktree with `validateRepo` before navigating (git skips its prune while another process holds the worktree-admin lock, so a deleted checkout can still be listed) and keys `applyRepoLens` on the path actually navigated to.
- Adds an `Open in main workspace` context-menu item (`openItem(item, { preferWorktree: false })`), offered only for a PR that resolves to a local repo.

### PR head lookup

- New `gh_pr_head_ref` command in `src-tauri/src/github/pr.rs` returning `PrHeadRef { head_ref_name, head_repo_full_name }`, with `pr_head_ref_query` addressing the PR by number rather than reading it out of `pr_poll_query`'s 30-PR window, and `pr_head_ref_from_value` mapping every absence (null `headRepository`, missing PR, errors-only envelope) to `""`.
- Registers the command in `src-tauri/src/lib.rs` and exposes `ghPrHeadRef` in `src/lib/git/api.ts` with the `PrHeadRef` interface in `src/lib/git/types.ts`.
- Replaces `pr.rs`'s local `host_from_url` body with a delegation to `crate::forge::remote_host`, so this module's host spelling can't drift from the one the rest of the app routes on. Side effects covered by new assertions: hosts now lowercase, and scp-form input parses (with `parse_pr_url_repo` still rejecting it on the `/pull/` check).

### Matching inbox rows to local clones

- `parse_owner_host` in `src-tauri/src/git/repo.rs` now returns a third component, the remote's repo name, surfaced as `RepoOwner.repo_name`; all call sites and tests updated, plus a wire-shape test pinning `repoName`.
- Threads `repoName` through persistence: `RecentRepo.repoName` and `persistRepoOwners` in `src/lib/settings/api.ts`, the mutation signature in `src/lib/settings/queries.ts`, the staleness check in `src/features/repository/RepoList.tsx`, and the clear path in `src/features/repository/useRepoVisibilityProbe.ts`.
- `matchLocalRepo` in `src/features/mywork/mywork-utils.ts` compares against `repoName ?? name`, so a clone in a renamed folder resolves exactly once a probe has touched the row.

### Server-side page truncation

- `src-tauri/src/github/my_work.rs` returns a `MyWorkPage { items, truncated }` envelope; `parse_my_work` now yields a `MyWorkLeg` carrying `raw_len`, and `merge_my_work` reports truncation when either leg came back at its `--limit` or the merged union overshot the page.
- `forge_my_work` in `src-tauri/src/forge/mod.rs`, `forgeMyWork` in `src/lib/git/api.ts`, and the `MyWorkPage` type in `src/lib/git/types.ts` follow the new shape; `useForgeMyWork`'s doc in `src/lib/git/queries.ts` notes the envelope.
- Deletes the hand-mirrored `MY_WORK_LIMIT` from `src/features/mywork/mywork-utils.ts`; `MyWorkBody` reads `work.data.truncated` instead of comparing item count to a constant.
- New tests cover the reachable arm the old heuristic missed: a capped leg whose dropped hits leave the page short while items are still missing on the server.

### Accessibility

- `src/features/explore/ExploreScreen.tsx`: `aria-controls` now gates on the same predicate as `aria-expanded`, so the input doesn't reference a listbox id that isn't mounted; the duplicate `aria-activedescendant` on the `ResultsList` container is removed (the input owns it).
- `src/features/explore/ExploreResultRow.tsx` and the inbox's `MyWorkRow` get `tabIndex={-1}` so options aren't Tab stops; the inbox listbox container drops its own `aria-activedescendant`.
- `MyWorkRow` gains `aria-busy` and a `CircleNotchIcon` spinner, armed after a `PENDING_AFFORDANCE_MS` (300ms) grace so a fast resolution never flashes it, with generation-owned arm/clear so a superseded open can't darken a row a newer one is still resolving.

### Documentation

- `README.md` and `src/features/help/content.ts` describe where a PR lands, the `Open in main workspace` escape hatch, the cases that fall back (fork PR, branch not checked out, slow network), the row spinner, and the remote-name matching; the help section's truncation-note wording changes from "when the page comes back full" to "when there may be more than the page holds".
- Extends `changelog.d/added-my-work-inbox.md` and adds `changelog.d/fixed-combobox-a11y.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests in **My work** now open in the worktree containing their head branch when available.
  * Added options to open pull requests in the main workspace, on GitHub, or copy their link.
  * Added a keyboard shortcut for opening **My work**.
  * Improved repository matching using the name recorded by the remote.
  * The inbox now reports when results are truncated.

* **Bug Fixes**
  * Improved keyboard and screen-reader navigation on Explore repositories.
  * Improved pull-request URL handling across supported remote formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->