### PR TITLE
fix(repository,branches,worktrees): keep header identity and guard promotion updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ PR badge.
 - **Local branch-protection rules**: naming, merge methods, require-PR, and
   force-push rules, shareable via a committed file or importable from
   GitHub. A promotion-branches list marks pull requests from those branches
-  as promotions and withholds the one-click update from the default branch,
-  on their PRs and in the branch menus alike, so promotion flows keep their
-  direction.
+  as promotions: their PRs stop offering the update from the base, and the
+  branch menus withhold the one-click update from the default branch, so
+  promotion flows keep their direction.
 
 ### History
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ PR badge.
 - **Local branch-protection rules**: naming, merge methods, require-PR, and
   force-push rules, shareable via a committed file or importable from
   GitHub. A promotion-branches list marks pull requests from those branches
-  as promotions, so GitDesktop stops offering to update them from their
-  base.
+  as promotions and withholds the one-click update from the default branch,
+  on their PRs and in the branch menus alike, so promotion flows keep their
+  direction.
 
 ### History
 

--- a/changelog.d/changed-sidebar-toggle-stays-top.md
+++ b/changelog.d/changed-sidebar-toggle-stays-top.md
@@ -1,0 +1,2 @@
+- The sidebar collapse control keeps one home: collapsed, it sits at the top of the icon
+  rail, above the tab icons, right where the expanded control lives.

--- a/changelog.d/changed-sidebar-toggle-stays-top.md
+++ b/changelog.d/changed-sidebar-toggle-stays-top.md
@@ -1,2 +1,2 @@
-- The sidebar collapse control keeps one home: collapsed, it sits at the top of the icon
-  rail, above the tab icons, right where the expanded control lives.
+- The sidebar collapse control stays in the tab row when expanded and sits at the top
+  of the icon rail, above the tab icons, when collapsed.

--- a/changelog.d/changed-worktree-header-identity.md
+++ b/changelog.d/changed-worktree-header-identity.md
@@ -1,0 +1,4 @@
+- Opening a linked worktree keeps the repository's name in the header, with the
+  worktree named beneath it, so you can always see which repository you're in — and
+  the repo switcher highlights the main workspace's entry while you're in one of its
+  worktrees.

--- a/changelog.d/fixed-promotion-branch-update-guard.md
+++ b/changelog.d/fixed-promotion-branch-update-guard.md
@@ -1,0 +1,3 @@
+- Promotion branches (from **Branch rules**) keep their direction of travel:
+  **Update from the default branch** is withheld on them, menu items and shortcut
+  alike, with the reason on the label. Updating one from its own upstream still works.

--- a/changelog.d/fixed-view-on-host-first-frame.md
+++ b/changelog.d/fixed-view-on-host-first-frame.md
@@ -1,0 +1,2 @@
+- **View on GitHub / GitLab / Bitbucket** and its shortcut are ready as a repository
+  opens, using the host GitDesktop already knows for it.

--- a/changelog.d/fixed-worktree-archive-offer.md
+++ b/changelog.d/fixed-worktree-archive-offer.md
@@ -1,0 +1,2 @@
+- The **Delete worktree** dialog says when the worktree's branch is already archived, and
+  the completion message matches the removal exactly.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -498,7 +498,8 @@ export const capabilities: Capability[] = [
   { group: "Admin & settings", label: "Branch-protection rules, locally" },
   {
     group: "Admin & settings",
-    label: "Promotion branches — no Update-branch on staging→production PRs",
+    label:
+      "Promotion branches — update offers withheld on their PRs and branch menus",
   },
   {
     group: "Admin & settings",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -92,9 +92,9 @@ rail always says where you are.
 The lists those tabs open (changes, commits, pull requests) fill the **sidebar** down
 the left. It narrows as you narrow the window, and collapses to a strip of tab icons:
 use the button at the end of the tab row, {{kbd:toggle-sidebar}}, or the command
-palette. Collapsed, the detail pane takes the full width and the icons still switch
-tabs; your filters, selections, and scroll position are all where you left them when
-you expand it again.
+palette. Collapsed, that same button sits at the top of the icon strip, the detail pane
+takes the full width, and the icons still switch tabs; your filters, selections, and
+scroll position are all where you left them when you expand it again.
 
 Switch tabs with the number keys ({{kbd:tab-changes}} through {{kbd:tab-insights}}; see
 *Keyboard & navigation*). Issues, Discussions, Actions, and Tags need \`gh\` and a
@@ -659,7 +659,9 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and the stash is kept as a backup. Your choice is remembered for next time.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it
   from the default branch** ({{kbd:update-from-default}}) — the last *without* checking it
-  out.
+  out. On a branch listed under **Promotion branches** in *Branch rules*, that update offer
+  is withheld, since a promotion branch takes its changes through promotions; the reason
+  rides the menu item's label, and its own **Update from _origin/…_** is unaffected.
 - **Change base…** — from the switcher's menu or the command palette — rebases the current
   branch onto a *different* branch, for the "I branched off the wrong one" case: pick the
   branch you meant to base on and the branch you actually did, and only your branch's own
@@ -758,8 +760,10 @@ from a repo's GitHub branch-protection rules. The same dialog keeps a **Promotio
 branches** list: a pull request from a branch you name there carries work onward rather
 than catching up, so GitDesktop stops offering to update it from its base. That applies
 to the repository's own pull requests — one from a fork keeps the update offer even if
-its branch shares the name. (For server-side enforcement, use **Rules** in *Repository
-settings*.)
+its branch shares the name. The branch switcher reads the same list: on a branch named
+there, **Update from _the default branch_** is withheld from the menus and the shortcut,
+with the reason on the label, while updating that branch from its own upstream stays
+available. (For server-side enforcement, use **Rules** in *Repository settings*.)
 
 ## Worktrees
 
@@ -775,7 +779,9 @@ sits in the collapsed "Archived" section, and filter text can hide the rest.
 - **Add** a worktree on a new branch (from any base) or an existing one; it's checked out
   into its own folder, defaulting to a sibling of the repository.
 - **Open** a worktree to make it the active repository — git commands then run in that
-  folder and the window title follows. Open the main workspace to switch back.
+  folder and the window title follows. The header keeps the repository's name, with the
+  worktree named beneath it, so you always know which repo you're in. Open the main
+  workspace to switch back.
 - **Rename** a worktree to move its folder to a new name in place; its branch is unchanged.
 - **Lock** a worktree (with an optional reason) so it won't be pruned, renamed, or
   removed: renaming needs an unlock first, and deleting asks for a forced confirmation.
@@ -783,8 +789,9 @@ sits in the collapsed "Archived" section, and filter text can hide the rest.
 - **Delete** a worktree to remove its folder; its branch is kept. The dialog offers to
   **archive that branch after the worktree is removed**, so a branch you're finished with
   drops into the "Archived" section on its own (offered whenever the worktree is on a
-  branch other than the default one). A worktree with uncommitted changes, or a locked
-  one, asks before force-removing. Removing a worktree can take a few minutes, and you can
+  branch other than the default one that isn't already archived — the dialog says so when
+  it is). A worktree with uncommitted changes, or a locked one, asks before
+  force-removing. Removing a worktree can take a few minutes, and you can
   close the dialog and carry on: the removal keeps a line at the top of the repository view
   until it finishes, its row here reads **Removing…**, and the actions held while it runs
   say *removal in progress*. It runs to completion once started, so there's nothing to

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -29,6 +29,7 @@ import { Input } from "@/components/ui/input";
 import {
   isDeletionBlocked,
   isMergeMethodAllowed,
+  isPromotionBranch,
   requiresPullRequest,
 } from "@/lib/branch-rules/match";
 import {
@@ -1234,6 +1235,22 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (!defaultName || target === defaultName) return;
     const base = defaultName;
     setOpen(false);
+    // The guard below reads not-a-promotion from the stand-in config while the
+    // rules are still loading, so it would pass vacuously — refuse instead of
+    // inverting a flow a settled rule names as promotion.
+    if (rulesSettling) {
+      toast.error("Branch rules are still loading — try again in a moment");
+      return;
+    }
+    // The doors into this are already disabled for promotion branches, but a
+    // rule can change under an open menu — and this is the only refusal the
+    // hotkey path passes through.
+    if (isPromotionBranch(rulesConfig, target)) {
+      toast.error(
+        `${target} is a promotion branch — it takes changes through promotions, not updates from ${base}`,
+      );
+      return;
+    }
     try {
       const outcome = await updateBranchFrom.mutateAsync({
         branch: target,
@@ -1615,7 +1632,13 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     () => {
       if (currentName) void doUpdateFromDefault(currentName);
     },
-    Boolean(defaultName && defaultName !== currentName && !busy),
+    Boolean(
+      defaultName &&
+        defaultName !== currentName &&
+        !busy &&
+        currentName &&
+        !isPromotionBranch(rulesConfig, currentName),
+    ),
   );
   const defaultBranchRow = allBranches.find((b) => b.name === defaultName);
   // The palette's own route to the same merge the row menu offers — so it needs
@@ -1760,6 +1783,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const div = divByName.get(branch.name);
     const canUpdate = Boolean(defaultName) && branch.name !== defaultName;
     const deletionBlocked = isDeletionBlocked(rulesConfig, branch.name);
+    // A promotion branch takes its changes through promotions, so the one-click
+    // update from the default branch is withheld.
+    const rowPromotion = isPromotionBranch(rulesConfig, branch.name);
     // Archiving hides a branch from the branch surfaces, so it's refused for a
     // branch that is somewhere in use: the one you're on, the default, and one
     // another worktree has checked out. Unarchiving is never refused — an
@@ -2101,10 +2127,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
             <>
               {canUpdate && (
                 <ContextMenuItem
-                  disabled={busy}
+                  disabled={busy || rowPromotion}
                   onClick={() => void doUpdateFromDefault(branch.name)}
                 >
                   Update from {defaultName}
+                  {rowPromotion ? " (promotion branch)" : ""}
                 </ContextMenuItem>
               )}
               {/* Pull the branch's own upstream in without switching — the star
@@ -2669,7 +2696,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     !defaultName ||
                     !currentName ||
                     defaultName === currentName ||
-                    busy
+                    busy ||
+                    Boolean(
+                      currentName &&
+                        isPromotionBranch(rulesConfig, currentName),
+                    )
                   }
                   reason={updateFromDefaultBlockedReason}
                   onClick={() => {
@@ -2677,6 +2708,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   }}
                 >
                   Update from {defaultName ?? "default branch"}
+                  {currentName && isPromotionBranch(rulesConfig, currentName)
+                    ? " (promotion branch)"
+                    : ""}
                 </MenuRow>
                 <MenuRow
                   disabled={otherBranches.length === 0 || !canMergeIntoCurrent}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -833,12 +833,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // still exists, and mid-removal is `refuseWhileLeaving`'s job), but a miss
     // is worthless from a list that is unanswered or in flight, because
     // react-query serves the previous data through a refetch and every worktree
-    // mutation invalidates this key. Routed through `fetchQuery` on that same
-    // key so a click during the refetch JOINS it instead of racing it with a
-    // second `git worktree list`. A failed lookup falls through to the ordinary
-    // checkout, where git refuses with its own message. Local rows only: a
-    // remote-only row's name has no local branch by construction, so no
-    // worktree can hold it and the lookup would only add a subprocess.
+    // mutation invalidates this key. (The header's always-on observer keeps the
+    // key warm under the hook's 30s staleTime, so a miss inside that window is
+    // trusted; git's own checkout refusal backstops it.) Routed through
+    // `fetchQuery` on that same key so a click during the refetch JOINS it
+    // instead of racing it with a second `git worktree list`. A failed lookup
+    // falls through to the ordinary checkout, where git refuses with its own
+    // message. Local rows only: a remote-only row's name has no local branch
+    // by construction, so no worktree can hold it and the lookup would only
+    // add a subprocess.
     if (
       remote === null &&
       !wtPath &&
@@ -1473,6 +1476,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       return headUnread ?? "HEAD is detached — there's no branch to update.";
     if (defaultName === currentName) return `You're already on ${defaultName}.`;
     if (busy) return "Another git operation is running.";
+    // The remaining arm is the promotion rule, which the label already states.
     return null;
   })();
   // The branch-count rows below share a shape: an unanswered branch list counts

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -392,6 +392,12 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   const lockCurrent = currentName
     ? requiresPullRequest(rulesConfig, currentName)
     : false;
+  // A promotion branch takes its changes through promotions, so the one-click
+  // update from the default branch is withheld (the current-branch twin of the
+  // per-row `rowPromotion`).
+  const currentPromotion = Boolean(
+    currentName && isPromotionBranch(rulesConfig, currentName),
+  );
   const canMergeIntoCurrent =
     !lockCurrent &&
     (currentName
@@ -1008,9 +1014,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
       // git refuses to delete the checked-out branch: move off it first — onto a
       // branch not already occupied by another worktree (that checkout fails too).
       if (deleteTarget === currentName) {
-        // Fetch occupancy FRESH: the cached `worktreeByBranch` is gated on the
-        // popover or the cleanup dialog being open, and the `delete-branch`
-        // hotkey opens neither — leaving the map empty and the guard moot.
+        // Fetch occupancy FRESH: `worktreeByBranch` only observes its query
+        // while the popover or cleanup dialog is open, and even a warm cache
+        // (the header keeps one now) can be stale for a guard this destructive.
         let occupied: Set<string>;
         try {
           const wts = await listUserWorktrees(repoPath);
@@ -1637,7 +1643,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         defaultName !== currentName &&
         !busy &&
         currentName &&
-        !isPromotionBranch(rulesConfig, currentName),
+        !currentPromotion,
     ),
   );
   const defaultBranchRow = allBranches.find((b) => b.name === defaultName);
@@ -2697,10 +2703,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     !currentName ||
                     defaultName === currentName ||
                     busy ||
-                    Boolean(
-                      currentName &&
-                        isPromotionBranch(rulesConfig, currentName),
-                    )
+                    currentPromotion
                   }
                   reason={updateFromDefaultBlockedReason}
                   onClick={() => {
@@ -2708,9 +2711,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   }}
                 >
                   Update from {defaultName ?? "default branch"}
-                  {currentName && isPromotionBranch(rulesConfig, currentName)
-                    ? " (promotion branch)"
-                    : ""}
+                  {currentPromotion ? " (promotion branch)" : ""}
                 </MenuRow>
                 <MenuRow
                   disabled={otherBranches.length === 0 || !canMergeIntoCurrent}

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -147,8 +147,9 @@ export function DeleteWorktreeDialog({
         </p>
 
         {/* While a removal that recorded an archive intent runs, keep showing
-            the checkbox even if the flag lands elsewhere — the dialog's job is
-            then to show what the running removal will do. */}
+            the checkbox even if the branch is archived from another surface
+            meanwhile — the dialog's job is then to show what the running
+            removal will do. */}
         {archivableBranch &&
           (alreadyArchived && (!removing || !inFlightArchive) ? (
             <p className="text-xs text-muted-foreground">

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { useDefaultBranch } from "@/lib/git/queries";
+import { useBranches, useDefaultBranch } from "@/lib/git/queries";
 import type { UserWorktree } from "@/lib/git/worktree";
 import {
   registerRemovalListener,
@@ -73,6 +73,12 @@ export function DeleteWorktreeDialog({
     worktree?.branch && worktree.branch !== defaultBranch.data
       ? worktree.branch
       : null;
+  // Only a SETTLED true replaces the offer with the explanation: a pending or
+  // failed read must not withdraw a checkbox that would work, and the store's
+  // completion-time re-check catches a branch archived while this sat open.
+  const branches = useBranches(repoPath);
+  const alreadyArchived =
+    branches.data?.find((b) => b.name === worktree?.branch)?.archived === true;
 
   // Behind a ref because the store invokes these from its own async stack, long
   // after the render that wrote them: what gets registered is a plain object
@@ -113,7 +119,8 @@ export function DeleteWorktreeDialog({
       path: worktree.path,
       name: worktree.branch || folderName(worktree.path),
       branch: worktree.branch || null,
-      archiveWhenDone: archiveAfter && Boolean(worktree.branch),
+      archiveWhenDone:
+        archiveAfter && Boolean(worktree.branch) && !alreadyArchived,
       force,
     });
     if (refused) toast.info(refused);
@@ -139,25 +146,34 @@ export function DeleteWorktreeDialog({
           {worktree?.path}
         </p>
 
-        {archivableBranch && (
-          <label
-            className={cn(
-              "flex items-start gap-2 text-xs text-muted-foreground",
-              removing ? "cursor-not-allowed opacity-70" : "cursor-pointer",
-            )}
-          >
-            <Checkbox
-              checked={removing ? inFlightArchive : archiveAfter}
-              disabled={removing}
-              onCheckedChange={(checked) => setArchiveAfter(checked === true)}
-            />
-            <span className="min-w-0">
-              Archive{" "}
-              <span className="font-mono break-all">{archivableBranch}</span>{" "}
-              after the worktree is removed
-            </span>
-          </label>
-        )}
+        {/* While a removal that recorded an archive intent runs, keep showing
+            the checkbox even if the flag lands elsewhere — the dialog's job is
+            then to show what the running removal will do. */}
+        {archivableBranch &&
+          (alreadyArchived && (!removing || !inFlightArchive) ? (
+            <p className="text-xs text-muted-foreground">
+              <span className="font-mono break-all">{archivableBranch}</span> is
+              already archived.
+            </p>
+          ) : (
+            <label
+              className={cn(
+                "flex items-start gap-2 text-xs text-muted-foreground",
+                removing ? "cursor-not-allowed opacity-70" : "cursor-pointer",
+              )}
+            >
+              <Checkbox
+                checked={removing ? inFlightArchive : archiveAfter}
+                disabled={removing}
+                onCheckedChange={(checked) => setArchiveAfter(checked === true)}
+              />
+              <span className="min-w-0">
+                Archive{" "}
+                <span className="font-mono break-all">{archivableBranch}</span>{" "}
+                after the worktree is removed
+              </span>
+            </label>
+          ))}
 
         {worktree?.isLocked && (
           <p className="text-xs text-warning">

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -106,7 +106,10 @@ export function RepoSwitcher() {
                 worktreeName && "h-auto py-1",
               )}
             >
-              <span className="flex min-w-0 flex-col items-start">
+              {/* Default (stretch) alignment on purpose: a non-stretched column
+                  child keeps its intrinsic width, so `truncate` never engages
+                  and long names paint past the button (measured). */}
+              <span className="flex min-w-0 flex-col">
                 <span
                   className="min-w-0 truncate text-sm font-medium leading-tight"
                   onMouseEnter={clipTitle(repoLabel)}

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -4,16 +4,22 @@ import {
   DownloadSimpleIcon,
   FolderOpenIcon,
   FolderPlusIcon,
+  TreeStructureIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { clipTitle } from "@/lib/clip-title";
+import { normPath } from "@/lib/git/path";
+import { useUserWorktrees } from "@/lib/git/queries";
 import { dispatchAction, useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import type { RecentRepo } from "@/lib/settings/api";
-import { useRepoAlias } from "@/lib/settings/queries";
+import { useRepoAlias, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
+import { cn } from "@/lib/utils";
 import { RemoveRepoDialog, RepoAliasDialog } from "./RepoDialogs";
 import { RepoList } from "./RepoList";
+
+const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
 
 /** A repository action row in the switcher footer (open / clone / create). */
 function ActionRow({
@@ -40,7 +46,29 @@ function ActionRow({
 export function RepoSwitcher() {
   const repoName = useUiStore((s) => s.repoName);
   const repoPath = useUiStore((s) => s.repoPath);
-  const alias = useRepoAlias(repoPath);
+  // In a linked worktree `repoPath` names the worktree FOLDER, so the slot would
+  // forget which repository you're in — line 1 keeps the repo, the worktree drops
+  // to a subtitle. Unconditional: this is a cheap local `git worktree list` and
+  // the header is always mounted.
+  const worktrees = useUserWorktrees(repoPath ?? "");
+  const worktreeList = worktrees.data ?? [];
+  const activeNorm = normPath(repoPath ?? "");
+  const currentWt = worktreeList.find((w) => normPath(w.path) === activeNorm);
+  const mainWt = worktreeList.find((w) => w.isMain);
+  const inLinkedWorktree = Boolean(currentWt && !currentWt.isMain);
+  const settings = useSettings();
+  // The alias lookup and the picker's highlight both compare paths by exact
+  // string, but git prints forward slashes while the app stores native
+  // separators — so resolve the main worktree to its recents row's own spelling
+  // before handing it to either. Unlisted (or not in a worktree) falls through
+  // to the path we already have.
+  const mainRepoPath =
+    inLinkedWorktree && mainWt
+      ? (settings.data?.recentRepos.find(
+          (r) => normPath(r.path) === normPath(mainWt.path),
+        )?.path ?? mainWt.path)
+      : repoPath;
+  const alias = useRepoAlias(mainRepoPath);
   const [open, setOpen] = useState(false);
   // Dialogs live outside the popover: closing it unmounts its contents.
   const [aliasTarget, setAliasTarget] = useState<RecentRepo | null>(null);
@@ -48,7 +76,15 @@ export function RepoSwitcher() {
 
   useHotkeyAction("show-repositories", () => setOpen(true));
 
-  const repoLabel = alias ?? repoName ?? "Repository";
+  const repoLabel =
+    alias ??
+    (inLinkedWorktree && mainWt
+      ? baseName(mainWt.path)
+      : (repoName ?? "Repository"));
+  // Both sides must resolve — line 1 names the repo from `mainWt` — so a still
+  // loading or failed worktree query renders the plain single line.
+  const worktreeName =
+    inLinkedWorktree && currentWt && mainWt ? baseName(currentWt.path) : null;
 
   return (
     <>
@@ -63,13 +99,36 @@ export function RepoSwitcher() {
               // branch label (shrink-20) and CI badge (shrink-4) absorb header
               // space pressure — even a tiny flex-shrink share would swap
               // characters for an ellipsis. max-w-56 still caps long names.
-              className="max-w-56 min-w-0 gap-1.5"
+              // The size's fixed h-7 can't hold two lines: the worktree line
+              // grows the button, which the items-center header row re-centers.
+              className={cn(
+                "max-w-56 min-w-0 gap-1.5",
+                worktreeName && "h-auto py-1",
+              )}
             >
-              <span
-                className="min-w-0 truncate text-sm font-medium"
-                onMouseEnter={clipTitle(repoLabel)}
-              >
-                {repoLabel}
+              <span className="flex min-w-0 flex-col items-start">
+                <span
+                  className="min-w-0 truncate text-sm font-medium leading-tight"
+                  onMouseEnter={clipTitle(repoLabel)}
+                >
+                  {repoLabel}
+                </span>
+                {worktreeName ? (
+                  <span className="flex min-w-0 items-center gap-1 text-[10px] leading-tight text-muted-foreground">
+                    <TreeStructureIcon
+                      className="size-3 shrink-0"
+                      weight="bold"
+                      aria-hidden
+                    />
+                    <span className="sr-only">worktree </span>
+                    <span
+                      className="min-w-0 truncate"
+                      onMouseEnter={clipTitle(worktreeName)}
+                    >
+                      {worktreeName}
+                    </span>
+                  </span>
+                ) : null}
               </span>
               <CaretDownIcon className="shrink-0 text-muted-foreground" />
             </Button>
@@ -83,7 +142,7 @@ export function RepoSwitcher() {
           >
             <Popover.Popup className="w-80 rounded-none bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10">
               <RepoList
-                currentPath={repoPath}
+                currentPath={mainRepoPath}
                 onOpened={() => setOpen(false)}
                 onAliasRepo={(repo) => {
                   setOpen(false);

--- a/src/features/repository/RepoSwitcher.tsx
+++ b/src/features/repository/RepoSwitcher.tsx
@@ -60,14 +60,20 @@ export function RepoSwitcher() {
   // The alias lookup and the picker's highlight both compare paths by exact
   // string, but git prints forward slashes while the app stores native
   // separators — so resolve the main worktree to its recents row's own spelling
-  // before handing it to either. Unlisted (or not in a worktree) falls through
-  // to the path we already have.
-  const mainRepoPath =
+  // before handing it to either.
+  const mainRow =
     inLinkedWorktree && mainWt
-      ? (settings.data?.recentRepos.find(
+      ? settings.data?.recentRepos.find(
           (r) => normPath(r.path) === normPath(mainWt.path),
-        )?.path ?? mainWt.path)
-      : repoPath;
+        )
+      : undefined;
+  const mainRepoPath =
+    inLinkedWorktree && mainWt ? (mainRow?.path ?? mainWt.path) : repoPath;
+  // The highlight falls back to the CHECKOUT's path when the main workspace has
+  // no recents row: a worktree opened via the picker is itself a row, and that
+  // row lighting up beats highlighting nothing.
+  const pickerCurrentPath =
+    inLinkedWorktree && mainWt ? (mainRow?.path ?? repoPath) : repoPath;
   const alias = useRepoAlias(mainRepoPath);
   const [open, setOpen] = useState(false);
   // Dialogs live outside the popover: closing it unmounts its contents.
@@ -145,7 +151,7 @@ export function RepoSwitcher() {
           >
             <Popover.Popup className="w-80 rounded-none bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10">
               <RepoList
-                currentPath={mainRepoPath}
+                currentPath={pickerCurrentPath}
                 onOpened={() => setOpen(false)}
                 onAliasRepo={(repo) => {
                   setOpen(false);

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -189,6 +189,22 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const isGitLab = provider === "gitlab";
   const isBitbucket = provider === "bitbucket";
   const remoteLabel = providerLabel(provider);
+  // The forge probe ends in a network call, so a repo open leaves the view item
+  // missing for its first seconds; the recents entry's last-known provider is all
+  // that item needs (openWeb resolves the URL at click time, unauthenticated).
+  // Membership-narrowed rather than cast: it is a stored plain string, and
+  // providerLabel reads an unrecognized one as "GitHub".
+  const persistedProvider =
+    repoEntry.provider === "github" ||
+    repoEntry.provider === "gitlab" ||
+    repoEntry.provider === "bitbucket"
+      ? repoEntry.provider
+      : undefined;
+  // Star, fork, and create-issue deliberately stay on `canGh` — they need the
+  // authenticated probe, and offering them before auth is known would be worse.
+  // The probe's provider wins once resolved: it is fresher than the stored one.
+  const canViewOnHost = canGh || persistedProvider !== undefined;
+  const viewLabel = providerLabel(provider ?? persistedProvider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");
   const owner = gh.data?.repo?.split("/")[0];
@@ -349,7 +365,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   }
 
   // Every menu entry doubles as a hotkey/palette action with the same gates.
-  useHotkeyAction("view-on-github", () => openWeb(), canGh);
+  useHotkeyAction("view-on-github", () => openWeb(), canViewOnHost);
   // create-issue is the in-app dialog (registered in RepositoryView + IssuesPanel);
   // the "Create issue on {host}" menu item below still opens the web page.
   useHotkeyAction("fork-repository", forkAction, canForkHere);
@@ -426,12 +442,14 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
         <DotsThreeVerticalIcon />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-60">
+        {canViewOnHost && (
+          <DropdownMenuItem onClick={() => openWeb()}>
+            <ArrowSquareOutIcon />
+            View on {viewLabel}
+          </DropdownMenuItem>
+        )}
         {canGh && (
           <>
-            <DropdownMenuItem onClick={() => openWeb()}>
-              <ArrowSquareOutIcon />
-              View on {remoteLabel}
-            </DropdownMenuItem>
             {canStar && (
               <DropdownMenuItem disabled={setStar.isPending} onClick={doStar}>
                 <StarIcon weight={starred ? "fill" : "regular"} />
@@ -463,9 +481,11 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
                   Fork repository…
                 </DropdownMenuItem>
               ))}
-            <DropdownMenuSeparator />
           </>
         )}
+        {/* Closes the host group whenever it rendered anything — the view item's
+            gate subsumes `canGh`, so this can't outlive an empty group. */}
+        {canViewOnHost && <DropdownMenuSeparator />}
         <DropdownMenuItem
           onClick={() =>
             openInTerminal(

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -208,7 +208,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const canViewOnHost =
     canGh ||
     persistedProvider === "bitbucket" ||
-    (persistedProvider !== undefined && gh.data === undefined);
+    (persistedProvider !== undefined && gh.isPending);
   const viewLabel = providerLabel(provider ?? persistedProvider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -190,10 +190,9 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const isBitbucket = provider === "bitbucket";
   const remoteLabel = providerLabel(provider);
   // The forge probe ends in a network call, so a repo open leaves the view item
-  // missing for its first seconds; the recents entry's last-known provider is all
-  // that item needs (openWeb resolves the URL at click time, unauthenticated).
-  // Membership-narrowed rather than cast: it is a stored plain string, and
-  // providerLabel reads an unrecognized one as "GitHub".
+  // missing for its first seconds; until the probe answers, the recents entry's
+  // last-known provider stands in. Membership-narrowed rather than cast: it is a
+  // stored plain string, and providerLabel reads an unrecognized one as "GitHub".
   const persistedProvider =
     repoEntry.provider === "github" ||
     repoEntry.provider === "gitlab" ||
@@ -202,8 +201,14 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
       : undefined;
   // Star, fork, and create-issue deliberately stay on `canGh` — they need the
   // authenticated probe, and offering them before auth is known would be worse.
-  // The probe's provider wins once resolved: it is fresher than the stored one.
-  const canViewOnHost = canGh || persistedProvider !== undefined;
+  // The stand-in never outlives a SETTLED probe on GitHub/GitLab: forgeRepoUrl
+  // shells `gh repo view` / `glab api` there, so "not ready" means the click
+  // would fail. Bitbucket's resolver is a local remote parse, so its item works
+  // regardless of the probe's verdict.
+  const canViewOnHost =
+    canGh ||
+    persistedProvider === "bitbucket" ||
+    (persistedProvider !== undefined && gh.data === undefined);
   const viewLabel = providerLabel(provider ?? persistedProvider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -203,12 +203,13 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // authenticated probe, and offering them before auth is known would be worse.
   // The stand-in never outlives a SETTLED probe on GitHub/GitLab: forgeRepoUrl
   // shells `gh repo view` / `glab api` there, so "not ready" means the click
-  // would fail. Bitbucket's resolver is a local remote parse, so its item works
-  // regardless of the probe's verdict.
+  // would fail. `!isPaused` keeps an offline session (the query parks, pending
+  // forever) from counting as in-flight. Bitbucket's resolver is a local remote
+  // parse, so its item works regardless of the probe's verdict.
   const canViewOnHost =
     canGh ||
     persistedProvider === "bitbucket" ||
-    (persistedProvider !== undefined && gh.isPending);
+    (persistedProvider !== undefined && gh.isPending && !gh.isPaused);
   const viewLabel = providerLabel(provider ?? persistedProvider);
   const canStar = canGh && forgeSupports(gh.data, "stars");
   const canCreateHostIssue = canGh && forgeSupports(gh.data, "issues");

--- a/src/features/repository/RepositoryView.tsx
+++ b/src/features/repository/RepositoryView.tsx
@@ -261,8 +261,8 @@ function SidebarRail({
   secondaryTabs: { tab: RepoTab; label: string }[];
   activeSecondaryLabel: string | null;
   taskRunning: boolean;
-  /** The expand control, pinned to the rail's foot. An action, not a tab: it
-   *  stays out of the arrow-key order and is reached by Tab. */
+  /** The expand control, pinned to the rail's head above the tabs. An action,
+   *  not a tab: it stays out of the arrow-key order and is reached by Tab. */
   toggle: ReactNode;
 }) {
   const activeId: RailId =
@@ -306,6 +306,10 @@ function SidebarRail({
       className="flex min-h-0 flex-1 flex-col overflow-y-auto"
       onKeyDownCapture={onKeyDownCapture}
     >
+      {toggle}
+      {/* Separates the action from the tab icons so it doesn't read as a
+          fourth tab; sitting at the head keeps it at the top in both modes. */}
+      <div aria-hidden className="mx-3 my-1 h-px shrink-0 bg-border" />
       {RAIL_TABS.map(({ id, label, icon: Icon }) => (
         <button
           key={id}
@@ -367,9 +371,6 @@ function SidebarRail({
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      {/* `mt-auto`: the toggle sits at the rail's foot, separated from the tabs
-          by whatever height is left, without a row of its own. */}
-      <div className="mt-auto">{toggle}</div>
     </nav>
   );
 }
@@ -712,7 +713,7 @@ export function RepositoryView() {
     sidebarBinding === null
       ? sidebarToggleLabel
       : `${sidebarToggleLabel} (${formatBinding(sidebarBinding)})`;
-  // One toggle with two homes — the tab row while expanded, the icon rail's foot
+  // One toggle with two homes — the tab row while expanded, the icon rail's head
   // while collapsed — and exactly one mounted at a time (each home renders under
   // the opposite condition), so both can carry the ref the focus-return effect
   // aims at.

--- a/src/lib/branch-rules/match.ts
+++ b/src/lib/branch-rules/match.ts
@@ -87,9 +87,10 @@ export function protectionsFor(
 
 /**
  * Whether `branch` is configured as a promotion branch — a pull request FROM it
- * carries work onward rather than catching up, so the update-from-base offer is
- * withheld. The user's own assertion about this repository, so it needs no
- * topology check to back it up.
+ * carries work onward rather than catching up, so its PRs withhold the
+ * update-from-base offer and the branch menus withhold the update from the
+ * default branch. The user's own assertion about this repository, so it needs
+ * no topology check to back it up.
  */
 export function isPromotionBranch(
   config: BranchRulesConfig,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -308,8 +308,10 @@ export function useUserWorktrees(repo: string, enabled = true) {
     // On the HOOK only — the header observes this key on every open repo, so
     // without a staleTime the window-focus refetch re-spawns `git worktree
     // list` on each Alt-Tab back (mutations invalidate the key regardless).
-    // The switcher's imperative fetchQuery spreads the OPTIONS and must keep
-    // fetch-always semantics for its checkout-redirect guard.
+    // Every hook consumer shares the bound: the pickers and the cleanup
+    // dialog open on data up to 30s old, so only external git changes ride
+    // the window. The switcher's imperative fetchQuery spreads the OPTIONS
+    // and must keep fetch-always semantics for its checkout-redirect guard.
     staleTime: 30_000,
   });
 }

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -308,10 +308,10 @@ export function useUserWorktrees(repo: string, enabled = true) {
     // On the HOOK only — the header observes this key on every open repo, so
     // without a staleTime the window-focus refetch re-spawns `git worktree
     // list` on each Alt-Tab back (mutations invalidate the key regardless).
-    // Every hook consumer shares the bound: the pickers and the cleanup
-    // dialog open on data up to 30s old, so only external git changes ride
-    // the window. The switcher's imperative fetchQuery spreads the OPTIONS
-    // and must keep fetch-always semantics for its checkout-redirect guard.
+    // Every hook consumer shares the bound and opens on data up to 30s old,
+    // so only external git changes ride the window. The switcher's imperative
+    // fetchQuery spreads the OPTIONS and must keep fetch-always semantics for
+    // its checkout-redirect guard.
     staleTime: 30_000,
   });
 }

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -299,11 +299,18 @@ export function userWorktreesOptions(repo: string) {
 
 /** The repo's user-facing worktrees (session worktrees filtered out by the
  *  backend). `enabled` gates the fetch to the surface asking for it — the
- *  manager, the branch switcher and its cleanup dialog, the branch pickers. */
+ *  manager, the branch switcher and its cleanup dialog, the branch pickers;
+ *  the repo header reads it ungated for the worktree subtitle. */
 export function useUserWorktrees(repo: string, enabled = true) {
   return useQuery({
     ...userWorktreesOptions(repo),
     enabled: enabled && Boolean(repo),
+    // On the HOOK only — the header observes this key on every open repo, so
+    // without a staleTime the window-focus refetch re-spawns `git worktree
+    // list` on each Alt-Tab back (mutations invalidate the key regardless).
+    // The switcher's imperative fetchQuery spreads the OPTIONS and must keep
+    // fetch-always semantics for its checkout-redirect guard.
+    staleTime: 30_000,
   });
 }
 

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import {
+  gitBranches,
   gitCheckoutBranch,
   gitDefaultBranch,
   gitSetBranchArchived,
@@ -332,6 +333,21 @@ async function archiveAfterRemoval(repoPath: string, branch: string) {
     toast.success("Worktree removed");
     toast.info(`Left ${branch} unarchived — it's the default branch.`);
     return;
+  }
+  // Already-archived is re-resolved here too, so a branch archived from the
+  // branch menu while the removal ran doesn't produce a success toast claiming
+  // this step changed something. Unlike the default-branch read this fails
+  // OPEN: the set is idempotent, so an unreadable list must not skip an archive
+  // that would have succeeded.
+  try {
+    const found = (await gitBranches(repoPath)).find((b) => b.name === branch);
+    if (found?.archived) {
+      toast.success("Worktree removed");
+      toast.info(`${branch} was already archived.`);
+      return;
+    }
+  } catch {
+    // Fall through to the archive.
   }
   try {
     await gitSetBranchArchived(repoPath, branch, true);


### PR DESCRIPTION
Five small fixes across the repository header, branch switcher, and worktree flows. Each one closes a gap where the UI showed the wrong thing or offered an action it shouldn't: the header lost the repository name inside a linked worktree, **Update from the default branch** was offered on promotion branches, **View on GitHub** went missing for the first seconds after a repo opened, the delete-worktree dialog offered to archive an already-archived branch, and the sidebar collapse control jumped from the top of the tab row to the foot of the icon rail.

### Repository header

- `src/features/repository/RepoSwitcher.tsx` now reads `useUserWorktrees` to detect a linked worktree and keeps the repository's name on line one, with the worktree name and a `TreeStructureIcon` beneath it (plus an `sr-only` "worktree" prefix). The button switches to `h-auto py-1` only when the second line renders, since the size's fixed `h-7` can't hold two lines.
- The same file resolves `mainRepoPath` through `useSettings().recentRepos` so the alias lookup and `RepoList`'s `currentPath` highlight compare against the recents row's own path spelling — git prints forward slashes where the app stores native separators. Falls back to `mainWt.path`, then `repoPath`.
- Both `repoLabel` and `worktreeName` require `currentWt` and `mainWt` to resolve, so a pending or failed worktree query renders the plain single line.

### Branch rules on promotion branches

- `src/features/repository/BranchSwitcher.tsx` imports `isPromotionBranch` and refuses `doUpdateFromDefault` for promotion branches at the shared choke point — the only refusal the hotkey path passes through. It also refuses while `rulesSettling`, since the stand-in config would otherwise report "not a promotion branch" vacuously.
- The row `ContextMenuItem` and the current-branch `MenuRow` both disable on `rowPromotion` / `isPromotionBranch(rulesConfig, currentName)` and append `" (promotion branch)"` to the label so the reason travels with the item.
- `useHotkeyAction` for update-from-default now includes `!isPromotionBranch(rulesConfig, currentName)` in its enabled predicate. Updating a promotion branch from its own upstream is untouched.

### Worktree deletion and archiving

- `src/features/repository/DeleteWorktreeDialog.tsx` reads `useBranches` and replaces the archive checkbox with "*branch* is already archived." on a settled `archived === true`; a pending or failed read leaves the working checkbox in place. The `archiveWhenDone` payload gains the same `!alreadyArchived` condition. During a removal that already recorded an archive intent, the checkbox stays visible so the dialog reflects what the running removal will do.
- `src/lib/stores/worktree-removal.ts` re-resolves already-archived inside `archiveAfterRemoval` via `gitBranches`, so a branch archived elsewhere while the removal ran reports "*branch* was already archived." instead of a success toast claiming a change. This read fails **open** — the set is idempotent, so an unreadable list falls through to the archive rather than skipping it.

### Repository menu on first frame

- `src/features/repository/RepositoryMenu.tsx` derives `persistedProvider` from the recents entry (membership-narrowed against `"github" | "gitlab" | "bitbucket"`, not cast) and gates **View on host** plus its `view-on-github` hotkey on the new `canViewOnHost`. The label prefers the live probe's provider once resolved.
- The view item moves out of the `canGh` block; star, fork, and create-issue deliberately stay on `canGh` since they need the authenticated probe. The trailing `DropdownMenuSeparator` moves to a `canViewOnHost` gate so it can't outlive an empty host group.

### Sidebar rail

- `src/features/repository/RepositoryView.tsx` moves `toggle` to the head of `SidebarRail`, above the tab icons, with a `bg-border` hairline separating it from the tabs so it doesn't read as a fourth tab. The former `mt-auto` foot placement and the two doc comments describing it are updated.

### Documentation

- `src/features/help/content.ts`: the sidebar section notes the collapse button sits at the top of the icon strip; the branch switcher and *Branch rules* sections describe the withheld update offer and its labelled reason; the worktrees section covers the preserved header identity and the already-archived case in the delete dialog.
- Five fragments under `changelog.d/`: `changed-sidebar-toggle-stays-top.md`, `changed-worktree-header-identity.md`, `fixed-promotion-branch-update-guard.md`, `fixed-view-on-host-first-frame.md`, and `fixed-worktree-archive-offer.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Moved the collapsed-sidebar toggle to the top of the icon rail.
  - Preserved repository identity and highlighted the main workspace for linked worktrees.
  - Restricted default-branch updates for promotion branches with clearer labels.
  - Made “View on host” actions available as soon as a repository opens.
  - Improved deletion messaging for archived worktree branches and prevented duplicate archive attempts.
  - Reduced unnecessary worktree refreshes when returning to the app.

- **Documentation**
  - Clarified sidebar controls, branch update restrictions, worktree identity, pull request rules, and branch archiving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->