### PR TITLE
feat(ai,dialogs): finish AI generations after their dialog closes

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -175,7 +175,16 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   `generator-dialog-finish-and-surface` guard in `pnpm run checks` is the
   ratchet; the deliberate abort-on-close surfaces (the PR edit dialogs, branch /
   rename / task dialogs) are exempt by hook choice or by having no
-  `useSeedOnOpen`.
+  `useSeedOnOpen`. A generation belongs to the repo it started in: the hook
+  takes `repoPath` plus the dialog's own `cancel` and `close`, and a switch
+  aborts the run, drops the latch, closes an open dialog, and disarms the
+  toast's action — `<RepositoryView>` is a single instance across repo switches,
+  so dialog state outlives the repo. Two contracts the types can't enforce: the
+  seed guard is `surface.shouldSkipSeed(generating)`, never a caller-owned
+  `generating ||` arm (a cancelled run keeps that flag true through its context
+  fetch; `consumeSkipSeed` remains only for caller-side identity drains), and
+  the repo-description store delivers only while the dialog reports General
+  active, stashing otherwise.
 - Worktree actions gate on in-flight removal/promote state: menu items disable
   with the parenthetical reason riding the label (a disabled menu item can't
   carry a tooltip), and mutation choke points re-check at fire time —

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -168,6 +168,14 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   sibling). The hook returns the `hint` string so buttons can't forget it.
   Recorded exception: surfaces with several per-row generators and no
   focused-row concept (Edit history's reword buttons) carry no chord.
+- A generator dialog that stays mounted across its own close rides
+  `useFinishAndSurface` (`src/features/conversations/useAiStream.ts`) — closing
+  never cancels the run; a settle while closed latches skip-seed (the reopen
+  shows the whole draft) and toasts it with a "View" reopen. The
+  `generator-dialog-finish-and-surface` guard in `pnpm run checks` is the
+  ratchet; the deliberate abort-on-close surfaces (the PR edit dialogs, branch /
+  rename / task dialogs) are exempt by hook choice or by having no
+  `useSeedOnOpen`.
 - Worktree actions gate on in-flight removal/promote state: menu items disable
   with the parenthetical reason riding the label (a disabled menu item can't
   carry a tooltip), and mutation choke points re-check at fire time —

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -175,16 +175,20 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   `generator-dialog-finish-and-surface` guard in `pnpm run checks` is the
   ratchet; the deliberate abort-on-close surfaces (the PR edit dialogs, branch /
   rename / task dialogs) are exempt by hook choice or by having no
-  `useSeedOnOpen`. A generation belongs to the repo it started in: the hook
-  takes `repoPath` plus the dialog's own `cancel` and `close`, and a switch
-  aborts the run, drops the latch, closes an open dialog, and disarms the
-  toast's action — `<RepositoryView>` is a single instance across repo switches,
-  so dialog state outlives the repo. Two contracts the types can't enforce: the
+  `useSeedOnOpen`. A generation belongs to the repo it started in: the hook takes
+  `repoPath` plus the dialog's own `cancel` and `close`, and a switch aborts the
+  run and closes an open dialog — `<RepositoryView>` is a single instance across
+  repo switches, so dialog state outlives the repo. A settled-unseen latch is
+  STAMPED with its run's repo and survives navigation; the first open releases
+  it, this repo's showing the draft and a foreign one destroying latch and toast
+  with the form its seed resets, while the toast's View re-checks the live repo
+  and names the origin on mismatch. Two contracts the types can't enforce: the
   seed guard is `surface.shouldSkipSeed(generating)`, never a caller-owned
   `generating ||` arm (a cancelled run keeps that flag true through its context
-  fetch; `consumeSkipSeed` remains only for caller-side identity drains), and
-  the repo-description store delivers only while the dialog reports General
-  active, stashing otherwise.
+  fetch; `consumeSkipSeed` is only for a caller discarding the waiting draft on
+  purpose — an identity axis that moved on, or an explicit draft request that
+  outranks it), and the repo-description store delivers only while the dialog
+  reports General active, stashing otherwise.
 - Worktree actions gate on in-flight removal/promote state: menu items disable
   with the parenthetical reason riding the label (a disabled menu item can't
   carry a tooltip), and mutation choke points re-check at fire time —

--- a/changelog.d/changed-ai-generate-finish-and-surface.md
+++ b/changelog.d/changed-ai-generate-finish-and-surface.md
@@ -1,0 +1,5 @@
+- An AI draft you start in a create dialog keeps running after you close the
+  dialog: reopen it and the whole draft is waiting, or press **View** on the
+  toast that announces it. Repository-settings description generations survive
+  closing settings the same way, and Enter submits a dialog exactly when its
+  submit button would.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -415,6 +415,22 @@ const EDITABLE_GUARD_RE = /\bisEditableTarget\s*\(/;
 const TYPEAHEAD_GUARD_RE = /\bisTypeaheadTarget\s*\(/;
 const TYPEAHEAD_KEY_RE = /\bisTypeaheadKey\s*\(/;
 
+// A generator dialog that stays mounted across its own close: a one-shot AI
+// generator hook, in a file that also seeds on open. Both halves are needed —
+// the generator is what a close would otherwise strand, and `useSeedOnOpen` is
+// what would wipe the finished draft on the next open. Surfaces with a
+// deliberate abort-on-close (the PR/issue EDIT dialogs, TaskDialog) carry no
+// seed-on-open, and the branch-name / commit-message generators are not in the
+// list, so both stay out by construction rather than by allowlist.
+// The hook list is explicit rather than a `useGenerate\w+` shape: the chord and
+// the commit-message path share that prefix without owning a dialog draft.
+// Bounded to .tsx, which is what keeps each hook's own definition file (a .ts
+// whose export line matches the call pattern) from reading as a call site.
+const GENERATOR_HOOK_RE =
+  /\buse(?:GeneratePrDescription|GenerateIssueDraft|GenerateReleaseNotes|GenerateRepoDescription)\s*\(/;
+const USE_SEED_ON_OPEN_CALL_RE = /\buseSeedOnOpen\s*\(/g;
+const FINISH_AND_SURFACE_RE = /\buseFinishAndSurface\s*\(/g;
+
 // The two halves of an async settings rollback. The gate: an OPTIMISTIC patch of
 // the settings cache — the file flips the preference itself so the UI can commit
 // before the store write resolves. The hit: that file's mutation `onError`
@@ -669,6 +685,17 @@ export const CHECKS = [
     ],
     message:
       "an open-transition reset must ride useSeedOnOpen (src/lib/use-seed-on-open.ts) — a hidden <Activity> tab re-mounts its effects on show, so a bare `useEffect(() => { if (open) seed(); }, [open])` re-fires and wipes the user's draft; a data-arrival or otherwise idempotent seed needs an allowlist entry with rationale",
+  },
+  {
+    name: "generator-dialog-finish-and-surface",
+    appliesTo: (file) => file.endsWith(".tsx") && notVendoredUi(file),
+    scan: unlessAllPresent(
+      [FINISH_AND_SURFACE_RE],
+      onlyWhen(USE_SEED_ON_OPEN_CALL_RE, perLine(GENERATOR_HOOK_RE)),
+    ),
+    allowlist: [],
+    message:
+      "closing a dialog must never discard a paid AI generation — a mounted generator dialog rides useFinishAndSurface (src/features/conversations/useAiStream.ts): a run that settles while the dialog is closed latches skip-seed so the reopen shows the draft, and toasts it with a View reopen; a surface that genuinely aborts its run on close needs an allowlist entry with rationale",
   },
   {
     name: "hand-rolled-diff-stat",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -423,7 +423,9 @@ const TYPEAHEAD_KEY_RE = /\bisTypeaheadKey\s*\(/;
 // seed-on-open, and the branch-name / commit-message generators are not in the
 // list, so both stay out by construction rather than by allowlist.
 // The hook list is explicit rather than a `useGenerate\w+` shape: the chord and
-// the commit-message path share that prefix without owning a dialog draft.
+// the commit-message path share that prefix without owning a dialog draft. That
+// makes the list the gate's reach: a NEW one-shot generator hook must be
+// appended here, or every dialog adopting it escapes this ratchet silently.
 // Bounded to .tsx, which is what keeps each hook's own definition file (a .ts
 // whose export line matches the call pattern) from reading as a call site.
 const GENERATOR_HOOK_RE =

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -55,6 +55,7 @@ const bareMutate = scanner("bare-mutate-in-converted-trees");
 const menuSuppression = scanner("context-menu-suppression");
 const loneActivity = scanner("lone-activity-boundary");
 const seedOnOpen = scanner("seed-effect-on-open");
+const finishAndSurface = scanner("generator-dialog-finish-and-surface");
 const diffStatPair = scanner("hand-rolled-diff-stat");
 const kindBadge = scanner("kind-badge-single-source");
 const nullFallback = scanner("null-suspense-fallback");
@@ -681,6 +682,61 @@ test("seed-effect-on-open ignores the hook and non-first-statement reads", () =>
     "}, [open]);",
   ].join("\n");
   assert.deepEqual(seedOnOpen(gate), []);
+});
+
+test("generator-dialog-finish-and-surface flags each generator hook", () => {
+  for (const hook of [
+    "useGeneratePrDescription",
+    "useGenerateIssueDraft",
+    "useGenerateReleaseNotes",
+    "useGenerateRepoDescription",
+  ]) {
+    const source = [
+      `  const { generate, generating } = ${hook}(repoPath);`,
+      "  const seedOnOpen = useEffectEvent(() => form.reset(seeds));",
+      "  useSeedOnOpen(open, seedOnOpen);",
+    ].join("\n");
+    assert.deepEqual(finishAndSurface(source), [1], `should flag ${hook}`);
+  }
+});
+
+test("generator-dialog-finish-and-surface needs both halves, and clears on the primitive", () => {
+  // The adopted shape — the negative control for the check.
+  const adopted = [
+    "  const { generate, generating } = useGeneratePrDescription(repoPath);",
+    "  const surface = useFinishAndSurface(open, { readyTitle: t });",
+    "  useSeedOnOpen(open, seedOnOpen);",
+  ].join("\n");
+  assert.deepEqual(finishAndSurface(adopted), []);
+  // Each half alone is ordinary: a generator on a surface with no open-transition
+  // seed (the edit dialogs), and a seeded dialog with no generator at all.
+  assert.deepEqual(
+    finishAndSurface(
+      "  const { generate } = useGeneratePrDescription(repoPath);",
+    ),
+    [],
+  );
+  assert.deepEqual(finishAndSurface("  useSeedOnOpen(open, seedOnOpen);"), []);
+  // A generator named in a comment is not a call site.
+  const documented = [
+    "  // useGeneratePrDescription() streams into this dialog's form.",
+    "  useSeedOnOpen(open, seedOnOpen);",
+  ].join("\n");
+  assert.deepEqual(finishAndSurface(documented), []);
+});
+
+test("generator-dialog-finish-and-surface applies to .tsx call sites only", () => {
+  // The .ts bound is what keeps each hook's own definition file — whose export
+  // line matches the call pattern — from reading as a violation.
+  const { appliesTo } = CHECKS.find(
+    (c) => c.name === "generator-dialog-finish-and-surface",
+  );
+  assert.equal(
+    appliesTo("src/features/pulls/useGeneratePrDescription.ts"),
+    false,
+  );
+  assert.equal(appliesTo("src/components/ui/dialog.tsx"), false);
+  assert.equal(appliesTo("src/features/pulls/CreatePrDialog.tsx"), true);
 });
 
 test("lone-activity-boundary flags a JSX Activity in either spelling", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -703,8 +703,12 @@ test("generator-dialog-finish-and-surface flags each generator hook", () => {
 test("generator-dialog-finish-and-surface needs both halves, and clears on the primitive", () => {
   // The adopted shape — the negative control for the check.
   const adopted = [
-    "  const { generate, generating } = useGeneratePrDescription(repoPath);",
-    "  const surface = useFinishAndSurface(open, { readyTitle: t });",
+    "  const { generate, cancel, generating } = useGeneratePrDescription(repo);",
+    "  const surface = useFinishAndSurface(repo, open, {",
+    "    cancel,",
+    "    generating,",
+    "    readyTitle: t,",
+    "  });",
     "  useSeedOnOpen(open, seedOnOpen);",
   ].join("\n");
   assert.deepEqual(finishAndSurface(adopted), []);

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -12,7 +12,7 @@ import { normPath } from "@/lib/git/path";
 import { loadSettings } from "@/lib/settings/api";
 import { repoNameFromPath } from "@/lib/stores/notifications";
 import { useUiStore } from "@/lib/stores/ui";
-import { toastError } from "@/lib/toast";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
 
 type Settings = Awaited<ReturnType<typeof loadSettings>>;
 
@@ -71,14 +71,24 @@ export function useAiStream(repoPath: string) {
         return buffer;
       } catch (e) {
         if (!abort.signal.aborted) {
+          // The surface that started this run may be off-screen by now, so a
+          // failure raised against another repo has to name the one it belongs to.
+          const away =
+            normPath(useUiStore.getState().repoPath ?? "") !==
+            normPath(repoPath)
+              ? `In ${repoNameFromPath(repoPath)}`
+              : undefined;
           if (e instanceof MissingApiKeyError) {
             toast.error(e.message, {
               duration: 8000,
+              description: away,
               action: {
                 label: "Open settings",
                 onClick: () => useUiStore.getState().openSettings("ai"),
               },
             });
+          } else if (away) {
+            toastErrorWithNote(e, away);
           } else {
             toastError(e);
           }
@@ -146,14 +156,20 @@ export interface FinishAndSurfaceOpts {
  *
  * A generation belongs to the repository it started in. `<RepositoryView>` is one
  * instance across repo switches, so the dialogs' state outlives the repo: a
- * switch therefore cancels the run and drops the latch (the identity-cancel the
- * edit views already use), and the toast's action refuses to fire once the live
- * repo is a different one. The draft a settled-but-unseen run left behind is
- * discarded by that switch — the toast announced it while the user was still in
- * the originating repo. `shouldSkipSeed` is the seed guard rather than each
- * caller's own `generating ||`, because `run` awaits its context fetch before
- * the stream and the abort reaches only the stream: a discarded run can keep
- * `generating` true for seconds, and a reopen inside that window must reseed.
+ * switch therefore cancels the run, closes an open dialog, and disarms the
+ * toast's action once the live repo is a different one (the identity-cancel the
+ * edit views already use). The latch is STAMPED with its run's repo and survives
+ * navigation, so a pure detour — away and back without opening the dialog
+ * elsewhere — still shows the waiting draft, which is what makes the toast's
+ * "waiting in <repo>" promise true. It is released by whichever open consumes it
+ * first: its own repo's, which shows the draft, or a FOREIGN repo's, because the
+ * draft lives in the dialog's ONE shared form and the seed that runs for another
+ * repo is the event that destroys it. The one deliberate discard left is the
+ * caller-side tag drain (`consumeSkipSeed`).
+ * `shouldSkipSeed` is the seed guard rather than each caller's own
+ * `generating ||`, because `run` awaits its context fetch before the stream and
+ * the abort reaches only the stream: a discarded run can keep `generating` true
+ * for seconds, and a reopen inside that window must reseed.
  */
 export function useFinishAndSurface(
   repoPath: string,
@@ -179,10 +195,12 @@ export function useFinishAndSurface(
   /** Seed-guard predicate: true ⇒ the caller's seedOnOpen must return without
    *  reseeding. A live run justifies the skip only while it still belongs here —
    *  one discarded by an identity switch does not; failing that, a settled-unseen
-   *  latch (consumed here) does. */
+   *  latch does, and only when its stamp is THIS repo (a foreign latch is left
+   *  alone, still waiting for the repo it belongs to). */
   shouldSkipSeed: (generating: boolean) => boolean;
-  /** Consume the settled-while-closed latch; true ⇒ the caller's seedOnOpen
-   *  must return without reseeding. */
+  /** Discard the latch whatever it is stamped with, reporting whether one was
+   *  there. The identity-CHECKED consumer is `shouldSkipSeed`; this is the
+   *  deliberate drain, for a caller whose own identity axis has moved on. */
   consumeSkipSeed: () => boolean;
 } {
   const repo = normPath(repoPath);
@@ -210,11 +228,14 @@ export function useFinishAndSurface(
       mountedRef.current = false;
     };
   }, []);
-  const skipSeedRef = useRef(false);
+  // The repo key a settled-unseen draft is waiting for; null = no draft waiting.
+  const latchRepoRef = useRef<string | null>(null);
   const abortedBySwitchRef = useRef(false);
 
   useCancelOnIdentityChange(repo, () => {
-    skipSeedRef.current = false;
+    // The latch is deliberately NOT cleared here: navigation alone destroys no
+    // draft, so a detour back still shows it. The foreign seed that DOES destroy
+    // it is what releases the latch.
     // The abort's settle lands after this effect — a microtask later at best,
     // seconds later when the run is still in its context fetch. Without this the
     // discarded run would re-latch and the next repo's open would show its
@@ -226,12 +247,6 @@ export function useFinishAndSurface(
     if (openRef.current) opts.close?.();
   });
 
-  const consumeLatch = () => {
-    const skip = skipSeedRef.current;
-    skipSeedRef.current = false;
-    return skip;
-  };
-
   return {
     noteRunSettled: (ok: boolean) => {
       if (abortedBySwitchRef.current) {
@@ -239,13 +254,15 @@ export function useFinishAndSurface(
         return;
       }
       if (openRef.current) return;
-      skipSeedRef.current = true;
+      // Stamped with the run's own repo: only that repo's seed may consume it,
+      // so the draft is still there whenever the user comes back to it.
+      const settleRepo = repoRef.current;
+      latchRepoRef.current = settleRepo;
       if (!ok || !mountedRef.current) return;
       // The action outlives the repo the run belongs to, so it re-checks the
       // live repo rather than the one captured here. Sonner dismisses the toast
       // on any action click, so the mismatch arm has to say where the draft is
       // rather than swallow the user's only pointer to it.
-      const settleRepo = repoRef.current;
       const settleRepoName = repoNameRef.current;
       const reopen = opts.reopen;
       toast.success(opts.readyTitle, {
@@ -271,8 +288,21 @@ export function useFinishAndSurface(
       // The latch stays unconsumed behind this short-circuit: a run that is
       // still ours will settle and latch, and that latch is for a later open.
       if (generating && !abortedBySwitchRef.current) return true;
-      return consumeLatch();
+      // The REF, not the render closure: callers are effect events today, but a
+      // long-lived closure would compare against a stale key.
+      if (latchRepoRef.current !== repoRef.current) {
+        // A foreign seed is about to run, and it resets the ONE shared form the
+        // waiting draft lives in — so the latch dies here, with the draft.
+        latchRepoRef.current = null;
+        return false;
+      }
+      latchRepoRef.current = null;
+      return true;
     },
-    consumeSkipSeed: consumeLatch,
+    consumeSkipSeed: () => {
+      const had = latchRepoRef.current !== null;
+      latchRepoRef.current = null;
+      return had;
+    },
   };
 }

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -156,9 +156,10 @@ export interface FinishAndSurfaceOpts {
  *
  * A generation belongs to the repository it started in. `<RepositoryView>` is one
  * instance across repo switches, so the dialogs' state outlives the repo: a
- * switch therefore cancels the run, closes an open dialog, and disarms the
- * toast's action once the live repo is a different one (the identity-cancel the
- * edit views already use). The latch is STAMPED with its run's repo and survives
+ * switch therefore cancels the run and closes an open dialog (the
+ * identity-cancel the edit views already use), while the toast's View re-checks
+ * the live repo — reopening only in the repo the run belongs to, and naming it
+ * otherwise. The latch is STAMPED with its run's repo and survives
  * navigation, so a pure detour — away and back without opening the dialog
  * elsewhere — still shows the waiting draft, which is what makes the toast's
  * "waiting in <repo>" promise true. It is released by whichever open consumes it

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -164,8 +164,9 @@ export interface FinishAndSurfaceOpts {
  * "waiting in <repo>" promise true. It is released by whichever open consumes it
  * first: its own repo's, which shows the draft, or a FOREIGN repo's, because the
  * draft lives in the dialog's ONE shared form and the seed that runs for another
- * repo is the event that destroys it. The one deliberate discard left is the
- * caller-side tag drain (`consumeSkipSeed`).
+ * repo is the event that destroys it. The deliberate discards are the caller's
+ * own: `consumeSkipSeed`, for an identity axis that moved on or a draft request
+ * that outranks the waiting one.
  * `shouldSkipSeed` is the seed guard rather than each caller's own
  * `generating ||`, because `run` awaits its context fetch before the stream and
  * the abort reaches only the stream: a discarded run can keep `generating` true
@@ -195,12 +196,14 @@ export function useFinishAndSurface(
   /** Seed-guard predicate: true ⇒ the caller's seedOnOpen must return without
    *  reseeding. A live run justifies the skip only while it still belongs here —
    *  one discarded by an identity switch does not; failing that, a settled-unseen
-   *  latch does, and only when its stamp is THIS repo (a foreign latch is left
-   *  alone, still waiting for the repo it belongs to). */
+   *  latch does. Either way the FIRST open releases it: this repo's shows the
+   *  draft, a foreign repo's destroys latch and toast along with the form its
+   *  seed is about to reset. */
   shouldSkipSeed: (generating: boolean) => boolean;
   /** Discard the latch whatever it is stamped with, reporting whether one was
-   *  there. The identity-CHECKED consumer is `shouldSkipSeed`; this is the
-   *  deliberate drain, for a caller whose own identity axis has moved on. */
+   *  there. `shouldSkipSeed` is the identity-CHECKED consumer; this is the drain
+   *  for a caller that means to throw the waiting draft away — an identity axis
+   *  that moved on, or an explicit draft request that outranks it. */
   consumeSkipSeed: () => boolean;
 } {
   const repo = normPath(repoPath);

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -1,4 +1,10 @@
-import { useCallback, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 import { createAiClient, MissingApiKeyError } from "@/lib/ai/client";
 import { loadSettings } from "@/lib/settings/api";
@@ -84,4 +90,78 @@ export function useAiStream(repoPath: string) {
   );
 
   return { generating, cancel, run };
+}
+
+/** Where a run that settles while its dialog is closed should surface. */
+export interface FinishAndSurfaceOpts {
+  /** toast.success title, e.g. "Pull request description ready". */
+  readyTitle: string;
+  /** Toast description, e.g. "It's waiting in the dialog." */
+  readyDescription?: string;
+  /** Reopens the surface (the toast's "View" action). Omit when no reliable
+   *  reopen path exists from a toast. */
+  reopen?: () => void;
+}
+
+/**
+ * Closing a generator dialog never cancels its run — this decides where the
+ * result lands instead. A run settling while the dialog is CLOSED latches
+ * skip-seed (the reopen keeps the whole draft rather than resetting it) and, on
+ * success, toasts with a "View" reopen; one settling while the dialog is OPEN is
+ * already visible in place, so it latches nothing.
+ *
+ * The latch is a ref, so it survives an `<Activity>` tab hide (which tears down
+ * effects but keeps refs) and dies with a true unmount, where nothing is left to
+ * skip. The toast alone gates on effects being live, since after an unmount
+ * there is no draft to promise — the accepted cost being that a run settling
+ * while its host tab is hidden resurfaces silently on reopen instead of
+ * toasting.
+ */
+export function useFinishAndSurface(
+  open: boolean,
+  opts: FinishAndSurfaceOpts,
+): {
+  /** Report a run settling; ok = a non-null result landed. */
+  noteRunSettled: (ok: boolean) => void;
+  /** Consume the settled-while-closed latch; true ⇒ the caller's seedOnOpen
+   *  must return without reseeding. */
+  consumeSkipSeed: () => boolean;
+} {
+  // Effects, never render-time ref writes: React may discard and replay a
+  // render, and both flags are read from stream continuations outside render.
+  // The open sync is a LAYOUT effect: a settle landing between the commit and a
+  // passive flush would otherwise read the previous open state and either miss
+  // the latch or toast over a dialog that is back on screen.
+  const openRef = useRef(open);
+  useLayoutEffect(() => {
+    openRef.current = open;
+  }, [open]);
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  const skipSeedRef = useRef(false);
+
+  return {
+    noteRunSettled: (ok: boolean) => {
+      if (openRef.current) return;
+      skipSeedRef.current = true;
+      if (!ok || !mountedRef.current) return;
+      toast.success(opts.readyTitle, {
+        description: opts.readyDescription,
+        duration: 10_000,
+        action: opts.reopen
+          ? { label: "View", onClick: opts.reopen }
+          : undefined,
+      });
+    },
+    consumeSkipSeed: () => {
+      const skip = skipSeedRef.current;
+      skipSeedRef.current = false;
+      return skip;
+    },
+  };
 }

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -230,7 +230,17 @@ export function useFinishAndSurface(
   }, []);
   // The repo key a settled-unseen draft is waiting for; null = no draft waiting.
   const latchRepoRef = useRef<string | null>(null);
+  const readyToastIdRef = useRef<string | number | null>(null);
   const abortedBySwitchRef = useRef(false);
+
+  // The ready toast is the latch's public face: once the draft has been
+  // delivered, destroyed, or drained, a surviving View would reopen onto a
+  // reseeded form and erase exactly what it promises.
+  const retireReadyToast = () => {
+    if (readyToastIdRef.current === null) return;
+    toast.dismiss(readyToastIdRef.current);
+    readyToastIdRef.current = null;
+  };
 
   useCancelOnIdentityChange(repo, () => {
     // The latch is deliberately NOT cleared here: navigation alone destroys no
@@ -265,7 +275,7 @@ export function useFinishAndSurface(
       // rather than swallow the user's only pointer to it.
       const settleRepoName = repoNameRef.current;
       const reopen = opts.reopen;
-      toast.success(opts.readyTitle, {
+      readyToastIdRef.current = toast.success(opts.readyTitle, {
         description: opts.readyDescription,
         duration: 10_000,
         action: reopen
@@ -294,14 +304,17 @@ export function useFinishAndSurface(
         // A foreign seed is about to run, and it resets the ONE shared form the
         // waiting draft lives in — so the latch dies here, with the draft.
         latchRepoRef.current = null;
+        retireReadyToast();
         return false;
       }
       latchRepoRef.current = null;
+      retireReadyToast();
       return true;
     },
     consumeSkipSeed: () => {
       const had = latchRepoRef.current !== null;
       latchRepoRef.current = null;
+      retireReadyToast();
       return had;
     },
   };

--- a/src/features/conversations/useAiStream.ts
+++ b/src/features/conversations/useAiStream.ts
@@ -1,13 +1,16 @@
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useRef,
   useState,
 } from "react";
 import { toast } from "sonner";
 import { createAiClient, MissingApiKeyError } from "@/lib/ai/client";
+import { normPath } from "@/lib/git/path";
 import { loadSettings } from "@/lib/settings/api";
+import { repoNameFromPath } from "@/lib/stores/notifications";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 
@@ -92,6 +95,30 @@ export function useAiStream(repoPath: string) {
   return { generating, cancel, run };
 }
 
+/**
+ * Cancels an in-flight generation when the entity on screen changes — the PR views
+ * keep their edit dialog mounted across a switch, so a stream started on one PR would
+ * otherwise keep writing into the next one's dialog.
+ *
+ * An EFFECT, not a render-time reset: cancelling aborts a live stream, and React may
+ * discard and replay a render. The ref is seeded with the current identity, so
+ * mounting cancels nothing, and it advances before the call so a re-render mid-cancel
+ * can't fire twice. `cancel` rides an effect event, so a caller passing an unstable
+ * function can't re-trigger the effect.
+ */
+export function useCancelOnIdentityChange(
+  identity: string,
+  cancel: () => void,
+): void {
+  const cancelNow = useEffectEvent(() => cancel());
+  const activeFor = useRef(identity);
+  useEffect(() => {
+    if (activeFor.current === identity) return;
+    activeFor.current = identity;
+    cancelNow();
+  }, [identity]);
+}
+
 /** Where a run that settles while its dialog is closed should surface. */
 export interface FinishAndSurfaceOpts {
   /** toast.success title, e.g. "Pull request description ready". */
@@ -116,26 +143,66 @@ export interface FinishAndSurfaceOpts {
  * there is no draft to promise — the accepted cost being that a run settling
  * while its host tab is hidden resurfaces silently on reopen instead of
  * toasting.
+ *
+ * A generation belongs to the repository it started in. `<RepositoryView>` is one
+ * instance across repo switches, so the dialogs' state outlives the repo: a
+ * switch therefore cancels the run and drops the latch (the identity-cancel the
+ * edit views already use), and the toast's action refuses to fire once the live
+ * repo is a different one. The draft a settled-but-unseen run left behind is
+ * discarded by that switch — the toast announced it while the user was still in
+ * the originating repo. `shouldSkipSeed` is the seed guard rather than each
+ * caller's own `generating ||`, because `run` awaits its context fetch before
+ * the stream and the abort reaches only the stream: a discarded run can keep
+ * `generating` true for seconds, and a reopen inside that window must reseed.
  */
 export function useFinishAndSurface(
+  repoPath: string,
   open: boolean,
-  opts: FinishAndSurfaceOpts,
+  opts: FinishAndSurfaceOpts & {
+    /** This dialog's generation cancel — invoked when the repo changes. */
+    cancel: () => void;
+    /** Whether a run is in flight, so the switch's own abort can be told from a
+     *  later genuine settle. */
+    generating: boolean;
+    /** Closes the dialog. Called when the repo changes with it still open: the
+     *  draft on screen belongs to the repo the user just left. */
+    close?: () => void;
+  },
 ): {
   /** Report a run settling; ok = a non-null result landed. */
   noteRunSettled: (ok: boolean) => void;
+  /** Whether the run in flight was discarded by an identity switch — a read,
+   *  never a consume. Callers whose seed guard has further arms keyed on the
+   *  form's retained values use it to skip them: those values are the old
+   *  identity's. */
+  runDiscardedBySwitch: () => boolean;
+  /** Seed-guard predicate: true ⇒ the caller's seedOnOpen must return without
+   *  reseeding. A live run justifies the skip only while it still belongs here —
+   *  one discarded by an identity switch does not; failing that, a settled-unseen
+   *  latch (consumed here) does. */
+  shouldSkipSeed: (generating: boolean) => boolean;
   /** Consume the settled-while-closed latch; true ⇒ the caller's seedOnOpen
    *  must return without reseeding. */
   consumeSkipSeed: () => boolean;
 } {
+  const repo = normPath(repoPath);
   // Effects, never render-time ref writes: React may discard and replay a
-  // render, and both flags are read from stream continuations outside render.
-  // The open sync is a LAYOUT effect: a settle landing between the commit and a
-  // passive flush would otherwise read the previous open state and either miss
-  // the latch or toast over a dialog that is back on screen.
+  // render, and these flags are read from stream continuations outside render.
+  // Both syncs are LAYOUT effects: a settle landing between the commit and a
+  // passive flush would otherwise read the previous open state — missing the
+  // latch, or toasting over a dialog that is back on screen.
   const openRef = useRef(open);
   useLayoutEffect(() => {
     openRef.current = open;
   }, [open]);
+  const repoRef = useRef(repo);
+  // The display name comes off the RAW path — the normalized key is lower-cased
+  // for comparison only.
+  const repoNameRef = useRef(repoNameFromPath(repoPath));
+  useLayoutEffect(() => {
+    repoRef.current = repo;
+    repoNameRef.current = repoNameFromPath(repoPath);
+  }, [repo, repoPath]);
   const mountedRef = useRef(false);
   useEffect(() => {
     mountedRef.current = true;
@@ -144,24 +211,68 @@ export function useFinishAndSurface(
     };
   }, []);
   const skipSeedRef = useRef(false);
+  const abortedBySwitchRef = useRef(false);
+
+  useCancelOnIdentityChange(repo, () => {
+    skipSeedRef.current = false;
+    // The abort's settle lands after this effect — a microtask later at best,
+    // seconds later when the run is still in its context fetch. Without this the
+    // discarded run would re-latch and the next repo's open would show its
+    // partial draft.
+    abortedBySwitchRef.current = opts.generating;
+    opts.cancel();
+    // A dialog left open now targets the new repo while holding the old repo's
+    // draft; closing hands the next open back to the seed.
+    if (openRef.current) opts.close?.();
+  });
+
+  const consumeLatch = () => {
+    const skip = skipSeedRef.current;
+    skipSeedRef.current = false;
+    return skip;
+  };
 
   return {
     noteRunSettled: (ok: boolean) => {
+      if (abortedBySwitchRef.current) {
+        abortedBySwitchRef.current = false;
+        return;
+      }
       if (openRef.current) return;
       skipSeedRef.current = true;
       if (!ok || !mountedRef.current) return;
+      // The action outlives the repo the run belongs to, so it re-checks the
+      // live repo rather than the one captured here. Sonner dismisses the toast
+      // on any action click, so the mismatch arm has to say where the draft is
+      // rather than swallow the user's only pointer to it.
+      const settleRepo = repoRef.current;
+      const settleRepoName = repoNameRef.current;
+      const reopen = opts.reopen;
       toast.success(opts.readyTitle, {
         description: opts.readyDescription,
         duration: 10_000,
-        action: opts.reopen
-          ? { label: "View", onClick: opts.reopen }
+        action: reopen
+          ? {
+              label: "View",
+              onClick: () => {
+                const live = normPath(useUiStore.getState().repoPath ?? "");
+                if (live === settleRepo) reopen();
+                else
+                  toast.info(
+                    `Waiting in ${settleRepoName} — switch back to see it.`,
+                  );
+              },
+            }
           : undefined,
       });
     },
-    consumeSkipSeed: () => {
-      const skip = skipSeedRef.current;
-      skipSeedRef.current = false;
-      return skip;
+    runDiscardedBySwitch: () => abortedBySwitchRef.current,
+    shouldSkipSeed: (generating: boolean) => {
+      // The latch stays unconsumed behind this short-circuit: a run that is
+      // still ours will settle and latch, and that latch is for a later open.
+      if (generating && !abortedBySwitchRef.current) return true;
+      return consumeLatch();
     },
+    consumeSkipSeed: consumeLatch,
   };
 }

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2471,10 +2471,10 @@ announces the draft when it lands, its **View** action brings the dialog back, a
 everything is waiting there, your own typing included. Switching repositories discards a
 draft that's still in flight, since it belongs to the repository it started in.
 
-A **repository description** keeps generating across a repository switch too, held for
-the repository it started in. Close Repository settings while it runs and a toast tells
-you when the description is ready; **View** reopens the dialog on **General**, and from
-another repository it names the one to switch back to.
+A repository description generated in **Repository settings** keeps running across a
+repository switch, held for the repository it started in. Close that dialog while it
+runs and a toast tells you when the description is ready; **View** reopens it on
+**General**, and from another repository it names the one to switch back to.
 
 ## Instructions & privacy
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2465,6 +2465,17 @@ AI streams into the same inputs you'd type in, so it's always editable: **commit
 messages**, **branch names**, **PR titles and descriptions**, **issue drafts**, **release
 notes**, and **repository descriptions**.
 
+Closing a dialog leaves its generation running. Draft an issue, a pull request, or
+release notes, close the dialog while it streams, and the run still finishes: a toast
+announces the draft when it lands, its **View** action brings the dialog back, and
+everything is waiting there, your own typing included. Switching repositories discards a
+draft that's still in flight, since it belongs to the repository it started in.
+
+A **repository description** keeps generating across a repository switch too, held for
+the repository it started in. Close Repository settings while it runs and a toast tells
+you when the description is ready; **View** reopens the dialog on **General**, and from
+another repository it names the one to switch back to.
+
 ## Instructions & privacy
 
 - **Instructions** steer every generation and every AI review. Set **global**

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { LabelChip } from "@/features/conversations/Thread";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { required, useAppForm } from "@/lib/form";
 import {
   useAddSubIssue,
@@ -79,6 +80,13 @@ export function CreateIssueDialog({
   const repoName = useUiStore((s) => s.repoName) ?? "";
   const aiEnabled = useAiEnabled();
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "Issue draft ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
   const [labels, setLabels] = useState<Set<string>>(new Set());
   const [assignees, setAssignees] = useState<ForgeUserRef[]>([]);
   const [milestone, setMilestone] = useState<number | null>(null);
@@ -148,6 +156,10 @@ export function CreateIssueDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // reset values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the whole draft in form state, which this reset would blank
+    // on reopen.
+    if (generating || surface.consumeSkipSeed()) return;
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
@@ -173,15 +185,20 @@ export function CreateIssueDialog({
   );
 
   // Shared by the Draft-with-AI button and the generate chord below.
-  function runGenerate() {
-    generate({
+  async function runGenerate() {
+    // `generate` resolves void and fires onResult only on a usable draft, so the
+    // flag is how the settle learns whether a result actually landed.
+    let ok = false;
+    await generate({
       notes,
       repoName,
       onResult: (d) => {
+        ok = true;
         if (d.title) form.setFieldValue("title", d.title);
         form.setFieldValue("body", d.body);
       },
     });
+    surface.noteRunSettled(ok);
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
@@ -194,6 +211,9 @@ export function CreateIssueDialog({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,
   });
+  // The one submit gate, shared by the button and the form's native submit:
+  // Enter must submit exactly when the button would.
+  const submitBlocked = generating;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -205,6 +225,7 @@ export function CreateIssueDialog({
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -384,7 +405,7 @@ export function CreateIssueDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={generating}>
+              <form.SubmitButton disabled={submitBlocked}>
                 {subIssueParentId
                   ? "Create sub-issue"
                   : isUpstream

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -2,7 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { SparkleIcon, TagIcon, XIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffectEvent, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -94,6 +94,8 @@ export function CreateIssueDialog({
   const [assignees, setAssignees] = useState<ForgeUserRef[]>([]);
   const [milestone, setMilestone] = useState<number | null>(null);
   const [issueType, setIssueType] = useState<IssueType | null>(null);
+  /** The lens the metadata pickers below were filled under. */
+  const stateLensRef = useRef(lens);
 
   const form = useAppForm({
     defaultValues: { title: "", body: "" },
@@ -159,10 +161,29 @@ export function CreateIssueDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // reset values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
-    // A generation still streaming — or one that settled while the dialog was
-    // closed — leaves the whole draft in form state, which this reset would blank
-    // on reopen.
-    if (surface.shouldSkipSeed(generating)) return;
+    // The only host that seeds this dialog clears its request at close, so a
+    // draft present here is always a fresh explicit ask (duplicate, reference)
+    // and outranks any waiting or streaming run.
+    const isNewRequest = initialDraft !== undefined;
+    if (isNewRequest) {
+      if (generating) cancel();
+      void surface.consumeSkipSeed();
+    } else if (surface.shouldSkipSeed(generating)) {
+      // A generation still streaming — or one that settled while the dialog was
+      // closed — leaves the whole draft in form state, which this reset would
+      // blank on reopen.
+      // Label sets, assignee ids, milestone numbers and org issue types are local
+      // to the create target, and the lens can move while a kept draft holds the
+      // seed off: the prose survives that switch, the picks can't.
+      if (stateLensRef.current !== lens) {
+        setLabels(new Set());
+        setAssignees([]);
+        setMilestone(null);
+        setIssueType(null);
+        stateLensRef.current = lens;
+      }
+      return;
+    }
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
@@ -171,6 +192,7 @@ export function CreateIssueDialog({
     setAssignees([]);
     setMilestone(null);
     setIssueType(null);
+    stateLensRef.current = lens;
   });
   useSeedOnOpen(open, seedOnOpen);
 

--- a/src/features/issues/CreateIssueDialog.tsx
+++ b/src/features/issues/CreateIssueDialog.tsx
@@ -82,7 +82,10 @@ export function CreateIssueDialog({
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel,
+    generating,
+    close: () => onOpenChange(false),
     readyTitle: "Issue draft ready",
     readyDescription: "It's waiting in the dialog.",
     reopen: () => onOpenChange(true),
@@ -159,7 +162,7 @@ export function CreateIssueDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the whole draft in form state, which this reset would blank
     // on reopen.
-    if (generating || surface.consumeSkipSeed()) return;
+    if (surface.shouldSkipSeed(generating)) return;
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
@@ -189,16 +192,21 @@ export function CreateIssueDialog({
     // `generate` resolves void and fires onResult only on a usable draft, so the
     // flag is how the settle learns whether a result actually landed.
     let ok = false;
-    await generate({
-      notes,
-      repoName,
-      onResult: (d) => {
-        ok = true;
-        if (d.title) form.setFieldValue("title", d.title);
-        form.setFieldValue("body", d.body);
-      },
-    });
-    surface.noteRunSettled(ok);
+    // finally: a throw past the stream (draft extraction, these field writes)
+    // must still settle, or the switch-abort latch stays armed for the next run.
+    try {
+      await generate({
+        notes,
+        repoName,
+        onResult: (d) => {
+          ok = true;
+          if (d.title) form.setFieldValue("title", d.title);
+          form.setFieldValue("body", d.body);
+        },
+      });
+    } finally {
+      surface.noteRunSettled(ok);
+    }
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -60,7 +60,10 @@ export function CreateJiraIssueDialog({
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel,
+    generating,
+    close: () => onOpenChange(false),
     readyTitle: "Issue draft ready",
     readyDescription: "It's waiting in the dialog.",
     reopen: () => onOpenChange(true),
@@ -117,7 +120,7 @@ export function CreateJiraIssueDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the whole draft in form state, which this reset would blank
     // on reopen.
-    if (generating || surface.consumeSkipSeed()) return;
+    if (surface.shouldSkipSeed(generating)) return;
     form.reset({ summary: "", body: "" }, { keepDefaultValues: true });
   });
   useSeedOnOpen(open, seedOnOpen);
@@ -149,16 +152,21 @@ export function CreateJiraIssueDialog({
     // `generate` resolves void and fires onResult only on a usable draft, so the
     // flag is how the settle learns whether a result actually landed.
     let ok = false;
-    await generate({
-      notes,
-      repoName,
-      onResult: (d) => {
-        ok = true;
-        if (d.title) form.setFieldValue("summary", d.title);
-        form.setFieldValue("body", d.body);
-      },
-    });
-    surface.noteRunSettled(ok);
+    // finally: a throw past the stream (draft extraction, these field writes)
+    // must still settle, or the switch-abort latch stays armed for the next run.
+    try {
+      await generate({
+        notes,
+        repoName,
+        onResult: (d) => {
+          ok = true;
+          if (d.title) form.setFieldValue("summary", d.title);
+          form.setFieldValue("body", d.body);
+        },
+      });
+    } finally {
+      surface.noteRunSettled(ok);
+    }
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING

--- a/src/features/issues/CreateJiraIssueDialog.tsx
+++ b/src/features/issues/CreateJiraIssueDialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { required, useAppForm } from "@/lib/form";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useJiraCreateIssue, useJiraIssueTypes } from "@/lib/jira/queries";
@@ -57,6 +58,13 @@ export function CreateJiraIssueDialog({
   const repoName = useUiStore((s) => s.repoName) ?? "";
   const aiEnabled = useAiEnabled();
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "Issue draft ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
 
   // Creatable types only (a subtask needs a parent — not offered here). Manual
   // useMemo is LOAD-BEARING: the submit handler's try/catch bails this component
@@ -103,8 +111,14 @@ export function CreateJiraIssueDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the reset
   // values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
-    form.reset({ summary: "", body: "" }, { keepDefaultValues: true });
+    // The previous attempt's error is stale on every open transition, guarded or
+    // not — it must clear even when the draft below is kept.
     setCreateError(null);
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the whole draft in form state, which this reset would blank
+    // on reopen.
+    if (generating || surface.consumeSkipSeed()) return;
+    form.reset({ summary: "", body: "" }, { keepDefaultValues: true });
   });
   useSeedOnOpen(open, seedOnOpen);
 
@@ -131,15 +145,20 @@ export function CreateJiraIssueDialog({
       : null;
 
   // Shared by the Draft-with-AI button and the generate chord below.
-  function runGenerate() {
-    generate({
+  async function runGenerate() {
+    // `generate` resolves void and fires onResult only on a usable draft, so the
+    // flag is how the settle learns whether a result actually landed.
+    let ok = false;
+    await generate({
       notes,
       repoName,
       onResult: (d) => {
+        ok = true;
         if (d.title) form.setFieldValue("summary", d.title);
         form.setFieldValue("body", d.body);
       },
     });
+    surface.noteRunSettled(ok);
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
@@ -152,6 +171,9 @@ export function CreateJiraIssueDialog({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,
   });
+  // The one submit gate, shared by the button and the form's native submit:
+  // Enter must submit exactly when the button would.
+  const submitBlocked = generating || !issueTypeId;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -163,6 +185,7 @@ export function CreateJiraIssueDialog({
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -297,7 +320,7 @@ export function CreateJiraIssueDialog({
             </Button>
             <form.AppForm>
               <span className="inline-flex" title={submitReason ?? undefined}>
-                <form.SubmitButton disabled={generating || !issueTypeId}>
+                <form.SubmitButton disabled={submitBlocked}>
                   Create issue
                 </form.SubmitButton>
               </span>

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -1,6 +1,6 @@
 import { SparkleIcon, XIcon } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
-import { useEffectEvent } from "react";
+import { useEffectEvent, useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -48,6 +48,8 @@ export function CreateLocalIssueDialog({
     readyDescription: "It's waiting in the dialog.",
     reopen: () => onOpenChange(true),
   });
+  /** The serialized explicit draft the current form state was seeded from. */
+  const seededDraftRef = useRef<string | null>(null);
 
   const form = useAppForm({
     defaultValues: { title: "", body: "" },
@@ -74,14 +76,27 @@ export function CreateLocalIssueDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // reset values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
-    // A generation still streaming — or one that settled while the dialog was
-    // closed — leaves the whole draft in form state, which this reset would blank
-    // on reopen.
-    if (surface.shouldSkipSeed(generating)) return;
+    const key = initialDraft
+      ? JSON.stringify([initialDraft.title, initialDraft.body])
+      : null;
+    // A plan or to-do handing over new content retargets the one shared form, so
+    // a waiting or streaming run's result must not survive into it; a reopen
+    // carrying the same content is the ordinary hold path below.
+    const isNewRequest = key !== null && key !== seededDraftRef.current;
+    if (isNewRequest) {
+      if (generating) cancel();
+      void surface.consumeSkipSeed();
+    } else if (surface.shouldSkipSeed(generating)) {
+      // A generation still streaming — or one that settled while the dialog was
+      // closed — leaves the whole draft in form state, which this reset would
+      // blank on reopen.
+      return;
+    }
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
     );
+    seededDraftRef.current = key;
   });
   useSeedOnOpen(open, seedOnOpen);
 

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { required, useAppForm } from "@/lib/form";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import { useCreateLocalIssue } from "@/lib/issues/queries";
@@ -37,6 +38,13 @@ export function CreateLocalIssueDialog({
   const repoName = useUiStore((s) => s.repoName) ?? "";
   const aiEnabled = useAiEnabled();
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "Issue draft ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
 
   const form = useAppForm({
     defaultValues: { title: "", body: "" },
@@ -63,6 +71,10 @@ export function CreateLocalIssueDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // reset values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the whole draft in form state, which this reset would blank
+    // on reopen.
+    if (generating || surface.consumeSkipSeed()) return;
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
@@ -71,15 +83,20 @@ export function CreateLocalIssueDialog({
   useSeedOnOpen(open, seedOnOpen);
 
   // Shared by the Draft-with-AI button and the generate chord below.
-  function runGenerate() {
-    generate({
+  async function runGenerate() {
+    // `generate` resolves void and fires onResult only on a usable draft, so the
+    // flag is how the settle learns whether a result actually landed.
+    let ok = false;
+    await generate({
       notes,
       repoName,
       onResult: (d) => {
+        ok = true;
         if (d.title) form.setFieldValue("title", d.title);
         form.setFieldValue("body", d.body);
       },
     });
+    surface.noteRunSettled(ok);
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING
@@ -92,6 +109,9 @@ export function CreateLocalIssueDialog({
     enabled: aiEnabled && !generating && notes.trim() !== "",
     run: runGenerate,
   });
+  // The one submit gate, shared by the button and the form's native submit:
+  // Enter must submit exactly when the button would.
+  const submitBlocked = generating;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -103,6 +123,7 @@ export function CreateLocalIssueDialog({
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -179,7 +200,7 @@ export function CreateLocalIssueDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={generating}>
+              <form.SubmitButton disabled={submitBlocked}>
                 Create local issue
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/issues/CreateLocalIssueDialog.tsx
+++ b/src/features/issues/CreateLocalIssueDialog.tsx
@@ -40,7 +40,10 @@ export function CreateLocalIssueDialog({
   const { generate, cancel, generating } = useGenerateIssueDraft(repoPath);
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel,
+    generating,
+    close: () => onOpenChange(false),
     readyTitle: "Issue draft ready",
     readyDescription: "It's waiting in the dialog.",
     reopen: () => onOpenChange(true),
@@ -74,7 +77,7 @@ export function CreateLocalIssueDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the whole draft in form state, which this reset would blank
     // on reopen.
-    if (generating || surface.consumeSkipSeed()) return;
+    if (surface.shouldSkipSeed(generating)) return;
     form.reset(
       { title: initialDraft?.title ?? "", body: initialDraft?.body ?? "" },
       { keepDefaultValues: true },
@@ -87,16 +90,21 @@ export function CreateLocalIssueDialog({
     // `generate` resolves void and fires onResult only on a usable draft, so the
     // flag is how the settle learns whether a result actually landed.
     let ok = false;
-    await generate({
-      notes,
-      repoName,
-      onResult: (d) => {
-        ok = true;
-        if (d.title) form.setFieldValue("title", d.title);
-        form.setFieldValue("body", d.body);
-      },
-    });
-    surface.noteRunSettled(ok);
+    // finally: a throw past the stream (draft extraction, these field writes)
+    // must still settle, or the switch-abort latch stays armed for the next run.
+    try {
+      await generate({
+        notes,
+        repoName,
+        onResult: (d) => {
+          ok = true;
+          if (d.title) form.setFieldValue("title", d.title);
+          form.setFieldValue("body", d.body);
+        },
+      });
+    } finally {
+      surface.noteRunSettled(ok);
+    }
   }
   // The generate chord drafts this issue while the dialog is open. It's mounted
   // on DialogContent, not the <form>: the X close button is a form SIBLING

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -67,7 +67,10 @@ export function CreateLocalPrDialog({
   // form state, and this surfaces the result while the dialog is away. The host's
   // onOpenChange only ever CLOSES, so the reopen goes through the store action —
   // seedless, since the skip-seed latch keeps the retained draft.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel,
+    generating,
+    close: () => onOpenChange(false),
     readyTitle: "PR description ready",
     readyDescription: "It's waiting in the dialog.",
     reopen: () => useUiStore.getState().openLocalPrCreate(),
@@ -189,7 +192,7 @@ export function CreateLocalPrDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the whole draft in form state, which this reset would blank
     // on reopen.
-    if (generating || surface.consumeSkipSeed()) return;
+    if (surface.shouldSkipSeed(generating)) return;
     // Reset the linked-issue chips (and their dismissed/probed refs) to empty —
     // the dialog opens with no seeded body refs; extraction/AI seeding then
     // repopulates from the head branch + commits.
@@ -265,10 +268,13 @@ export function CreateLocalPrDialog({
       [],
       notes.trim() || undefined,
       buildIssueCandidates(),
-    ).then((final) => {
+    ).then(
       // Resolves with the COMPLETE draft, or null on bail/abort/error.
-      surface.noteRunSettled(final !== null);
-    });
+      (final) => surface.noteRunSettled(final !== null),
+      // Two-arm, never a trailing .catch: a settle must be reported exactly
+      // once, and a throw in the arm above must not report a second time.
+      () => surface.noteRunSettled(false),
+    );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding while this
   // dialog is open. `run` is undefined with AI off — no Generate surface, so

--- a/src/features/pulls/CreateLocalPrDialog.tsx
+++ b/src/features/pulls/CreateLocalPrDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { REVIEWER_NOTES_MARKER } from "@/lib/ai/notes-context";
 import { triggerAutomations } from "@/lib/automations/runner";
 import { required, useAppForm } from "@/lib/form";
@@ -62,6 +63,15 @@ export function CreateLocalPrDialog({
   const createPr = useCreateLocalPr(repoPath);
   const { generate, cancel, generating } = useGeneratePrDescription(repoPath);
   const aiEnabled = useAiEnabled();
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away. The host's
+  // onOpenChange only ever CLOSES, so the reopen goes through the store action —
+  // seedless, since the skip-seed latch keeps the retained draft.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "PR description ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => useUiStore.getState().openLocalPrCreate(),
+  });
   // Linked issues: real repo issues to reference. A local PR's `Closes #N` lines
   // survive promotion verbatim into the real forge PR, so these become real
   // closing refs later — intended. Non-AI surface (shown under Hide-AI too),
@@ -176,6 +186,10 @@ export function CreateLocalPrDialog({
   // keepDefaultValues: otherwise the per-render options sync clobbers the
   // seeded head/base back to empty (untouched form).
   const seedOnOpen = useEffectEvent(() => {
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the whole draft in form state, which this reset would blank
+    // on reopen.
+    if (generating || surface.consumeSkipSeed()) return;
     // Reset the linked-issue chips (and their dismissed/probed refs) to empty —
     // the dialog opens with no seeded body refs; extraction/AI seeding then
     // repopulates from the head branch + commits.
@@ -251,7 +265,10 @@ export function CreateLocalPrDialog({
       [],
       notes.trim() || undefined,
       buildIssueCandidates(),
-    );
+    ).then((final) => {
+      // Resolves with the COMPLETE draft, or null on bail/abort/error.
+      surface.noteRunSettled(final !== null);
+    });
   }
   // Context-sensitive reuse of the `generate-commit-message` binding while this
   // dialog is open. `run` is undefined with AI off — no Generate surface, so
@@ -261,6 +278,9 @@ export function CreateLocalPrDialog({
     run: aiEnabled ? runGenerate : undefined,
   });
   const generateHint = generateChord.hint;
+  // The one submit gate, shared by the button, the mod+enter chord, and the
+  // form's native submit: Enter must submit exactly when the button would.
+  const submitBlocked = generating;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -279,7 +299,7 @@ export function CreateLocalPrDialog({
         onKeyDown={(e) => {
           if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
             e.preventDefault();
-            if (!generating) form.handleSubmit();
+            if (!submitBlocked) form.handleSubmit();
             return;
           }
           // The generate chord runs this dialog's own Generate while it's open.
@@ -298,6 +318,7 @@ export function CreateLocalPrDialog({
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -450,7 +471,7 @@ export function CreateLocalPrDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={generating} title={SUBMIT_HINT}>
+              <form.SubmitButton disabled={submitBlocked} title={SUBMIT_HINT}>
                 Create local PR
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -657,7 +657,6 @@ export function CreatePrDialog({
   // AI title+description generation — shared by the Generate button and the
   // dialog-local generate chord.
   function runGenerate() {
-    aiDescriptionRef.current = true;
     setDroppedLabels([]);
     // Grounded issue candidates the model may link: current chips pinned first,
     // then the highest-scoring OPEN issues, capped at 8 (the hook records the set
@@ -675,6 +674,10 @@ export function CreatePrDialog({
       (d) => {
         form.setFieldValue("title", d.title);
         form.setFieldValue("body", d.body);
+        // Flagged on delivery, not on start: a run that writes nothing (bailed,
+        // failed, aborted before the first chunk) leaves a hand-typed
+        // description, and the reopen may skip the seed that would reset this.
+        if (d.body.trim()) aiDescriptionRef.current = true;
         // Additive: union the model's (already repo-validated) labels with the
         // user's manual picks, never replace.
         setLabels((prev) => new Set([...prev, ...d.labels]));

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -216,7 +216,10 @@ export function CreatePrDialog({
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away. Both
   // hosts pass a plain open setter, so `onOpenChange(true)` reopens.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel,
+    generating,
+    close: () => onOpenChange(false),
     readyTitle: isGitLab
       ? "Merge request description ready"
       : "Pull request description ready",
@@ -446,14 +449,16 @@ export function CreatePrDialog({
     // differs from the branch they are on now. The `||` short-circuit is
     // deliberate — while a generation or create is in flight the pr-create
     // latches stay unconsumed, so a later reopen after a failure still
-    // preserves the draft.
+    // preserves the draft. A run discarded by a repo switch skips those arms
+    // entirely: the retained head is the OLD repo's, so keying this repo's
+    // latches on it would spend a latch that was never formed for it.
     if (seededRef.current) {
       const retained = form.state.values.head || h;
       if (
-        generating ||
-        surface.consumeSkipSeed() ||
-        isCreatingPrFor(repoPath, retained) ||
-        consumeLastFailed(repoPath, retained)
+        surface.shouldSkipSeed(generating) ||
+        (!surface.runDiscardedBySwitch() &&
+          (isCreatingPrFor(repoPath, retained) ||
+            consumeLastFailed(repoPath, retained)))
       )
         return;
     } else {
@@ -694,10 +699,15 @@ export function CreatePrDialog({
       issueCandidates,
       // Grounded Jira mention candidates — empty/undefined ⇒ no Jira variant.
       jiraCandidates,
-    ).then((final) => {
-      if (final) setDroppedLabels(final.droppedLabels);
-      surface.noteRunSettled(final !== null);
-    });
+    ).then(
+      (final) => {
+        if (final) setDroppedLabels(final.droppedLabels);
+        surface.noteRunSettled(final !== null);
+      },
+      // Two-arm, never a trailing .catch: a settle must be reported exactly
+      // once, and a throw in the arm above must not report a second time.
+      () => surface.noteRunSettled(false),
+    );
   }
   // Context-sensitive reuse of the `generate-commit-message` binding while this
   // dialog is open. `run` is undefined with AI off — no Generate surface, so

--- a/src/features/pulls/CreatePrDialog.tsx
+++ b/src/features/pulls/CreatePrDialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { LabelChip } from "@/features/conversations/Thread";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { AssigneesPopover } from "@/features/issues/IssueMetaPickers";
 import { REVIEWER_NOTES_MARKER } from "@/lib/ai/notes-context";
 import { track } from "@/lib/analytics";
@@ -212,6 +213,16 @@ export function CreatePrDialog({
   const prNoun = isGitLab ? "merge request" : "pull request";
   const { generate, cancel, generating } = useGeneratePrDescription(repoPath);
   const aiEnabled = useAiEnabled();
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away. Both
+  // hosts pass a plain open setter, so `onOpenChange(true)` reopens.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: isGitLab
+      ? "Merge request description ready"
+      : "Pull request description ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
   const aiDescriptionRef = useRef(false);
   // Whether THIS mount has seeded, so the skip below can tell a reopen (form
   // state may hold a draft the user typed) from a fresh mount (it cannot).
@@ -427,16 +438,20 @@ export function CreatePrDialog({
   // seeded values back to empty on an untouched form.
   const seedOnOpen = useEffectEvent(() => {
     const h = defaultHead ?? currentName ?? names[0] ?? "";
-    // A create still running in the background — or one that failed while the
-    // dialog was closed — leaves everything the user typed in form state, and
-    // this reset would blank it on reopen. The draft's identity is the RETAINED
-    // form head, not this open's default: the user may have submitted a head
-    // that differs from the branch they are on now. The `||` short-circuit is
-    // deliberate — while a create is in flight the latch stays unconsumed, so a
-    // later reopen after it fails still preserves the draft.
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — and a create still running in the background, or one that failed
+    // while closed, all leave everything the user typed in form state, and this
+    // reset would blank it on reopen. The draft's identity is the RETAINED form
+    // head, not this open's default: the user may have submitted a head that
+    // differs from the branch they are on now. The `||` short-circuit is
+    // deliberate — while a generation or create is in flight the pr-create
+    // latches stay unconsumed, so a later reopen after a failure still
+    // preserves the draft.
     if (seededRef.current) {
       const retained = form.state.values.head || h;
       if (
+        generating ||
+        surface.consumeSkipSeed() ||
         isCreatingPrFor(repoPath, retained) ||
         consumeLastFailed(repoPath, retained)
       )
@@ -575,6 +590,16 @@ export function CreatePrDialog({
       (createLens === "upstream" || !p.crossRepository),
   );
 
+  // The one submit gate, shared by the button, the mod+enter chord, and the
+  // form's native submit: Enter must submit exactly when the button would.
+  const submitBlocked =
+    generating ||
+    nothingToMerge ||
+    baseLoading ||
+    isSubmitting ||
+    creatingElsewhere ||
+    Boolean(existingPr);
+
   // Linked-issue chip cluster — extraction seeding, AI union, candidate ranking and
   // the chip mutations live in the shared hook. Gated on a usable tracker AND the
   // dialog being open; the parent target reads the parent's issues (createLens).
@@ -671,6 +696,7 @@ export function CreatePrDialog({
       jiraCandidates,
     ).then((final) => {
       if (final) setDroppedLabels(final.droppedLabels);
+      surface.noteRunSettled(final !== null);
     });
   }
   // Context-sensitive reuse of the `generate-commit-message` binding while this
@@ -695,18 +721,7 @@ export function CreatePrDialog({
         onKeyDown={(e) => {
           if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
             e.preventDefault();
-            if (
-              !(
-                generating ||
-                nothingToMerge ||
-                baseLoading ||
-                isSubmitting ||
-                creatingThisHead ||
-                Boolean(existingPr)
-              )
-            ) {
-              form.handleSubmit();
-            }
+            if (!submitBlocked) form.handleSubmit();
             return;
           }
           // The generate chord runs this dialog's own Generate while it's open.
@@ -725,6 +740,7 @@ export function CreatePrDialog({
           className="flex min-h-0 min-w-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -1137,13 +1153,7 @@ export function CreatePrDialog({
               <form.Subscribe selector={(s) => s.values.draft}>
                 {(draft) => (
                   <form.SubmitButton
-                    disabled={
-                      generating ||
-                      nothingToMerge ||
-                      baseLoading ||
-                      creatingElsewhere ||
-                      Boolean(existingPr)
-                    }
+                    disabled={submitBlocked}
                     aria-describedby={
                       creatingElsewhere ? creatingHintId : undefined
                     }

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -41,6 +41,7 @@ import {
   useEditTitleBody,
 } from "@/features/conversations/EditTitleBodyDialog";
 import { LocalComment } from "@/features/conversations/LocalComment";
+import { useCancelOnIdentityChange } from "@/features/conversations/useAiStream";
 import { useLocalConversation } from "@/features/conversations/useLocalConversation";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -89,10 +90,7 @@ import {
   type TimelineEntry,
 } from "./PrTimeline";
 import { ResolveConflictsView } from "./ResolveConflictsView";
-import {
-  useCancelOnIdentityChange,
-  useGeneratePrDescription,
-} from "./useGeneratePrDescription";
+import { useGeneratePrDescription } from "./useGeneratePrDescription";
 import {
   composeBodyWithRefs,
   splitBodyRefBlock,

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -3500,8 +3500,7 @@ export function RemotePrView({
         form={edit.form}
         open={edit.open}
         onOpenChange={(open) => {
-          // The dialog stays mounted, so cancel any in-flight generation when it
-          // closes (unlike the create dialogs, which unmount on close).
+          // The dialog stays mounted, so cancel any in-flight generation on close.
           if (!open) prGen.cancel();
           edit.setOpen(open);
         }}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -65,6 +65,7 @@ import { ProjectsPopover } from "@/features/conversations/ProjectsPopover";
 import { makeQuoteReply } from "@/features/conversations/quoteReply";
 import { ReactionBar } from "@/features/conversations/ReactionBar";
 import { AuthorAvatar, LabelChip } from "@/features/conversations/Thread";
+import { useCancelOnIdentityChange } from "@/features/conversations/useAiStream";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import type { LineWidget } from "@/features/diff/DiffSurface";
@@ -222,10 +223,7 @@ import {
   unmetRequiredChecks,
   useBranchRequiredChecks,
 } from "./useBranchRequiredChecks";
-import {
-  useCancelOnIdentityChange,
-  useGeneratePrDescription,
-} from "./useGeneratePrDescription";
+import { useGeneratePrDescription } from "./useGeneratePrDescription";
 import {
   composeBodyWithJiraRefs,
   composeBodyWithRefs,

--- a/src/features/pulls/useGeneratePrDescription.ts
+++ b/src/features/pulls/useGeneratePrDescription.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useEffectEvent, useRef } from "react";
+import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAiStream } from "@/features/conversations/useAiStream";
 import { aiExcludePatterns } from "@/lib/ai/ignore";
@@ -234,28 +234,4 @@ export function useGeneratePrDescription(repoPath: string) {
   );
 
   return { generate, generateFromDiff, cancel, generating };
-}
-
-/**
- * Cancels an in-flight generation when the entity on screen changes — the PR views
- * keep their edit dialog mounted across a switch, so a stream started on one PR would
- * otherwise keep writing into the next one's dialog.
- *
- * An EFFECT, not a render-time reset: cancelling aborts a live stream, and React may
- * discard and replay a render. The ref is seeded with the current identity, so
- * mounting cancels nothing, and it advances before the call so a re-render mid-cancel
- * can't fire twice. `cancel` rides an effect event, so a caller passing an unstable
- * function can't re-trigger the effect.
- */
-export function useCancelOnIdentityChange(
-  identity: string,
-  cancel: () => void,
-): void {
-  const cancelNow = useEffectEvent(() => cancel());
-  const activeFor = useRef(identity);
-  useEffect(() => {
-    if (activeFor.current === identity) return;
-    activeFor.current = identity;
-    cancelNow();
-  }, [identity]);
 }

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -1,5 +1,5 @@
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { toast } from "sonner";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
@@ -74,6 +74,7 @@ export function BitbucketGeneralSection({
 
   return (
     <BitbucketGeneralForm
+      key={repoPath}
       repoPath={repoPath}
       settings={settings.data}
       branches={branches.data ?? []}
@@ -143,8 +144,9 @@ function BitbucketGeneralForm({
   }, []);
 
   // Take a result that settled while no section was mounted, then stay the
-  // recipient for one that settles during this mount.
-  useEffect(() => {
+  // recipient for one that settles during this mount. A LAYOUT effect: a settle
+  // between the commit and a passive flush would find no listener and toast.
+  useLayoutEffect(() => {
     const pending = consumePendingRepoDesc(repoPath);
     if (pending) applyResult(pending);
     return registerRepoDescListener(repoPath, applyResult);

--- a/src/features/repo-settings/BitbucketGeneralSection.tsx
+++ b/src/features/repo-settings/BitbucketGeneralSection.tsx
@@ -1,5 +1,5 @@
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,15 @@ import type {
 } from "@/lib/git/types";
 import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
+import {
+  cancelRepoDescGeneration,
+  claimRepoDescGeneration,
+  consumePendingRepoDesc,
+  type RepoDescResult,
+  registerRepoDescListener,
+  settleRepoDescGeneration,
+  useIsGeneratingRepoDesc,
+} from "@/lib/stores/repo-description-generation";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
@@ -114,6 +123,11 @@ function BitbucketGeneralForm({
   const repoName =
     useUiStore((s) => s.repoName) ?? repoPath.split(/[/\\]/).pop() ?? repoPath;
   const descGen = useGenerateRepoDescription(repoPath);
+  // A run started here outlives this form (the dialog and the rail both unmount
+  // their section immediately), so the store owns it: `generating` covers the
+  // stream this mount launched, the store covers one it inherited.
+  const storeBusy = useIsGeneratingRepoDesc(repoPath);
+  const busy = descGen.generating || storeBusy;
 
   function set<K extends keyof BitbucketRepoSettingsInput>(
     key: K,
@@ -122,19 +136,41 @@ function BitbucketGeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Seeds the draft the way a manual edit would, so the Save bar goes live.
+  // Bitbucket has no topics field, so the result's topics are dropped.
+  const applyResult = useCallback(({ description }: RepoDescResult) => {
+    if (description) setForm((f) => ({ ...f, description }));
+  }, []);
+
+  // Take a result that settled while no section was mounted, then stay the
+  // recipient for one that settles during this mount.
+  useEffect(() => {
+    const pending = consumePendingRepoDesc(repoPath);
+    if (pending) applyResult(pending);
+    return registerRepoDescListener(repoPath, applyResult);
+  }, [repoPath, applyResult]);
+
   // Shared by the Generate button and the settings dialog's generate chord,
   // which this publishes to — the shell owns the chord because it owns the
   // DialogContent every section renders inside.
-  function runGenerate() {
-    descGen.generate({
-      repoName,
-      onResult: ({ description }) => {
-        if (description) set("description", description);
-      },
-    });
+  async function runGenerate() {
+    if (!claimRepoDescGeneration(repoPath, descGen.cancel)) return;
+    let result: RepoDescResult | null = null;
+    try {
+      await descGen.generate({
+        repoName,
+        onResult: (r) => {
+          result = r;
+        },
+      });
+    } finally {
+      // In a `finally` because nothing else clears the lane: a throw between
+      // the claim and here would leave every surface for this repo busy.
+      settleRepoDescGeneration(repoPath, result);
+    }
   }
   const { hint: generateHint } = usePublishGenerateAction(
-    aiEnabled && aiConfigured && !descGen.generating,
+    aiEnabled && aiConfigured && !busy,
     runGenerate,
   );
 
@@ -182,13 +218,16 @@ function BitbucketGeneralForm({
               <SparkleIcon data-icon="inline-start" />
               Set up AI
             </Button>
-          ) : descGen.generating ? (
+          ) : busy ? (
             <Button
               type="button"
               variant="ghost"
               size="xs"
               className="text-muted-foreground"
-              onClick={descGen.cancel}
+              onClick={() => {
+                if (descGen.generating) descGen.cancel();
+                else cancelRepoDescGeneration(repoPath);
+              }}
             >
               <Spinner data-icon="inline-start" />
               Cancel
@@ -304,7 +343,7 @@ function BitbucketGeneralForm({
 
       <div className="flex items-center justify-end gap-2 border-t pt-3">
         <Button
-          disabled={!dirty || update.isPending || descGen.generating}
+          disabled={!dirty || update.isPending || busy}
           onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { ArrowSquareOutIcon, SparkleIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import { SelectClipText } from "@/components/select-clip-text";
@@ -29,6 +29,15 @@ import {
 import type { Branch, RepoSettings, RepoSettingsInput } from "@/lib/git/types";
 import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
+import {
+  cancelRepoDescGeneration,
+  claimRepoDescGeneration,
+  consumePendingRepoDesc,
+  type RepoDescResult,
+  registerRepoDescListener,
+  settleRepoDescGeneration,
+  useIsGeneratingRepoDesc,
+} from "@/lib/stores/repo-description-generation";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
@@ -224,6 +233,11 @@ function GeneralForm({
   const repoName =
     useUiStore((s) => s.repoName) ?? repoPath.split(/[/\\]/).pop() ?? repoPath;
   const descGen = useGenerateRepoDescription(repoPath);
+  // A run started here outlives this form (the dialog and the rail both unmount
+  // their section immediately), so the store owns it: `generating` covers the
+  // stream this mount launched, the store covers one it inherited.
+  const storeBusy = useIsGeneratingRepoDesc(repoPath);
+  const busy = descGen.generating || storeBusy;
 
   function set<K extends keyof RepoSettingsInput>(
     key: K,
@@ -232,20 +246,42 @@ function GeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Seeds the draft the way a manual edit would, so the Save bar goes live.
+  const applyResult = useCallback(({ description, topics }: RepoDescResult) => {
+    if (description) setForm((f) => ({ ...f, description }));
+    if (topics.length)
+      setForm((f) => ({ ...f, topics: normalizeTopics(topics) }));
+  }, []);
+
+  // Take a result that settled while no section was mounted, then stay the
+  // recipient for one that settles during this mount.
+  useEffect(() => {
+    const pending = consumePendingRepoDesc(repoPath);
+    if (pending) applyResult(pending);
+    return registerRepoDescListener(repoPath, applyResult);
+  }, [repoPath, applyResult]);
+
   // Shared by the Generate button and the settings dialog's generate chord,
   // which this publishes to — the shell owns the chord because it owns the
   // DialogContent every section renders inside.
-  function runGenerate() {
-    descGen.generate({
-      repoName,
-      onResult: ({ description, topics }) => {
-        if (description) set("description", description);
-        if (topics.length) set("topics", normalizeTopics(topics));
-      },
-    });
+  async function runGenerate() {
+    if (!claimRepoDescGeneration(repoPath, descGen.cancel)) return;
+    let result: RepoDescResult | null = null;
+    try {
+      await descGen.generate({
+        repoName,
+        onResult: (r) => {
+          result = r;
+        },
+      });
+    } finally {
+      // In a `finally` because nothing else clears the lane: a throw between
+      // the claim and here would leave every surface for this repo busy.
+      settleRepoDescGeneration(repoPath, result);
+    }
   }
   const { hint: generateHint } = usePublishGenerateAction(
-    aiEnabled && aiConfigured && !descGen.generating,
+    aiEnabled && aiConfigured && !busy,
     runGenerate,
   );
 
@@ -294,13 +330,16 @@ function GeneralForm({
               <SparkleIcon data-icon="inline-start" />
               Set up AI
             </Button>
-          ) : descGen.generating ? (
+          ) : busy ? (
             <Button
               type="button"
               variant="ghost"
               size="xs"
               className="text-muted-foreground"
-              onClick={descGen.cancel}
+              onClick={() => {
+                if (descGen.generating) descGen.cancel();
+                else cancelRepoDescGeneration(repoPath);
+              }}
             >
               <Spinner data-icon="inline-start" />
               Cancel
@@ -542,9 +581,7 @@ function GeneralForm({
           </span>
         )}
         <Button
-          disabled={
-            !dirty || !mergeValid || update.isPending || descGen.generating
-          }
+          disabled={!dirty || !mergeValid || update.isPending || busy}
           onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}

--- a/src/features/repo-settings/GeneralSettingsSection.tsx
+++ b/src/features/repo-settings/GeneralSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { ArrowSquareOutIcon, SparkleIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { toast } from "sonner";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import { SelectClipText } from "@/components/select-clip-text";
@@ -72,7 +72,10 @@ export function GeneralSettingsSection({
   }
 
   return (
+    // Keyed by repo: a cache-warm switch would otherwise reconcile the form in
+    // place, carrying the previous repo's draft and its generation's abort handle.
     <GeneralForm
+      key={repoPath}
       repoPath={repoPath}
       settings={settings.data}
       branches={branches.data ?? []}
@@ -254,8 +257,9 @@ function GeneralForm({
   }, []);
 
   // Take a result that settled while no section was mounted, then stay the
-  // recipient for one that settles during this mount.
-  useEffect(() => {
+  // recipient for one that settles during this mount. A LAYOUT effect: a settle
+  // between the commit and a passive flush would find no listener and toast.
+  useLayoutEffect(() => {
     const pending = consumePendingRepoDesc(repoPath);
     if (pending) applyResult(pending);
     return registerRepoDescListener(repoPath, applyResult);

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -1,5 +1,5 @@
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { toast } from "sonner";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
@@ -75,6 +75,7 @@ export function GitLabGeneralSection({
 
   return (
     <GitLabGeneralForm
+      key={repoPath}
       repoPath={repoPath}
       settings={settings.data}
       branches={branches.data ?? []}
@@ -198,8 +199,9 @@ function GitLabGeneralForm({
   }, []);
 
   // Take a result that settled while no section was mounted, then stay the
-  // recipient for one that settles during this mount.
-  useEffect(() => {
+  // recipient for one that settles during this mount. A LAYOUT effect: a settle
+  // between the commit and a passive flush would find no listener and toast.
+  useLayoutEffect(() => {
     const pending = consumePendingRepoDesc(repoPath);
     if (pending) applyResult(pending);
     return registerRepoDescListener(repoPath, applyResult);

--- a/src/features/repo-settings/GitLabGeneralSection.tsx
+++ b/src/features/repo-settings/GitLabGeneralSection.tsx
@@ -1,5 +1,5 @@
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,15 @@ import type {
 } from "@/lib/git/types";
 import { usePublishGenerateAction } from "@/lib/hotkeys/useGenerateChord";
 import { useAiConfigured, useAiEnabled } from "@/lib/settings/queries";
+import {
+  cancelRepoDescGeneration,
+  claimRepoDescGeneration,
+  consumePendingRepoDesc,
+  type RepoDescResult,
+  registerRepoDescListener,
+  settleRepoDescGeneration,
+  useIsGeneratingRepoDesc,
+} from "@/lib/stores/repo-description-generation";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
 import { DescriptionField } from "./DescriptionField";
@@ -168,6 +177,11 @@ function GitLabGeneralForm({
   const repoName =
     useUiStore((s) => s.repoName) ?? repoPath.split(/[/\\]/).pop() ?? repoPath;
   const descGen = useGenerateRepoDescription(repoPath);
+  // A run started here outlives this form (the dialog and the rail both unmount
+  // their section immediately), so the store owns it: `generating` covers the
+  // stream this mount launched, the store covers one it inherited.
+  const storeBusy = useIsGeneratingRepoDesc(repoPath);
+  const busy = descGen.generating || storeBusy;
 
   function set<K extends keyof GitLabRepoSettingsInput>(
     key: K,
@@ -176,20 +190,42 @@ function GitLabGeneralForm({
     setForm((f) => ({ ...f, [key]: value }));
   }
 
+  // Seeds the draft the way a manual edit would, so the Save bar goes live.
+  const applyResult = useCallback(({ description, topics }: RepoDescResult) => {
+    if (description) setForm((f) => ({ ...f, description }));
+    if (topics.length)
+      setForm((f) => ({ ...f, topics: normalizeGlTopics(topics) }));
+  }, []);
+
+  // Take a result that settled while no section was mounted, then stay the
+  // recipient for one that settles during this mount.
+  useEffect(() => {
+    const pending = consumePendingRepoDesc(repoPath);
+    if (pending) applyResult(pending);
+    return registerRepoDescListener(repoPath, applyResult);
+  }, [repoPath, applyResult]);
+
   // Shared by the Generate button and the settings dialog's generate chord,
   // which this publishes to — the shell owns the chord because it owns the
   // DialogContent every section renders inside.
-  function runGenerate() {
-    descGen.generate({
-      repoName,
-      onResult: ({ description, topics }) => {
-        if (description) set("description", description);
-        if (topics.length) set("topics", normalizeGlTopics(topics));
-      },
-    });
+  async function runGenerate() {
+    if (!claimRepoDescGeneration(repoPath, descGen.cancel)) return;
+    let result: RepoDescResult | null = null;
+    try {
+      await descGen.generate({
+        repoName,
+        onResult: (r) => {
+          result = r;
+        },
+      });
+    } finally {
+      // In a `finally` because nothing else clears the lane: a throw between
+      // the claim and here would leave every surface for this repo busy.
+      settleRepoDescGeneration(repoPath, result);
+    }
   }
   const { hint: generateHint } = usePublishGenerateAction(
-    aiEnabled && aiConfigured && !descGen.generating,
+    aiEnabled && aiConfigured && !busy,
     runGenerate,
   );
 
@@ -237,13 +273,16 @@ function GitLabGeneralForm({
               <SparkleIcon data-icon="inline-start" />
               Set up AI
             </Button>
-          ) : descGen.generating ? (
+          ) : busy ? (
             <Button
               type="button"
               variant="ghost"
               size="xs"
               className="text-muted-foreground"
-              onClick={descGen.cancel}
+              onClick={() => {
+                if (descGen.generating) descGen.cancel();
+                else cancelRepoDescGeneration(repoPath);
+              }}
             >
               <Spinner data-icon="inline-start" />
               Cancel
@@ -423,7 +462,7 @@ function GitLabGeneralForm({
 
       <div className="flex items-center justify-end gap-2 border-t pt-3">
         <Button
-          disabled={!dirty || update.isPending || descGen.generating}
+          disabled={!dirty || update.isPending || busy}
           onClick={handleSave}
         >
           {update.isPending && <Spinner data-icon="inline-start" />}

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -63,7 +63,10 @@ import {
   useGenerateChord,
 } from "@/lib/hotkeys/useGenerateChord";
 import { quickTransition } from "@/lib/motion";
-import { registerRepoSettingsOpenMarker } from "@/lib/stores/repo-description-generation";
+import {
+  registerRepoDescActiveSection,
+  registerRepoSettingsOpenMarker,
+} from "@/lib/stores/repo-description-generation";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { BitbucketBranchRestrictionsSection } from "./BitbucketBranchRestrictionsSection";
@@ -369,6 +372,14 @@ export function RepoSettingsDialog({
   // the marker's lifetime is the dialog's: a description generation settling
   // with no section listening reads it to pick toast copy that still works.
   useEffect(() => registerRepoSettingsOpenMarker(repoPath), [repoPath]);
+
+  // Which section is live, for that same generation's delivery. Read here
+  // rather than from the section itself: the crossfade keeps an exiting
+  // section mounted, while these effects run on the switch.
+  useEffect(() => {
+    if (activeSection !== "general") return;
+    return registerRepoDescActiveSection(repoPath);
+  }, [repoPath, activeSection]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -9,7 +9,7 @@ import {
   TrashIcon,
 } from "@phosphor-icons/react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { type ComponentType, useEffect, useState } from "react";
+import { type ComponentType, useLayoutEffect, useState } from "react";
 import { toast } from "sonner";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import { NavRail, type NavRailGroup } from "@/components/NavRail";
@@ -368,15 +368,19 @@ export function RepoSettingsDialog({
     run: generate.runPublished,
   });
 
+  // Both registrations are LAYOUT effects: a generation settling between the
+  // commit and a passive flush would read the previous state and announce
+  // itself wrongly — the same window `useFinishAndSurface` documents.
+  //
   // This tree is mounted only while the dialog is open (its host gates it), so
   // the marker's lifetime is the dialog's: a description generation settling
   // with no section listening reads it to pick toast copy that still works.
-  useEffect(() => registerRepoSettingsOpenMarker(repoPath), [repoPath]);
+  useLayoutEffect(() => registerRepoSettingsOpenMarker(repoPath), [repoPath]);
 
   // Which section is live, for that same generation's delivery. Read here
   // rather than from the section itself: the crossfade keeps an exiting
   // section mounted, while these effects run on the switch.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (activeSection !== "general") return;
     return registerRepoDescActiveSection(repoPath);
   }, [repoPath, activeSection]);

--- a/src/features/repo-settings/RepoSettingsDialog.tsx
+++ b/src/features/repo-settings/RepoSettingsDialog.tsx
@@ -9,7 +9,7 @@ import {
   TrashIcon,
 } from "@phosphor-icons/react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { type ComponentType, useState } from "react";
+import { type ComponentType, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import { NavRail, type NavRailGroup } from "@/components/NavRail";
@@ -63,6 +63,7 @@ import {
   useGenerateChord,
 } from "@/lib/hotkeys/useGenerateChord";
 import { quickTransition } from "@/lib/motion";
+import { registerRepoSettingsOpenMarker } from "@/lib/stores/repo-description-generation";
 import { toastError } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { BitbucketBranchRestrictionsSection } from "./BitbucketBranchRestrictionsSection";
@@ -363,6 +364,11 @@ export function RepoSettingsDialog({
     enabled: true,
     run: generate.runPublished,
   });
+
+  // This tree is mounted only while the dialog is open (its host gates it), so
+  // the marker's lifetime is the dialog's: a description generation settling
+  // with no section listening reads it to pick toast copy that still works.
+  useEffect(() => registerRepoSettingsOpenMarker(repoPath), [repoPath]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -141,7 +141,10 @@ export function PublishDialog({
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away. The lone
   // host passes a plain open setter, so `onOpenChange(true)` reopens.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel: descGen.cancel,
+    generating: descGen.generating,
+    close: () => onOpenChange(false),
     readyTitle: "Repository description ready",
     readyDescription: "It's waiting in the dialog.",
     reopen: () => onOpenChange(true),
@@ -263,7 +266,7 @@ export function PublishDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the description and topics in form state, which this
     // reset would blank on reopen.
-    if (descGen.generating || surface.consumeSkipSeed()) return;
+    if (surface.shouldSkipSeed(descGen.generating)) return;
     form.reset({
       name: defaultName,
       description: "",
@@ -310,20 +313,25 @@ export function PublishDialog({
     // The hook resolves void and fires `onResult` only for a run that produced
     // usable content, so this flag is the settled-with-result signal.
     let ok = false;
-    await descGen.generate({
-      repoName: nameVal.trim() || defaultName,
-      onResult: ({ description, topics }) => {
-        ok = true;
-        if (description) {
-          form.setFieldValue("description", description);
-        }
-        // Bitbucket has no topics field — drop that arm.
-        if (!isBitbucket && topics.length) {
-          form.setFieldValue("topics", topics.join(" "));
-        }
-      },
-    });
-    surface.noteRunSettled(ok);
+    try {
+      await descGen.generate({
+        repoName: nameVal.trim() || defaultName,
+        onResult: ({ description, topics }) => {
+          ok = true;
+          if (description) {
+            form.setFieldValue("description", description);
+          }
+          // Bitbucket has no topics field — drop that arm.
+          if (!isBitbucket && topics.length) {
+            form.setFieldValue("topics", topics.join(" "));
+          }
+        },
+      });
+    } finally {
+      // Every arm reports: a throw that skipped this would strand the surface's
+      // one-shot state armed, swallowing the next run's settle.
+      surface.noteRunSettled(ok);
+    }
   }
   // This dialog opens from the header over any tab, including Changes where the
   // global generate-commit-message action is live. The chord is swallowed here

--- a/src/features/repository/PublishDialog.tsx
+++ b/src/features/repository/PublishDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { required, useAppForm } from "@/lib/form";
 import {
   useBbWorkspaces,
@@ -137,6 +138,14 @@ export function PublishDialog({
   const publish = usePublishRepo(repoPath);
   const aiEnabled = useAiEnabled();
   const descGen = useGenerateRepoDescription(repoPath);
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away. The lone
+  // host passes a plain open setter, so `onOpenChange(true)` reopens.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "Repository description ready",
+    readyDescription: "It's waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
   const isGitLab = provider === "gitlab";
   const isBitbucket = provider === "bitbucket";
   const isGitHub = provider === "github";
@@ -250,7 +259,11 @@ export function PublishDialog({
   // advisory names the Owner select, so it rides only the arm that renders one.
   const nameWarning = ghPickerActive ? ghNameWarning : NAME_WARNINGS[provider];
 
-  const seedOnOpen = useEffectEvent(() =>
+  const seedOnOpen = useEffectEvent(() => {
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the description and topics in form state, which this
+    // reset would blank on reopen.
+    if (descGen.generating || surface.consumeSkipSeed()) return;
     form.reset({
       name: defaultName,
       description: "",
@@ -259,8 +272,8 @@ export function PublishDialog({
       workspace: "",
       owner: "",
       isPrivate: true,
-    }),
-  );
+    });
+  });
   useSeedOnOpen(open, seedOnOpen);
 
   // Workspaces load after the dialog opens, so seed the picker once they arrive
@@ -293,10 +306,14 @@ export function PublishDialog({
   }, [open, isGitHub, defaultOwner, ownerLogins]);
 
   // Shared by the Generate button and the generate chord below.
-  function runGenerate() {
-    descGen.generate({
+  async function runGenerate() {
+    // The hook resolves void and fires `onResult` only for a run that produced
+    // usable content, so this flag is the settled-with-result signal.
+    let ok = false;
+    await descGen.generate({
       repoName: nameVal.trim() || defaultName,
       onResult: ({ description, topics }) => {
+        ok = true;
         if (description) {
           form.setFieldValue("description", description);
         }
@@ -306,6 +323,7 @@ export function PublishDialog({
         }
       },
     });
+    surface.noteRunSettled(ok);
   }
   // This dialog opens from the header over any tab, including Changes where the
   // global generate-commit-message action is live. The chord is swallowed here
@@ -316,6 +334,10 @@ export function PublishDialog({
     enabled: aiEnabled && !descGen.generating,
     run: runGenerate,
   });
+
+  // The one submit gate, shared by the button and the form's native submit:
+  // Enter must submit exactly when the button would.
+  const submitBlocked = descGen.generating || bbBlocked || ghBlocked;
 
   const githubScope = ghPickerActive ? (
     <>
@@ -340,6 +362,7 @@ export function PublishDialog({
           className="flex min-h-0 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -520,9 +543,7 @@ export function PublishDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton
-                disabled={descGen.generating || bbBlocked || ghBlocked}
-              >
+              <form.SubmitButton disabled={submitBlocked}>
                 Publish
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/repository/RepoSettingsDialogFallback.tsx
+++ b/src/features/repository/RepoSettingsDialogFallback.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -6,6 +7,7 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
+import { registerRepoSettingsOpenMarker } from "@/lib/stores/repo-description-generation";
 import { cn } from "@/lib/utils";
 
 /** Six rows: the shortest provider rail (GitLab) offers six sections, and the
@@ -20,10 +22,17 @@ const RAIL_ROW_WIDTHS = ["w-16", "w-20", "w-14", "w-24", "w-12", "w-18"];
  * stays skeletal here rather than flashing a label the repo's forge contradicts.
  */
 export function RepoSettingsDialogFallback({
+  repoPath,
   onOpenChange,
 }: {
+  repoPath: string;
   onOpenChange: (open: boolean) => void;
 }) {
+  // This frame is a dialog-open period like any other, so it carries the marker
+  // too: a description generation settling here would otherwise offer a "View"
+  // deep link that the open dialog's own host drops.
+  useLayoutEffect(() => registerRepoSettingsOpenMarker(repoPath), [repoPath]);
+
   // The Changes-tab generator must not run behind this frame. A defined `run`
   // is what arms the hook's swallow at all, and the chord is then swallowed
   // whenever it may fire (the hook mirrors the global listener's own guards);

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -256,17 +256,29 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     openRepoSettings();
   });
 
+  // Whether the admin gate has an answer yet — settled either way, error
+  // included, so a failed probe releases the request instead of pinning it.
+  const settingsGateResolved =
+    !gh.isPending && (!settingsReady || !admin.isPending);
+
   // A one-shot deep link raised by another surface (the Findings tab's "turn on
   // Dependabot" card). Not keyed on the dialog's open state, so re-opening the
   // dialog can never re-fire it.
   useEffect(() => {
     if (!repoSettingsRequest) return;
-    // Same admin gate as the menu item: the dialog is admin-only, so a request
-    // raised before the gate was known must not open it. Cleared either way —
-    // a refused request is dropped rather than left to fire later.
+    // Same admin gate as the menu item: the dialog is admin-only. An unresolved
+    // gate HOLDS the request — clearing mid-probe drops a deep link whose toast
+    // is already gone — and a resolved refusal drops it rather than letting it
+    // fire later.
+    if (!settingsGateResolved) return;
     if (canOpenRepoSettings) openRepoSettingsAt(repoSettingsRequest);
     clearRepoSettingsRequest();
-  }, [repoSettingsRequest, clearRepoSettingsRequest, canOpenRepoSettings]);
+  }, [
+    repoSettingsRequest,
+    clearRepoSettingsRequest,
+    canOpenRepoSettings,
+    settingsGateResolved,
+  ]);
 
   // The palette and the Findings deep link have no menu to warm on, so the open
   // itself warms too; the shared import means this and the menu preload resolve
@@ -607,7 +619,10 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
         ) : (
           <Suspense
             fallback={
-              <RepoSettingsDialogFallback onOpenChange={closeRepoSettings} />
+              <RepoSettingsDialogFallback
+                repoPath={repoPath}
+                onOpenChange={closeRepoSettings}
+              />
             }
           >
             <RepoSettingsDialog

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -59,6 +59,7 @@ import {
   openWithDefault,
   openWithProgram,
 } from "@/lib/git/api";
+import { normPath } from "@/lib/git/path";
 import {
   EMPTY_NAMESPACES,
   forgeFeatureReady,
@@ -266,18 +267,26 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // dialog can never re-fire it.
   useEffect(() => {
     if (!repoSettingsRequest) return;
+    // The request names the repo it was raised for, and the gate hold below can
+    // carry it across a repo switch — opening another repo's settings is worse
+    // than dropping it, and a deferral would only re-offer it on a third repo.
+    if (repoSettingsRequest.repo !== normPath(repoPath)) {
+      clearRepoSettingsRequest();
+      return;
+    }
     // Same admin gate as the menu item: the dialog is admin-only. An unresolved
     // gate HOLDS the request — clearing mid-probe drops a deep link whose toast
     // is already gone — and a resolved refusal drops it rather than letting it
     // fire later.
     if (!settingsGateResolved) return;
-    if (canOpenRepoSettings) openRepoSettingsAt(repoSettingsRequest);
+    if (canOpenRepoSettings) openRepoSettingsAt(repoSettingsRequest.section);
     clearRepoSettingsRequest();
   }, [
     repoSettingsRequest,
     clearRepoSettingsRequest,
     canOpenRepoSettings,
     settingsGateResolved,
+    repoPath,
   ]);
 
   // The palette and the Findings deep link have no menu to warm on, so the open

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -267,9 +267,9 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   // dialog can never re-fire it.
   useEffect(() => {
     if (!repoSettingsRequest) return;
-    // The request names the repo it was raised for, and the gate hold below can
-    // carry it across a repo switch — opening another repo's settings is worse
-    // than dropping it, and a deferral would only re-offer it on a third repo.
+    // The request names the repo it was raised for. CROSS_REPO_RESET already
+    // nulls it on every repo switch, so this drop is the backstop for a route
+    // that ever sets repoPath without the reset — never fire it cross-repo.
     if (repoSettingsRequest.repo !== normPath(repoPath)) {
       clearRepoSettingsRequest();
       return;

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -1582,7 +1582,7 @@ export function FindingsPanel({
                 onRetry={() => alerts.refetch()}
                 onEnable={
                   canOpenRepoSettings
-                    ? () => requestRepoSettings("security")
+                    ? () => requestRepoSettings("security", repoPath)
                     : undefined
                 }
               />
@@ -1688,7 +1688,7 @@ export function FindingsPanel({
                 onRetry={() => codeScanning.refetch()}
                 onEnable={
                   canOpenRepoSettings
-                    ? () => requestRepoSettings("security")
+                    ? () => requestRepoSettings("security", repoPath)
                     : undefined
                 }
               />
@@ -1808,7 +1808,7 @@ export function FindingsPanel({
                 onRetry={() => secrets.refetch()}
                 onEnable={
                   canOpenRepoSettings
-                    ? () => requestRepoSettings("security")
+                    ? () => requestRepoSettings("security", repoPath)
                     : undefined
                 }
               />

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { useSelector } from "@tanstack/react-store";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffectEvent, useRef, useState } from "react";
+import { useEffectEvent, useLayoutEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import {
@@ -48,9 +48,13 @@ import {
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useFinishAndSurface } from "@/features/conversations/useAiStream";
+import {
+  useCancelOnIdentityChange,
+  useFinishAndSurface,
+} from "@/features/conversations/useAiStream";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { useAppForm } from "@/lib/form";
+import { normPath } from "@/lib/git/path";
 import {
   useBranches,
   useCreateRelease,
@@ -110,11 +114,38 @@ export function CreateReleaseDialog({
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away. Both
   // hosts pass a plain open setter, so `onOpenChange(true)` reopens.
-  const surface = useFinishAndSurface(open, {
+  const surface = useFinishAndSurface(repoPath, open, {
+    cancel: aiNotes.cancel,
+    // The AI stream alone: the From-GitHub mutation is not what a switch aborts.
+    generating: aiNotes.generating,
+    close: () => onOpenChange(false),
     readyTitle: "Release notes ready",
     readyDescription: "They're waiting in the dialog.",
     reopen: () => onOpenChange(true),
   });
+  // The dialog is retained across repo AND tag switches, so nothing a run settles
+  // may write this form or skip its seed for the identity now on screen: the
+  // GitHub mutation validates start-vs-live identity; the AI stream is cancelled
+  // at the switch and its settle swallowed.
+  const tagIdentity = initialTag ?? "";
+  const liveTagRef = useRef(tagIdentity);
+  useLayoutEffect(() => {
+    liveTagRef.current = tagIdentity;
+  }, [tagIdentity]);
+  const tagSwitchAbortRef = useRef(false);
+  useCancelOnIdentityChange(tagIdentity, () => {
+    void surface.consumeSkipSeed();
+    tagSwitchAbortRef.current = aiNotes.generating;
+    aiNotes.cancel();
+  });
+  // The From-GitHub run's identity while it is in flight; nothing cancels it.
+  const ghRunIdentityRef = useRef<{ repo: string; tag: string } | null>(null);
+  const ghRunIsForThisIdentity = () => {
+    const run = ghRunIdentityRef.current;
+    return (
+      run !== null && run.repo === normPath(repoPath) && run.tag === tagIdentity
+    );
+  };
   // GitLab has no draft/pre-release/latest concepts and no auto-notes API, so
   // those checkboxes and the "From GitHub" generator hide there (AI notes still
   // work — they fall back to local commits).
@@ -210,7 +241,13 @@ export function CreateReleaseDialog({
     // A generation still streaming — or one that settled while the dialog was
     // closed — leaves the notes and the rest of the draft in form state, which
     // this reset would blank on reopen.
-    if (busyGenerating || surface.consumeSkipSeed()) return;
+    if (
+      surface.shouldSkipSeed(
+        aiNotes.generating && !tagSwitchAbortRef.current,
+      ) ||
+      (githubNotes.isPending && ghRunIsForThisIdentity())
+    )
+      return;
     form.reset(
       {
         ...RELEASE_DEFAULTS,
@@ -241,6 +278,13 @@ export function CreateReleaseDialog({
   async function generateFromGithub() {
     if (!tagTrimmed) return;
     const requestedFor = tagTrimmed;
+    // This mutation outlives both axes, and no identity-cancel can abort it.
+    const startRepo = normPath(repoPath);
+    const startTag = tagIdentity;
+    const switchedAway = () =>
+      normPath(useUiStore.getState().repoPath ?? "") !== startRepo ||
+      liveTagRef.current !== startTag;
+    ghRunIdentityRef.current = { repo: startRepo, tag: startTag };
     let gen: GeneratedNotes;
     try {
       gen = await githubNotes.mutateAsync({
@@ -249,11 +293,17 @@ export function CreateReleaseDialog({
         previousTag: effectivePreviousTag,
       });
     } catch (e) {
+      if (switchedAway()) return;
       toastError(e);
       // Still a settle: the typed draft has to survive one reopen for a retry.
       surface.noteRunSettled(false);
       return;
+    } finally {
+      // The run is over on every arm, the foreign-refused ones included.
+      ghRunIdentityRef.current = null;
     }
+    // Nothing below awaits, so this one check covers every settle arm that follows.
+    if (switchedAway()) return;
     // The response belongs to the tag it was requested for — a reseeded or
     // retyped form is another release, and stale notes must not touch it.
     if (form.getFieldValue("tag").trim() !== requestedFor) {
@@ -283,6 +333,13 @@ export function CreateReleaseDialog({
         onResult: (body) => form.setFieldValue("notes", body),
       })
       .then((final) => {
+        // The tag switch's own abort settles here — swallow it, never re-latch.
+        // Exactly one swallow consumes a settle; the repo flag can't also arm
+        // while tag hosts unmount on a repo switch — else, per-run tokens.
+        if (tagSwitchAbortRef.current) {
+          tagSwitchAbortRef.current = false;
+          return;
+        }
         // Resolves with the COMPLETE notes, or null — an aborted stream still
         // fired `onResult` with its partials, so that can't be the signal.
         surface.noteRunSettled(final !== null);

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -344,19 +344,31 @@ export function CreateReleaseDialog({
         isGitHub,
         onResult: (body) => form.setFieldValue("notes", body),
       })
-      .then((final) => {
-        // The tag switch's own abort settles here — swallow it, never re-latch.
-        // Exactly one swallow consumes a settle; the repo flag can't also arm
-        // while tag hosts unmount on a repo switch — else, per-run tokens.
-        if (tagSwitchAbortRef.current) {
-          tagSwitchAbortRef.current = false;
-          return;
-        }
-        // Resolves with the COMPLETE notes, or null — an aborted stream still
-        // fired `onResult` with its partials, so that can't be the signal.
-        settleTagRef.current = tagIdentity;
-        surface.noteRunSettled(final !== null);
-      });
+      .then(
+        (final) => {
+          // The tag switch's own abort settles here — swallow it, never re-latch.
+          // Exactly one swallow consumes a settle; the repo flag can't also arm
+          // while tag hosts unmount on a repo switch — else, per-run tokens.
+          if (tagSwitchAbortRef.current) {
+            tagSwitchAbortRef.current = false;
+            return;
+          }
+          // Resolves with the COMPLETE notes, or null — an aborted stream still
+          // fired `onResult` with its partials, so that can't be the signal.
+          settleTagRef.current = tagIdentity;
+          surface.noteRunSettled(final !== null);
+        },
+        // Two-arm, never a trailing .catch: a settle must be reported exactly
+        // once, and a throw in the arm above must not report a second time. The
+        // swallow repeats here — only a settle clears the flag.
+        () => {
+          if (tagSwitchAbortRef.current) {
+            tagSwitchAbortRef.current = false;
+            return;
+          }
+          surface.noteRunSettled(false);
+        },
+      );
   }
 
   // The generate chord drives the AI item only — never the From-GitHub one, and

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -340,7 +340,7 @@ export function CreateReleaseDialog({
     aiNotes
       .generate({
         tag: requestedFor,
-        target: showTarget ? target.trim() : tagTrimmed,
+        target: showTarget ? target.trim() : requestedFor,
         previousTag: effectivePreviousTag,
         repoName,
         isGitHub,

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -334,15 +334,21 @@ export function CreateReleaseDialog({
 
   function generateWithAi() {
     if (!tagTrimmed) return;
+    // Same requestedFor rule as From-GitHub: a retyped form is another release.
+    const requestedFor = tagTrimmed;
     form.setFieldValue("notes", "");
     aiNotes
       .generate({
-        tag: tagTrimmed,
+        tag: requestedFor,
         target: showTarget ? target.trim() : tagTrimmed,
         previousTag: effectivePreviousTag,
         repoName,
         isGitHub,
-        onResult: (body) => form.setFieldValue("notes", body),
+        onResult: (body) => {
+          if (form.getFieldValue("tag").trim() === requestedFor) {
+            form.setFieldValue("notes", body);
+          }
+        },
       })
       .then(
         (final) => {
@@ -351,6 +357,10 @@ export function CreateReleaseDialog({
           // while tag hosts unmount on a repo switch — else, per-run tokens.
           if (tagSwitchAbortRef.current) {
             tagSwitchAbortRef.current = false;
+            return;
+          }
+          if (form.getFieldValue("tag").trim() !== requestedFor) {
+            surface.noteRunSettled(false);
             return;
           }
           // Resolves with the COMPLETE notes, or null — an aborted stream still

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useFinishAndSurface } from "@/features/conversations/useAiStream";
 import { useMentionCandidates } from "@/features/conversations/useMentionCandidates";
 import { useAppForm } from "@/lib/form";
 import {
@@ -105,6 +106,15 @@ export function CreateReleaseDialog({
   const createRelease = useCreateRelease(repoPath);
   const githubNotes = useGithubReleaseNotes(repoPath);
   const aiNotes = useGenerateReleaseNotes(repoPath);
+  const busyGenerating = githubNotes.isPending || aiNotes.generating;
+  // Closing mid-generation never cancels the run: it finishes into the retained
+  // form state, and this surfaces the result while the dialog is away. Both
+  // hosts pass a plain open setter, so `onOpenChange(true)` reopens.
+  const surface = useFinishAndSurface(open, {
+    readyTitle: "Release notes ready",
+    readyDescription: "They're waiting in the dialog.",
+    reopen: () => onOpenChange(true),
+  });
   // GitLab has no draft/pre-release/latest concepts and no auto-notes API, so
   // those checkboxes and the "From GitHub" generator hide there (AI notes still
   // work — they fall back to local commits).
@@ -197,6 +207,10 @@ export function CreateReleaseDialog({
     : "";
 
   const seedOnOpen = useEffectEvent(() => {
+    // A generation still streaming — or one that settled while the dialog was
+    // closed — leaves the notes and the rest of the draft in form state, which
+    // this reset would blank on reopen.
+    if (busyGenerating || surface.consumeSkipSeed()) return;
     form.reset(
       {
         ...RELEASE_DEFAULTS,
@@ -221,8 +235,6 @@ export function CreateReleaseDialog({
     setTagOpen(false);
   }
 
-  const busyGenerating = githubNotes.isPending || aiNotes.generating;
-
   // Awaited like the submit above: react-query drops per-call callbacks once the
   // observer loses listeners, and this dialog's host panel hides with its tab
   // while generation is still in flight.
@@ -238,29 +250,43 @@ export function CreateReleaseDialog({
       });
     } catch (e) {
       toastError(e);
+      // Still a settle: the typed draft has to survive one reopen for a retry.
+      surface.noteRunSettled(false);
       return;
     }
     // The response belongs to the tag it was requested for — a reseeded or
     // retyped form is another release, and stale notes must not touch it.
-    if (form.getFieldValue("tag").trim() !== requestedFor) return;
+    if (form.getFieldValue("tag").trim() !== requestedFor) {
+      surface.noteRunSettled(false);
+      return;
+    }
     if (gen.body) form.setFieldValue("notes", gen.body);
     if (gen.name && !form.getFieldValue("title").trim()) {
       form.setFieldValue("title", gen.name);
     }
     notesEditorRef.current?.showPreview();
+    // Only a body is notes "waiting in the dialog" — a name-only response has
+    // nothing for the toast to promise.
+    surface.noteRunSettled(Boolean(gen.body));
   }
 
   function generateWithAi() {
     if (!tagTrimmed) return;
     form.setFieldValue("notes", "");
-    aiNotes.generate({
-      tag: tagTrimmed,
-      target: showTarget ? target.trim() : tagTrimmed,
-      previousTag: effectivePreviousTag,
-      repoName,
-      isGitHub,
-      onResult: (body) => form.setFieldValue("notes", body),
-    });
+    aiNotes
+      .generate({
+        tag: tagTrimmed,
+        target: showTarget ? target.trim() : tagTrimmed,
+        previousTag: effectivePreviousTag,
+        repoName,
+        isGitHub,
+        onResult: (body) => form.setFieldValue("notes", body),
+      })
+      .then((final) => {
+        // Resolves with the COMPLETE notes, or null — an aborted stream still
+        // fired `onResult` with its partials, so that can't be the signal.
+        surface.noteRunSettled(final !== null);
+      });
   }
 
   // The generate chord drives the AI item only — never the From-GitHub one, and
@@ -282,6 +308,10 @@ export function CreateReleaseDialog({
     ? aiNotesHintTitle
     : "Enable AI in Settings first.";
 
+  // The one submit gate, shared by the button and the form's native submit:
+  // Enter must submit exactly when the button would.
+  const submitBlocked = !tagTrimmed || busyGenerating;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* A fixed height (not a cap): release bodies routinely run thousands of
@@ -294,6 +324,7 @@ export function CreateReleaseDialog({
           className="flex min-h-0 flex-1 flex-col gap-4"
           onSubmit={(e) => {
             e.preventDefault();
+            if (submitBlocked) return;
             form.handleSubmit();
           }}
         >
@@ -543,7 +574,7 @@ export function CreateReleaseDialog({
               Cancel
             </Button>
             <form.AppForm>
-              <form.SubmitButton disabled={!tagTrimmed || busyGenerating}>
+              <form.SubmitButton disabled={submitBlocked}>
                 {draft ? "Save draft" : "Publish release"}
               </form.SubmitButton>
             </form.AppForm>

--- a/src/features/tags/CreateReleaseDialog.tsx
+++ b/src/features/tags/CreateReleaseDialog.tsx
@@ -111,6 +111,16 @@ export function CreateReleaseDialog({
   const githubNotes = useGithubReleaseNotes(repoPath);
   const aiNotes = useGenerateReleaseNotes(repoPath);
   const busyGenerating = githubNotes.isPending || aiNotes.generating;
+  // The dialog is retained across repo AND tag switches, so nothing a run settles
+  // may write this form or skip its seed for the identity now on screen: the
+  // GitHub mutation validates start-vs-live identity; the AI stream is cancelled
+  // at the switch and its settle swallowed.
+  const tagIdentity = initialTag ?? "";
+  const liveTagRef = useRef(tagIdentity);
+  useLayoutEffect(() => {
+    liveTagRef.current = tagIdentity;
+  }, [tagIdentity]);
+  const settleTagRef = useRef(tagIdentity);
   // Closing mid-generation never cancels the run: it finishes into the retained
   // form state, and this surfaces the result while the dialog is away. Both
   // hosts pass a plain open setter, so `onOpenChange(true)` reopens.
@@ -121,17 +131,18 @@ export function CreateReleaseDialog({
     close: () => onOpenChange(false),
     readyTitle: "Release notes ready",
     readyDescription: "They're waiting in the dialog.",
-    reopen: () => onOpenChange(true),
+    reopen: () => {
+      // A tag switch drains the latch, so the notes are gone — say so instead of
+      // opening an emptied dialog. Inert in TagsPanel, whose tagIdentity is "".
+      if (liveTagRef.current !== settleTagRef.current) {
+        toast.info(
+          `Those notes were for ${settleTagRef.current} — they were discarded when you switched tags.`,
+        );
+        return;
+      }
+      onOpenChange(true);
+    },
   });
-  // The dialog is retained across repo AND tag switches, so nothing a run settles
-  // may write this form or skip its seed for the identity now on screen: the
-  // GitHub mutation validates start-vs-live identity; the AI stream is cancelled
-  // at the switch and its settle swallowed.
-  const tagIdentity = initialTag ?? "";
-  const liveTagRef = useRef(tagIdentity);
-  useLayoutEffect(() => {
-    liveTagRef.current = tagIdentity;
-  }, [tagIdentity]);
   const tagSwitchAbortRef = useRef(false);
   useCancelOnIdentityChange(tagIdentity, () => {
     void surface.consumeSkipSeed();
@@ -317,6 +328,7 @@ export function CreateReleaseDialog({
     notesEditorRef.current?.showPreview();
     // Only a body is notes "waiting in the dialog" — a name-only response has
     // nothing for the toast to promise.
+    settleTagRef.current = startTag;
     surface.noteRunSettled(Boolean(gen.body));
   }
 
@@ -342,6 +354,7 @@ export function CreateReleaseDialog({
         }
         // Resolves with the COMPLETE notes, or null — an aborted stream still
         // fired `onResult` with its partials, so that can't be the signal.
+        settleTagRef.current = tagIdentity;
         surface.noteRunSettled(final !== null);
       });
   }

--- a/src/features/tags/useGenerateReleaseNotes.ts
+++ b/src/features/tags/useGenerateReleaseNotes.ts
@@ -71,6 +71,10 @@ async function gatherReleaseSource(
  * `target` since `previousTag` (the prior release), falling back to recent
  * commits. Streams into the notes field so the user previews + edits before
  * publishing. Mirrors useGenerateIssueDraft.
+ *
+ * `generate` resolves the COMPLETE notes, or null when nothing usable landed —
+ * a bail, abort, error, or a blank completion. Callers need that to tell a
+ * settled run from an aborted one, whose per-chunk `onResult` still fired.
  */
 export function useGenerateReleaseNotes(repoPath: string) {
   const { generating, cancel, run } = useAiStream(repoPath);
@@ -106,8 +110,13 @@ export function useGenerateReleaseNotes(repoPath: string) {
         { onChunk: (buffer) => opts.onResult(buffer) },
       );
 
-      if (buffer !== null && !buffer.trim())
+      // A blank completion is a failed generation, so it collapses to the same
+      // null a bail/abort/error resolves — one owner for "no notes landed".
+      if (buffer !== null && !buffer.trim()) {
         toast.error("Couldn't generate notes — try again.");
+        return null;
+      }
+      return buffer;
     },
     [repoPath, run],
   );

--- a/src/lib/stores/repo-description-generation.ts
+++ b/src/lib/stores/repo-description-generation.ts
@@ -184,7 +184,7 @@ function announcePendingRepoDesc(repoPath: string): void {
                 );
                 return;
               }
-              ui.requestRepoSettings("general");
+              ui.requestRepoSettings("general", repoPath);
             },
           },
         }),

--- a/src/lib/stores/repo-description-generation.ts
+++ b/src/lib/stores/repo-description-generation.ts
@@ -1,0 +1,162 @@
+import { toast } from "sonner";
+import { create } from "zustand";
+import { normPath } from "@/lib/git/path";
+import { useUiStore } from "./ui";
+
+/** What one finished generation has to hand back to a form. */
+export interface RepoDescResult {
+  description: string;
+  topics: string[];
+}
+
+/**
+ * AI description generations, held outside the settings dialog's tree: the
+ * dialog unmounts on close and the rail unmounts the outgoing section on every
+ * switch, so a stream settling afterwards would land on a dead component and a
+ * paid run would be lost. Claimed here, its result is delivered to a mounted
+ * section or stashed for the next one. Keyed by {@link normPath} repo path and
+ * never cleared on repo switch — a run belongs to the repo it started in.
+ */
+interface RepoDescGenerationState {
+  /** repo key → the running generation's abort hook. Presence IS the busy flag,
+   *  so a reopened section paints busy for a run it never started. */
+  inFlight: Record<string, { cancel: () => void }>;
+  /** repo key → a result that settled with no section mounted to take it. */
+  pending: Record<string, RepoDescResult>;
+}
+
+const useStore = create<RepoDescGenerationState>()(() => ({
+  inFlight: {},
+  pending: {},
+}));
+
+/** Mounted sections waiting for a result, newest last. A stack rather than one
+ *  slot: each unregister splices only itself, so an unmounting section can never
+ *  linger as the recipient while a live one exists. Listeners never affect
+ *  rendering, so they live beside the store, not in its state. */
+const listeners = new Map<string, ((result: RepoDescResult) => void)[]>();
+
+/** Repos whose settings dialog is mounted, counted so overlapping mounts can't
+ *  clear each other. The dialog's host DROPS a request to open it while it is
+ *  already open, so a "View" action offered then would be dead. */
+const openDialogs = new Map<string, number>();
+
+/** Marks this repo's settings dialog as mounted; call the returned function on
+ *  unmount. */
+export function registerRepoSettingsOpenMarker(repoPath: string): () => void {
+  const repo = normPath(repoPath);
+  openDialogs.set(repo, (openDialogs.get(repo) ?? 0) + 1);
+  return () => {
+    const count = openDialogs.get(repo);
+    if (count === undefined) return;
+    if (count > 1) openDialogs.set(repo, count - 1);
+    else openDialogs.delete(repo);
+  };
+}
+
+/**
+ * Claims the lane for one repo. Returns false when a generation is already
+ * running there — the caller no-ops, because whatever surface is mounted already
+ * paints the busy affordance for it. Call this synchronously before the first
+ * await: the stream runs for a while behind a closed dialog.
+ */
+export function claimRepoDescGeneration(
+  repoPath: string,
+  cancel: () => void,
+): boolean {
+  const repo = normPath(repoPath);
+  if (useStore.getState().inFlight[repo]) return false;
+  useStore.setState((s) => ({
+    inFlight: { ...s.inFlight, [repo]: { cancel } },
+  }));
+  return true;
+}
+
+/**
+ * Releases the lane and routes the outcome. `null` (bailed, aborted, or errored)
+ * only frees it — those paths have already toasted for themselves. A result goes
+ * to the newest mounted listener when there is one; otherwise it waits in
+ * `pending` for the next section to mount, and a toast says so, since a result
+ * nobody can see is the failure this store exists to prevent.
+ */
+export function settleRepoDescGeneration(
+  repoPath: string,
+  result: RepoDescResult | null,
+): void {
+  const repo = normPath(repoPath);
+  useStore.setState((s) => {
+    if (!s.inFlight[repo]) return s;
+    const { [repo]: _settled, ...rest } = s.inFlight;
+    return { inFlight: rest };
+  });
+  if (!result) return;
+  const apply = listeners.get(repo)?.at(-1);
+  if (apply) {
+    apply(result);
+    return;
+  }
+  useStore.setState((s) => ({ pending: { ...s.pending, [repo]: result } }));
+  // With the dialog open on another section the deep link is refused, so that
+  // arm names the section to switch to instead of offering a dead button.
+  const dialogOpen = openDialogs.has(repo);
+  toast.success("Repository description ready", {
+    description: dialogOpen
+      ? "Switch to the General section to review it."
+      : "Reopen Repository settings to review.",
+    duration: 10_000,
+    ...(dialogOpen
+      ? {}
+      : {
+          action: {
+            label: "View",
+            onClick: () => useUiStore.getState().requestRepoSettings("general"),
+          },
+        }),
+  });
+}
+
+/** Registers a mounted section's field-apply for one repo; call the returned
+ *  function on unmount. */
+export function registerRepoDescListener(
+  repoPath: string,
+  apply: (result: RepoDescResult) => void,
+): () => void {
+  const repo = normPath(repoPath);
+  const stack = listeners.get(repo) ?? [];
+  stack.push(apply);
+  listeners.set(repo, stack);
+  return () => {
+    const cur = listeners.get(repo);
+    if (!cur) return;
+    const i = cur.indexOf(apply);
+    if (i !== -1) cur.splice(i, 1);
+    if (cur.length === 0) listeners.delete(repo);
+  };
+}
+
+/** Reads and clears the result a closed dialog never got to show. */
+export function consumePendingRepoDesc(
+  repoPath: string,
+): RepoDescResult | null {
+  const repo = normPath(repoPath);
+  const result = useStore.getState().pending[repo];
+  if (!result) return null;
+  useStore.setState((s) => {
+    const { [repo]: _taken, ...rest } = s.pending;
+    return { pending: rest };
+  });
+  return result;
+}
+
+/** Aborts the running generation for one repo — the affordance a section that
+ *  remounted over an orphaned run needs. The stream's own settle clears the
+ *  lane; a missing entry is a no-op. */
+export function cancelRepoDescGeneration(repoPath: string): void {
+  useStore.getState().inFlight[normPath(repoPath)]?.cancel();
+}
+
+/** True while a description generation is running for this repo, whichever
+ *  surface started it. */
+export function useIsGeneratingRepoDesc(repoPath: string): boolean {
+  return useStore((s) => Boolean(s.inFlight[normPath(repoPath)]));
+}

--- a/src/lib/stores/repo-description-generation.ts
+++ b/src/lib/stores/repo-description-generation.ts
@@ -142,13 +142,27 @@ export function settleRepoDescGeneration(
   }, PENDING_ANNOUNCE_DELAY_MS);
 }
 
+/** The live announcement per repo. The toast is the stash's public face: once
+ *  the pending result has been delivered or replaced, a surviving View is a
+ *  dead click at a dialog that is already open. */
+const announceToasts = new Map<string, string | number>();
+
+function retireAnnounceToast(repo: string): void {
+  const id = announceToasts.get(repo);
+  if (id === undefined) return;
+  toast.dismiss(id);
+  announceToasts.delete(repo);
+}
+
 /** The one announcement for a stashed result. Its copy is decided at FIRE time
  *  because the fallback can run long after the settle: while the dialog is open
  *  its host drops a deep link, so that arm points at the section instead. */
 function announcePendingRepoDesc(repoPath: string): void {
   const repo = normPath(repoPath);
+  // One live announcement per repo — a fresh stash replaces its predecessor's.
+  retireAnnounceToast(repo);
   const dialogOpen = openDialogs.has(repo);
-  toast.success("Repository description ready", {
+  const id = toast.success("Repository description ready", {
     description: dialogOpen
       ? "Switch to the General section to review it."
       : "Reopen Repository settings to review.",
@@ -175,6 +189,7 @@ function announcePendingRepoDesc(repoPath: string): void {
           },
         }),
   });
+  announceToasts.set(repo, id);
 }
 
 /** Registers a mounted section's field-apply for one repo; call the returned
@@ -203,6 +218,8 @@ export function consumePendingRepoDesc(
   const repo = normPath(repoPath);
   const result = useStore.getState().pending[repo];
   if (!result) return null;
+  // The stash is being delivered, so its announcement has been made good.
+  retireAnnounceToast(repo);
   useStore.setState((s) => {
     const { [repo]: _taken, ...rest } = s.pending;
     return { pending: rest };

--- a/src/lib/stores/repo-description-generation.ts
+++ b/src/lib/stores/repo-description-generation.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { create } from "zustand";
 import { normPath } from "@/lib/git/path";
+import { repoNameFromPath } from "./notifications";
 import { useUiStore } from "./ui";
 
 /** What one finished generation has to hand back to a form. */
@@ -16,6 +17,12 @@ export interface RepoDescResult {
  * paid run would be lost. Claimed here, its result is delivered to a mounted
  * section or stashed for the next one. Keyed by {@link normPath} repo path and
  * never cleared on repo switch — a run belongs to the repo it started in.
+ *
+ * The key is the CHECKOUT path, not `--git-common-dir`: this is ephemeral UI
+ * bookkeeping rather than app data, and two worktrees of one repo run two
+ * independent lanes with their own dialogs. PublishDialog's generator stays
+ * outside this lane deliberately — an unpublished repo and a remote admin's
+ * settings barely overlap, and it does its own finish-and-surface.
  */
 interface RepoDescGenerationState {
   /** repo key → the running generation's abort hook. Presence IS the busy flag,
@@ -157,9 +164,10 @@ function announcePendingRepoDesc(repoPath: string): void {
               // still recoverable, so say where rather than doing nothing —
               // clicking dismisses the toast, and with it the only pointer.
               if (normPath(ui.repoPath ?? "") !== repo) {
-                const name =
-                  repoPath.split(/[/\\]/).filter(Boolean).pop() ?? repoPath;
-                toast.info(`Waiting in ${name} — switch back to see it.`);
+                // Name off the RAW path — the key is lower-cased for comparison.
+                toast.info(
+                  `Waiting in ${repoNameFromPath(repoPath)} — switch back to see it.`,
+                );
                 return;
               }
               ui.requestRepoSettings("general");

--- a/src/lib/stores/repo-description-generation.ts
+++ b/src/lib/stores/repo-description-generation.ts
@@ -36,21 +36,36 @@ const useStore = create<RepoDescGenerationState>()(() => ({
  *  rendering, so they live beside the store, not in its state. */
 const listeners = new Map<string, ((result: RepoDescResult) => void)[]>();
 
-/** Repos whose settings dialog is mounted, counted so overlapping mounts can't
- *  clear each other. The dialog's host DROPS a request to open it while it is
- *  already open, so a "View" action offered then would be dead. */
+/** Repos whose settings dialog is mounted. Its host DROPS a request to open it
+ *  while it is already open, so a "View" action offered then would be dead. */
 const openDialogs = new Map<string, number>();
 
 /** Marks this repo's settings dialog as mounted; call the returned function on
  *  unmount. */
 export function registerRepoSettingsOpenMarker(repoPath: string): () => void {
-  const repo = normPath(repoPath);
-  openDialogs.set(repo, (openDialogs.get(repo) ?? 0) + 1);
+  return mark(openDialogs, normPath(repoPath));
+}
+
+/** Repos whose settings dialog is showing its General section. The crossfade
+ *  keeps an EXITING section mounted — listener included — for the whole fade,
+ *  so delivery follows the dialog's own view, which is outside the animation. */
+const generalSections = new Map<string, number>();
+
+/** Marks this repo's General section as the dialog's active one; call the
+ *  returned function when it stops being active. */
+export function registerRepoDescActiveSection(repoPath: string): () => void {
+  return mark(generalSections, normPath(repoPath));
+}
+
+/** Counted rather than a flag, so overlapping registrations for one key —
+ *  StrictMode's double-invoke included — can't clear each other. */
+function mark(counts: Map<string, number>, key: string): () => void {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
   return () => {
-    const count = openDialogs.get(repo);
+    const count = counts.get(key);
     if (count === undefined) return;
-    if (count > 1) openDialogs.set(repo, count - 1);
-    else openDialogs.delete(repo);
+    if (count > 1) counts.set(key, count - 1);
+    else counts.delete(key);
   };
 }
 
@@ -72,12 +87,16 @@ export function claimRepoDescGeneration(
   return true;
 }
 
+/** Long enough to outlast the section crossfade, so the fallback announcement
+ *  only fires when the arriving General section really never mounted. */
+const PENDING_ANNOUNCE_DELAY_MS = 800;
+
 /**
  * Releases the lane and routes the outcome. `null` (bailed, aborted, or errored)
  * only frees it — those paths have already toasted for themselves. A result goes
- * to the newest mounted listener when there is one; otherwise it waits in
- * `pending` for the next section to mount, and a toast says so, since a result
- * nobody can see is the failure this store exists to prevent.
+ * to the newest listener while General is the live section; otherwise it waits
+ * in `pending` and gets announced, at once or once the crossfade has had its
+ * chance — a result nobody can see is what this store prevents.
  */
 export function settleRepoDescGeneration(
   repoPath: string,
@@ -90,14 +109,37 @@ export function settleRepoDescGeneration(
     return { inFlight: rest };
   });
   if (!result) return;
-  const apply = listeners.get(repo)?.at(-1);
-  if (apply) {
-    apply(result);
-    return;
+  // Deliver only while General is the dialog's active section: a section on its
+  // way out still holds a registered listener, and applying there writes into a
+  // form that is about to be discarded.
+  const generalActive = generalSections.has(repo);
+  if (generalActive) {
+    const apply = listeners.get(repo)?.at(-1);
+    if (apply) {
+      apply(result);
+      return;
+    }
   }
   useStore.setState((s) => ({ pending: { ...s.pending, [repo]: result } }));
-  // With the dialog open on another section the deep link is refused, so that
-  // arm names the section to switch to instead of offering a dead button.
+  if (!generalActive) {
+    announcePendingRepoDesc(repoPath);
+    return;
+  }
+  // Mid-switch ONTO General: the arriving section is expected to consume this,
+  // but leaving or closing inside the fade breaks that promise, so one timer
+  // turns a stash nobody claimed into a late announcement.
+  setTimeout(() => {
+    if (!useStore.getState().pending[repo]) return;
+    if (listeners.get(repo)?.length) return;
+    announcePendingRepoDesc(repoPath);
+  }, PENDING_ANNOUNCE_DELAY_MS);
+}
+
+/** The one announcement for a stashed result. Its copy is decided at FIRE time
+ *  because the fallback can run long after the settle: while the dialog is open
+ *  its host drops a deep link, so that arm points at the section instead. */
+function announcePendingRepoDesc(repoPath: string): void {
+  const repo = normPath(repoPath);
   const dialogOpen = openDialogs.has(repo);
   toast.success("Repository description ready", {
     description: dialogOpen
@@ -109,7 +151,19 @@ export function settleRepoDescGeneration(
       : {
           action: {
             label: "View",
-            onClick: () => useUiStore.getState().requestRepoSettings("general"),
+            onClick: () => {
+              const ui = useUiStore.getState();
+              // The request targets the ACTIVE repo. Away from it the result is
+              // still recoverable, so say where rather than doing nothing —
+              // clicking dismisses the toast, and with it the only pointer.
+              if (normPath(ui.repoPath ?? "") !== repo) {
+                const name =
+                  repoPath.split(/[/\\]/).filter(Boolean).pop() ?? repoPath;
+                toast.info(`Waiting in ${name} — switch back to see it.`);
+                return;
+              }
+              ui.requestRepoSettings("general");
+            },
           },
         }),
   });

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { normPath } from "@/lib/git/path";
 import type { CommitAuthor, RemoteLens, RepoInfo } from "@/lib/git/types";
 import type { PrSection } from "@/lib/pulls/pr-section";
 import { startViewTransition } from "@/lib/view-transition";
@@ -321,9 +322,14 @@ interface UiState {
   findingsLimits: FindingsLimits;
   /** A one-shot request to open Repository Settings at a section, raised by
    *  another surface (the Findings tab's "Dependabot is off" card, the
-   *  description-ready toast). The menu that owns the dialog consumes and
-   *  clears it. */
-  repoSettingsRequest: "security" | "general" | null;
+   *  description-ready toast). Stamped with the {@link normPath} repo it was
+   *  raised for: its consumer can hold it while an admin probe resolves, so it
+   *  can outlive a repo switch and must never fire against another repo. The
+   *  menu that owns the dialog consumes and clears it. */
+  repoSettingsRequest: {
+    section: "security" | "general";
+    repo: string;
+  } | null;
   /** Selected tag (by name) on the Tags tab. */
   selectedTag: { tag: string } | null;
   /** Selected TODO on the Code TODOs tab. Carries the scan's authoritative
@@ -455,8 +461,12 @@ interface UiState {
   selectFinding: (finding: SelectedFinding | null) => void;
   setFindingsLimits: (limits: FindingsLimits) => void;
   /** Ask whichever surface owns the Repository Settings dialog to open it at
-   *  `section`. Cleared by that surface as it opens (one-shot). */
-  requestRepoSettings: (section: "security" | "general") => void;
+   *  `section`, for the repo `repoPath` names. Cleared by that surface as it
+   *  opens (one-shot). */
+  requestRepoSettings: (
+    section: "security" | "general",
+    repoPath: string,
+  ) => void;
   clearRepoSettingsRequest: () => void;
   selectTag: (tag: { tag: string } | null) => void;
   setSelectedTodo: (
@@ -696,7 +706,8 @@ export const useUiStore = create<UiState>()((set, get) => {
     selectRun: (id) => set({ selectedRunId: id }),
     selectFinding: (finding) => set({ selectedFinding: finding }),
     setFindingsLimits: (limits) => set({ findingsLimits: limits }),
-    requestRepoSettings: (section) => set({ repoSettingsRequest: section }),
+    requestRepoSettings: (section, repoPath) =>
+      set({ repoSettingsRequest: { section, repo: normPath(repoPath) } }),
     clearRepoSettingsRequest: () => set({ repoSettingsRequest: null }),
     selectTag: (tag) => set({ selectedTag: tag }),
     setSelectedTodo: (todo) => set({ selectedTodo: todo }),

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -320,9 +320,10 @@ interface UiState {
   /** Per-category row limits on the Findings tab; "Load more" bumps one. */
   findingsLimits: FindingsLimits;
   /** A one-shot request to open Repository Settings at a section, raised by
-   *  another surface (the Findings tab's "Dependabot is off" card). The menu
-   *  that owns the dialog consumes and clears it. */
-  repoSettingsRequest: "security" | null;
+   *  another surface (the Findings tab's "Dependabot is off" card, the
+   *  description-ready toast). The menu that owns the dialog consumes and
+   *  clears it. */
+  repoSettingsRequest: "security" | "general" | null;
   /** Selected tag (by name) on the Tags tab. */
   selectedTag: { tag: string } | null;
   /** Selected TODO on the Code TODOs tab. Carries the scan's authoritative
@@ -455,7 +456,7 @@ interface UiState {
   setFindingsLimits: (limits: FindingsLimits) => void;
   /** Ask whichever surface owns the Repository Settings dialog to open it at
    *  `section`. Cleared by that surface as it opens (one-shot). */
-  requestRepoSettings: (section: "security") => void;
+  requestRepoSettings: (section: "security" | "general") => void;
   clearRepoSettingsRequest: () => void;
   selectTag: (tag: { tag: string } | null) => void;
   setSelectedTodo: (

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -323,9 +323,9 @@ interface UiState {
   /** A one-shot request to open Repository Settings at a section, raised by
    *  another surface (the Findings tab's "Dependabot is off" card, the
    *  description-ready toast). Stamped with the {@link normPath} repo it was
-   *  raised for: its consumer can hold it while an admin probe resolves, so it
-   *  can outlive a repo switch and must never fire against another repo. The
-   *  menu that owns the dialog consumes and clears it. */
+   *  raised for: CROSS_REPO_RESET already nulls this on every repo switch, so
+   *  the stamp is the backstop for a route that ever sets repoPath without it.
+   *  The menu that owns the dialog consumes and clears it. */
   repoSettingsRequest: {
     section: "security" | "general";
     repo: string;


### PR DESCRIPTION
Closing a create dialog mid-generation used to strand the run: the stream was orphaned and the next open reset the form, so a paid generation was gone. Generations now keep running after their dialog closes, land in the retained draft, and announce themselves with a toast that reopens the surface. The same guarantee extends to repository-settings description generations, which previously died with the section that started them.

### Shared primitive

- Adds `useFinishAndSurface` to `src/features/conversations/useAiStream.ts`. `noteRunSettled(ok)` reports a run settling; a settle that lands while the dialog is closed latches skip-seed and, on success, toasts with a `View` reopen. `consumeSkipSeed()` is what the caller's `seedOnOpen` reads to return without reseeding.
- The open flag syncs in a layout effect, so a settle landing between commit and a passive flush reads the current open state. The skip-seed latch is a ref, so it survives an `<Activity>` tab hide and dies with a true unmount, where there is no draft left to protect.

### Create dialogs

- Wires the hook through `CreateIssueDialog.tsx`, `CreateJiraIssueDialog.tsx`, `CreateLocalIssueDialog.tsx`, `CreateLocalPrDialog.tsx`, `CreatePrDialog.tsx`, `PublishDialog.tsx` and `CreateReleaseDialog.tsx`: each `seedOnOpen` bails while a generation is streaming or when the skip-seed latch fires, and each `runGenerate` awaits the stream so it can report whether a usable result landed.
- `CreatePrDialog.tsx` folds the generation guard into the existing in-flight-create / last-failed latch chain, preserving the `||` short-circuit that keeps those latches unconsumed while a run is live.
- `CreateLocalPrDialog.tsx` reopens through `useUiStore.getState().openLocalPrCreate()`, since its host's `onOpenChange` only ever closes.
- `CreateJiraIssueDialog.tsx` hoists `setCreateError(null)` above the new guard, so a stale create error still clears on every open transition even when the draft is kept.
- `CreateReleaseDialog.tsx` reports settles on both the From-GitHub and AI paths, and only promises waiting notes when a body actually landed. `src/features/tags/useGenerateReleaseNotes.ts` now resolves the complete notes or `null`, collapsing a blank completion into the same null a bail, abort or error returns.

### Submit gates

- Each of those dialogs derives one `submitBlocked` value shared by the submit button, the mod+enter chord and the form's native `onSubmit`, so Enter submits exactly when the button would. That closes a divergence in `CreatePrDialog.tsx`, where the chord tested `creatingThisHead` while the button tested `creatingElsewhere` and only the chord tested `isSubmitting`, and adds the missing native-submit guard across the set.

### Repository-settings descriptions

- Adds `src/lib/stores/repo-description-generation.ts`, a per-repo lane keyed by `normPath` that claims a run, holds its cancel hook, delivers the result to the newest mounted listener, and stashes it in `pending` when no section is mounted. The settings dialog unmounts on close and the rail unmounts the outgoing section on every switch, so the run has to outlive both.
- `GeneralSettingsSection.tsx`, `GitLabGeneralSection.tsx` and `BitbucketGeneralSection.tsx` claim the lane before generating, settle it in a `finally` so a throw can't leave every surface busy, consume any pending result on mount, register an apply callback, and combine local and store state into one `busy` flag driving the Generate/Cancel affordance and the Save button. Cancel routes to `cancelRepoDescGeneration` for a run this mount didn't start.
- `RepoSettingsDialog.tsx` registers an open marker for the dialog's lifetime, so a settle with no listener picks toast copy that works: "Switch to the General section" while the dialog is open, otherwise a `View` action that deep-links into it.
- `src/lib/stores/ui.ts` widens `repoSettingsRequest` and `requestRepoSettings` to accept `"general"` alongside `"security"`.

### Guardrail and docs

- Adds the `generator-dialog-finish-and-surface` check to `scripts/check-banned-patterns.mjs`: a `.tsx` calling one of the four generator hooks alongside `useSeedOnOpen` must also call `useFinishAndSurface`. The `.tsx` bound is what keeps each hook's own definition file from reading as a call site.
- Covers it in `scripts/checks.test.mjs` with a positive per generator hook, negative controls for each half alone, for a hook named only in a comment, for the adopted shape, and for the `appliesTo` file bound.
- Documents the convention and the deliberately exempt surfaces in `.claude/skills/gd-conventions/SKILL.md`, adds the changelog fragment `changelog.d/changed-ai-generate-finish-and-surface.md`, and trims the now-stale parenthetical in `RemotePrView.tsx` (its edit dialog still cancels on close by design).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-generated issue, pull request, release, publish, and repository-description drafts continue after dialogs close.
  * Completed drafts can be reopened through a **View** action in notifications.
  * Repository-description generation persists while navigating settings and remains tied to the correct repository.
  * Pressing Enter follows the same submission rules as the submit button.
  * Repository Settings deep links wait for access checks before opening.

* **Bug Fixes**
  * Prevented stale drafts and results after switching repositories, tags, or related contexts.

* **Documentation**
  * Added Help guidance for background AI generation and draft recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->