### PR TITLE
fix(settings,git): heal off-list settings and add ahead-only compares

### DIFF
--- a/changelog.d/fixed-settings-select-junk-values.md
+++ b/changelog.d/fixed-settings-select-junk-values.md
@@ -1,3 +1,2 @@
-- Settings now recover to their defaults when `settings.json` carries an
-  unrecognized value (hand-edits included), so the pickers show the choice
-  that is actually in effect.
+- Invalid picker-backed values in `settings.json` now reset to valid
+  choices, so settings pickers show the value that is in effect.

--- a/changelog.d/fixed-settings-select-junk-values.md
+++ b/changelog.d/fixed-settings-select-junk-values.md
@@ -1,0 +1,3 @@
+- Settings now recover to their defaults when `settings.json` carries an
+  unrecognized value (hand-edits included), so every picker shows the choice
+  that is actually in effect.

--- a/changelog.d/fixed-settings-select-junk-values.md
+++ b/changelog.d/fixed-settings-select-junk-values.md
@@ -1,3 +1,3 @@
 - Settings now recover to their defaults when `settings.json` carries an
-  unrecognized value (hand-edits included), so every picker shows the choice
+  unrecognized value (hand-edits included), so the pickers show the choice
   that is actually in effect.

--- a/changelog.d/fixed-settings-select-junk-values.md
+++ b/changelog.d/fixed-settings-select-junk-values.md
@@ -1,2 +1,3 @@
-- Invalid picker-backed values in `settings.json` now reset to valid
-  choices, so settings pickers show the value that is in effect.
+- Settings whose value comes from a fixed list of choices now recover
+  when `settings.json` holds an unrecognized value, so each picker shows
+  the choice that's in effect.

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -57,8 +57,8 @@ pub async fn git_compare_branches(
 }
 
 /// The `ahead` half of [`git_compare_branches`] alone. Most callers discard
-/// `behind`, and its log walk is pure cost on always-mounted surfaces that
-/// refetch whenever a fetch lands.
+/// `behind`, so its log walk is pure cost — the ahead-only form halves the
+/// spawns for the dialog and generation callers that propose or preview.
 #[tauri::command]
 pub async fn git_branch_ahead(
     repo_path: String,

--- a/src-tauri/src/git/compare.rs
+++ b/src-tauri/src/git/compare.rs
@@ -56,6 +56,43 @@ pub async fn git_compare_branches(
     Ok(BranchComparison { ahead, behind })
 }
 
+/// The `ahead` half of [`git_compare_branches`] alone. Most callers discard
+/// `behind`, and its log walk is pure cost on always-mounted surfaces that
+/// refetch whenever a fetch lands.
+#[tauri::command]
+pub async fn git_branch_ahead(
+    repo_path: String,
+    base: String,
+    compare: String,
+) -> AppResult<Vec<CommitSummary>> {
+    validate_ref(&base)?;
+    validate_ref(&compare)?;
+    log_range(&repo_path, &format!("{base}..{compare}")).await
+}
+
+/// How many commits `base..compare` holds, for callers that render only the
+/// number: `rev-list --count` skips formatting and parsing every commit.
+#[tauri::command]
+pub async fn git_branch_ahead_count(
+    repo_path: String,
+    base: String,
+    compare: String,
+) -> AppResult<u32> {
+    validate_ref(&base)?;
+    validate_ref(&compare)?;
+    let out = run_git(
+        Some(&repo_path),
+        &["rev-list", "--count", &format!("{base}..{compare}")],
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    let text = out.stdout_lossy();
+    let count = text.trim();
+    count
+        .parse()
+        .map_err(|_| AppError::Command(format!("unexpected rev-list --count output: {count}")))
+}
+
 /// Files that differ between the merge base of `base`/`compare` and `compare`
 /// — i.e. the net change `compare` introduces relative to `base` (the
 /// three-dot diff, the same set a PR would show).
@@ -1191,6 +1228,89 @@ mod tests {
             cmp.ahead[0].tags.is_empty(),
             "an untagged commit reports no tags"
         );
+    }
+
+    /// The ahead-only commands must stay interchangeable with the halves of
+    /// `git_compare_branches` they replace: same commits, same newest-first order,
+    /// and a count equal to that list's length. The fixture puts a commit on the
+    /// base side too, so an ahead-only walk is provably not the whole range.
+    #[tokio::test]
+    async fn branch_ahead_matches_the_compare_ahead_half() {
+        let (_base, repo) = seed_repo("branch-ahead").await;
+        let root = std::path::Path::new(&repo);
+
+        std::fs::write(root.join("seed.txt"), "seed\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "seed"]).await;
+        // `git init` picks the default branch name from the host's config.
+        let base_branch = run(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+            .await
+            .trim()
+            .to_string();
+
+        run(&repo, &["checkout", "-qb", "feature"]).await;
+        for n in ["first", "second"] {
+            std::fs::write(root.join(format!("{n}.txt")), format!("{n}\n")).unwrap();
+            run(&repo, &["add", "-A"]).await;
+            run(&repo, &["commit", "-qm", &format!("feature {n}")]).await;
+        }
+
+        run(&repo, &["checkout", "-q", &base_branch]).await;
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        run(&repo, &["add", "-A"]).await;
+        run(&repo, &["commit", "-qm", "base work"]).await;
+
+        let cmp = git_compare_branches(repo.clone(), base_branch.clone(), "feature".into())
+            .await
+            .unwrap();
+        let ahead = git_branch_ahead(repo.clone(), base_branch.clone(), "feature".into())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            ahead.iter().map(|c| &c.hash).collect::<Vec<_>>(),
+            cmp.ahead.iter().map(|c| &c.hash).collect::<Vec<_>>(),
+            "same commits in the same order as the compare command's ahead half"
+        );
+        assert_eq!(
+            ahead.iter().map(|c| c.subject.as_str()).collect::<Vec<_>>(),
+            vec!["feature second", "feature first"],
+            "newest-first, and the base-side commit is absent"
+        );
+        assert_eq!(cmp.behind.len(), 1, "the fixture has a base-only commit");
+
+        let count = git_branch_ahead_count(repo, base_branch, "feature".into())
+            .await
+            .unwrap();
+        assert_eq!(
+            count as usize,
+            ahead.len(),
+            "the count equals the ahead list's length"
+        );
+    }
+
+    /// Both ahead-only commands share `git_compare_branches`' guard: an
+    /// option-shaped ref is rejected before any git runs, on either side.
+    #[tokio::test]
+    async fn branch_ahead_rejects_option_like_refs() {
+        let (_base, repo) = seed_repo("branch-ahead-badref").await;
+
+        for (base, compare) in [("-oops", "HEAD"), ("HEAD", "-oops")] {
+            let err = git_branch_ahead(repo.clone(), base.into(), compare.into())
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, AppError::InvalidArgument(_)),
+                "git_branch_ahead rejects a leading-dash ref ({base}..{compare})"
+            );
+            let err = git_branch_ahead_count(repo.clone(), base.into(), compare.into())
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, AppError::InvalidArgument(_)),
+                "git_branch_ahead_count rejects a leading-dash ref ({base}..{compare})"
+            );
+        }
     }
 
     /// `exclude` hides matching files from BOTH the diff text and the file list, and

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -305,6 +305,8 @@ pub fn run() {
             git::stats::git_code_frequency,
             git::stats::git_punch_card,
             git::compare::git_compare_branches,
+            git::compare::git_branch_ahead,
+            git::compare::git_branch_ahead_count,
             git::compare::git_branch_diff_files,
             git::compare::git_branch_file_diff,
             git::compare::git_branch_diff,

--- a/src-tauri/src/mcp_server/generate.rs
+++ b/src-tauri/src/mcp_server/generate.rs
@@ -1313,14 +1313,14 @@ impl GitDesktopMcp {
 
         // The commits the PR would introduce = base..head "ahead" set (compare =
         // head), exactly as the in-app Create-PR flow derives `commitSubjects` from
-        // `git_compare_branches(...).ahead`. Best-effort: an error yields no list.
-        let commit_subjects = crate::git::compare::git_compare_branches(
+        // `git_branch_ahead`. Best-effort: an error yields no list.
+        let commit_subjects = crate::git::compare::git_branch_ahead(
             self.repo.clone(),
             base.clone(),
             head.clone(),
         )
         .await
-        .map(|c| c.ahead.into_iter().map(|s| s.subject).collect::<Vec<_>>())
+        .map(|ahead| ahead.into_iter().map(|s| s.subject).collect::<Vec<_>>())
         .unwrap_or_default();
 
         // Labels are best-effort: a forge error omits the section entirely rather
@@ -1809,9 +1809,9 @@ async fn ref_exists(repo: &str, full_ref: &str) -> bool {
 }
 
 /// Subjects of the commits `HEAD` adds over `base`, newest first, capped at
-/// [`BRANCH_FALLBACK_MAX_SUBJECTS`]. Not `git_compare_branches`: that also walks the
-/// `behind` side this caller discards, and the MCP server has no query cache to
-/// amortize it. Best-effort — a git failure yields an empty list, not a failed recipe.
+/// [`BRANCH_FALLBACK_MAX_SUBJECTS`]. Not `git_branch_ahead`: a subjects-only walk
+/// capped in-git (`--format=%s -n`) beats parsing full summaries just to keep their
+/// subjects. Best-effort — a git failure yields an empty list, not a failed recipe.
 async fn branch_commit_subjects(repo: &str, base: &str) -> Vec<String> {
     let max = BRANCH_FALLBACK_MAX_SUBJECTS.to_string();
     let range = format!("{base}..HEAD");

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -17,7 +17,7 @@ import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
 import {
   forgeFeatureReady,
-  useCompareBranches,
+  useBranchAhead,
   useDefaultBranch,
   useForgeStatus,
   useRepoStatus,
@@ -205,8 +205,8 @@ export function CreateLocalPrDialog({
   const base = useSelector(form.store, (s) => s.values.base);
   // Live notes feed the AI-description prompt and the ReviewerNotesField seeding.
   const notes = useSelector(form.store, (s) => s.values.notes);
-  const comparison = useCompareBranches(repoPath, base || null, head || null);
-  const ahead = comparison.data?.ahead ?? [];
+  const comparison = useBranchAhead(repoPath, base || null, head || null);
+  const ahead = comparison.data ?? [];
   const sameBranch = base === head;
 
   // Shared chip state machine — enabled while the dialog is open and the tracker

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -31,7 +31,7 @@ import * as api from "@/lib/git/api";
 import {
   forgeFeatureReady,
   useAddRemote,
-  useCompareBranches,
+  useBranchAhead,
   useCreatePr,
   useDefaultBranch,
   useForgeStatus,
@@ -554,8 +554,8 @@ export function CreatePrDialog({
           ? `upstream/${base}`
           : base
         : null;
-  const comparison = useCompareBranches(repoPath, compareBaseRef, head || null);
-  const ahead = comparison.data?.ahead ?? [];
+  const comparison = useBranchAhead(repoPath, compareBaseRef, head || null);
+  const ahead = comparison.data ?? [];
   // A head equal to the parent's base name is still a distinct ref (local branch
   // vs. `upstream/<name>`), so only treat identical refs as "same branch".
   const sameBranch = compareBaseRef !== null && compareBaseRef === head;

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -43,13 +43,13 @@ import { normPath } from "@/lib/git/path";
 import {
   branchRewriteStatusOptions,
   forgeFeatureReady,
+  useBranchAhead,
   useBranchDivergence,
   useBranches,
   useBranchResetToUpstream,
   useBranchRewriteStatus,
   useCheckoutBranch,
   useCheckoutRemoteBranch,
-  useCompareBranches,
   useDefaultBranch,
   useDeleteBranch,
   useDeleteRemoteBranch,
@@ -627,12 +627,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   ]);
   // Commits the named ref has that the default doesn't. A null base leaves the
   // query disabled (both dialogs closed, or no resolvable default).
-  const committedCompare = useCompareBranches(
-    repoPath,
-    committedBase,
-    namedRef,
-  );
-  // Mirrors `useCompareBranches`' own enabled condition — a query that never
+  const committedCompare = useBranchAhead(repoPath, committedBase, namedRef);
+  // Mirrors `useBranchAhead`'s own enabled condition — a query that never
   // runs (base === compare: naming the local default with no `origin/<default>`)
   // must not read as "still loading" forever.
   const comparing =
@@ -652,7 +648,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         ? "error"
         : "ready";
   const committedFallback = useMemo(() => {
-    const ahead = committedCompare.data?.ahead ?? [];
+    const ahead = committedCompare.data ?? [];
     if (!committedBase || !namedRef || ahead.length === 0) return null;
     // `ahead` is newest-first (plain `git log base..<ref>`); cap the subjects.
     return {

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -38,7 +38,7 @@ import {
 import {
   useAppendRepoAiIgnore,
   useAppendToGitignore,
-  useCompareBranches,
+  useBranchAheadCount,
   useDefaultBranch,
   useDiscardAll,
   useDiscardPaths,
@@ -255,14 +255,12 @@ export function ChangesPanel({
     currentName !== null &&
     defaultName !== null &&
     currentName !== defaultName;
-  const aheadOfDefault = useCompareBranches(
+  const aheadOfDefault = useBranchAheadCount(
     repoPath,
     canCompareDefault ? defaultName : null,
     canCompareDefault ? currentName : null,
   );
-  const proposeCount = canCompareDefault
-    ? (aheadOfDefault.data?.ahead.length ?? 0)
-    : 0;
+  const proposeCount = canCompareDefault ? (aheadOfDefault.data ?? 0) : 0;
 
   const text = filterText.trim().toLowerCase();
   function visible(entry: FileEntry): boolean {

--- a/src/features/repository/RebaseOntoDialog.tsx
+++ b/src/features/repository/RebaseOntoDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { clipTitleFromText } from "@/lib/clip-title";
-import { useCompareBranches } from "@/lib/git/queries";
+import { useBranchAhead } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 
@@ -83,12 +83,12 @@ export function RebaseOntoDialog({
   // against the literal `HEAD` ref (what the rebase itself operates on, so the
   // preview and the action can never disagree), gated on the dialog being open
   // so it doesn't fetch in the background.
-  const comparison = useCompareBranches(
+  const comparison = useBranchAhead(
     repoPath,
     open && oldBase && !sameBranch ? oldBase : null,
     open ? "HEAD" : null,
   );
-  const moving = comparison.data?.ahead ?? [];
+  const moving = comparison.data ?? [];
   const movingCount = moving.length;
   // No clean-tree term: uncommitted changes are handled by the caller's stash →
   // rebase → reapply offer, not by blocking the run.

--- a/src/features/sessions/SessionComposer.tsx
+++ b/src/features/sessions/SessionComposer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/ai/slash";
 import { useAgentCommands, useTrackedFiles } from "@/lib/git/queries";
 import { quickTransition } from "@/lib/motion";
+import { asMcpServerArray } from "@/lib/settings/api";
 import {
   isServerAvailable,
   isServerDefaultOn,
@@ -398,7 +399,7 @@ export function SessionComposer({
   // `mcpSupportedFor`; the picker self-hides when empty.
   const mcpRegistry = useMemo(
     () =>
-      (settings.data?.mcpServers ?? []).filter((s) =>
+      asMcpServerArray(settings.data?.mcpServers).filter((s) =>
         isServerAvailable(s, repoKeys),
       ),
     [settings.data?.mcpServers, repoKeys],

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -21,7 +21,7 @@ import {
   squashWorktree,
 } from "@/lib/git/worktree";
 import { notify } from "@/lib/notify";
-import { loadSettings } from "@/lib/settings/api";
+import { asMcpServerArray, loadSettings } from "@/lib/settings/api";
 import {
   isServerAvailable,
   mcpServerUsableBy,
@@ -315,7 +315,9 @@ async function runTurn(
       )
     : [];
   const mcpServers = mcpIds.length
-    ? ((await loadSettings().catch(() => null))?.mcpServers ?? []).filter(
+    ? asMcpServerArray(
+        (await loadSettings().catch(() => null))?.mcpServers,
+      ).filter(
         (srv) =>
           mcpIds.includes(srv.id) &&
           isServerAvailable(srv, repoKeys) &&

--- a/src/features/settings/AgentSandboxField.tsx
+++ b/src/features/settings/AgentSandboxField.tsx
@@ -28,19 +28,24 @@ import {
   scaffoldCustomDockerfile,
 } from "@/lib/ai/sandbox";
 import { useContainerStatus } from "@/lib/ai/sandbox-queries";
+import { AGENT_ISOLATIONS, NODE_VERSIONS } from "@/lib/settings/api";
 import { toastError } from "@/lib/toast";
 
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
 type AgentId = "claude" | "codex" | "opencode" | "copilot";
+type NodeVersion = (typeof NODE_VERSIONS)[number];
+type AgentIsolation = (typeof AGENT_ISOLATIONS)[number];
 
-/** Node base-image versions offered (current LTS first). */
-const NODE_VERSIONS = ["24", "22", "20"];
 /** Trigger labels — without them Base UI shows the raw version, dropping the
- *  "(LTS)" note the popup carries. */
-const NODE_VERSION_ITEMS: Record<string, string> = Object.fromEntries(
-  NODE_VERSIONS.map((v) => [v, v === "24" ? `${v} (LTS)` : v]),
-);
+ *  "(LTS)" note the popup carries. Record-typed against NODE_VERSIONS, which
+ *  `loadSettings` also heals against, so an added version can't reach one
+ *  without the other. */
+const NODE_VERSION_ITEMS: Record<NodeVersion, string> = {
+  "24": "24 (LTS)",
+  "22": "22",
+  "20": "20",
+};
 /** Container-capable agents installed into the managed image. */
 const IMAGE_AGENTS: { id: AgentId; label: string }[] = [
   { id: "claude", label: "Claude Code" },
@@ -66,10 +71,10 @@ export function AgentSandboxField({
   onProviders,
   repoPath,
 }: {
-  value: "worktree" | "container";
-  onChange: (value: "worktree" | "container") => void;
-  nodeVersion: string;
-  onNodeVersion: (v: string) => void;
+  value: AgentIsolation;
+  onChange: (value: AgentIsolation) => void;
+  nodeVersion: NodeVersion;
+  onNodeVersion: (v: NodeVersion) => void;
   providers: AgentId[];
   onProviders: (v: AgentId[]) => void;
   /** The open repo, for the per-repo custom-image row (null = no repo open). */
@@ -129,7 +134,7 @@ export function AgentSandboxField({
               <Select
                 items={NODE_VERSION_ITEMS}
                 value={nodeVersion}
-                onValueChange={(v) => v && onNodeVersion(v)}
+                onValueChange={(v) => v && onNodeVersion(v as NodeVersion)}
               >
                 <SelectTrigger
                   size="sm"

--- a/src/features/settings/AgentSandboxField.tsx
+++ b/src/features/settings/AgentSandboxField.tsx
@@ -28,12 +28,16 @@ import {
   scaffoldCustomDockerfile,
 } from "@/lib/ai/sandbox";
 import { useContainerStatus } from "@/lib/ai/sandbox-queries";
-import { AGENT_ISOLATIONS, NODE_VERSIONS } from "@/lib/settings/api";
+import {
+  type AGENT_ISOLATIONS,
+  type IMAGE_AGENT_IDS,
+  NODE_VERSIONS,
+} from "@/lib/settings/api";
 import { toastError } from "@/lib/toast";
 
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
-type AgentId = "claude" | "codex" | "opencode" | "copilot";
+type AgentId = (typeof IMAGE_AGENT_IDS)[number];
 type NodeVersion = (typeof NODE_VERSIONS)[number];
 type AgentIsolation = (typeof AGENT_ISOLATIONS)[number];
 

--- a/src/features/settings/AgentSandboxField.tsx
+++ b/src/features/settings/AgentSandboxField.tsx
@@ -30,7 +30,7 @@ import {
 import { useContainerStatus } from "@/lib/ai/sandbox-queries";
 import {
   type AGENT_ISOLATIONS,
-  type IMAGE_AGENT_IDS,
+  IMAGE_AGENT_IDS,
   NODE_VERSIONS,
 } from "@/lib/settings/api";
 import { toastError } from "@/lib/toast";
@@ -50,13 +50,15 @@ const NODE_VERSION_ITEMS: Record<NodeVersion, string> = {
   "22": "22",
   "20": "20",
 };
-/** Container-capable agents installed into the managed image. */
-const IMAGE_AGENTS: { id: AgentId; label: string }[] = [
-  { id: "claude", label: "Claude Code" },
-  { id: "codex", label: "Codex" },
-  { id: "opencode", label: "opencode" },
-  { id: "copilot", label: "GitHub Copilot" },
-];
+/** Container-capable agents installed into the managed image. Record-typed against
+ *  IMAGE_AGENT_IDS, which the checkbox row renders from, so a new agent can't reach
+ *  the settings type without a label here. */
+const IMAGE_AGENT_LABELS: Record<AgentId, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+  opencode: "opencode",
+  copilot: "GitHub Copilot",
+};
 
 /**
  * Opt-in control for running agent sessions inside a Docker/Podman container
@@ -158,20 +160,20 @@ export function AgentSandboxField({
             </label>
             <div className="flex items-center gap-3">
               <span className="text-muted-foreground">Agents</span>
-              {IMAGE_AGENTS.map((a) => {
-                const on = providers.includes(a.id);
+              {IMAGE_AGENT_IDS.map((id) => {
+                const on = providers.includes(id);
                 return (
                   <label
-                    key={a.id}
+                    key={id}
                     className="flex cursor-pointer items-center gap-1.5"
                   >
                     <Checkbox
                       checked={on}
                       // Can't uncheck the last remaining agent.
                       disabled={on && providers.length === 1}
-                      onCheckedChange={(c) => toggleProvider(a.id, c === true)}
+                      onCheckedChange={(c) => toggleProvider(id, c === true)}
                     />
-                    {a.label}
+                    {IMAGE_AGENT_LABELS[id]}
                   </label>
                 );
               })}

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { detectAgentCli, providerKind } from "@/lib/ai/agent";
+import { type AgentKind, detectAgentCli, providerKind } from "@/lib/ai/agent";
 import {
   entryMatchesUrl,
   isHostAllowed,
@@ -374,15 +374,16 @@ type DefaultAgentChoice = "auto" | DefaultAgentId;
 
 /** Default-agent labels — same `items` contract as the maps above. "auto" is the
  *  UI stand-in for an absent `defaultAgent` (follow the AI provider), so it is a
- *  key here but not a member of DEFAULT_AGENT_IDS, which `loadSettings` heals
- *  against. */
-const DEFAULT_AGENT_ITEMS: Record<DefaultAgentChoice, string> = {
+ *  key here but not a member of DEFAULT_AGENT_IDS. Tied to BOTH lists: `AgentKind`
+ *  is what the backend can actually run, DEFAULT_AGENT_IDS is what `loadSettings`
+ *  heals against, and a new agent must reach this picker through both. */
+const DEFAULT_AGENT_ITEMS: Record<"auto" | AgentKind, string> = {
   auto: "Auto — follow the AI provider",
   claude: "Claude",
   codex: "Codex",
   copilot: "GitHub Copilot",
   opencode: "opencode",
-};
+} satisfies Record<DefaultAgentChoice, string>;
 
 /** Ollama base-URL field — the URL the local/LAN Ollama server is reached at. */
 function OllamaConfig({

--- a/src/features/settings/AiProviderSection.tsx
+++ b/src/features/settings/AiProviderSection.tsx
@@ -39,7 +39,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { type AgentKind, detectAgentCli, providerKind } from "@/lib/ai/agent";
+import { detectAgentCli, providerKind } from "@/lib/ai/agent";
 import {
   entryMatchesUrl,
   isHostAllowed,
@@ -47,7 +47,6 @@ import {
 } from "@/lib/ai/allowed-hosts";
 import { LOGIN_COMMAND } from "@/lib/ai/cli-client";
 import { createAiClient } from "@/lib/ai/client";
-import type { ReviewContextSize } from "@/lib/ai/context-budget";
 import { modelPickerEmptyText, useAvailableModels } from "@/lib/ai/models";
 import {
   ALL_PROVIDER_IDS,
@@ -60,6 +59,10 @@ import {
   PROVIDERS_REQUIRING_KEY,
 } from "@/lib/ai/providers";
 import {
+  REVIEW_CONTEXT_SIZES,
+  type ReviewContextSize,
+} from "@/lib/ai/review-context-size";
+import {
   REVIEW_EFFORTS,
   type ReviewEffort,
   reviewEffortCapable,
@@ -68,6 +71,7 @@ import { REVIEW_TIMEOUTS, type ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiProviderId, AiSettings } from "@/lib/ai/types";
 import { required, useAppForm, withForm } from "@/lib/form";
 import { deleteSecret, setSecret } from "@/lib/git/api";
+import type { DEFAULT_AGENT_IDS } from "@/lib/settings/api";
 import { settingsKeys, useSecretPreview } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage } from "@/lib/tauri/invoke";
@@ -365,9 +369,14 @@ const REVIEW_EFFORT_ITEMS: Record<ReviewEffort, string> = {
   xhigh: "Max",
 };
 
+type DefaultAgentId = (typeof DEFAULT_AGENT_IDS)[number];
+type DefaultAgentChoice = "auto" | DefaultAgentId;
+
 /** Default-agent labels — same `items` contract as the maps above. "auto" is the
- *  UI stand-in for an absent `defaultAgent` (follow the AI provider). */
-const DEFAULT_AGENT_ITEMS: Record<"auto" | AgentKind, string> = {
+ *  UI stand-in for an absent `defaultAgent` (follow the AI provider), so it is a
+ *  key here but not a member of DEFAULT_AGENT_IDS, which `loadSettings` heals
+ *  against. */
+const DEFAULT_AGENT_ITEMS: Record<DefaultAgentChoice, string> = {
   auto: "Auto — follow the AI provider",
   claude: "Claude",
   codex: "Codex",
@@ -690,13 +699,10 @@ export const AiProviderSection = withForm({
       form.store,
       (s) => s.values.reviewTimeout ?? "auto",
     );
-    // Render-coerce junk from a hand-edited settings.json to "auto" so the
-    // trigger shows what the run will actually do (reviewEffortLevel treats
-    // unknown values as ""); the stored value heals on the next pick.
-    const reviewEffort = useSelector(form.store, (s) => {
-      const v = s.values.reviewEffort;
-      return v && REVIEW_EFFORTS.includes(v) ? v : "auto";
-    });
+    const reviewEffort = useSelector(
+      form.store,
+      (s) => s.values.reviewEffort ?? "auto",
+    );
     // `undefined` = Auto (no explicit default; new runs follow `ai.provider`).
     const defaultAgent = useSelector(form.store, (s) => s.values.defaultAgent);
     const agentIsolation = useSelector(
@@ -1111,13 +1117,11 @@ export const AiProviderSection = withForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(Object.keys(REVIEW_CONTEXT_ITEMS) as ReviewContextSize[]).map(
-                  (id) => (
-                    <SelectItem key={id} value={id}>
-                      {REVIEW_CONTEXT_ITEMS[id]}
-                    </SelectItem>
-                  ),
-                )}
+                {REVIEW_CONTEXT_SIZES.map((id) => (
+                  <SelectItem key={id} value={id}>
+                    {REVIEW_CONTEXT_ITEMS[id]}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
@@ -1219,7 +1223,7 @@ export const AiProviderSection = withForm({
                 // truly absent and the resolver falls through to the provider.
                 form.setFieldValue(
                   "defaultAgent",
-                  v === "auto" ? undefined : (v as AgentKind),
+                  v === "auto" ? undefined : (v as DefaultAgentId),
                 );
               }}
             >
@@ -1227,13 +1231,13 @@ export const AiProviderSection = withForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(
-                  Object.keys(DEFAULT_AGENT_ITEMS) as ("auto" | AgentKind)[]
-                ).map((id) => (
-                  <SelectItem key={id} value={id}>
-                    {DEFAULT_AGENT_ITEMS[id]}
-                  </SelectItem>
-                ))}
+                {(Object.keys(DEFAULT_AGENT_ITEMS) as DefaultAgentChoice[]).map(
+                  (id) => (
+                    <SelectItem key={id} value={id}>
+                      {DEFAULT_AGENT_ITEMS[id]}
+                    </SelectItem>
+                  ),
+                )}
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">

--- a/src/features/settings/GeneralSection.tsx
+++ b/src/features/settings/GeneralSection.tsx
@@ -7,9 +7,15 @@ import { PRIVACY_POLICY_URL, resetAnalyticsId } from "@/lib/analytics";
 import { useAutomations } from "@/lib/automations/queries";
 import { anyAutomationEnabled } from "@/lib/automations/types";
 import { withForm } from "@/lib/form";
+import type { AUTO_FETCH_INTERVALS } from "@/lib/settings/api";
 import { settingsFormOpts } from "./settings-form";
 
-const FETCH_INTERVAL_OPTIONS: Record<string, string> = {
+/** Record-typed against AUTO_FETCH_INTERVALS, which `loadSettings` also heals
+ *  against, so an added cadence can't reach one without the other. */
+const FETCH_INTERVAL_OPTIONS: Record<
+  (typeof AUTO_FETCH_INTERVALS)[number],
+  string
+> = {
   "5": "Every 5 minutes",
   "10": "Every 10 minutes",
   "15": "Every 15 minutes",

--- a/src/features/settings/McpServersSection.tsx
+++ b/src/features/settings/McpServersSection.tsx
@@ -16,7 +16,7 @@ import { withForm } from "@/lib/form";
 import { deleteMcpSecret } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
-import type { McpServer } from "@/lib/settings/api";
+import { asMcpServerArray, type McpServer } from "@/lib/settings/api";
 import {
   effectiveMcpState,
   foldServerScopeKeys,
@@ -39,7 +39,13 @@ import { settingsFormOpts } from "./settings-form";
 export const McpServersSection = withForm({
   ...settingsFormOpts,
   render: function McpServersSectionRender({ form }) {
-    const servers = useSelector(form.store, (s) => s.values.mcpServers);
+    // The registry as an array whatever the stored container is: `loadSettings`
+    // preserves a corrupt non-array rather than destroying it, so this section
+    // renders empty and every edit below BUILDS FROM this guarded view — writing a
+    // real array back is the repair, and it only ever happens on a deliberate edit.
+    const list = useSelector(form.store, (s) =>
+      asMcpServerArray(s.values.mcpServers),
+    );
     // The draft AI allow list, shared with the AI provider screen. Rows already
     // in the registry keep a warn-only "host not allowed" badge and go on
     // working. On REGISTRATION the seams explain the block in place and the
@@ -68,8 +74,6 @@ export const McpServersSection = withForm({
     // palette can deep-link to it (see openMcpBrowse).
     const browseOpen = useUiStore((s) => s.mcpBrowseOpen);
     const setBrowseOpen = useUiStore((s) => s.setMcpBrowseOpen);
-
-    const list = servers ?? [];
 
     function setServers(next: McpServer[]) {
       form.setFieldValue("mcpServers", next);
@@ -100,7 +104,10 @@ export const McpServersSection = withForm({
     // open for adding several. Functional update so back-to-back adds compose.
     function appendServer(server: McpServer) {
       if (admitServers([server]).length === 0) return;
-      form.setFieldValue("mcpServers", (prev) => [...(prev ?? []), server]);
+      form.setFieldValue("mcpServers", (prev) => [
+        ...asMcpServerArray(prev),
+        server,
+      ]);
     }
 
     async function saveServer(server: McpServer) {
@@ -121,7 +128,7 @@ export const McpServersSection = withForm({
       // Re-read via the functional setter so this async write composes with any
       // interleaving edit instead of clobbering it.
       form.setFieldValue("mcpServers", (prev) => {
-        const cur = prev ?? [];
+        const cur = asMcpServerArray(prev);
         return cur.some((s) => s.id === folded.id)
           ? cur.map((s) => (s.id === folded.id ? folded : s))
           : [...cur, folded];
@@ -171,7 +178,7 @@ export const McpServersSection = withForm({
       // Re-read `list` via the functional setter so this async write composes with
       // any interleaving edit rather than clobbering it.
       form.setFieldValue("mcpServers", (prev) =>
-        (prev ?? []).map((s) => (s.id === server.id ? next : s)),
+        asMcpServerArray(prev).map((s) => (s.id === server.id ? next : s)),
       );
     }
 

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -1,8 +1,11 @@
 import { withForm } from "@/lib/form";
+import type { PR_CHECK_SCOPES } from "@/lib/settings/api";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { settingsFormOpts } from "./settings-form";
 
-const CHECK_OPTIONS: Record<string, string> = {
+/** Record-typed against PR_CHECK_SCOPES, which `loadSettings` also heals against,
+ *  so an added scope can't reach one without the other. */
+const CHECK_OPTIONS: Record<(typeof PR_CHECK_SCOPES)[number], string> = {
   off: "Off",
   mine: "My pull requests only",
   all: "All open pull requests",

--- a/src/features/settings/mcp/McpServerDialog.tsx
+++ b/src/features/settings/mcp/McpServerDialog.tsx
@@ -21,7 +21,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { deleteMcpSecret, setMcpSecret } from "@/lib/git/api";
-import type { McpServer } from "@/lib/settings/api";
+import { MCP_TRANSPORTS, type McpServer } from "@/lib/settings/api";
 import {
   emptyMcpServer,
   entriesFor,
@@ -218,7 +218,7 @@ export function McpServerDialog({
             </div>
             <LabeledGroup label="Transport">
               <div className="flex gap-1">
-                {(["stdio", "http"] as const).map((t) => (
+                {MCP_TRANSPORTS.map((t) => (
                   <Button
                     key={t}
                     type="button"

--- a/src/features/settings/mcp/PerRepoStateControl.tsx
+++ b/src/features/settings/mcp/PerRepoStateControl.tsx
@@ -40,8 +40,10 @@ export function PerRepoStateControl({
   const baseline = server.enabled ? "On" : "Optional";
   // Labels, built here because the inherited option names the baseline; without
   // them Base UI shows the raw value ("optional") in the trigger. The popup
-  // renders from this map too, so the two can never drift.
-  const items: Record<string, string> = {
+  // renders from this map too, so the two can never drift. Record-typed against
+  // McpRepoState — plus "default", which is stored as key ABSENCE — so a new
+  // state can't reach `loadSettings`'s heal without a label here.
+  const items: Record<McpRepoState | "default", string> = {
     default: `Default · ${baseline}`,
     on: "On",
     optional: "Optional",

--- a/src/features/tags/useGenerateReleaseNotes.ts
+++ b/src/features/tags/useGenerateReleaseNotes.ts
@@ -4,7 +4,7 @@ import { useAiStream } from "@/features/conversations/useAiStream";
 import { buildReleaseNotesPrompt } from "@/lib/ai/prompt";
 import {
   ghReleaseGenerateNotes,
-  gitCompareBranches,
+  gitBranchAhead,
   gitRecentCommits,
   readRepoInstructions,
 } from "@/lib/git/api";
@@ -48,12 +48,12 @@ async function gatherReleaseSource(
   if (!changelog.trim()) {
     try {
       if (opts.previousTag && opts.target) {
-        const cmp = await gitCompareBranches(
+        const ahead = await gitBranchAhead(
           repoPath,
           opts.previousTag,
           opts.target,
         );
-        subjects = cmp.ahead.map((c) => c.subject);
+        subjects = ahead.map((c) => c.subject);
       }
     } catch {
       // Range failed (e.g. unrelated refs) — fall back to recent commits.

--- a/src/lib/ai/context-budget.ts
+++ b/src/lib/ai/context-budget.ts
@@ -1,11 +1,6 @@
 import { guardedFetch } from "./guarded-fetch";
+import type { ReviewContextSize } from "./review-context-size";
 import type { AiProviderId, AiSettings } from "./types";
-
-/** How much diff + prior-discussion context an AI review sends, scaled to the
- *  reviewing model's context window. `"auto"` probes the window (live for
- *  Ollama, a per-provider fallback tier otherwise); the others force a fixed
- *  multiplier of the default budget profile. */
-export type ReviewContextSize = "auto" | "small" | "medium" | "large";
 
 /** The set of character caps that shape a review prompt. Each field is scaled
  *  from {@link DEFAULT_BUDGET_PROFILE} by a per-model multiplier at review time;

--- a/src/lib/ai/review-context-size.ts
+++ b/src/lib/ai/review-context-size.ts
@@ -1,0 +1,19 @@
+/** The Review-context choices offered in Settings, in render order. The
+ *  `ReviewContextSize` union derives from this list, so the Settings labels map
+ *  stays exhaustive and the menu can't silently drop an option.
+ *
+ *  A leaf module rather than part of context-budget.ts, which the value list
+ *  would otherwise pull into a cycle: settings/api.ts reads this list to heal a
+ *  stored value, and context-budget.ts reaches api.ts through guarded-fetch. */
+export const REVIEW_CONTEXT_SIZES = [
+  "auto",
+  "small",
+  "medium",
+  "large",
+] as const;
+
+/** How much diff + prior-discussion context an AI review sends, scaled to the
+ *  reviewing model's context window. `"auto"` probes the window (live for
+ *  Ollama, a per-provider fallback tier otherwise); the others force a fixed
+ *  multiplier of the default budget profile. */
+export type ReviewContextSize = (typeof REVIEW_CONTEXT_SIZES)[number];

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -1381,6 +1381,18 @@ export const gitCompareBranches = (
 ) =>
   invoke<BranchComparison>("git_compare_branches", { repoPath, base, compare });
 
+export const gitBranchAhead = (
+  repoPath: string,
+  base: string,
+  compare: string,
+) => invoke<CommitSummary[]>("git_branch_ahead", { repoPath, base, compare });
+
+export const gitBranchAheadCount = (
+  repoPath: string,
+  base: string,
+  compare: string,
+) => invoke<number>("git_branch_ahead_count", { repoPath, base, compare });
+
 export const gitBranchDiffFiles = (
   repoPath: string,
   base: string,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -146,6 +146,10 @@ export const repoKeys = {
     ["repo", repo, "commit", hash, "diff", file] as const,
   compare: (repo: string, base: string, compare: string) =>
     ["repo", repo, "compare", base, compare] as const,
+  branchAhead: (repo: string, base: string, compare: string) =>
+    ["repo", repo, "compare", base, compare, "ahead"] as const,
+  branchAheadCount: (repo: string, base: string, compare: string) =>
+    ["repo", repo, "compare", base, compare, "ahead-count"] as const,
   branchDiffFiles: (repo: string, base: string, compare: string) =>
     ["repo", repo, "compare", base, compare, "files"] as const,
   branchFileDiff: (repo: string, base: string, compare: string, file: string) =>
@@ -868,6 +872,34 @@ export function useCompareBranches(
   return useQuery({
     queryKey: repoKeys.compare(repo, base ?? "", compare ?? ""),
     queryFn: () => api.gitCompareBranches(repo, base ?? "", compare ?? ""),
+    enabled: base !== null && compare !== null && base !== compare,
+  });
+}
+
+/** `base..compare` only, for the callers that never read `behind` — one log
+ *  walk instead of two. Same enabled gate as {@link useCompareBranches}. */
+export function useBranchAhead(
+  repo: string,
+  base: string | null,
+  compare: string | null,
+) {
+  return useQuery({
+    queryKey: repoKeys.branchAhead(repo, base ?? "", compare ?? ""),
+    queryFn: () => api.gitBranchAhead(repo, base ?? "", compare ?? ""),
+    enabled: base !== null && compare !== null && base !== compare,
+  });
+}
+
+/** Just how many commits `base..compare` holds, for callers that render only
+ *  the number. Same enabled gate as {@link useCompareBranches}. */
+export function useBranchAheadCount(
+  repo: string,
+  base: string | null,
+  compare: string | null,
+) {
+  return useQuery({
+    queryKey: repoKeys.branchAheadCount(repo, base ?? "", compare ?? ""),
+    queryFn: () => api.gitBranchAheadCount(repo, base ?? "", compare ?? ""),
     enabled: base !== null && compare !== null && base !== compare,
   });
 }

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -185,9 +185,10 @@ export interface NotificationSettings {
   actionRuns: boolean;
 }
 
-/** The agent CLIs offerable as the Default agent, in render order. Spelled out
- *  here rather than imported from lib/ai (which mirrors the same list as
- *  `AgentKind`) to keep settings free of an ai import cycle, even a type-only one. */
+/** The agent CLIs offerable as the Default agent, in render order. Spelled out here
+ *  rather than reusing lib/ai's identical `AgentKind` list because `lib/ai/agent.ts`
+ *  imports this module, so importing back from it is the one edge that would close a
+ *  cycle. (Other lib/ai leaves are imported above — they import nothing of ours.) */
 export const DEFAULT_AGENT_IDS = [
   "claude",
   "codex",
@@ -197,6 +198,16 @@ export const DEFAULT_AGENT_IDS = [
 
 /** The agent-session isolation modes offered in Settings. */
 export const AGENT_ISOLATIONS = ["worktree", "container"] as const;
+
+/** The container-capable agents installable into the managed image. Typing only —
+ *  `loadSettings` deliberately does not heal `agentImageProviders` (see
+ *  {@link healEnumerated}). */
+export const IMAGE_AGENT_IDS = [
+  "claude",
+  "codex",
+  "opencode",
+  "copilot",
+] as const;
 
 /** Node base-image majors offered for the agent container image (current LTS
  *  first). The Settings picker renders this list; `loadSettings` heals against it. */
@@ -237,9 +248,9 @@ export interface AppSettings {
   closeToTray: boolean;
   /** Which agent CLI a new Session, Plan, or Research run starts on. Not in
    *  DEFAULT_SETTINGS — its absence is the meaningful "Auto" state: follow the
-   *  main AI provider when that's an agent CLI, else Claude. Inline union (the
-   *  sessions store does the same) to avoid a settings↔ai import cycle, even a
-   *  type-only one. */
+   *  main AI provider when that's an agent CLI, else Claude. Keyed to the local
+   *  DEFAULT_AGENT_IDS rather than lib/ai's `AgentKind` (the sessions store does the
+   *  same) because `lib/ai/agent.ts` imports this module — see that list. */
   defaultAgent?: (typeof DEFAULT_AGENT_IDS)[number];
   /** How write-capable agent sessions are isolated. "worktree" = the throwaway
    *  git worktree only (host, full-auto); "container" = also run inside an
@@ -250,7 +261,7 @@ export interface AppSettings {
    *  "24"). */
   agentImageNodeVersion: (typeof NODE_VERSIONS)[number];
   /** Which container-capable agents to bake into the image. */
-  agentImageProviders: ("claude" | "codex" | "opencode" | "copilot")[];
+  agentImageProviders: (typeof IMAGE_AGENT_IDS)[number][];
   globalInstructions: string;
   /** gitignore-style globs (one per line) excluded from AI context. */
   aiIgnorePatterns: string;
@@ -457,6 +468,16 @@ const pick = <T extends string>(
   fallback: T,
 ): T => (allowed.includes(value as T) ? (value as T) : fallback);
 
+/** Re-pairs a stored AI config whose provider is off-list. The model belongs to its
+ *  provider, so healing the provider alone would leave a pair the UI can never mint —
+ *  `switchProvider` always re-pairs via `defaultModelForProvider`. Membership is
+ *  checked against the FULL provider list, never a per-surface filtered subset: a
+ *  valid provider that some picker hides must survive the load untouched. */
+const healAi = (stored: AiSettings, fallback: AiSettings): AiSettings =>
+  ALL_PROVIDER_IDS.includes(stored.provider)
+    ? stored
+    : { ...stored, provider: fallback.provider, model: fallback.model };
+
 /** Heals one server's enumerated fields: an off-list `transport` falls back to the
  *  empty-draft default, and per-repo override entries whose value isn't a real state
  *  are dropped — absence IS the "Default" choice there, so a junk entry heals by
@@ -464,13 +485,21 @@ const pick = <T extends string>(
  *  object when nothing was junk, and passes through anything that isn't a server
  *  object at all: the heal's premise is that settings.json lies, so it must not
  *  assume shape either. */
-function healMcpServer(server: McpServer): McpServer {
-  if (typeof server !== "object" || server === null) return server;
-  let healed = server;
-  const transport = pick(server.transport, MCP_TRANSPORTS, "stdio");
-  if (transport !== server.transport) healed = { ...healed, transport };
-  const overrides = server.repoOverrides;
-  if (typeof overrides === "object" && overrides !== null) {
+function healMcpServer(server: unknown): McpServer {
+  // Arrays are excluded explicitly (`typeof [] === "object"`): spreading one would
+  // fabricate a phantom `{transport: "stdio"}` server that the next write persists.
+  if (typeof server !== "object" || server === null || Array.isArray(server))
+    return server as McpServer;
+  const stored = server as McpServer;
+  let healed = stored;
+  const transport = pick(stored.transport, MCP_TRANSPORTS, "stdio");
+  if (transport !== stored.transport) healed = { ...healed, transport };
+  const overrides = stored.repoOverrides;
+  if (
+    typeof overrides === "object" &&
+    overrides !== null &&
+    !Array.isArray(overrides)
+  ) {
     const kept = Object.entries(overrides).filter(([, state]) =>
       (MCP_REPO_STATES as readonly string[]).includes(state),
     );
@@ -504,34 +533,14 @@ function healEnumerated(settings: AppSettings): AppSettings {
     ...(defaultAgent && DEFAULT_AGENT_IDS.includes(defaultAgent)
       ? { defaultAgent }
       : {}),
-    // Provider ids heal against the FULL list, never a per-surface filtered subset:
-    // a valid provider that some picker hides must survive the load untouched.
-    ai: {
-      ...settings.ai,
-      provider: pick(
-        settings.ai.provider,
-        ALL_PROVIDER_IDS,
-        DEFAULT_SETTINGS.ai.provider,
-      ),
-    },
-    reviewAi: {
-      ...settings.reviewAi,
-      provider: pick(
-        settings.reviewAi.provider,
-        ALL_PROVIDER_IDS,
-        DEFAULT_SETTINGS.reviewAi.provider,
-      ),
-    },
+    ai: healAi(settings.ai, DEFAULT_SETTINGS.ai),
+    reviewAi: healAi(settings.reviewAi, DEFAULT_SETTINGS.reviewAi),
     ...(settings.securityReviewAi
       ? {
-          securityReviewAi: {
-            ...settings.securityReviewAi,
-            provider: pick(
-              settings.securityReviewAi.provider,
-              ALL_PROVIDER_IDS,
-              DEFAULT_SETTINGS.reviewAi.provider,
-            ),
-          },
+          securityReviewAi: healAi(
+            settings.securityReviewAi,
+            DEFAULT_SETTINGS.reviewAi,
+          ),
         }
       : {}),
     reviewContextSize: pick(

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -103,6 +103,10 @@ export interface CustomCommand {
  *  importing that module — "default" is key ABSENCE, so it is not a member. */
 export const MCP_REPO_STATES = ["on", "optional", "off"] as const;
 
+/** How a server is reached. The Add/Edit dialog's transport toggle renders from
+ *  this list and `loadSettings` heals against it, so the two can't drift. */
+export const MCP_TRANSPORTS = ["stdio", "http"] as const;
+
 /** One ordered environment variable / request header entry in an MCP server
  *  definition. Secret-bearing entries keep their `value` empty here (the real
  *  value lives in the OS keychain — see `McpServer.secretKeys`). */
@@ -141,7 +145,7 @@ export interface McpServer {
    *  "off". Absent for a repo = inherit `enabled`. Meaningless for repo-scoped servers. */
   repoOverrides?: Record<string, (typeof MCP_REPO_STATES)[number]>;
   /** "stdio" = a local subprocess; "http" = a remote streamable-HTTP server. */
-  transport: "stdio" | "http";
+  transport: (typeof MCP_TRANSPORTS)[number];
   /** Executable to launch (stdio only), e.g. `npx`. */
   command: string;
   /** Arguments passed to `command` (stdio only). */
@@ -453,20 +457,28 @@ const pick = <T extends string>(
   fallback: T,
 ): T => (allowed.includes(value as T) ? (value as T) : fallback);
 
-/** Drops per-repo override entries whose value isn't a real state — absence IS the
- *  "Default" choice, so a junk entry heals by disappearing rather than by picking a
- *  state the user never made. Returns the server untouched when nothing was junk,
- *  and passes through anything that isn't a server object at all: the heal's whole
- *  premise is that settings.json lies, so it must not assume shape either. */
+/** Heals one server's enumerated fields: an off-list `transport` falls back to the
+ *  empty-draft default, and per-repo override entries whose value isn't a real state
+ *  are dropped — absence IS the "Default" choice there, so a junk entry heals by
+ *  disappearing rather than by picking a state the user never made. Returns the same
+ *  object when nothing was junk, and passes through anything that isn't a server
+ *  object at all: the heal's premise is that settings.json lies, so it must not
+ *  assume shape either. */
 function healMcpServer(server: McpServer): McpServer {
   if (typeof server !== "object" || server === null) return server;
+  let healed = server;
+  const transport = pick(server.transport, MCP_TRANSPORTS, "stdio");
+  if (transport !== server.transport) healed = { ...healed, transport };
   const overrides = server.repoOverrides;
-  if (typeof overrides !== "object" || overrides === null) return server;
-  const kept = Object.entries(overrides).filter(([, state]) =>
-    (MCP_REPO_STATES as readonly string[]).includes(state),
-  );
-  if (kept.length === Object.keys(overrides).length) return server;
-  return { ...server, repoOverrides: Object.fromEntries(kept) };
+  if (typeof overrides === "object" && overrides !== null) {
+    const kept = Object.entries(overrides).filter(([, state]) =>
+      (MCP_REPO_STATES as readonly string[]).includes(state),
+    );
+    if (kept.length !== Object.keys(overrides).length) {
+      healed = { ...healed, repoOverrides: Object.fromEntries(kept) };
+    }
+  }
+  return healed;
 }
 
 /**
@@ -476,9 +488,12 @@ function healMcpServer(server: McpServer): McpServer {
  * trigger whose next Save persists the junk. Silent and deterministic, so a healed
  * value simply rides the next natural settings write.
  *
- * Fields whose membership is only known at runtime are deliberately absent: terminal
- * / terminalPath / externalEditor (their own custom sentinels), syntaxMap (user-defined
- * language ids), hotkeys, and MCP server scopes (repo identities).
+ * Deliberately not healed: terminal / terminalPath / externalEditor (their own custom
+ * sentinels), syntaxMap (user-defined language ids), hotkeys, and MCP server scopes,
+ * whose membership is only known at runtime; plus agentImageProviders, which is
+ * statically enumerable but validated where it is consumed (render_dockerfile refuses
+ * an agent it has no package for) and rendered by no picker, so a stray entry sits
+ * inert in the file.
  */
 function healEnumerated(settings: AppSettings): AppSettings {
   // Destructured out because an off-list agent must heal to ABSENT — that absence is
@@ -555,12 +570,16 @@ function healEnumerated(settings: AppSettings): AppSettings {
       DIFF_VIEW_MODES,
       DEFAULT_SETTINGS.diffViewMode,
     ),
-    // A non-array here would throw, and every writer in the serialized RMW chain
-    // re-reads through loadSettings — so the throw would lock the user out of
-    // repairing the file from inside the app.
+    // A corrupt container is passed through, never substituted: every writer in the
+    // serialized RMW chain re-reads through loadSettings, so a stand-in [] would
+    // persist on the next unrelated write and destroy whatever definitions the shape
+    // held. Untouched, the MCP surfaces degrade exactly as they did before this heal
+    // existed and the file stays repairable. null/undefined resets — nothing to lose.
     mcpServers: Array.isArray(settings.mcpServers)
       ? settings.mcpServers.map(healMcpServer)
-      : DEFAULT_SETTINGS.mcpServers,
+      : settings.mcpServers == null
+        ? []
+        : settings.mcpServers,
   };
 }
 

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -1,11 +1,15 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
-import type { ReviewContextSize } from "@/lib/ai/context-budget";
-import type { ReviewEffort } from "@/lib/ai/review-effort";
-import type { ReviewTimeout } from "@/lib/ai/review-timeout";
+import { ALL_PROVIDER_IDS } from "@/lib/ai/providers";
+import {
+  REVIEW_CONTEXT_SIZES,
+  type ReviewContextSize,
+} from "@/lib/ai/review-context-size";
+import { REVIEW_EFFORTS, type ReviewEffort } from "@/lib/ai/review-effort";
+import { REVIEW_TIMEOUTS, type ReviewTimeout } from "@/lib/ai/review-timeout";
 import type { AiSettings, ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
-import type { ThemeSetting } from "@/lib/theme";
+import { THEME_ORDER, type ThemeSetting } from "@/lib/theme";
 
 export interface RecentRepo {
   path: string;
@@ -94,6 +98,11 @@ export interface CustomCommand {
   prompt: string;
 }
 
+/** A global server's per-repo states. Declared here rather than beside
+ *  {@link McpRepoState} in ./mcp so `loadSettings` can heal against it without
+ *  importing that module — "default" is key ABSENCE, so it is not a member. */
+export const MCP_REPO_STATES = ["on", "optional", "off"] as const;
+
 /** One ordered environment variable / request header entry in an MCP server
  *  definition. Secret-bearing entries keep their `value` empty here (the real
  *  value lives in the OS keychain — see `McpServer.secretKeys`). */
@@ -130,7 +139,7 @@ export interface McpServer {
   /** Per-repo overrides of a GLOBAL server's state, keyed by the repo's worktree-stable
    *  identity (legacy raw-path keys honored on read, folded on write): "on" / "optional" /
    *  "off". Absent for a repo = inherit `enabled`. Meaningless for repo-scoped servers. */
-  repoOverrides?: Record<string, "on" | "optional" | "off">;
+  repoOverrides?: Record<string, (typeof MCP_REPO_STATES)[number]>;
   /** "stdio" = a local subprocess; "http" = a remote streamable-HTTP server. */
   transport: "stdio" | "http";
   /** Executable to launch (stdio only), e.g. `npx`. */
@@ -147,9 +156,15 @@ export interface McpServer {
   secretKeys: string[];
 }
 
+/** The background-fetch cadences offered in Settings, in render order. */
+export const AUTO_FETCH_INTERVALS = ["5", "10", "15", "30", "60"] as const;
+
 /** Background-fetch cadence, in minutes (stored as a string so it binds to the
  *  settings Select directly). */
-export type AutoFetchInterval = "5" | "10" | "15" | "30" | "60";
+export type AutoFetchInterval = (typeof AUTO_FETCH_INTERVALS)[number];
+
+/** The CI-check notification scopes offered in Settings, in render order. */
+export const PR_CHECK_SCOPES = ["off", "mine", "all"] as const;
 
 export interface NotificationSettings {
   /** Automation results (review posted / ready / failed). */
@@ -157,7 +172,7 @@ export interface NotificationSettings {
   /** An AI code review or security audit you started finishing in the background. */
   reviews: boolean;
   /** CI check completion on open PRs. */
-  prChecks: "off" | "mine" | "all";
+  prChecks: (typeof PR_CHECK_SCOPES)[number];
   /** PRs opened / merged / closed in the current repo. */
   prActivity: boolean;
   /** Review decisions on PRs you authored. */
@@ -165,6 +180,26 @@ export interface NotificationSettings {
   /** Workflow runs finishing (success/failure) on the current branch. */
   actionRuns: boolean;
 }
+
+/** The agent CLIs offerable as the Default agent, in render order. Spelled out
+ *  here rather than imported from lib/ai (which mirrors the same list as
+ *  `AgentKind`) to keep settings free of an ai import cycle, even a type-only one. */
+export const DEFAULT_AGENT_IDS = [
+  "claude",
+  "codex",
+  "copilot",
+  "opencode",
+] as const;
+
+/** The agent-session isolation modes offered in Settings. */
+export const AGENT_ISOLATIONS = ["worktree", "container"] as const;
+
+/** Node base-image majors offered for the agent container image (current LTS
+ *  first). The Settings picker renders this list; `loadSettings` heals against it. */
+export const NODE_VERSIONS = ["24", "22", "20"] as const;
+
+/** The diff layouts offered in the diff surface's view toggle. */
+export const DIFF_VIEW_MODES = ["unified", "split"] as const;
 
 export interface AppSettings {
   ai: AiSettings;
@@ -201,15 +236,15 @@ export interface AppSettings {
    *  main AI provider when that's an agent CLI, else Claude. Inline union (the
    *  sessions store does the same) to avoid a settings↔ai import cycle, even a
    *  type-only one. */
-  defaultAgent?: "claude" | "codex" | "copilot" | "opencode";
+  defaultAgent?: (typeof DEFAULT_AGENT_IDS)[number];
   /** How write-capable agent sessions are isolated. "worktree" = the throwaway
    *  git worktree only (host, full-auto); "container" = also run inside an
    *  ephemeral Docker/Podman container for kernel-enforced filesystem
    *  confinement (opt-in; needs Docker/Podman installed). */
-  agentIsolation: "worktree" | "container";
+  agentIsolation: (typeof AGENT_ISOLATIONS)[number];
   /** Node base-image major version for the agent container image (digits, e.g.
    *  "24"). */
-  agentImageNodeVersion: string;
+  agentImageNodeVersion: (typeof NODE_VERSIONS)[number];
   /** Which container-capable agents to bake into the image. */
   agentImageProviders: ("claude" | "codex" | "opencode" | "copilot")[];
   globalInstructions: string;
@@ -295,7 +330,7 @@ export interface AppSettings {
    *  softer dark variant that lifts surfaces off pure black to reduce eye strain. Applied
    *  outside the bulk settings form (apply-on-change), like diffViewMode. */
   theme: ThemeSetting;
-  diffViewMode: "unified" | "split";
+  diffViewMode: (typeof DIFF_VIEW_MODES)[number];
   /** Which conversation-list sections the user collapsed, keyed `"<feature>:<kind>"`
    *  (`pulls:local`, `issues:remote`, …); a missing key = expanded. Global and
    *  feature-scoped, so the remote key collapses that section across every repo. */
@@ -411,13 +446,133 @@ function getStore(): Promise<Store> {
   return storePromise;
 }
 
+/** The stored value when it is one of `allowed`, else `fallback`. */
+const pick = <T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T => (allowed.includes(value as T) ? (value as T) : fallback);
+
+/** Drops per-repo override entries whose value isn't a real state — absence IS the
+ *  "Default" choice, so a junk entry heals by disappearing rather than by picking a
+ *  state the user never made. Returns the server untouched when nothing was junk,
+ *  and passes through anything that isn't a server object at all: the heal's whole
+ *  premise is that settings.json lies, so it must not assume shape either. */
+function healMcpServer(server: McpServer): McpServer {
+  if (typeof server !== "object" || server === null) return server;
+  const overrides = server.repoOverrides;
+  if (typeof overrides !== "object" || overrides === null) return server;
+  const kept = Object.entries(overrides).filter(([, state]) =>
+    (MCP_REPO_STATES as readonly string[]).includes(state),
+  );
+  if (kept.length === Object.keys(overrides).length) return server;
+  return { ...server, repoOverrides: Object.fromEntries(kept) };
+}
+
+/**
+ * Coerces every statically-enumerable field to its default when the stored value is
+ * off-list. settings.json is hand-editable and no writer validates membership, so an
+ * unrecognized string otherwise reaches a `Select` with no matching item — an empty
+ * trigger whose next Save persists the junk. Silent and deterministic, so a healed
+ * value simply rides the next natural settings write.
+ *
+ * Fields whose membership is only known at runtime are deliberately absent: terminal
+ * / terminalPath / externalEditor (their own custom sentinels), syntaxMap (user-defined
+ * language ids), hotkeys, and MCP server scopes (repo identities).
+ */
+function healEnumerated(settings: AppSettings): AppSettings {
+  // Destructured out because an off-list agent must heal to ABSENT — that absence is
+  // the meaningful "Auto" state, so a stand-in string would silently pin an agent.
+  const { defaultAgent, ...rest } = settings;
+  return {
+    ...rest,
+    ...(defaultAgent && DEFAULT_AGENT_IDS.includes(defaultAgent)
+      ? { defaultAgent }
+      : {}),
+    // Provider ids heal against the FULL list, never a per-surface filtered subset:
+    // a valid provider that some picker hides must survive the load untouched.
+    ai: {
+      ...settings.ai,
+      provider: pick(
+        settings.ai.provider,
+        ALL_PROVIDER_IDS,
+        DEFAULT_SETTINGS.ai.provider,
+      ),
+    },
+    reviewAi: {
+      ...settings.reviewAi,
+      provider: pick(
+        settings.reviewAi.provider,
+        ALL_PROVIDER_IDS,
+        DEFAULT_SETTINGS.reviewAi.provider,
+      ),
+    },
+    ...(settings.securityReviewAi
+      ? {
+          securityReviewAi: {
+            ...settings.securityReviewAi,
+            provider: pick(
+              settings.securityReviewAi.provider,
+              ALL_PROVIDER_IDS,
+              DEFAULT_SETTINGS.reviewAi.provider,
+            ),
+          },
+        }
+      : {}),
+    reviewContextSize: pick(
+      settings.reviewContextSize,
+      REVIEW_CONTEXT_SIZES,
+      "auto",
+    ),
+    reviewTimeout: pick(settings.reviewTimeout, REVIEW_TIMEOUTS, "auto"),
+    reviewEffort: pick(settings.reviewEffort, REVIEW_EFFORTS, "auto"),
+    notifications: {
+      ...settings.notifications,
+      prChecks: pick(
+        settings.notifications.prChecks,
+        PR_CHECK_SCOPES,
+        DEFAULT_SETTINGS.notifications.prChecks,
+      ),
+    },
+    agentIsolation: pick(
+      settings.agentIsolation,
+      AGENT_ISOLATIONS,
+      DEFAULT_SETTINGS.agentIsolation,
+    ),
+    agentImageNodeVersion: pick(
+      settings.agentImageNodeVersion,
+      NODE_VERSIONS,
+      DEFAULT_SETTINGS.agentImageNodeVersion,
+    ),
+    autoFetchInterval: pick(
+      settings.autoFetchInterval,
+      AUTO_FETCH_INTERVALS,
+      DEFAULT_SETTINGS.autoFetchInterval,
+    ),
+    theme: pick(settings.theme, THEME_ORDER, DEFAULT_SETTINGS.theme),
+    diffViewMode: pick(
+      settings.diffViewMode,
+      DIFF_VIEW_MODES,
+      DEFAULT_SETTINGS.diffViewMode,
+    ),
+    // A non-array here would throw, and every writer in the serialized RMW chain
+    // re-reads through loadSettings — so the throw would lock the user out of
+    // repairing the file from inside the app.
+    mcpServers: Array.isArray(settings.mcpServers)
+      ? settings.mcpServers.map(healMcpServer)
+      : DEFAULT_SETTINGS.mcpServers,
+  };
+}
+
 /** Loads settings, healing an older or partial saved object against DEFAULT_SETTINGS:
  *  any field absent (stored before that field shipped) reads as its default. Nested
- *  ai/reviewAi/notifications objects are merged, not replaced. */
+ *  ai/reviewAi/notifications objects are merged, not replaced. Enumerated fields are
+ *  then membership-checked by {@link healEnumerated}, so every caller — the settings
+ *  form, the pre-React theme apply, and the RMW writers below — sees a valid object. */
 export async function loadSettings(): Promise<AppSettings> {
   const store = await getStore();
   const saved = await store.get<Partial<AppSettings>>("settings");
-  return {
+  return healEnumerated({
     ...DEFAULT_SETTINGS,
     ...saved,
     ai: { ...DEFAULT_SETTINGS.ai, ...saved?.ai },
@@ -437,7 +592,7 @@ export async function loadSettings(): Promise<AppSettings> {
       ...DEFAULT_SETTINGS.notifications,
       ...saved?.notifications,
     },
-  };
+  });
 }
 
 /**

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -510,17 +510,16 @@ function healMcpServer(server: unknown): McpServer {
   return healed;
 }
 
-/** The settings' MCP registry as a real array. `loadSettings` deliberately passes a
- *  corrupt (non-array) container through instead of substituting one, so no background
- *  write destroys the definitions it holds (see {@link healEnumerated}); every READER
- *  goes through this instead, seeing an empty list rather than throwing on `.filter`.
- *
- *  The settings DRAFT keeps the raw stored value, so saving an unrelated setting
- *  round-trips a corrupt container untouched. Only the MCP section repairs it: it
- *  renders from this guarded view and builds every write from it, so a deliberate
- *  add/edit/remove is what replaces the corrupt value with a real array. */
+/** The settings' MCP registry as a real array of real objects — a corrupt container
+ *  OR element reads as absent, never throws, and is never substituted in the stored
+ *  value (see {@link healEnumerated}; the repair path lives in `McpServersSection`). */
 export const asMcpServerArray = (value: unknown): McpServer[] =>
-  Array.isArray(value) ? value : [];
+  Array.isArray(value)
+    ? value.filter(
+        (s): s is McpServer =>
+          typeof s === "object" && s !== null && !Array.isArray(s),
+      )
+    : [];
 
 /**
  * Coerces every statically-enumerable field to its default when the stored value is

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -510,6 +510,18 @@ function healMcpServer(server: unknown): McpServer {
   return healed;
 }
 
+/** The settings' MCP registry as a real array. `loadSettings` deliberately passes a
+ *  corrupt (non-array) container through instead of substituting one, so no background
+ *  write destroys the definitions it holds (see {@link healEnumerated}); every READER
+ *  goes through this instead, seeing an empty list rather than throwing on `.filter`.
+ *
+ *  The settings DRAFT keeps the raw stored value, so saving an unrelated setting
+ *  round-trips a corrupt container untouched. Only the MCP section repairs it: it
+ *  renders from this guarded view and builds every write from it, so a deliberate
+ *  add/edit/remove is what replaces the corrupt value with a real array. */
+export const asMcpServerArray = (value: unknown): McpServer[] =>
+  Array.isArray(value) ? value : [];
+
 /**
  * Coerces every statically-enumerable field to its default when the stored value is
  * off-list. settings.json is hand-editable and no writer validates membership, so an

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -510,9 +510,10 @@ function healMcpServer(server: unknown): McpServer {
   return healed;
 }
 
-/** The settings' MCP registry as a real array of real objects — a corrupt container
- *  OR element reads as absent, never throws, and is never substituted in the stored
- *  value (see {@link healEnumerated}; the repair path lives in `McpServersSection`). */
+/** The settings' MCP registry as a real array of objects — a corrupt container, or
+ *  an element that isn't an object at all, reads as absent and is never substituted
+ *  in the stored value (see {@link healEnumerated}; the repair path lives in
+ *  `McpServersSection`). */
 export const asMcpServerArray = (value: unknown): McpServer[] =>
   Array.isArray(value)
     ? value.filter(

--- a/src/lib/settings/mcp.ts
+++ b/src/lib/settings/mcp.ts
@@ -1,6 +1,6 @@
 import { hostLabel, isHostAllowed } from "@/lib/ai/allowed-hosts";
 import { repoIdentity } from "@/lib/git/repo-identity";
-import type { McpKeyValue, McpServer } from "./api";
+import type { MCP_REPO_STATES, McpKeyValue, McpServer } from "./api";
 
 /** Server name = the key in the generated MCP config: letters/digits/`-`/`_`,
  *  must start with a letter or digit, no spaces. */
@@ -56,7 +56,7 @@ export function isServerInScope(
  *  A global server can be overridden per repo (`repoOverrides`, keyed by identity
  *  or a legacy raw path); otherwise — and always for repo-scoped servers — it
  *  follows `enabled` (on / optional). */
-export type McpRepoState = "on" | "optional" | "off";
+export type McpRepoState = (typeof MCP_REPO_STATES)[number];
 export function effectiveMcpState(
   server: McpServer,
   repoKeys: RepoKeys,

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,5 +1,11 @@
 import { darkQuery } from "@/lib/use-is-dark";
 
+/** Order the "Cycle theme" command steps through, and the picker's render order.
+ *  `loadSettings` heals a stored theme against this list, so it is the single
+ *  source: a theme reachable in the UI but missing here would be silently reset
+ *  to "system" on load. */
+export const THEME_ORDER = ["system", "light", "dark", "slate"] as const;
+
 /**
  * The user's theme preference (Settings → Appearance). `"system"` follows the OS
  * color scheme; `"light"` / `"dark"` force it; `"slate"` is a softer dark variant
@@ -9,7 +15,7 @@ import { darkQuery } from "@/lib/use-is-dark";
  * very first paint on a cold boot reflects a saved override with no flash before
  * the async settings store resolves.
  */
-export type ThemeSetting = "system" | "light" | "dark" | "slate";
+export type ThemeSetting = (typeof THEME_ORDER)[number];
 
 /** Human labels for the picker (also the source for the palette `items` map). */
 export const THEME_LABELS: Record<ThemeSetting, string> = {
@@ -18,9 +24,6 @@ export const THEME_LABELS: Record<ThemeSetting, string> = {
   dark: "Dark",
   slate: "Slate",
 };
-
-/** Order the "Cycle theme" command steps through. */
-export const THEME_ORDER: ThemeSetting[] = ["system", "light", "dark", "slate"];
 
 /** The theme one step after `current` in {@link THEME_ORDER} (wraps around). */
 export function nextTheme(current: ThemeSetting): ThemeSetting {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -33,12 +33,13 @@ export function nextTheme(current: ThemeSetting): ThemeSetting {
 
 const LS_KEY = "gd-theme";
 
+/** Membership derived from {@link THEME_ORDER}, not re-enumerated: this gates the
+ *  pre-paint boot read, the one theme path no type-check covers, so a hand-listed
+ *  copy would reject a newly added theme and flash "system" until the store loads. */
 function isTheme(value: unknown): value is ThemeSetting {
   return (
-    value === "system" ||
-    value === "light" ||
-    value === "dark" ||
-    value === "slate"
+    typeof value === "string" &&
+    (THEME_ORDER as readonly string[]).includes(value)
   );
 }
 


### PR DESCRIPTION
`settings.json` is hand-editable and no writer validated membership, so an unrecognized value reached a Settings `Select` with no matching item — an empty trigger whose next Save persisted the junk. `loadSettings` now coerces every statically-enumerable field back to its default, and each option list becomes a single exported source that both the heal and the picker's label map are typed against. The second half of the change adds ahead-only branch compare commands so the callers that never read `behind` stop paying for its log walk.

### Settings healing

- Adds `healEnumerated`, the `pick` helper, and `healMcpServer` to `src/lib/settings/api.ts`, applied to the merged object inside `loadSettings` so the settings form, the pre-React theme apply, and the serialized read-modify-write writers all see a valid object. Provider ids heal against the full `ALL_PROVIDER_IDS` rather than a per-surface subset; `defaultAgent` heals to *absent* (the meaningful "Auto" state); a `null` `mcpServers` resets to the default, while any other corrupt shape passes through untouched so the file stays repairable in an editor. Junk `repoOverrides` entries are dropped, since absence is the "Default" choice, and an off-list `transport` falls back to `"stdio"`.
- Documents the deliberate exclusions in the `healEnumerated` doc comment: `terminal` / `terminalPath` / `externalEditor`, `syntaxMap`, `hotkeys`, and MCP server scopes are runtime-valued, not enumerable. `agentImageProviders` stays unhealed too: it is validated where it is consumed, and no picker renders it.
- Exports the option lists from `src/lib/settings/api.ts` — `MCP_REPO_STATES`, `MCP_TRANSPORTS`, `AUTO_FETCH_INTERVALS`, `PR_CHECK_SCOPES`, `DEFAULT_AGENT_IDS`, `AGENT_ISOLATIONS`, `NODE_VERSIONS`, `DIFF_VIEW_MODES` — and derives the matching `AppSettings` / `NotificationSettings` / `McpServer` field types from them.
- Makes `THEME_ORDER` in `src/lib/theme.ts` an `as const` list that `ThemeSetting` derives from, so the cycle order, the picker order, and the heal share one source — and `isTheme` checks membership against the same list.
- Adds `src/lib/ai/review-context-size.ts` holding `REVIEW_CONTEXT_SIZES` and `ReviewContextSize`, moved out of `src/lib/ai/context-budget.ts`: as a leaf module it lets `settings/api.ts` read the value list without the cycle through `guarded-fetch`.
- Derives `McpRepoState` in `src/lib/settings/mcp.ts` from `MCP_REPO_STATES`.
- Types the Settings label maps against those lists so an added option can't reach the heal without a label (or vice versa): `GeneralSection.tsx`, `NotificationsSection.tsx`, `mcp/PerRepoStateControl.tsx`, and `AgentSandboxField.tsx` (whose `NODE_VERSION_ITEMS` becomes an explicit record and whose props take `AgentIsolation` / `NodeVersion`); `mcp/McpServerDialog.tsx` renders its transport toggle from `MCP_TRANSPORTS`.
- In `AiProviderSection.tsx`, renders the Review-context menu from `REVIEW_CONTEXT_SIZES`, introduces `DefaultAgentChoice` for the `"auto"` stand-in, and drops the render-time coercion of `reviewEffort` now that the stored value is healed at load.
- Records the user-facing outcome in `changelog.d/fixed-settings-select-junk-values.md`. No README / site / guide change: the behavior it fixes was never documented as such.

### Ahead-only branch compares

- Adds `git_branch_ahead` and `git_branch_ahead_count` to `src-tauri/src/git/compare.rs`, both behind the same `validate_ref` guard as `git_compare_branches`; the count command uses `rev-list --count` instead of formatting and parsing every commit. Registered in `src-tauri/src/lib.rs`.
- Covers them with two tokio tests in `compare.rs`: one asserts the ahead list matches `git_compare_branches`' ahead half in content and newest-first order (the fixture carries a base-only commit, so an ahead-only walk is provably not the whole range) and that the count equals its length; the other asserts option-shaped refs are rejected on either side.
- Adds the `gitBranchAhead` / `gitBranchAheadCount` bindings in `src/lib/git/api.ts` and the `useBranchAhead` / `useBranchAheadCount` hooks plus `repoKeys.branchAhead` / `branchAheadCount` in `src/lib/git/queries.ts`, keeping `useCompareBranches`' enabled gate.
- Migrates the callers that discarded `behind`: `CreatePrDialog.tsx`, `CreateLocalPrDialog.tsx`, `BranchSwitcher.tsx`, `RebaseOntoDialog.tsx`, `useGenerateReleaseNotes.ts`, and the PR-body recipe in `src-tauri/src/mcp_server/generate.rs`. `ChangesPanel.tsx` moves to the count hook, since it renders only the number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated ahead-commit and ahead-count calculations for branches.
  - Improved pull request creation, rebasing, branch switching, change counts, and release-note generation using ahead-commit data.
  - Centralized available settings choices, theme ordering, and review context-size options.

- **Bug Fixes**
  - Invalid or hand-edited settings values now fall back to safe defaults.
  - Settings pickers display the effective selected values.
  - Invalid AI provider settings are reset consistently.
  - Corrupt MCP server settings are handled safely without creating phantom entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->