### PR TITLE
feat(branches,worktrees): open worktrees from their branch rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ PR badge.
   row shows when that worktree was last active, so the ones you've finished
   with are easy to spot. One-click jumps to the main workspace sit right in
   the branch switcher, where selecting a branch that's checked out elsewhere
-  opens its worktree straight away, that branch's context menu carries every
-  worktree action, and a *Worktrees* row opens the full manager.
+  opens that folder straight away, that branch's context menu carries the
+  worktree actions, and a *Worktrees* row opens the full manager.
 - **Compare**: a tab with a three-dot diff, commits ahead/behind,
   merge/rebase, and jump-to-PR. Each ahead/behind commit shows its tag chips
   and carries a context menu — checkout, cherry-pick, create a branch or tag,

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ PR badge.
   you can work on several branches in parallel folders without stashing. Each
   row shows when that worktree was last active, so the ones you've finished
   with are easy to spot. One-click jumps to the main workspace sit right in
-  the branch switcher, where each worktree row also carries a context menu
-  with the management actions it supports, and a branch's own menu can remove
-  its worktree.
+  the branch switcher, where selecting a branch that's checked out elsewhere
+  opens its worktree straight away, that branch's context menu carries every
+  worktree action, and a *Worktrees* row opens the full manager.
 - **Compare**: a tab with a three-dot diff, commits ahead/behind,
   merge/rebase, and jump-to-PR. Each ahead/behind commit shows its tag chips
   and carries a context menu — checkout, cherry-pick, create a branch or tag,

--- a/changelog.d/changed-branch-dropdown-worktrees.md
+++ b/changelog.d/changed-branch-dropdown-worktrees.md
@@ -1,0 +1,6 @@
+- **Open a branch's worktree in one click.** Selecting a branch that's checked
+  out in another worktree now opens that worktree straight away, and the
+  branch's context menu carries every worktree action: open, copy path,
+  rename, lock, promote to the main workspace, and delete. **Worktrees…** in
+  the branch dropdown opens the full manager, and every unavailable action row
+  in the dropdown itself now says why.

--- a/changelog.d/changed-branch-dropdown-worktrees.md
+++ b/changelog.d/changed-branch-dropdown-worktrees.md
@@ -1,6 +1,6 @@
-- **Open a branch's worktree in one click.** Selecting a branch that's checked
-  out in another worktree now opens that worktree straight away, and the
-  branch's context menu carries every worktree action: open, copy path,
+- **Open a branch's folder in one click.** Selecting a branch that's checked
+  out in another folder now opens that folder straight away, and the
+  branch's context menu carries the worktree actions: open, copy path,
   rename, lock, promote to the main workspace, and delete. **Worktrees…** in
   the branch dropdown opens the full manager, and every unavailable action row
   in the dropdown itself now says why.

--- a/site/src/content/blog/work-on-two-branches-at-once.md
+++ b/site/src/content/blog/work-on-two-branches-at-once.md
@@ -199,10 +199,10 @@ by its **Repair links** button.
 Two of its choices map straight onto the rules above. Switch to a
 branch that lives in another worktree and you don't get the
 `already used by worktree` error: the branch is badged, and choosing
-it offers to open that worktree instead. And **Promote to main
-workspace** collapses the sequence the one-checkout rule forces
-(remove the worktree first, then check its branch out in the main
-workspace) into one action, once the worktree is clean.
+it opens that worktree instead. And **Promote to main workspace**
+collapses the sequence the one-checkout rule forces (remove the
+worktree first, then check its branch out in the main workspace)
+into one action, once the worktree is clean.
 
 Branches take turns only when you give them one folder to take turns
 in. The habit outlived the constraint by a decade.

--- a/site/src/content/blog/work-on-two-branches-at-once.md
+++ b/site/src/content/blog/work-on-two-branches-at-once.md
@@ -199,7 +199,7 @@ by its **Repair links** button.
 Two of its choices map straight onto the rules above. Switch to a
 branch that lives in another worktree and you don't get the
 `already used by worktree` error: the branch is badged, and choosing
-it opens that worktree instead. And **Promote to main workspace**
+it opens that folder instead. And **Promote to main workspace**
 collapses the sequence the one-checkout rule forces (remove the
 worktree first, then check its branch out in the main workspace)
 into one action, once the worktree is clean.

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -753,11 +753,13 @@ settings*.)
 
 ## Worktrees
 
-**Worktrees…** (in the ⋮ menu, or the command palette) manages linked worktrees — extra
-folders that each check out a different branch of the same repository, so you can build,
-test, or review several branches at once without stashing or switching. Each row
-shows when git last did work in that worktree (hover the time for the exact date),
-so the ones you've finished with stand out.
+**Worktrees…** manages linked worktrees — extra folders that each check out a different
+branch of the same repository, so you can build, test, or review several branches at once
+without stashing or switching. Open it from the ⋮ menu, the command palette, or
+**Worktrees (N)…** in the branch switcher, where *N* is how many linked worktrees you have.
+Each row shows when git last did work in that worktree (hover the time for the exact date),
+so the ones you've finished with stand out; a worktree on a detached checkout appears here
+only, since no branch row can host it.
 
 - **Add** a worktree on a new branch (from any base) or an existing one; it's checked out
   into its own folder, defaulting to a sibling of the repository.
@@ -791,21 +793,23 @@ so the ones you've finished with stand out.
   folder in your file manager, which otherwise breaks the path each worktree records.
 
 A branch can only be checked out in one worktree at a time, so the list excludes branches
-already in use. The **branch switcher** knows this too: a branch that's checked out in
-another worktree is badged, and choosing it offers to open that worktree instead of failing
-with a checkout error. You can also **Delete worktree…** straight from that badged branch's
-context menu (disabled when the badge points at the main workspace, which can't be
-removed, and while that worktree's removal is already running) — the branch stays, and
-its **Delete…** item un-disables once the worktree is gone. When you're in a linked
-worktree the switcher reminds you that a branch checkout lands *there* (not the
-main workspace) and offers a one-click **Open main workspace**, and its
-**Worktrees** section jumps you straight to any other worktree — no detour through a
-checked-out branch. Each of those rows carries the worktree management actions on its
-context menu — **Open worktree**, **Copy path**, **Rename…**, **Lock…**/**Unlock**,
-**Promote to main workspace…**, **Delete worktree…** — with the ones a row doesn't support
-(the main workspace, a detached checkout, a locked worktree, one being removed) hidden or
-disabled with the reason in the label. **Open main workspace** and
-**Promote this worktree to main workspace** are in the command palette too.
+already in use. The **branch switcher** knows this too, and every branch appears there
+exactly once: a branch that's checked out in another worktree is badged, and choosing it
+opens that worktree straight away. That badged row owns the worktree, so its context menu
+carries the worktree actions as their own group: **Open worktree**, **Copy path**,
+**Rename worktree…**, **Lock…**/**Unlock**, **Promote to main workspace…**, and
+**Delete worktree…**. The ones a worktree doesn't support are hidden or disabled with the
+reason in the label — the main workspace can't be removed, a locked one has to be unlocked
+before it can be renamed or promoted, and one whose removal is already running turns its
+actions away until it finishes.
+The branch's own items read **Rename branch…** and **Delete branch…**, so the two pairs
+can't be confused; a deleted worktree leaves its branch behind, and **Delete branch…**
+un-disables once the worktree is gone. The dropdown's own action rows say why when one of
+them is unavailable. When you're in a linked worktree the switcher reminds you that a
+branch checkout lands *there* (not the main workspace) and offers a one-click
+**Open main workspace**.
+**Open main workspace** and **Promote this worktree to main workspace** are in the command
+palette too.
 
 A repository's local pull requests, issues, review history, and per-repo settings are shared
 across all its worktrees, so you see the same ones whichever folder you're working in.{{ai}}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -616,7 +616,7 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 - **Create** a branch ({{kbd:new-branch}}), **rename** ({{kbd:rename-branch}}), **delete**
   ({{kbd:delete-branch}}), or **archive** it — archiving hides a branch without deleting
   it, collapsing it into an "Archived" section. The branch you're on, the default branch,
-  and a branch checked out in another worktree can't be archived (unless you're already
+  and a branch checked out in another folder can't be archived (unless you're already
   deleting that worktree); **Unarchive** has no such limit — it works even on the branch
   you're checked out on. When creating, the **Base it on** picker is a searchable list
   grouped into **Local** and **Remote** branches, so you can start from *any* branch — not
@@ -633,7 +633,7 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   calls merged, and idle ones, start **pre-checked**; a pull-request match goes by branch
   name, so it never pre-checks a row on its own — it badges one for you to confirm. Review
   the list, then **archive** them (reversible) or **delete** them together. The current
-  branch, the default branch, and branches checked out in another worktree are never
+  branch, the default branch, and branches checked out in another folder are never
   included (archiving still offers one whose worktree you're already deleting); deleting
   also skips protected branches.
 {{ai}}- **Generate a branch name with AI** from your working-tree changes when creating
@@ -755,16 +755,17 @@ settings*.)
 
 **Worktrees…** manages linked worktrees — extra folders that each check out a different
 branch of the same repository, so you can build, test, or review several branches at once
-without stashing or switching. Open it from the ⋮ menu, the command palette, or
-**Worktrees (N)…** in the branch switcher, where *N* is how many linked worktrees you have.
+without stashing or switching. Open it from the ⋮ menu, the command palette, or the
+**Worktrees…** row in the branch switcher, which shows a count once you have some.
 Each row shows when git last did work in that worktree (hover the time for the exact date),
-so the ones you've finished with stand out; a worktree on a detached checkout appears here
-only, since no branch row can host it.
+so the ones you've finished with stand out. What the branch switcher can show doesn't limit
+this list: one on a detached checkout has no branch row at all, one on an archived branch
+sits in the collapsed "Archived" section, and filter text can hide the rest.
 
 - **Add** a worktree on a new branch (from any base) or an existing one; it's checked out
   into its own folder, defaulting to a sibling of the repository.
 - **Open** a worktree to make it the active repository — git commands then run in that
-  folder and the window title follows. Open the main worktree to switch back.
+  folder and the window title follows. Open the main workspace to switch back.
 - **Rename** a worktree to move its folder to a new name in place; its branch is unchanged.
 - **Lock** a worktree (with an optional reason) so it won't be pruned, renamed, or
   removed: renaming needs an unlock first, and deleting asks for a forced confirmation.
@@ -777,8 +778,8 @@ only, since no branch row can host it.
   close the dialog and carry on: the removal keeps a line at the top of the repository view
   until it finishes, its row here reads **Removing…**, and the actions held while it runs
   say *removal in progress*. It runs to completion once started, so there's nothing to
-  cancel. The main worktree, and whichever one you're currently in, can't be renamed or
-  deleted — switch away first. A locked worktree can't be renamed until you unlock it.
+  cancel. The main workspace, and whichever worktree you're currently in, can't be renamed
+  or deleted — switch away first. A locked worktree can't be renamed until you unlock it.
 - **Promote to main workspace** brings a worktree's branch into your main checkout: it
   removes the worktree (a branch can't be checked out in two at once) and checks that branch
   out in the main workspace. The worktree must be clean first; any uncommitted work in the
@@ -794,12 +795,15 @@ only, since no branch row can host it.
 
 A branch can only be checked out in one worktree at a time, so the list excludes branches
 already in use. The **branch switcher** knows this too, and every branch appears there
-exactly once: a branch that's checked out in another worktree is badged, and choosing it
-opens that worktree straight away. That badged row owns the worktree, so its context menu
-carries the worktree actions as their own group: **Open worktree**, **Copy path**,
-**Rename worktree…**, **Lock…**/**Unlock**, **Promote to main workspace…**, and
+exactly once: a branch that's checked out in another folder is badged with where it lives
+(another worktree, or your main workspace when you're working in a linked one), and
+choosing it opens that folder straight away. That badged row owns the checkout, so its
+context menu carries the worktree actions as their own group: **Open worktree**
+(**Open main workspace** on a main-workspace row), **Copy path**, **Rename worktree…**,
+**Lock…**/**Unlock**, **Promote to main workspace…**, and
 **Delete worktree…**. The ones a worktree doesn't support are hidden or disabled with the
-reason in the label — the main workspace can't be removed, a locked one has to be unlocked
+reason in the label — a main-workspace row drops **Lock…**/**Unlock** and **Promote to main
+workspace…** entirely and can't be renamed or removed, a locked worktree has to be unlocked
 before it can be renamed or promoted, and one whose removal is already running turns its
 actions away until it finishes.
 The branch's own items read **Rename branch…** and **Delete branch…**, so the two pairs
@@ -807,9 +811,8 @@ can't be confused; a deleted worktree leaves its branch behind, and **Delete bra
 un-disables once the worktree is gone. The dropdown's own action rows say why when one of
 them is unavailable. When you're in a linked worktree the switcher reminds you that a
 branch checkout lands *there* (not the main workspace) and offers a one-click
-**Open main workspace**.
-**Open main workspace** and **Promote this worktree to main workspace** are in the command
-palette too.
+**Open main workspace**. That action and **Promote this worktree to main workspace** are in
+the command palette too.
 
 A repository's local pull requests, issues, review history, and per-repo settings are shared
 across all its worktrees, so you see the same ones whichever folder you're working in.{{ai}}

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -806,6 +806,7 @@ reason in the label — a main-workspace row drops **Lock…**/**Unlock** and **
 workspace…** entirely and can't be renamed or removed, a locked worktree has to be unlocked
 before it can be renamed or promoted, and one whose removal is already running turns its
 actions away until it finishes.
+
 The branch's own items read **Rename branch…** and **Delete branch…**, so the two pairs
 can't be confused; a deleted worktree leaves its branch behind, and **Delete branch…**
 un-disables once the worktree is gone. The dropdown's own action rows say why when one of

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -76,7 +76,7 @@ import {
 import type { Branch, ForkPrMatch, RemoteBranch } from "@/lib/git/types";
 import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
 import { secondaryClickLabel } from "@/lib/hotkeys/binding";
-import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
+import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import {
   LOCAL_AUDIT_STATE,
@@ -101,6 +101,10 @@ import {
   WORKTREE_PROMOTING_MESSAGE,
 } from "@/lib/stores/worktree-removal";
 import { toastError } from "@/lib/toast";
+import {
+  ARIA_DISABLED_CLASS,
+  useDisabledReason,
+} from "@/lib/use-disabled-reason";
 import { useRetained } from "@/lib/use-retained";
 import { cn } from "@/lib/utils";
 import {
@@ -175,22 +179,43 @@ const PR_STATE_LABEL: Record<PrAuditState, string> = {
 
 function MenuRow({
   disabled,
+  reason,
   onClick,
   children,
 }: {
   disabled?: boolean;
+  /** Why the row is held. Absent leaves an ordinary native disable — used where
+   *  the label already states the reason. */
+  reason?: string | null;
   onClick: () => void;
   children: React.ReactNode;
 }) {
+  const { blockedReason, reasonId, wrapperTitle, describedBy, nativeProps } =
+    useDisabledReason({ disabled, reason, onClick });
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+    // Block, not the span default: the row's `w-full` needs a full-width parent
+    // to size against inside the menu's block container.
+    <span
+      className={cn("block w-full", blockedReason && "cursor-not-allowed")}
+      title={wrapperTitle}
     >
-      {children}
-    </button>
+      <button
+        {...nativeProps}
+        type="button"
+        aria-describedby={describedBy}
+        className={cn(
+          "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50",
+          ARIA_DISABLED_CLASS,
+        )}
+      >
+        {children}
+      </button>
+      {blockedReason ? (
+        <span id={reasonId} className="sr-only">
+          {blockedReason}
+        </span>
+      ) : null}
+    </span>
   );
 }
 
@@ -287,17 +312,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const [reapplyOnSwitch, setReapplyOnSwitch] = useState(false);
   // Why a first switch attempt didn't work, shown when the dialog re-opens.
   const [switchHint, setSwitchHint] = useState<string | null>(null);
-  // A branch checked out in another worktree, awaiting confirm to open it.
-  const [worktreeSwitchTarget, setWorktreeSwitchTarget] = useState<{
-    name: string;
-    path: string;
-  } | null>(null);
-  const shownWorktreeSwitchTarget = useRetained(worktreeSwitchTarget);
   // The worktree pending a "Promote to main workspace" confirm — set by the
-  // palette action and the Worktrees-section row menu (the Worktrees dialog
+  // palette action and the branch row's worktree menu (the Worktrees dialog
   // hosts its own promote flow).
   const [promoteTarget, setPromoteTarget] = useState<UserWorktree | null>(null);
-  // Worktrees-section row menu targets — the rename and lock flows reuse the
+  // Branch-row worktree menu targets — the rename and lock flows reuse the
   // Worktrees dialog's own dialogs.
   const [renameWorktreeTarget, setRenameWorktreeTarget] =
     useState<UserWorktree | null>(null);
@@ -490,10 +509,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
 
   // Branches checked out in *another* worktree → that worktree's path. Git
   // forbids the same branch in two worktrees, so these can't be checked out
-  // here; the row offers to open the worktree instead. The active repo's own
-  // branch is excluded (it's the one you're on). Fetched while the menu OR the
-  // cleanup dialog is open: that dialog's archive and delete exclusions read
-  // this map, and the cleanup hotkey closes the menu on its way to it.
+  // here; the row opens that worktree instead. The active repo's own branch is
+  // excluded (it's the one you're on). Fetched while the menu OR the cleanup
+  // dialog is open: that dialog's archive and delete exclusions read this map,
+  // and the cleanup hotkey closes the menu on its way to it.
   const userWorktrees = useUserWorktrees(repoPath, open || cleanupOpen);
   const activeNorm = normPath(repoPath);
   const worktreeByBranch = useMemo(() => {
@@ -504,8 +523,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
     return map;
   }, [userWorktrees.data, activeNorm]);
-  // Cross-worktree navigation (same fetch as the map above): the main
-  // workspace, the other worktrees you can jump to, and whether you're
+  // Cross-worktree state (same fetch as the map above): the main workspace the
+  // banner links to, the count the Worktrees row shows, and whether you're
   // currently in a linked (non-main) worktree — where a branch checkout lands
   // here, not in main.
   const worktreeList = userWorktrees.data ?? [];
@@ -513,9 +532,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     (w) => normPath(w.path) === activeNorm,
   );
   const mainWorktree = worktreeList.find((w) => w.isMain);
-  const otherWorktrees = worktreeList.filter(
-    (w) => normPath(w.path) !== activeNorm,
-  );
+  // Linked ones only: the main workspace isn't a "worktree" in user vocabulary,
+  // and this is the set the dialog's own empty state keys on.
+  const linkedWorktreeCount = worktreeList.filter((w) => !w.isMain).length;
   const inLinkedWorktree = Boolean(currentWorktree && !currentWorktree.isMain);
   // A worktree whose folder is being removed still lists (the removal outlives
   // the dialog that started it), but nothing may act on it until it settles.
@@ -669,10 +688,6 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     ...visibleBranches,
     ...(showArchived ? archivedBranches : []),
     ...(showRemote ? remoteOnly : []),
-    // The Worktrees section is a selectable list too — key its rows by path so
-    // arrow nav flows from the branch rows straight into it (each row carries a
-    // matching `data-row`). Paths use forward slashes, safe as a data-row value.
-    ...otherWorktrees.map((w) => ({ name: w.path })),
   ];
   const onBranchKeyDown = listKeyboardNav({
     items: navBranches,
@@ -682,6 +697,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   });
   const stashes = stashCount.data ?? 0;
   const hasChanges = (status.data?.entries.length ?? 0) > 0;
+  // The live answer, readable AFTER an await — same pattern as `currentNameRef`.
+  // `switchTo` can resume on a worktree lookup that outlived the render it
+  // started in, and a tree that turned dirty meanwhile must still get the
+  // bring/stash choice instead of a silent checkout.
+  const hasChangesRef = useRef(hasChanges);
+  useEffect(() => {
+    hasChangesRef.current = hasChanges;
+  }, [hasChanges]);
   // Rebase refuses only on dirty TRACKED files, so the proactive stash offer
   // keys on this — an untracked-only tree rebases fine, and stashing it
   // unasked would move those files into a stash on any replay conflict.
@@ -744,21 +767,46 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     }
   }
 
-  function switchTo(name: string, remote: string | null = null) {
+  // Now async: the worktree answer decides whether a row checks out or
+  // navigates, and it can still be in flight when the click lands.
+  async function switchTo(name: string, remote: string | null = null) {
     if (amending) return; // guarded by the disabled trigger; belt-and-suspenders
     setOpen(false);
-    // A branch that's checked out in another worktree can't be checked out here
-    // (git forbids it); offer to open that worktree instead of erroring.
-    const wtPath = worktreeByBranch.get(name);
+    // A branch checked out in another worktree can't be checked out here (git
+    // forbids it), so the row navigates there instead. No confirm: the row's
+    // chip already says where the branch lives, and opening a folder is not a
+    // destructive act.
+    let wtPath = worktreeByBranch.get(name);
+    // The open-gated read hasn't answered yet, and an empty map would read as
+    // "not in a worktree" — ask git rather than acting on a missing answer. A
+    // failed lookup falls through to the ordinary checkout, where git refuses
+    // with its own message. Local rows only: a remote-only row's name has no
+    // local branch by construction, so no worktree can hold it and the lookup
+    // would only delay the checkout by a subprocess.
+    if (
+      remote === null &&
+      !wtPath &&
+      userWorktrees.data === undefined &&
+      !userWorktrees.isError
+    ) {
+      try {
+        const wts = await listUserWorktrees(repoPath);
+        wtPath = wts.find(
+          (w) => w.branch === name && normPath(w.path) !== activeNorm,
+        )?.path;
+      } catch {
+        // fall through
+      }
+    }
     if (wtPath) {
-      // Its folder is on its way out — offering to open it would land the app
-      // in a directory mid-deletion.
+      // Its folder is on its way out — opening it would land the app in a
+      // directory mid-deletion.
       if (refuseWhileLeaving(wtPath, removingPaths.has(wtPath))) return;
-      setWorktreeSwitchTarget({ name, path: wtPath });
+      openWorktree(wtPath);
       return;
     }
     // with work in progress, let the user choose to bring or stash it
-    if (hasChanges) {
+    if (hasChangesRef.current) {
       setSwitchHint(null);
       setReapplyOnSwitch(settings.data?.reapplyStashOnSwitch ?? false);
       setSwitchTarget({ name, remote });
@@ -1231,6 +1279,110 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     switchAutostash.isPending ||
     recovery.pending;
 
+  // Every "there is none" reason below derives from a query whose empty answer
+  // and whose UNANSWERED state are the same value — `?? null` for the names,
+  // `?? 0` for the counts. Asserting the absence on that value tells a user with
+  // a dirty tree on `master` that HEAD is detached and nothing is uncommitted,
+  // so each such arm says "still checking" until its own read lands. All four
+  // reads are unconditional, so `isPending` is the first-answer window and
+  // nothing else; an ERRORED read is not pending and falls through to the
+  // assertion, since no answer is coming.
+  const headReadPending = status.isPending;
+  const defaultBranchReadPending = defaultBranch.isPending;
+  const branchesReadPending = branches.isPending;
+  const stashCountReadPending = stashCount.isPending;
+
+  // Why each multi-condition menu row is held, arms in the order that row's own
+  // `disabled` expression tests them. Null where the label already carries the
+  // reason — a row must not say it twice.
+  const renameCurrentBlockedReason = headReadPending
+    ? "Checking the current branch…"
+    : "HEAD is detached — there's no current branch to rename.";
+  const deleteCurrentBlockedReason = (() => {
+    if (!currentName) {
+      if (headReadPending) return "Checking the current branch…";
+      return "HEAD is detached — there's no current branch to delete.";
+    }
+    // The remaining arm is branch protection, which the label already states.
+    return null;
+  })();
+  const updateFromDefaultBlockedReason = (() => {
+    if (!defaultName) {
+      if (defaultBranchReadPending) return "Checking the default branch…";
+      return "This repository has no default branch.";
+    }
+    if (!currentName) {
+      if (headReadPending) return "Checking the current branch…";
+      return "HEAD is detached — there's no branch to update.";
+    }
+    if (defaultName === currentName) return `You're already on ${defaultName}.`;
+    if (busy) return "Another git operation is running.";
+    return null;
+  })();
+  // The three rows below share a shape: a still-loading branch list counts as
+  // zero, but a branch rule holds whether or not that list has landed — so a
+  // pending count yields to the rule arms rather than displacing them, and only
+  // a row with no rule against it reports that it's still checking.
+  const mergeIntoCurrentBlockedReason = (() => {
+    if (otherBranches.length === 0) {
+      if (!branchesReadPending)
+        return "There are no other branches to merge from.";
+      if (canMergeIntoCurrent) return "Checking branches…";
+    }
+    if (lockCurrent) return null; // the label says "(requires PR)"
+    if (!canMergeIntoCurrent)
+      return `A branch rule doesn't allow merge commits on ${currentName}.`;
+    return null;
+  })();
+  const squashIntoCurrentBlockedReason = (() => {
+    if (otherBranches.length === 0) {
+      if (!branchesReadPending)
+        return "There are no other branches to merge from.";
+      if (canSquashIntoCurrent) return "Checking branches…";
+    }
+    if (lockCurrent)
+      return `A branch rule requires a pull request to change ${currentName}.`;
+    if (!canSquashIntoCurrent)
+      return `A branch rule doesn't allow squash merges on ${currentName}.`;
+    return null;
+  })();
+  const rebaseCurrentBlockedReason = (() => {
+    if (otherBranches.length === 0) {
+      if (!branchesReadPending)
+        return "There are no other branches to rebase onto.";
+      if (!lockCurrent) return "Checking branches…";
+    }
+    if (lockCurrent)
+      return `A branch rule requires a pull request to change ${currentName}.`;
+    return null;
+  })();
+  const changeBaseBlockedReason = (() => {
+    if (!currentName) {
+      if (headReadPending) return "Checking the current branch…";
+      return "HEAD is detached — there's no branch to rebase.";
+    }
+    if (otherBranches.length < 2) {
+      if (!branchesReadPending)
+        return "Changing the base needs at least two other branches.";
+      // `busy` joins the rule arms here: it too is true right now, whatever the
+      // branch count turns out to be.
+      if (!lockCurrent && !busy) return "Checking branches…";
+    }
+    if (lockCurrent)
+      return `A branch rule requires a pull request to change ${currentName}.`;
+    if (busy) return "Another git operation is running.";
+    return null;
+  })();
+  const noChangesBlockedReason = headReadPending
+    ? "Checking for uncommitted changes…"
+    : "There are no uncommitted changes.";
+  const popStashBlockedReason = stashCountReadPending
+    ? "Checking for stashes…"
+    : "There are no stashes to pop.";
+  const viewStashesBlockedReason = stashCountReadPending
+    ? "Checking for stashes…"
+    : "There are no stashes.";
+
   // Hotkey handlers reuse the menu's own flows, so every gate (clean tree,
   // stash count, picker availability) and confirm dialog applies equally.
   useHotkeyAction("show-branches", () => setOpen(true), !amending);
@@ -1483,8 +1635,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // archived branch can be checked out, and this is its only way back.
     const archiveLabel = branch.archived ? "Unarchive" : "Archive";
     // The worktree (other than the active checkout) this branch occupies, when
-    // any — the Delete worktree… item gates on it (git refuses to remove the
-    // main working tree).
+    // any — the row's whole worktree menu group hangs off it, and it narrows the
+    // object those items act on.
     const rowWorktree = (userWorktrees.data ?? []).find(
       (w) => w.path === worktreeByBranch.get(branch.name),
     );
@@ -1492,6 +1644,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const rowWorktreeRemoving = Boolean(
       rowWorktree && removingPaths.has(rowWorktree.path),
     );
+    const wtLabel = (label: string, otherReason?: string) =>
+      worktreeItemLabel(label, rowWorktreeRemoving, otherReason);
+    const renameWorktreeBlockedReason = (() => {
+      if (rowWorktree?.isMain) return "main workspace";
+      if (rowWorktree?.isLocked) return "locked";
+      return undefined;
+    })();
     // Best-effort by design: a null `defaultName` (still loading, or unresolvable)
     // drops the default-branch guard rather than disabling Archive everywhere.
     // The worktree guard is HELD rather than dropped while its read is in
@@ -1596,7 +1755,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               data-row={branch.name}
               className="flex w-full flex-col gap-y-0.5 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
               onClick={() => {
-                if (!branch.isCurrent) switchTo(branch.name);
+                if (!branch.isCurrent) void switchTo(branch.name);
               }}
             >
               <span className="flex w-full items-center gap-2">
@@ -1653,9 +1812,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 {inWorktree && (
                   <span
                     className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
-                    title={`Checked out in another worktree (${worktreeByBranch.get(
-                      branch.name,
-                    )}) — open it instead of switching`}
+                    title={`Checked out in worktree ${baseName(
+                      worktreeByBranch.get(branch.name) ?? "",
+                    )} (${worktreeByBranch.get(branch.name)}) — this row opens it`}
                   >
                     <TreeStructureIcon className="size-3" weight="bold" />
                     worktree
@@ -1908,7 +2067,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             </>
           )}
           <ContextMenuItem onClick={() => openRename(branch.name)}>
-            Rename…
+            Rename branch…
           </ContextMenuItem>
           <ContextMenuItem
             onClick={() => copyText(branch.name, "Branch name copied")}
@@ -1924,21 +2083,101 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               : `${archiveLabel} (${archiveBlockedReason})`}
           </ContextMenuItem>
           <ContextMenuSeparator />
-          {inWorktree && (
-            <ContextMenuItem
-              disabled={rowWorktree?.isMain || rowWorktreeRemoving}
-              onClick={() => {
-                if (!rowWorktree) return;
-                setOpen(false);
-                setRemoveWorktreeTarget(rowWorktree);
-              }}
-            >
-              {worktreeItemLabel(
-                "Delete worktree…",
-                rowWorktreeRemoving,
-                rowWorktree?.isMain ? "main workspace" : undefined,
+          {rowWorktree && (
+            <>
+              <ContextMenuItem
+                disabled={rowWorktreeRemoving}
+                onClick={() => {
+                  if (refuseWhileLeaving(rowWorktree.path, rowWorktreeRemoving))
+                    return;
+                  setOpen(false);
+                  openWorktree(rowWorktree.path);
+                }}
+              >
+                {wtLabel("Open worktree")}
+              </ContextMenuItem>
+              {/* Copying a path acts on nothing, so a removal doesn't block it. */}
+              <ContextMenuItem
+                onClick={() => copyText(rowWorktree.path, "Path copied")}
+              >
+                Copy path
+              </ContextMenuItem>
+              <ContextMenuItem
+                // git worktree move refuses the main worktree and a locked one.
+                disabled={
+                  rowWorktree.isMain ||
+                  rowWorktree.isLocked ||
+                  rowWorktreeRemoving
+                }
+                onClick={() => {
+                  setOpen(false);
+                  setRenameWorktreeTarget(rowWorktree);
+                }}
+              >
+                {wtLabel("Rename worktree…", renameWorktreeBlockedReason)}
+              </ContextMenuItem>
+              {!rowWorktree.isMain &&
+                (rowWorktree.isLocked ? (
+                  <ContextMenuItem
+                    // In-place state change: the list refreshes via the
+                    // mutation's invalidation, so the popover stays open.
+                    disabled={rowWorktreeRemoving}
+                    onClick={() => {
+                      // The menu can outlive the state that disabled this item,
+                      // and a promote's claim never re-renders it.
+                      if (
+                        refuseWhileLeaving(
+                          rowWorktree.path,
+                          rowWorktreeRemoving,
+                        )
+                      )
+                        return;
+                      void doUnlockWorktree(rowWorktree.path);
+                    }}
+                  >
+                    {wtLabel("Unlock")}
+                  </ContextMenuItem>
+                ) : (
+                  <ContextMenuItem
+                    disabled={rowWorktreeRemoving}
+                    onClick={() => {
+                      setOpen(false);
+                      setLockWorktreeTarget(rowWorktree);
+                    }}
+                  >
+                    {wtLabel("Lock…")}
+                  </ContextMenuItem>
+                ))}
+              {/* Promote moves this worktree's branch into the main workspace,
+                  so it needs a linked worktree with a branch. */}
+              {!rowWorktree.isMain && !rowWorktree.isDetached && (
+                <ContextMenuItem
+                  disabled={rowWorktree.isLocked || rowWorktreeRemoving}
+                  onClick={() => {
+                    setOpen(false);
+                    setPromoteTarget(rowWorktree);
+                  }}
+                >
+                  {wtLabel(
+                    "Promote to main workspace…",
+                    rowWorktree.isLocked ? "locked" : undefined,
+                  )}
+                </ContextMenuItem>
               )}
-            </ContextMenuItem>
+              <ContextMenuItem
+                disabled={rowWorktree.isMain || rowWorktreeRemoving}
+                onClick={() => {
+                  setOpen(false);
+                  setRemoveWorktreeTarget(rowWorktree);
+                }}
+              >
+                {wtLabel(
+                  "Delete worktree…",
+                  rowWorktree.isMain ? "main workspace" : undefined,
+                )}
+              </ContextMenuItem>
+              <ContextMenuSeparator />
+            </>
           )}
           <ContextMenuItem
             disabled={deletionBlocked || inWorktree}
@@ -1948,10 +2187,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             }}
           >
             {deletionBlocked
-              ? "Delete… (protected)"
+              ? "Delete branch… (protected)"
               : inWorktree
-                ? "Delete… (in worktree)"
-                : "Delete…"}
+                ? "Delete branch… (in worktree)"
+                : "Delete branch…"}
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
@@ -1973,7 +2212,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               data-row={branch.name}
               title={`Check out ${branch.name} — creates a local branch tracking ${branch.remote}/${branch.name}`}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
-              onClick={() => switchTo(branch.name, branch.remote)}
+              onClick={() => void switchTo(branch.name, branch.remote)}
             >
               <CloudArrowDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
               <span className="min-w-0 flex-1 truncate">{branch.name}</span>
@@ -1991,7 +2230,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         />
         <ContextMenuContent className="min-w-48">
-          <ContextMenuItem onClick={() => switchTo(branch.name, branch.remote)}>
+          <ContextMenuItem
+            onClick={() => void switchTo(branch.name, branch.remote)}
+          >
             Check out
           </ContextMenuItem>
           <ContextMenuItem
@@ -2172,168 +2413,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   </>
                 )}
               </div>
-              {otherWorktrees.length > 0 && (
-                <div className="border-t py-1">
-                  <p className="px-3 py-1 text-[11px] font-medium text-muted-foreground">
-                    Worktrees
-                  </p>
-                  {/* No isCurrent gating on these menus: otherWorktrees excludes
-                      the active checkout, by the same normalized-path comparison
-                      the whole section keys on. */}
-                  {otherWorktrees.map((w) => {
-                    const isRemoving = removingPaths.has(w.path);
-                    const itemLabel = (label: string, otherReason?: string) =>
-                      worktreeItemLabel(label, isRemoving, otherReason);
-                    const renameBlockedReason = (() => {
-                      if (w.isMain) return "main workspace";
-                      if (w.isLocked) return "locked";
-                      return undefined;
-                    })();
-                    return (
-                      <ContextMenu key={w.path}>
-                        <ContextMenuTrigger
-                          render={
-                            <button
-                              type="button"
-                              data-row={w.path}
-                              // Not `disabled`: the row must stay focusable so
-                              // arrow-key nav can move through it.
-                              aria-disabled={isRemoving || undefined}
-                              title={
-                                isRemoving ? "Removal in progress" : undefined
-                              }
-                              className={cn(
-                                "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none",
-                                isRemoving && "cursor-default",
-                              )}
-                              onClick={() => {
-                                if (refuseWhileLeaving(w.path, isRemoving))
-                                  return;
-                                setOpen(false);
-                                openWorktree(w.path);
-                              }}
-                            >
-                              <TreeStructureIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                              <span className="min-w-0 flex-1 truncate">
-                                {w.isDetached
-                                  ? "detached HEAD"
-                                  : w.branch || "—"}
-                              </span>
-                              {w.isMain && (
-                                <Badge variant="secondary" className="shrink-0">
-                                  Main
-                                </Badge>
-                              )}
-                              <span
-                                className="max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground"
-                                // Full path, not the folder name the row already
-                                // shows — the path is what disambiguates.
-                                onMouseEnter={clipTitle(w.path)}
-                              >
-                                {baseName(w.path)}
-                              </span>
-                            </button>
-                          }
-                        />
-                        <ContextMenuContent className="min-w-48">
-                          <ContextMenuItem
-                            disabled={isRemoving}
-                            onClick={() => {
-                              if (refuseWhileLeaving(w.path, isRemoving))
-                                return;
-                              setOpen(false);
-                              openWorktree(w.path);
-                            }}
-                          >
-                            {itemLabel("Open worktree")}
-                          </ContextMenuItem>
-                          {/* Copying a path acts on nothing, so a removal doesn't
-                            block it. */}
-                          <ContextMenuItem
-                            onClick={() => copyText(w.path, "Path copied")}
-                          >
-                            Copy path
-                          </ContextMenuItem>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            // git worktree move refuses the main worktree and a
-                            // locked one.
-                            disabled={w.isMain || w.isLocked || isRemoving}
-                            onClick={() => {
-                              setOpen(false);
-                              setRenameWorktreeTarget(w);
-                            }}
-                          >
-                            {itemLabel("Rename…", renameBlockedReason)}
-                          </ContextMenuItem>
-                          {!w.isMain &&
-                            (w.isLocked ? (
-                              <ContextMenuItem
-                                // In-place state change: the list refreshes via the
-                                // mutation's invalidation, so the popover stays open.
-                                disabled={isRemoving}
-                                onClick={() => {
-                                  // The menu can outlive the state that disabled
-                                  // this item, and a promote's claim never
-                                  // re-renders it.
-                                  if (refuseWhileLeaving(w.path, isRemoving))
-                                    return;
-                                  void doUnlockWorktree(w.path);
-                                }}
-                              >
-                                {itemLabel("Unlock")}
-                              </ContextMenuItem>
-                            ) : (
-                              <ContextMenuItem
-                                disabled={isRemoving}
-                                onClick={() => {
-                                  setOpen(false);
-                                  setLockWorktreeTarget(w);
-                                }}
-                              >
-                                {itemLabel("Lock…")}
-                              </ContextMenuItem>
-                            ))}
-                          {/* Promote moves this worktree's branch into the main
-                            workspace, so it needs a linked worktree with a
-                            branch. */}
-                          {!w.isMain && !w.isDetached && (
-                            <ContextMenuItem
-                              disabled={w.isLocked || isRemoving}
-                              onClick={() => {
-                                setOpen(false);
-                                setPromoteTarget(w);
-                              }}
-                            >
-                              {itemLabel(
-                                "Promote to main workspace…",
-                                w.isLocked ? "locked" : undefined,
-                              )}
-                            </ContextMenuItem>
-                          )}
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            disabled={w.isMain || isRemoving}
-                            onClick={() => {
-                              setOpen(false);
-                              setRemoveWorktreeTarget(w);
-                            }}
-                          >
-                            {itemLabel(
-                              "Delete worktree…",
-                              w.isMain ? "main workspace" : undefined,
-                            )}
-                          </ContextMenuItem>
-                        </ContextMenuContent>
-                      </ContextMenu>
-                    );
-                  })}
-                </div>
-              )}
               <div className="border-t py-1">
                 <MenuRow onClick={openCreate}>New branch…</MenuRow>
                 <MenuRow
                   disabled={!currentName}
+                  reason={renameCurrentBlockedReason}
                   onClick={() => {
                     if (!currentName) return;
                     openRename(currentName);
@@ -2345,6 +2429,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   disabled={
                     !currentName || isDeletionBlocked(rulesConfig, currentName)
                   }
+                  reason={deleteCurrentBlockedReason}
                   onClick={() => {
                     if (!currentName) return;
                     setOpen(false);
@@ -2363,10 +2448,29 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 >
                   Clean up branches…
                 </MenuRow>
+                {/* Dispatched, not owned: RepositoryMenu holds the one
+                    WorktreesDialog instance and the one "worktrees" handler, so
+                    a second mount here would stack a duplicate dialog on top of
+                    it, and a second registration would shadow the ⋮ menu's
+                    handler (dispatch runs the newest enabled one). Direct call
+                    in the same tick, as RepoSwitcher's rows do — the palette's
+                    setTimeout exists for closing a MODAL, which a popover
+                    isn't. */}
+                <MenuRow
+                  onClick={() => {
+                    setOpen(false);
+                    if (!dispatchAction("worktrees"))
+                      toast.error("Couldn't open the worktree manager.");
+                  }}
+                >
+                  Worktrees
+                  {linkedWorktreeCount > 0 ? ` (${linkedWorktreeCount})` : ""}…
+                </MenuRow>
               </div>
               <div className="border-t py-1">
                 <MenuRow
                   disabled={!hasChanges}
+                  reason={noChangesBlockedReason}
                   onClick={() => {
                     setOpen(false);
                     setDiscardAllOpen(true);
@@ -2376,6 +2480,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </MenuRow>
                 <MenuRow
                   disabled={!hasChanges}
+                  reason={noChangesBlockedReason}
                   onClick={() => {
                     setOpen(false);
                     setStashAllOpen(true);
@@ -2385,6 +2490,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </MenuRow>
                 <MenuRow
                   disabled={stashes === 0}
+                  reason={popStashBlockedReason}
                   onClick={() => {
                     setOpen(false);
                     setStashPopOpen(true);
@@ -2394,6 +2500,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </MenuRow>
                 <MenuRow
                   disabled={stashes === 0}
+                  reason={viewStashesBlockedReason}
                   onClick={() => {
                     setOpen(false);
                     setStashesView("stashes");
@@ -2430,6 +2537,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     defaultName === currentName ||
                     busy
                   }
+                  reason={updateFromDefaultBlockedReason}
                   onClick={() => {
                     if (currentName) void doUpdateFromDefault(currentName);
                   }}
@@ -2438,6 +2546,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </MenuRow>
                 <MenuRow
                   disabled={otherBranches.length === 0 || !canMergeIntoCurrent}
+                  reason={mergeIntoCurrentBlockedReason}
                   onClick={() => openPicker("merge")}
                 >
                   {lockCurrent
@@ -2446,12 +2555,14 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 </MenuRow>
                 <MenuRow
                   disabled={otherBranches.length === 0 || !canSquashIntoCurrent}
+                  reason={squashIntoCurrentBlockedReason}
                   onClick={() => openPicker("squash")}
                 >
                   Squash and merge into current branch…
                 </MenuRow>
                 <MenuRow
                   disabled={otherBranches.length === 0 || lockCurrent}
+                  reason={rebaseCurrentBlockedReason}
                   onClick={() => openPicker("rebase")}
                 >
                   Rebase current branch…
@@ -2463,6 +2574,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     lockCurrent ||
                     busy
                   }
+                  reason={changeBaseBlockedReason}
                   onClick={openRebaseOnto}
                 >
                   Change base…
@@ -2606,29 +2718,6 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         repoPath={repoPath}
         open={opHistoryOpen}
         onOpenChange={setOpHistoryOpen}
-      />
-
-      <ConfirmDialog
-        open={worktreeSwitchTarget !== null}
-        onCancel={() => setWorktreeSwitchTarget(null)}
-        title="Open worktree?"
-        body={
-          <>
-            <span className="font-mono">{shownWorktreeSwitchTarget?.name}</span>{" "}
-            is checked out in another worktree. A branch can only be in one
-            worktree at a time, so open that worktree instead of switching here.
-          </>
-        }
-        confirmLabel="Open worktree"
-        onConfirm={() => {
-          const target = worktreeSwitchTarget;
-          setWorktreeSwitchTarget(null);
-          if (!target) return;
-          // This dialog can outlive the state that would have refused it.
-          if (refuseWhileLeaving(target.path, removingPaths.has(target.path)))
-            return;
-          openWorktree(target.path);
-        }}
       />
 
       <ConfirmDialog

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -732,15 +732,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   });
   const stashes = stashCount.data ?? 0;
   const hasChanges = (status.data?.entries.length ?? 0) > 0;
-  // The live answer, readable AFTER an await — same pattern as `currentNameRef`.
-  // `switchTo` can resume on a worktree lookup that outlived the render it
-  // started in, and a tree that turned dirty meanwhile must still get the
-  // bring/stash choice instead of a silent checkout.
   // Which switch attempt is current. `switchTo` can suspend on the worktree
   // lookup, and the popover reopens long before a stalled `git worktree list`
   // returns — so a later attempt must be able to retire an earlier one rather
   // than both acting.
   const switchRequestRef = useRef(0);
+  // The live answer, readable AFTER an await — same pattern as `currentNameRef`.
+  // `switchTo` can resume on a worktree lookup that outlived the render it
+  // started in, and a tree that turned dirty meanwhile must still get the
+  // bring/stash choice instead of a silent checkout.
   const hasChangesRef = useRef(hasChanges);
   useEffect(() => {
     hasChangesRef.current = hasChanges;
@@ -858,12 +858,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       }
       // BELOW the try/catch, so every exit passes it — resolved, rejected, and
       // found-nothing alike. This await outlives its render and everything past
-      // here is a global write, so each pre-await read is re-taken: the repo
-      // (acting would target the one the user left), the attempt (the popover
-      // reopens while a stalled lookup is out, so a later pick already started
-      // its own switch), and amend mode (entered elsewhere meanwhile; a
-      // checkout would strand it). The rest already read live — `hasChangesRef`
-      // and the removal store below.
+      // here is a global write, so every read that GATES that write is re-taken:
+      // the repo (acting would target the one the user left), the attempt (the
+      // popover reopens while a stalled lookup is out, so a later pick already
+      // started its own switch), and amend mode (entered elsewhere meanwhile; a
+      // checkout would strand it) — plus `hasChangesRef` and the removal store
+      // below, which read live. The reapply default stays the click render's
+      // value on purpose: it only seeds a checkbox the user then sees.
       const live = useUiStore.getState();
       if (
         switchRequest !== switchRequestRef.current ||
@@ -892,7 +893,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       // (it toasts that itself) and when the user switched repos mid-validate
       // (silent by design) — a success toast over either would claim a
       // navigation that never happened.
-      const navigated = await openWorktree(wtPath);
+      // The attempt check rides INTO the open: `validateRepo` is a second await
+      // downstream of this function's guard, and a newer pick during it leaves
+      // the repo unchanged, so only the attempt identity can retire this one.
+      const navigated = await openWorktree(
+        wtPath,
+        () => switchRequest === switchRequestRef.current,
+      );
       // Only when this call resolved the worktree itself: that state is exactly
       // the one where the map was empty, so the row carried no chip and the whole
       // app just changed folders with no prior signal. Say so after the fact.

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -72,6 +72,7 @@ import {
   useUnlockUserWorktree,
   useUpdateBranchFrom,
   useUserWorktrees,
+  worktreeKey,
 } from "@/lib/git/queries";
 import type { Branch, ForkPrMatch, RemoteBranch } from "@/lib/git/types";
 import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
@@ -810,18 +811,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // path — the chip already says where the branch lives, and opening a folder
     // is not a destructive act.
     let wtPath = worktreeByBranch.get(name);
-    // The open-gated read hasn't answered yet, and an empty map would read as
-    // "not in a worktree" — ask git rather than acting on a missing answer. A
-    // failed lookup falls through to the ordinary checkout, where git refuses
-    // with its own message. Local rows only: a remote-only row's name has no
-    // local branch by construction, so no worktree can hold it and the lookup
-    // would only delay the checkout by a subprocess.
     let resolvedHere: UserWorktree | undefined;
-    // Only a NEGATIVE answer is distrusted: a hit is still a hit (removal is
-    // `refuseWhileLeaving`'s job), but a miss is worthless while the list is
-    // unanswered OR being refetched — react-query serves the previous data
-    // through a refetch, and every worktree mutation invalidates this key, so
-    // the miss right after one is exactly the wrong answer.
+    // The open-gated read hasn't answered yet, or is answering again — and only
+    // a NEGATIVE verdict is distrusted: a hit stays a hit (a listed worktree
+    // still exists, and mid-removal is `refuseWhileLeaving`'s job), but a miss
+    // is worthless from a list that is unanswered or in flight, because
+    // react-query serves the previous data through a refetch and every worktree
+    // mutation invalidates this key. Routed through `fetchQuery` on that same
+    // key so a click during the refetch JOINS it instead of racing it with a
+    // second `git worktree list`. A failed lookup falls through to the ordinary
+    // checkout, where git refuses with its own message. Local rows only: a
+    // remote-only row's name has no local branch by construction, so no
+    // worktree can hold it and the lookup would only add a subprocess.
     if (
       remote === null &&
       !wtPath &&
@@ -829,7 +830,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       (userWorktrees.data === undefined || userWorktrees.isFetching)
     ) {
       try {
-        const wts = await listUserWorktrees(repoPath);
+        const wts = await queryClient.fetchQuery({
+          queryKey: worktreeKey(repoPath),
+          queryFn: () => listUserWorktrees(repoPath),
+        });
         resolvedHere = wts.find(
           (w) => w.branch === name && normPath(w.path) !== activeNorm,
         );

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -141,6 +141,39 @@ import {
 /** Last path segment (folder name), tolerating either separator. */
 const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
 
+/** How a branch row NAMES the checkout holding its branch — chip, tooltip, open
+ *  item, after-the-fact toast, and the phrases that say a row is held because of
+ *  it. Git counts the main workspace as a worktree and this row can point at it
+ *  when you're standing in a linked one, but users don't call it one; routing
+ *  the naming through one record keeps a later phrase from drifting back.
+ *  "Rename worktree…" and "Delete worktree…" are deliberately NOT routed here:
+ *  they name the git operation, and their held-reason carries the naming instead.
+ *  `noun` is bare, for badges and parenthetical reasons. */
+const ROW_CHECKOUT_COPY = {
+  linked: {
+    noun: "worktree",
+    open: "Open worktree",
+    title: (path: string) =>
+      `Checked out in worktree ${baseName(path)} (${path}) — this row opens it`,
+    opened: (path: string) => `Opened worktree ${baseName(path)}`,
+    blocked: "checked out in another worktree",
+    held: "in a worktree",
+  },
+  main: {
+    noun: "main workspace",
+    open: "Open main workspace",
+    title: (path: string) =>
+      `Checked out in the main workspace (${path}) — this row opens it`,
+    opened: (_path: string) => "Opened the main workspace",
+    blocked: "checked out in the main workspace",
+    held: "in the main workspace",
+  },
+} as const;
+
+/** Which {@link ROW_CHECKOUT_COPY} arm a listed worktree speaks in. */
+const rowCheckoutCopy = (isMain: boolean | undefined) =>
+  ROW_CHECKOUT_COPY[isMain ? "main" : "linked"];
+
 /** Sentence-initial form of the platform's secondary-click word — for
  *  status-icon hints where the phrase leads a sentence. */
 const secondaryClickCapitalized =
@@ -773,9 +806,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (amending) return; // guarded by the disabled trigger; belt-and-suspenders
     setOpen(false);
     // A branch checked out in another worktree can't be checked out here (git
-    // forbids it), so the row navigates there instead. No confirm: the row's
-    // chip already says where the branch lives, and opening a folder is not a
-    // destructive act.
+    // forbids it), so the row navigates there instead. No confirm on the badged
+    // path — the chip already says where the branch lives, and opening a folder
+    // is not a destructive act.
     let wtPath = worktreeByBranch.get(name);
     // The open-gated read hasn't answered yet, and an empty map would read as
     // "not in a worktree" — ask git rather than acting on a missing answer. A
@@ -783,6 +816,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // with its own message. Local rows only: a remote-only row's name has no
     // local branch by construction, so no worktree can hold it and the lookup
     // would only delay the checkout by a subprocess.
+    let resolvedHere: UserWorktree | undefined;
     if (
       remote === null &&
       !wtPath &&
@@ -791,18 +825,34 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     ) {
       try {
         const wts = await listUserWorktrees(repoPath);
-        wtPath = wts.find(
+        resolvedHere = wts.find(
           (w) => w.branch === name && normPath(w.path) !== activeNorm,
-        )?.path;
+        );
+        wtPath = resolvedHere?.path;
       } catch {
         // fall through
       }
+      // BELOW the try/catch, so every exit from the lookup passes it — resolved,
+      // rejected, and found-nothing alike. This await outlives the render it
+      // started in, and everything past here is a repo-bound global write
+      // (navigate, checkout, or the bring/stash dialog); the user can switch
+      // repositories meanwhile, and acting then targets the repo they left.
+      if (useUiStore.getState().repoPath !== repoPath) return;
     }
     if (wtPath) {
       // Its folder is on its way out — opening it would land the app in a
       // directory mid-deletion.
       if (refuseWhileLeaving(wtPath, removingPaths.has(wtPath))) return;
-      openWorktree(wtPath);
+      // Awaited for its verdict: it resolves false both when the open failed
+      // (it toasts that itself) and when the user switched repos mid-validate
+      // (silent by design) — a success toast over either would claim a
+      // navigation that never happened.
+      const navigated = await openWorktree(wtPath);
+      // Only when this call resolved the worktree itself: that state is exactly
+      // the one where the map was empty, so the row carried no chip and the whole
+      // app just changed folders with no prior signal. Say so after the fact.
+      if (navigated && resolvedHere)
+        toast.success(rowCheckoutCopy(resolvedHere.isMain).opened(wtPath));
       return;
     }
     // with work in progress, let the user choose to bring or stash it
@@ -1283,51 +1333,81 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // and whose UNANSWERED state are the same value — `?? null` for the names,
   // `?? 0` for the counts. Asserting the absence on that value tells a user with
   // a dirty tree on `master` that HEAD is detached and nothing is uncommitted,
-  // so each such arm says "still checking" until its own read lands. All four
-  // reads are unconditional, so `isPending` is the first-answer window and
-  // nothing else; an ERRORED read is not pending and falls through to the
-  // assertion, since no answer is coming.
-  const headReadPending = status.isPending;
-  const defaultBranchReadPending = defaultBranch.isPending;
-  const branchesReadPending = branches.isPending;
-  const stashCountReadPending = stashCount.isPending;
+  // so no arm may assert an absence until its own read has actually answered.
+  // All four are unconditional, so `isPending` is the first-answer window and
+  // nothing else. A failed first read leaves the SAME undefined value a pending
+  // one does, so it gets its own arm rather than the assertion — and it isn't
+  // even short-lived: the query client retries once, only `status` polls, so for
+  // branches/defaultBranch/stashCount the failure stands until a refocus or an
+  // invalidation. Each value below is null once its read has answered, and
+  // otherwise the honest reason it can't.
+  const unread = (
+    q: { isPending: boolean; isError: boolean; data: unknown },
+    checking: string,
+    failed: string,
+  ) => {
+    if (q.isPending) return checking;
+    // An error over data that already landed is a failed REFRESH, not a missing
+    // answer: the row still has something true to say, so it says it.
+    if (q.isError && q.data === undefined) return failed;
+    return null;
+  };
+  const headUnread = unread(
+    status,
+    "Checking the current branch…",
+    "Couldn't read the repository status.",
+  );
+  const changesUnread = unread(
+    status,
+    "Checking for uncommitted changes…",
+    "Couldn't read the repository status.",
+  );
+  const defaultBranchUnread = unread(
+    defaultBranch,
+    "Checking the default branch…",
+    "Couldn't read the default branch.",
+  );
+  const branchesUnread = unread(
+    branches,
+    "Checking branches…",
+    "Couldn't read the branch list.",
+  );
+  const stashCountUnread = unread(
+    stashCount,
+    "Checking for stashes…",
+    "Couldn't read the stashes.",
+  );
 
   // Why each multi-condition menu row is held, arms in the order that row's own
   // `disabled` expression tests them. Null where the label already carries the
   // reason — a row must not say it twice.
-  const renameCurrentBlockedReason = headReadPending
-    ? "Checking the current branch…"
-    : "HEAD is detached — there's no current branch to rename.";
+  const renameCurrentBlockedReason =
+    headUnread ?? "HEAD is detached — there's no current branch to rename.";
   const deleteCurrentBlockedReason = (() => {
-    if (!currentName) {
-      if (headReadPending) return "Checking the current branch…";
-      return "HEAD is detached — there's no current branch to delete.";
-    }
+    if (!currentName)
+      return (
+        headUnread ?? "HEAD is detached — there's no current branch to delete."
+      );
     // The remaining arm is branch protection, which the label already states.
     return null;
   })();
   const updateFromDefaultBlockedReason = (() => {
-    if (!defaultName) {
-      if (defaultBranchReadPending) return "Checking the default branch…";
-      return "This repository has no default branch.";
-    }
-    if (!currentName) {
-      if (headReadPending) return "Checking the current branch…";
-      return "HEAD is detached — there's no branch to update.";
-    }
+    if (!defaultName)
+      return defaultBranchUnread ?? "This repository has no default branch.";
+    if (!currentName)
+      return headUnread ?? "HEAD is detached — there's no branch to update.";
     if (defaultName === currentName) return `You're already on ${defaultName}.`;
     if (busy) return "Another git operation is running.";
     return null;
   })();
-  // The three rows below share a shape: a still-loading branch list counts as
-  // zero, but a branch rule holds whether or not that list has landed — so a
-  // pending count yields to the rule arms rather than displacing them, and only
-  // a row with no rule against it reports that it's still checking.
+  // The branch-count rows below share a shape: an unanswered branch list counts
+  // as zero, but a branch rule holds whether or not that list has landed — so an
+  // unanswered count yields to the rule arms rather than displacing them, and
+  // only a row with no rule against it reports that the list isn't in yet.
   const mergeIntoCurrentBlockedReason = (() => {
     if (otherBranches.length === 0) {
-      if (!branchesReadPending)
-        return "There are no other branches to merge from.";
-      if (canMergeIntoCurrent) return "Checking branches…";
+      if (!branchesUnread) return "There are no other branches to merge from.";
+      if (canMergeIntoCurrent) return branchesUnread;
     }
     if (lockCurrent) return null; // the label says "(requires PR)"
     if (!canMergeIntoCurrent)
@@ -1336,9 +1416,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   })();
   const squashIntoCurrentBlockedReason = (() => {
     if (otherBranches.length === 0) {
-      if (!branchesReadPending)
-        return "There are no other branches to merge from.";
-      if (canSquashIntoCurrent) return "Checking branches…";
+      if (!branchesUnread) return "There are no other branches to merge from.";
+      if (canSquashIntoCurrent) return branchesUnread;
     }
     if (lockCurrent)
       return `A branch rule requires a pull request to change ${currentName}.`;
@@ -1348,40 +1427,33 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   })();
   const rebaseCurrentBlockedReason = (() => {
     if (otherBranches.length === 0) {
-      if (!branchesReadPending)
-        return "There are no other branches to rebase onto.";
-      if (!lockCurrent) return "Checking branches…";
+      if (!branchesUnread) return "There are no other branches to rebase onto.";
+      if (!lockCurrent) return branchesUnread;
     }
     if (lockCurrent)
       return `A branch rule requires a pull request to change ${currentName}.`;
     return null;
   })();
   const changeBaseBlockedReason = (() => {
-    if (!currentName) {
-      if (headReadPending) return "Checking the current branch…";
-      return "HEAD is detached — there's no branch to rebase.";
-    }
+    if (!currentName)
+      return headUnread ?? "HEAD is detached — there's no branch to rebase.";
     if (otherBranches.length < 2) {
-      if (!branchesReadPending)
+      if (!branchesUnread)
         return "Changing the base needs at least two other branches.";
       // `busy` joins the rule arms here: it too is true right now, whatever the
       // branch count turns out to be.
-      if (!lockCurrent && !busy) return "Checking branches…";
+      if (!lockCurrent && !busy) return branchesUnread;
     }
     if (lockCurrent)
       return `A branch rule requires a pull request to change ${currentName}.`;
     if (busy) return "Another git operation is running.";
     return null;
   })();
-  const noChangesBlockedReason = headReadPending
-    ? "Checking for uncommitted changes…"
-    : "There are no uncommitted changes.";
-  const popStashBlockedReason = stashCountReadPending
-    ? "Checking for stashes…"
-    : "There are no stashes to pop.";
-  const viewStashesBlockedReason = stashCountReadPending
-    ? "Checking for stashes…"
-    : "There are no stashes.";
+  const noChangesBlockedReason =
+    changesUnread ?? "There are no uncommitted changes.";
+  const popStashBlockedReason =
+    stashCountUnread ?? "There are no stashes to pop.";
+  const viewStashesBlockedReason = stashCountUnread ?? "There are no stashes.";
 
   // Hotkey handlers reuse the menu's own flows, so every gate (clean tree,
   // stash count, picker availability) and confirm dialog applies equally.
@@ -1573,11 +1645,17 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   useHotkeyAction("discard-all", () => setDiscardAllOpen(true), hasChanges);
   // Cross-worktree navigation (palette-only). They can fire while the popover is
   // closed, so they can't rely on the open-gated `userWorktrees` cache — fetch
-  // the worktree list fresh, like the delete-branch off-switch does.
+  // the worktree list fresh, like the delete-branch off-switch does. Both then
+  // re-check the live repo before acting on the answer: the lookup outlives the
+  // render it started in, and acting on its answer after a repo switch would
+  // navigate to (or offer to promote) a worktree of the repo the user just left.
+  // `useOpenWorktree`'s own guard can't see this window — it captures the live
+  // repo when it is CALLED, which is already after this await.
   useHotkeyAction("open-main-workspace", async () => {
     setOpen(false);
     try {
       const wts = await listUserWorktrees(repoPath);
+      if (useUiStore.getState().repoPath !== repoPath) return;
       const main = wts.find((w) => w.isMain);
       if (!main) {
         toast.error("Couldn't find the main workspace for this repository.");
@@ -1596,6 +1674,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     setOpen(false);
     try {
       const wts = await listUserWorktrees(repoPath);
+      if (useUiStore.getState().repoPath !== repoPath) return;
       const here = wts.find((w) => normPath(w.path) === normPath(repoPath));
       if (!here || here.isMain) {
         toast.info(
@@ -1641,13 +1720,18 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       (w) => w.path === worktreeByBranch.get(branch.name),
     );
     const inWorktree = rowWorktree !== undefined;
+    // `worktreeByBranch` admits the main workspace (it's a worktree to git, and
+    // any checkout other than the active one qualifies), so the strings that NAME
+    // this row's holding checkout come from the record instead of saying
+    // "worktree" flat.
+    const rowCopy = rowCheckoutCopy(rowWorktree?.isMain);
     const rowWorktreeRemoving = Boolean(
       rowWorktree && removingPaths.has(rowWorktree.path),
     );
     const wtLabel = (label: string, otherReason?: string) =>
       worktreeItemLabel(label, rowWorktreeRemoving, otherReason);
     const renameWorktreeBlockedReason = (() => {
-      if (rowWorktree?.isMain) return "main workspace";
+      if (rowWorktree?.isMain) return rowCopy.noun;
       if (rowWorktree?.isLocked) return "locked";
       return undefined;
     })();
@@ -1672,7 +1756,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         return null;
       if (userWorktrees.data === undefined && !userWorktrees.isError)
         return "checking worktrees…";
-      if (inWorktree) return "checked out in another worktree";
+      if (inWorktree) return rowCopy.blocked;
       return null;
     })();
     // Outbound sync gating. `pushable` = tracked on a KNOWN remote and ahead →
@@ -1809,15 +1893,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     </span>
                   );
                 })()}
-                {inWorktree && (
+                {rowWorktree && (
                   <span
                     className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
-                    title={`Checked out in worktree ${baseName(
-                      worktreeByBranch.get(branch.name) ?? "",
-                    )} (${worktreeByBranch.get(branch.name)}) — this row opens it`}
+                    title={rowCopy.title(rowWorktree.path)}
                   >
                     <TreeStructureIcon className="size-3" weight="bold" />
-                    worktree
+                    {rowCopy.noun}
                   </span>
                 )}
                 {/* Two distinct indicators: the sync indicator shows the
@@ -2094,7 +2176,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   openWorktree(rowWorktree.path);
                 }}
               >
-                {wtLabel("Open worktree")}
+                {wtLabel(rowCopy.open)}
               </ContextMenuItem>
               {/* Copying a path acts on nothing, so a removal doesn't block it. */}
               <ContextMenuItem
@@ -2173,7 +2255,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
               >
                 {wtLabel(
                   "Delete worktree…",
-                  rowWorktree.isMain ? "main workspace" : undefined,
+                  rowWorktree.isMain ? rowCopy.noun : undefined,
                 )}
               </ContextMenuItem>
               <ContextMenuSeparator />
@@ -2189,7 +2271,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             {deletionBlocked
               ? "Delete branch… (protected)"
               : inWorktree
-                ? "Delete branch… (in worktree)"
+                ? `Delete branch… (${rowCopy.held})`
                 : "Delete branch…"}
           </ContextMenuItem>
         </ContextMenuContent>

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -64,6 +64,7 @@ import {
   useRemoteBranches,
   useRemotes,
   useRepoStatus,
+  userWorktreesOptions,
   useSetBranchArchived,
   useStashAll,
   useStashCount,
@@ -72,7 +73,6 @@ import {
   useUnlockUserWorktree,
   useUpdateBranchFrom,
   useUserWorktrees,
-  worktreeKey,
 } from "@/lib/git/queries";
 import type { Branch, ForkPrMatch, RemoteBranch } from "@/lib/git/types";
 import { listUserWorktrees, type UserWorktree } from "@/lib/git/worktree";
@@ -98,6 +98,7 @@ import { useConfirm } from "@/lib/stores/confirm";
 import { type SelectedPr, useUiStore } from "@/lib/stores/ui";
 import {
   isWorktreePromoting,
+  useWorktreeRemovalStore,
   useWorktreeRemovals,
   WORKTREE_PROMOTING_MESSAGE,
 } from "@/lib/stores/worktree-removal";
@@ -830,9 +831,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       (userWorktrees.data === undefined || userWorktrees.isFetching)
     ) {
       try {
+        // Shared options, not a second spelling: this key's `networkMode:
+        // "always"` is what keeps an offline read from PARKING forever, and a
+        // parked fetch would hang this await with the popover already closed —
+        // no navigation, no checkout, no toast. `retry: false` drops the
+        // client's one retry plus backoff when this call STARTS the fetch; a
+        // call that joins one already in flight inherits that fetch's options.
         const wts = await queryClient.fetchQuery({
-          queryKey: worktreeKey(repoPath),
-          queryFn: () => listUserWorktrees(repoPath),
+          ...userWorktreesOptions(repoPath),
+          retry: false,
         });
         resolvedHere = wts.find(
           (w) => w.branch === name && normPath(w.path) !== activeNorm,
@@ -851,7 +858,19 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (wtPath) {
       // Its folder is on its way out — opening it would land the app in a
       // directory mid-deletion.
-      if (refuseWhileLeaving(wtPath, removingPaths.has(wtPath))) return;
+      // Read at FIRE time, not from the render's Set: this line can run after
+      // the lookup's await, and a removal that started meanwhile would be
+      // invisible to a pre-await snapshot. `refuseWhileLeaving` already reads
+      // the promote half live; this is its removal twin.
+      if (
+        refuseWhileLeaving(
+          wtPath,
+          Boolean(
+            useWorktreeRemovalStore.getState().byRepo[repoPath]?.[wtPath],
+          ),
+        )
+      )
+        return;
       // Awaited for its verdict: it resolves false both when the open failed
       // (it toasts that itself) and when the user switched repos mid-validate
       // (silent by design) — a success toast over either would claim a

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -736,6 +736,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // `switchTo` can resume on a worktree lookup that outlived the render it
   // started in, and a tree that turned dirty meanwhile must still get the
   // bring/stash choice instead of a silent checkout.
+  // Which switch attempt is current. `switchTo` can suspend on the worktree
+  // lookup, and the popover reopens long before a stalled `git worktree list`
+  // returns — so a later attempt must be able to retire an earlier one rather
+  // than both acting.
+  const switchRequestRef = useRef(0);
   const hasChangesRef = useRef(hasChanges);
   useEffect(() => {
     hasChangesRef.current = hasChanges;
@@ -806,6 +811,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // navigates, and it can still be in flight when the click lands.
   async function switchTo(name: string, remote: string | null = null) {
     if (amending) return; // guarded by the disabled trigger; belt-and-suspenders
+    // Claimed after the amending bail so a no-op click can't retire a real
+    // attempt that is still resolving.
+    const switchRequest = ++switchRequestRef.current;
     setOpen(false);
     // A branch checked out in another worktree can't be checked out here (git
     // forbids it), so the row navigates there instead. No confirm on the badged
@@ -848,12 +856,21 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       } catch {
         // fall through
       }
-      // BELOW the try/catch, so every exit from the lookup passes it — resolved,
-      // rejected, and found-nothing alike. This await outlives the render it
-      // started in, and everything past here is a repo-bound global write
-      // (navigate, checkout, or the bring/stash dialog); the user can switch
-      // repositories meanwhile, and acting then targets the repo they left.
-      if (useUiStore.getState().repoPath !== repoPath) return;
+      // BELOW the try/catch, so every exit passes it — resolved, rejected, and
+      // found-nothing alike. This await outlives its render and everything past
+      // here is a global write, so each pre-await read is re-taken: the repo
+      // (acting would target the one the user left), the attempt (the popover
+      // reopens while a stalled lookup is out, so a later pick already started
+      // its own switch), and amend mode (entered elsewhere meanwhile; a
+      // checkout would strand it). The rest already read live — `hasChangesRef`
+      // and the removal store below.
+      const live = useUiStore.getState();
+      if (
+        switchRequest !== switchRequestRef.current ||
+        live.repoPath !== repoPath ||
+        live.amendingHash !== null
+      )
+        return;
     }
     if (wtPath) {
       // Its folder is on its way out — opening it would land the app in a

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -817,11 +817,16 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // local branch by construction, so no worktree can hold it and the lookup
     // would only delay the checkout by a subprocess.
     let resolvedHere: UserWorktree | undefined;
+    // Only a NEGATIVE answer is distrusted: a hit is still a hit (removal is
+    // `refuseWhileLeaving`'s job), but a miss is worthless while the list is
+    // unanswered OR being refetched — react-query serves the previous data
+    // through a refetch, and every worktree mutation invalidates this key, so
+    // the miss right after one is exactly the wrong answer.
     if (
       remote === null &&
       !wtPath &&
-      userWorktrees.data === undefined &&
-      !userWorktrees.isError
+      !userWorktrees.isError &&
+      (userWorktrees.data === undefined || userWorktrees.isFetching)
     ) {
       try {
         const wts = await listUserWorktrees(repoPath);

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -1471,7 +1471,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     () => {
       // Target: the highlighted row when the list is open, else the current
       // branch. An open list with a highlight that resolves to no local branch
-      // (remote-only row / worktree path) is a real miss, not a fallback.
+      // (a remote-only row) is a real miss, not a fallback.
       let branch: Branch | undefined;
       if (open && activeBranch) {
         branch = branches.data?.find((b) => b.name === activeBranch);
@@ -1665,7 +1665,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         toast.info("Already in the main workspace.");
         return;
       }
-      openWorktree(main.path);
+      void openWorktree(main.path);
     } catch (e) {
       toastError(e);
     }
@@ -2173,7 +2173,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   if (refuseWhileLeaving(rowWorktree.path, rowWorktreeRemoving))
                     return;
                   setOpen(false);
-                  openWorktree(rowWorktree.path);
+                  void openWorktree(rowWorktree.path);
                 }}
               >
                 {wtLabel(rowCopy.open)}
@@ -2429,7 +2429,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       className="shrink-0 cursor-pointer font-medium text-primary hover:underline"
                       onClick={() => {
                         setOpen(false);
-                        openWorktree(mainWorktree.path);
+                        void openWorktree(mainWorktree.path);
                       }}
                     >
                       Open main workspace

--- a/src/features/repository/CleanupBranchesDialog.tsx
+++ b/src/features/repository/CleanupBranchesDialog.tsx
@@ -97,9 +97,10 @@ export type WorktreeCheckState = "pending" | "failed" | "checked";
  *
  *  A PARKED read (react-query's offline mode) counts as failed rather than
  *  pending: nothing will resolve it on its own, so the list must paint with the
- *  caveat instead of waiting out the session. `useUserWorktrees` sets
- *  `networkMode: "always"` for its local git read, which should keep that arm
- *  unreachable — it is the net for a caller that doesn't.
+ *  caveat instead of waiting out the session. `userWorktreesOptions` sets
+ *  `networkMode: "always"` for that local git read — shared by the hook and by
+ *  the switcher's imperative `fetchQuery` — which should keep that arm
+ *  unreachable; this is the net for a caller that doesn't.
  *
  *  Placeholder data is a stand-in for another key's rows, never an answer about
  *  this repo, so it reads as pending. That query sets no placeholder today; this

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -534,7 +534,7 @@ function RowTags({
 /** A disabled menu item can't carry a tooltip, so its blocking reason rides the
  *  label. A removal in progress outranks the other reasons — the worktree is on
  *  its way out, whatever else is true of it. Shared with the branch switcher's
- *  worktree rows and its badged-branch Delete item, not just this manager. */
+ *  badged-branch worktree items, not just this manager. */
 export function worktreeItemLabel(
   label: string,
   isRemoving: boolean,

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -159,16 +159,22 @@ export function useOpenRepoByPath() {
 export function useOpenWorktree() {
   const openRepo = useUiStore((s) => s.openRepo);
   return useCallback(
-    async (path: string) => {
+    async (path: string, stillWanted?: () => boolean) => {
       // `openRepo` writes GLOBAL navigation state, so it may only fire while the
       // app is still on the repo this call started from — the user can switch
       // repositories while `validateRepo` runs, and an unguarded write would yank
       // them back into the previous repo's worktree. The toast stays
       // unconditional: the validation failed wherever they are now.
+      //
+      // `stillWanted` covers what the repo check can't: a caller sequencing
+      // several opens (the branch switcher) can have the user pick again while
+      // THIS validate runs, and the repo is unchanged in that case. A caller
+      // whose open stands alone passes nothing.
       const firedOn = useUiStore.getState().repoPath;
       try {
         const info = await validateRepo(path);
         if (useUiStore.getState().repoPath !== firedOn) return false;
+        if (stillWanted && !stillWanted()) return false;
         openRepo(info);
         return true;
       } catch (e) {

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -150,11 +150,17 @@ export function useOpenRepoByPath() {
  * are child checkouts of a repo already in the switcher, not first-class repos.
  *
  * Resolves TRUE only once the app is actually in the worktree — false when the
- * open failed (which toasts) or was abandoned because the user switched repos
- * meanwhile (which is silent). A caller that reports the navigation to the user
- * must await this and gate on it; callers that only navigate ignore the value,
- * awaited or not. The guard reads the live repo when this is CALLED, so a caller
- * that awaits something else FIRST needs its own check before calling.
+ * open failed (which toasts), when the user switched repos meanwhile, or when
+ * `stillWanted` retired it; the latter two are silent. A caller that reports the
+ * navigation to the user must await this and gate on it; callers that only
+ * navigate ignore the value, awaited or not. The guard reads the live repo when
+ * this is CALLED, so a caller that awaits something else FIRST needs its own
+ * check before calling.
+ *
+ * @param stillWanted Re-checked after `validateRepo`, for a caller that
+ * sequences several opens: a newer one can start while this validate runs, and
+ * the repo is unchanged in that case, so only the caller knows it is stale. A
+ * standalone open passes nothing.
  */
 export function useOpenWorktree() {
   const openRepo = useUiStore((s) => s.openRepo);

--- a/src/features/repository/useOpenRepoByPath.ts
+++ b/src/features/repository/useOpenRepoByPath.ts
@@ -148,16 +148,32 @@ export function useOpenRepoByPath() {
  * resolves it to the worktree root — so opening it Just Works. Unlike
  * {@link useOpenRepoByPath} this does NOT record the path in recents: worktrees
  * are child checkouts of a repo already in the switcher, not first-class repos.
+ *
+ * Resolves TRUE only once the app is actually in the worktree — false when the
+ * open failed (which toasts) or was abandoned because the user switched repos
+ * meanwhile (which is silent). A caller that reports the navigation to the user
+ * must await this and gate on it; callers that only navigate ignore the value,
+ * awaited or not. The guard reads the live repo when this is CALLED, so a caller
+ * that awaits something else FIRST needs its own check before calling.
  */
 export function useOpenWorktree() {
   const openRepo = useUiStore((s) => s.openRepo);
   return useCallback(
     async (path: string) => {
+      // `openRepo` writes GLOBAL navigation state, so it may only fire while the
+      // app is still on the repo this call started from — the user can switch
+      // repositories while `validateRepo` runs, and an unguarded write would yank
+      // them back into the previous repo's worktree. The toast stays
+      // unconditional: the validation failed wherever they are now.
+      const firedOn = useUiStore.getState().repoPath;
       try {
         const info = await validateRepo(path);
+        if (useUiStore.getState().repoPath !== firedOn) return false;
         openRepo(info);
+        return true;
       } catch (e) {
         toastError(e);
+        return false;
       }
     },
     [openRepo],

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -284,18 +284,26 @@ export function useRemoteBranches(repo: string, enabled = true) {
 export const worktreeKey = (repo: string) =>
   ["repo", repo, "user-worktrees"] as const;
 
+/** Shared so an imperative `fetchQuery` on this key can't run under different
+ *  options than the hook: a local `git worktree list` read, and react-query's
+ *  default "online" mode parks the fetch whenever the OS reports no connection —
+ *  a parked query is neither loading nor errored, so a consumer awaiting one
+ *  waits forever. */
+export function userWorktreesOptions(repo: string) {
+  return {
+    queryKey: worktreeKey(repo),
+    queryFn: () => listUserWorktrees(repo),
+    networkMode: "always" as const,
+  };
+}
+
 /** The repo's user-facing worktrees (session worktrees filtered out by the
  *  backend). `enabled` gates the fetch to the surface asking for it — the
  *  manager, the branch switcher and its cleanup dialog, the branch pickers. */
 export function useUserWorktrees(repo: string, enabled = true) {
   return useQuery({
-    queryKey: worktreeKey(repo),
-    queryFn: () => listUserWorktrees(repo),
+    ...userWorktreesOptions(repo),
     enabled: enabled && Boolean(repo),
-    // A local `git worktree list` read. react-query's default "online" mode
-    // parks the fetch whenever the OS reports no connection, and a parked query
-    // is neither loading nor errored — a consumer waiting on it waits forever.
-    networkMode: "always",
   });
 }
 


### PR DESCRIPTION
Selecting a branch that's checked out in another worktree now opens that worktree directly instead of routing through a confirm dialog, and the branch's own row becomes the single place its worktree is managed. This collapses the branch switcher's duplicate listing of a branch (once as a branch row, once in a separate *Worktrees* section) into one row per branch, and adds spoken reasons to every held action row in the dropdown.

### Branch switcher (`src/features/repository/BranchSwitcher.tsx`)

- `switchTo` becomes async: when a local branch's worktree answer hasn't landed yet (`userWorktrees.data === undefined` and not errored), it calls `listUserWorktrees(repoPath)` before deciding, so a click on a not-yet-resolved row navigates rather than falling into a checkout git will refuse. Remote-only rows skip the lookup by construction. Call sites now `void switchTo(…)`.
- Removes the `worktreeSwitchTarget` state, its `useRetained` mirror, and the "Open worktree?" `ConfirmDialog` — a badged row calls `openWorktree` directly, still gated by `refuseWhileLeaving` for a worktree mid-removal.
- Adds `hasChangesRef` (kept in sync via `useEffect`), so the bring/stash choice is decided on the live dirty-tree answer after `switchTo`'s await rather than the value captured at render.
- Deletes the whole **Worktrees** section (`otherWorktrees` list, its rows and per-row context menus) from the dropdown, and drops those rows from `navBranches` keyboard nav. `otherWorktrees` is replaced by `linkedWorktreeCount` (non-main only), which feeds the new **Worktrees (N)…** row.
- Moves the full worktree action set onto the badged branch row's context menu, hanging off `rowWorktree`: **Open worktree**, **Copy path**, **Rename worktree…**, **Lock…**/**Unlock**, **Promote to main workspace…**, **Delete worktree…**, with the existing `worktreeItemLabel` reasons (`main workspace`, `locked`, removal in progress) via a local `wtLabel` helper and `renameWorktreeBlockedReason`.
- Disambiguates the branch's own items as **Rename branch…** / **Delete branch… (protected|in worktree)** so they can't be read as worktree actions, and rewrites the `worktree` chip tooltip to name the folder and say the row opens it.
- Adds a **Worktrees (N)…** row that `dispatchAction("worktrees")` rather than mounting a second `WorktreesDialog`, with a `toast.error` fallback when no handler is registered; the comment records why ownership stays in `RepositoryMenu`.

### Disabled-reason coverage in the dropdown

- `MenuRow` gains a `reason` prop and routes through `useDisabledReason` / `ARIA_DISABLED_CLASS` from `@/lib/use-disabled-reason`, wrapping the button in a block-level `span` that carries the `title` and an `sr-only` reason node referenced by `aria-describedby`.
- Adds per-row reason expressions ordered to match each row's own `disabled` arms: `renameCurrentBlockedReason`, `deleteCurrentBlockedReason`, `updateFromDefaultBlockedReason`, `mergeIntoCurrentBlockedReason`, `squashIntoCurrentBlockedReason`, `rebaseCurrentBlockedReason`, `changeBaseBlockedReason`, `noChangesBlockedReason`, `popStashBlockedReason`, `viewStashesBlockedReason`. Each distinguishes "still checking" from a real absence using the query `isPending` flags (`status`, `defaultBranch`, `branches`, `stashCount`), so an unanswered read never asserts a false absence; rows whose label already states the reason pass `null`.

### Documentation

- `changelog.d/changed-branch-dropdown-worktrees.md` — new `changed` fragment covering one-click worktree open, the branch-row action set, **Worktrees…**, and the spoken reasons.
- `src/features/help/content.ts` — rewrites the *Worktrees* guide section: **Worktrees (N)…** as a third entry point, "every branch appears exactly once", the badged row owning the worktree action group, the **Rename branch…**/**Delete branch…** naming, and the note that a detached-checkout worktree appears only in the dialog since no branch row can host it.
- `README.md` — updates the worktrees bullet to describe selecting a badged branch opening its worktree, the branch context menu carrying every worktree action, and the *Worktrees* row.
- `site/src/content/blog/work-on-two-branches-at-once.md` — corrects the paragraph that said choosing a badged branch "offers to open that worktree"; it now opens it.
- `src/features/repository/WorktreesDialog.tsx` — updates the `worktreeItemLabel` doc comment to name its remaining consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branches checked out in another worktree now open that folder directly.
  * Added worktree actions—including open, copy path, rename, lock/unlock, promote, and delete—to the branch menu.
  * Added a **Worktrees…** option to open the full Worktrees manager.
  * Unavailable actions now explain why they cannot be used.

* **Bug Fixes**
  * Improved worktree navigation reliability when repositories change during loading or validation.

* **Documentation**
  * Updated help, blog, README, and changelog content with the latest worktree navigation and management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->