### PR TITLE
fix(automations,ai): persist commit reviews and guard forge references

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,3 +61,9 @@ jobs:
       # Check-only (biome ci never writes); `pnpm lint` locally is --write.
       - name: Lint and format check
         run: pnpm exec biome ci ./src/
+
+      # The reference-detector suite's render oracle needs `marked` from
+      # node_modules and skips in the no-install guards job — this installed
+      # job is its one enforced run.
+      - name: Reference-detector suite (render oracle enforced)
+        run: node --test "scripts/comment-refs.test.mjs"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,7 @@ on:
       - "pnpm-workspace.yaml"
       - "patches/**"
       - "src/**"
+      - "scripts/**" # the reference-detector suite step reads these
       - "index.html"
       - "vite.config.ts"
       - "tsconfig*.json"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -61,8 +61,10 @@ jobs:
 
       # Negative controls for the scanners themselves — their worst failure is a
       # silent fail-open, so the fixtures that prove each predicate still fires
-      # run in CI. The test file is stdlib-only (node:test, node:assert), so this
-      # job still needs no install step. The argument is a QUOTED glob, not the
+      # run in CI. The test files run installless here (node:test/node:assert;
+      # optional imports like the marked render oracle skip when absent), so this
+      # job needs no install step — the frontend job is the oracle's enforced,
+      # installed run. The argument is a QUOTED glob, not the
       # `scripts` directory: node 24's runner resolves a bare directory path as
       # an entry module and dies with MODULE_NOT_FOUND.
       - name: Guard self-tests

--- a/changelog.d/fixed-ai-review-ref-confirm.md
+++ b/changelog.d/fixed-ai-review-ref-confirm.md
@@ -1,4 +1,4 @@
 - Posting an AI review now warns when the text carries `#N`-style references
   that will link and notify other threads, and asks before publishing. Automated
-  runs, where there's no one to ask, post those references as plain text and
-  note it in the comment.
+  runs, where there's no one to ask, post those references as plain text where
+  the format allows and name in the comment any that stay live.

--- a/changelog.d/fixed-ai-review-ref-confirm.md
+++ b/changelog.d/fixed-ai-review-ref-confirm.md
@@ -1,4 +1,4 @@
-- Posting an AI review now flags `#N`-style references before publishing and
-  asks whether they're meant to link, so a review lands on the thread you meant
-  and nowhere else. Automated runs, where there's no one to ask, post those
-  references as plain text and note it in the comment.
+- Posting an AI review now warns when the text carries `#N`-style references
+  that will link and notify other threads, and asks before publishing. Automated
+  runs, where there's no one to ask, post those references as plain text and
+  note it in the comment.

--- a/changelog.d/fixed-ai-review-ref-confirm.md
+++ b/changelog.d/fixed-ai-review-ref-confirm.md
@@ -1,0 +1,4 @@
+- Posting an AI review now flags `#N`-style references before publishing and
+  asks whether they're meant to link, so a review lands on the thread you meant
+  and nowhere else. Automated runs, where there's no one to ask, post those
+  references as plain text and note it in the comment.

--- a/changelog.d/fixed-automation-inbox-rows.md
+++ b/changelog.d/fixed-automation-inbox-rows.md
@@ -1,0 +1,2 @@
+- Every finished automated review lands in Notifications with a click-through:
+  a pull request review opens its PR, a commit review opens the review text.

--- a/changelog.d/fixed-automation-stale-diff.md
+++ b/changelog.d/fixed-automation-stale-diff.md
@@ -1,0 +1,2 @@
+- Automated reviews of a remote pull request cover the PR's real changes even
+  when the local copies of its branches are behind the remote.

--- a/changelog.d/fixed-commit-review-durability.md
+++ b/changelog.d/fixed-commit-review-durability.md
@@ -1,0 +1,3 @@
+- Automated commit reviews are kept between sessions, so the review text
+  (including partial output from a run that hit its timeout) is still there
+  after a restart and reopens from its notification.

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -246,6 +246,145 @@ test("the valid destination forms are definitions", () => {
   }
 });
 
+// A definition line inside a multi-line code span is not a definition, so its label
+// must not resolve a later use site whose reference the renderer leaves live.
+const DEF_INSIDE_SPAN =
+  "See:\n`\n[dest #5]: /url\n`\n\nAlso [dest #5] is unresolved.\n";
+// Deferred destinations that are really BLOCK STARTS. CommonMark settles block
+// structure before it looks for definitions, so none of these supplies a destination:
+// the `]:` line stays a paragraph (or becomes a setext heading) and its reference is
+// live, as is the use site below. Verified against GitHub 2026-09-08.
+//
+// marked 18.0.11 disagrees on the leaf shapes — it swallows `---`, `***`, a type-6
+// tag and a fence line into the destination and renders the pair as an empty
+// definition. Where a fixture is marked-divergent it is pinned directly here and
+// kept out of the renderer-oracle sweep; the container shapes below are NOT
+// divergent (marked and the forge agree the marker prevents the definition).
+const DEF_DEFERRED_SETEXT = "[dest #5]:\n---\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_BREAK = "[dest #5]:\n***\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_TAG =
+  "[dest #5]:\n<details>x</details>\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_FENCE = "[dest #5]:\n```\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_QUOTE = "[dest #5]:\n> x\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_BULLET = "[dest #5]:\n- item\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_ORDERED = "[dest #5]:\n1. item\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_HEADING = "[dest #5]:\n## H\n\nAlso [dest #5] here.\n";
+/** Fixtures the renderer oracle cannot judge, and why — kept to the ones that
+ *  actually misbehave rather than the whole divergent family. Under marked the fence
+ *  line becomes the destination, so the pair is a definition; wrapping the reference
+ *  inside the LABEL changes that label, the use site below stops resolving against
+ *  it, and it falls back to live text. The count is therefore 1 before and 1 after,
+ *  and the strictly-decreases arm reads a regression where the forge sees two
+ *  references correctly wrapped. The other divergent shapes (`---`, `***`, a type-6
+ *  tag) still decrease under both models, so they stay in the sweep; all four are
+ *  pinned directly regardless. */
+const ORACLE_EXCLUDED = new Set([DEF_DEFERRED_FENCE]);
+
+test("a definition inside a code span defines nothing", () => {
+  // Phase 0 runs the character scan for exactly this: without span state it would
+  // collect a phantom label and phase 1 would skip the live use site below.
+  assert.deepEqual(findSuspectRefs(DEF_INSIDE_SPAN), ["#5"]);
+  assert.ok(neutralizeSuspectRefs(DEF_INSIDE_SPAN).text.includes("`#5`"));
+});
+
+test("a block start is not a deferred destination", () => {
+  // Every one of these leaves both references live, so both must be detected. The
+  // leaf shapes are pinned here rather than through the oracle because marked reads
+  // them as definitions; the container shapes are not divergent.
+  for (const source of [
+    DEF_DEFERRED_SETEXT,
+    DEF_DEFERRED_BREAK,
+    DEF_DEFERRED_TAG,
+    DEF_DEFERRED_FENCE,
+    DEF_DEFERRED_QUOTE,
+    DEF_DEFERRED_BULLET,
+    DEF_DEFERRED_ORDERED,
+    // A space makes a bare destination invalid, so the heading shape needs no rule
+    // of its own — DEFINITION_TAIL already rejects it.
+    DEF_DEFERRED_HEADING,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.notEqual(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+const DEF_DEFERRED_QUOTE_TIGHT = "[dest #5]:\n>x\n\nAlso [dest #5] here.\n";
+const DEF_DEFERRED_TYPE7 = "[dest #5]:\n<span>\n\nAlso [dest #5] here.\n";
+
+test("a blockquote marker needs no space to stop a definition", () => {
+  // `>x` is still a blockquote, so the container check has to read the marker rather
+  // than rely on the destination grammar rejecting a space.
+  assert.deepEqual(findSuspectRefs(DEF_DEFERRED_QUOTE_TIGHT), ["#5"]);
+});
+
+test("a type-7 tag DOES supply a deferred destination", () => {
+  // The counterpart that keeps the predicate honest: type 7 cannot interrupt a
+  // paragraph, so unlike a type-6 tag it never displaces the definition.
+  assert.deepEqual(findSuspectRefs(DEF_DEFERRED_TYPE7), []);
+  assert.equal(
+    neutralizeSuspectRefs(DEF_DEFERRED_TYPE7).text,
+    DEF_DEFERRED_TYPE7,
+  );
+});
+
+const DEF_DEFERRED_IN_QUOTE =
+  "> [dest #5]:\n> /url\n>\n> Also [dest #5] here.\n";
+
+// A LAZY continuation — a shallower line under a quoted definition — folds back into
+// the same paragraph, so it still supplies the destination. Rejecting it wraps a
+// working URL's fragment.
+const DEF_LAZY_CONTINUATION = "> [dest]:\n/a?x=#5\n";
+const DEF_LAZY_DEDENT = "> > [dest]:\n> /a?x=#5\n";
+const DEF_LAZY_WITH_USE = "> [dest]:\n/a?x=#5\n>\n> See [dest] now.\n";
+const DEF_LAZY_BLOCK_START = "> [dest #5]:\n---\n\nAlso [dest #5] here.\n";
+
+test("a lazy continuation still carries the destination", () => {
+  // Only a container that OPENS ends the definition; a shallower line does not.
+  for (const source of [
+    DEF_LAZY_CONTINUATION,
+    DEF_LAZY_DEDENT,
+    DEF_LAZY_WITH_USE,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+test("a lazy continuation that starts a block still ends the definition", () => {
+  // The block-start checks apply on the lazy path too — `---` is a setext underline
+  // here, so the label's own reference stays live.
+  assert.deepEqual(findSuspectRefs(DEF_LAZY_BLOCK_START), ["#5"]);
+});
+
+test("a container already open still carries the destination", () => {
+  // The depths are COMPARED, not required to be zero: a quoted definition's
+  // destination wears the same `>` its label did, and rejecting it would splice
+  // backticks into a working URL.
+  assert.deepEqual(findSuspectRefs(DEF_DEFERRED_IN_QUOTE), []);
+  assert.equal(
+    neutralizeSuspectRefs(DEF_DEFERRED_IN_QUOTE).text,
+    DEF_DEFERRED_IN_QUOTE,
+  );
+  // And with nothing after the `]:` at all there is no destination to defer to.
+  assert.deepEqual(findSuspectRefs("[dest #5]:"), ["#5"]);
+  assert.deepEqual(findSuspectRefs("[dest #5]:\n"), ["#5"]);
+});
+
+test("a real deferred destination still forms a definition", () => {
+  // The next line is ordinary text, so it supplies the destination and both lines
+  // are skipped — the behaviour the block-start rule must not disturb.
+  for (const source of [
+    "[dest #5]:\n/url\n\nAlso [dest #5] here.\n",
+    LINK_DEF_SPLIT,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
 test("a malformed definition line is prose", () => {
   // A bracket that never closes, an all-whitespace label, and a missing colon are
   // none of them definitions, so each stays scannable.
@@ -361,6 +500,135 @@ test("a tag alone on its line is a type-7 block, whatever the tag", () => {
   assert.deepEqual(out.survived, ["`#5`"]);
 });
 
+const HTML_TYPE7_MID_PARAGRAPH = "text\n<span>\n#5\n";
+const HTML_TYPE7_AFTER_BLANK = "text\n\n<span>\n#5\n";
+const HTML_TYPE6_MID_PARAGRAPH = "text\n<details>\n#5\n";
+
+test("a type-6 tag DOES interrupt a paragraph", () => {
+  // The counterpart to the gate below: types 1 and 6 may interrupt, so this opener
+  // is not gated and the reference under it is held rather than wrapped.
+  const out = neutralizeSuspectRefs(HTML_TYPE6_MID_PARAGRAPH);
+  assert.equal(out.text, HTML_TYPE6_MID_PARAGRAPH);
+  assert.deepEqual(out.survived, ["`#5`"]);
+});
+
+// A container that OPENS on the line starts a fresh block context, so a type-7 tag
+// may open inside it even mid-paragraph. The paragraph flag alone is depth-blind and
+// said no, which wrapped these references inside raw HTML with a false claim.
+const HTML_TYPE7_IN_CONTAINER = [
+  "text\n> <span>\n> #5\n",
+  "text\n> <span id=x>\n> #5\n",
+  "text\n- <span>\n  #5\n",
+  "text\n1. <span>\n   #5\n",
+  "text\n> > <span>\n> > #5\n",
+  "text\n> </span>\n> #5\n",
+];
+
+const HTML_TYPE7_CONTAINER_ALREADY_OPEN = "> text\n> <span>\n> #5\n";
+const HTML_TYPE7_AFTER_QUOTED_FENCE =
+  "> ```\n> c\n> ```\n> text\n> <span>\n> #5\n";
+
+test("a container already open does not restart the paragraph", () => {
+  // The depth has to INCREASE. Inside a quote that was already there the tag is
+  // still mid-paragraph, so the reference below it is live prose and wraps — and
+  // the second shape proves the depth stays fresh across skipped fence lines.
+  for (const source of [
+    HTML_TYPE7_CONTAINER_ALREADY_OPEN,
+    HTML_TYPE7_AFTER_QUOTED_FENCE,
+  ]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.deepEqual(out.wrapped, ["`#5`"], label);
+    assert.deepEqual(out.survived, [], label);
+  }
+});
+
+test("a type-7 tag opens inside a container that starts on its line", () => {
+  for (const source of HTML_TYPE7_IN_CONTAINER) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, ["`#5`"], label);
+  }
+});
+
+// `paragraphLimit` inspects only lines AFTER the one a span opened on, so type 7 can
+// never open there. Passing that on keeps the closer search and the scan agreeing
+// about where the paragraph ends — otherwise the scan walks through a mid-paragraph
+// `<span>` line the limit stopped at, and the span it should have entered never opens.
+const SPAN_ACROSS_TYPE7 = "text ` open\n<span>\nstill ` closed\ncode #5 here\n";
+const SPAN_HIDING_A_DEFINITION =
+  "text `\n<span>\n[d #5]: /u2\n`\n\nSee [d #5] now.\n";
+
+// A span CANDIDATE must not run through a container-opening line. If the closer
+// search reads past one, the span opens, the `span === 0` guard suppresses the whole
+// HTML arm on that line, and the reference inside the raw block is wrapped and
+// falsely claimed. Both call sites read one shared container notion for that reason.
+const SPAN_THROUGH_QUOTE_TYPE7 = "text ` open\n> <span>\n> a ` b #5";
+const SPAN_THROUGH_LIST_TYPE7 = "text ` open\n- <span>\n  a ` b #5";
+const SPAN_THROUGH_NESTED_TYPE7 = "text ` open\n> - <span>\n>   a ` b #5";
+const SPAN_THROUGH_DEDENT_TYPE7 = "> text ` open\n<span>\n> a ` b #5";
+
+test("a span candidate cannot run through a container-opening type-7 line", () => {
+  for (const source of [
+    SPAN_THROUGH_QUOTE_TYPE7,
+    SPAN_THROUGH_LIST_TYPE7,
+    SPAN_THROUGH_NESTED_TYPE7,
+  ]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, ["`#5`"], label);
+  }
+});
+
+test("a span candidate cannot run through a dedenting type-7 line", () => {
+  // The depth DROP ends the paragraph just as a rise does, so the two call sites
+  // read a change of depth rather than an increase.
+  const out = neutralizeSuspectRefs(SPAN_THROUGH_DEDENT_TYPE7);
+  assert.equal(out.text, SPAN_THROUGH_DEDENT_TYPE7);
+  assert.deepEqual(out.survived, ["`#5`"]);
+});
+
+test("a depth drop lets a type-7 block open", () => {
+  const source = "> text\n<span>\n> #5\n";
+  const out = neutralizeSuspectRefs(source);
+  assert.equal(out.text, source);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#5`"]);
+});
+
+test("a code span closes across a mid-paragraph type-7 line", () => {
+  // The tick pairs, so it is not a live stray and the wrap needs only one backtick.
+  assert.equal(
+    neutralizeSuspectRefs(SPAN_ACROSS_TYPE7).text,
+    "text ` open\n<span>\nstill ` closed\ncode `#5` here\n",
+  );
+  // And the span's contents stay untouched: the definition line inside it is code,
+  // so only the live use site below is wrapped.
+  assert.equal(
+    neutralizeSuspectRefs(SPAN_HIDING_A_DEFINITION).text,
+    "text `\n<span>\n[d #5]: /u2\n`\n\nSee [d `#5`] now.\n",
+  );
+});
+
+test("a type-7 tag cannot interrupt a paragraph", () => {
+  // Mid-paragraph the renderer keeps both lines in the paragraph, so the reference
+  // is live and wrapping it beats disclosing a phantom survivor.
+  const mid = neutralizeSuspectRefs(HTML_TYPE7_MID_PARAGRAPH);
+  assert.equal(mid.text, "text\n<span>\n`#5`\n");
+  assert.deepEqual(mid.wrapped, ["`#5`"]);
+  assert.deepEqual(mid.survived, []);
+  // After a blank line it really does open a block, and the reference is held.
+  const after = neutralizeSuspectRefs(HTML_TYPE7_AFTER_BLANK);
+  assert.equal(after.text, HTML_TYPE7_AFTER_BLANK);
+  assert.deepEqual(after.survived, ["`#5`"]);
+});
+
 test("wrapped and held references are reported side by side", () => {
   const out = neutralizeSuspectRefs(HTML_MIXED);
   assert.equal(out.text, "prose `#7`\n\n<details>\nFixes #8\n</details>");
@@ -426,6 +694,8 @@ const FENCE_QUOTE_UNPAIRED_REPLY =
 const FENCE_QUOTE_UNPAIRED_MIN = "> ~~~\n> code\n\nFixes #123\n";
 const FENCE_QUOTE_LAZY = "> ~~~\nFixes #123\n";
 const FENCE_UNQUOTED_UNPAIRED = "```\nFixes #123\n";
+// A fence opens at the blockquote content column, and pairs only at its own depth.
+const FENCE_IN_QUOTE = "> ~~~\n> #123\n> ~~~\n";
 
 test("an unterminated fence in a blockquote ends with the blockquote", () => {
   // A blank line ends the quote, and so does a line that drops below its depth.
@@ -525,8 +795,6 @@ test("a blockquote's own blank line and indent are read at its content column", 
   }
 });
 
-// A fence opens at the blockquote content column, and pairs only at its own depth.
-const FENCE_IN_QUOTE = "> ~~~\n> #123\n> ~~~\n";
 const FENCE_DEPTH_MISMATCH = "> ```\n> a\n```\n#123\n";
 const FENCE_QUOTE_THEN_PROSE = "> ~~~\n> a\n> ~~~\n\n#123\n";
 
@@ -547,6 +815,10 @@ test("a fence pairs only at its own container depth", () => {
     neutralizeSuspectRefs(FENCE_DEPTH_MISMATCH).text,
     FENCE_DEPTH_MISMATCH,
   );
+});
+
+test("a fence recovers when a deeper quote drops a level", () => {
+  assert.deepEqual(findSuspectRefs("> > ~~~\n> > c\n> after #1\n"), ["#1"]);
 });
 
 // Backslash-parity fixtures; rule on `isEscaped`, guard below pins the counts.
@@ -602,25 +874,6 @@ test("an escaped reference inside a raw HTML block is held in BOTH modes", () =>
     assert.deepEqual(out.wrapped, [], label);
     assert.deepEqual(out.survived, [`\`${ESC_1}\``], label);
   }
-});
-
-test("the footer names an escaped reference held inside raw HTML", () => {
-  const body = buildAiCommentBody({
-    ...PARTS,
-    text: ESCAPED_IN_HTML,
-    neutralizeRefs: true,
-  });
-  assert.ok(body.includes(ESCAPED_IN_HTML), body);
-  assert.ok(
-    body.endsWith(
-      `_This automated run could not neutralize \`${ESC_1}\` — verify before trusting any links it created._`,
-    ),
-    body,
-  );
-});
-
-test("a fence recovers when a deeper quote drops a level", () => {
-  assert.deepEqual(findSuspectRefs("> > ~~~\n> > c\n> after #1\n"), ["#1"]);
 });
 
 test("the GitLab mode leaves an escaped trigger alone", () => {
@@ -940,6 +1193,34 @@ const CORPUS = [
   FENCE_NESTED_BLANK,
   HTML_QUOTE_BLANK_INSIDE,
   ESCAPED_IN_HTML,
+  HTML_TYPE7_MID_PARAGRAPH,
+  HTML_TYPE7_AFTER_BLANK,
+  HTML_TYPE6_MID_PARAGRAPH,
+  DEF_INSIDE_SPAN,
+  DEF_DEFERRED_SETEXT,
+  DEF_DEFERRED_BREAK,
+  DEF_DEFERRED_TAG,
+  DEF_DEFERRED_FENCE,
+  DEF_DEFERRED_QUOTE,
+  DEF_DEFERRED_BULLET,
+  DEF_DEFERRED_ORDERED,
+  DEF_DEFERRED_HEADING,
+  ...HTML_TYPE7_IN_CONTAINER,
+  SPAN_ACROSS_TYPE7,
+  SPAN_HIDING_A_DEFINITION,
+  DEF_DEFERRED_QUOTE_TIGHT,
+  DEF_DEFERRED_TYPE7,
+  DEF_DEFERRED_IN_QUOTE,
+  DEF_LAZY_CONTINUATION,
+  DEF_LAZY_DEDENT,
+  DEF_LAZY_WITH_USE,
+  DEF_LAZY_BLOCK_START,
+  SPAN_THROUGH_QUOTE_TYPE7,
+  SPAN_THROUGH_LIST_TYPE7,
+  SPAN_THROUGH_NESTED_TYPE7,
+  SPAN_THROUGH_DEDENT_TYPE7,
+  HTML_TYPE7_CONTAINER_ALREADY_OPEN,
+  HTML_TYPE7_AFTER_QUOTED_FENCE,
   INDENT_AFTER_HEADING,
   INDENT_AFTER_SETEXT,
   INDENT_AFTER_BREAK,
@@ -1047,6 +1328,9 @@ test("a wrapped ref never renders more exposed than it started", async (t) => {
   }
   const md = new Marked();
   for (const source of CORPUS) {
+    // marked parses a few geometries differently from the forges; those are pinned
+    // directly instead — see ORACLE_EXCLUDED for which and why.
+    if (ORACLE_EXCLUDED.has(source)) continue;
     const out = neutralizeSuspectRefs(source);
     if (out.wrapped.length === 0 && out.survived.length === 0) continue;
     const after = outsideCode(md.parse(out.text));
@@ -1222,6 +1506,21 @@ test("the disclosure names the escaped form it actually shipped", () => {
   );
   // The footer's own copy sits in a code span, so it mints no reference either.
   assert.deepEqual(findSuspectRefs(body), []);
+});
+
+test("the footer names an escaped reference held inside raw HTML", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: ESCAPED_IN_HTML,
+    neutralizeRefs: true,
+  });
+  assert.ok(body.includes(ESCAPED_IN_HTML), body);
+  assert.ok(
+    body.endsWith(
+      `_This automated run could not neutralize \`${ESC_1}\` — verify before trusting any links it created._`,
+    ),
+    body,
+  );
 });
 
 test("without the flag the refs are left exactly as written", () => {

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -1,0 +1,252 @@
+// Pins the forge-reference detector that keeps a posted AI review from minting
+// stray cross-references, plus the branded comment body it feeds. The prior fix
+// for this was prompt-only and shipped no test, which is why the regression came
+// back unnoticed.
+//
+// The import below reaches straight into `src/` and relies on Node's default type
+// stripping (>= 23.6) — that pairing is itself under test: stripping ERASES types
+// rather than compiling them and resolves no bundler aliases, so
+// `comment-branding.ts` must stay dependency-free and erasable-syntax-only. A
+// runtime import added there fails this file, which is the point.
+//
+// Node's stdlib test runner and node: imports only, no dev dependency, so the
+// CI `guards` job runs `node --test "scripts/*.test.mjs"` with no install step.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildAiCommentBody,
+  findSuspectRefs,
+  formatRefList,
+  neutralizeSuspectRefs,
+} from "../src/lib/ai/comment-branding.ts";
+
+// ------------------------------------------------------------ findSuspectRefs
+
+test("a bare reference in prose is a hit", () => {
+  assert.deepEqual(findSuspectRefs("Fixes #123 now"), ["#123"]);
+});
+
+test("parentheses do not neutralize a reference", () => {
+  assert.deepEqual(findSuspectRefs("See (#123) for detail"), ["#123"]);
+});
+
+test("a list item's reference is a hit", () => {
+  assert.deepEqual(findSuspectRefs("- fixes #7"), ["#7"]);
+});
+
+test("an inline code span hides its references", () => {
+  assert.deepEqual(findSuspectRefs("the token `#123` stays plain"), []);
+  // A doubled run closes only on a run of exactly two.
+  assert.deepEqual(findSuspectRefs("``a ` #123``"), []);
+});
+
+test("a backtick fence hides its references, with or without a language tag", () => {
+  assert.deepEqual(findSuspectRefs("```\nFixes #123\n```\n"), []);
+  assert.deepEqual(findSuspectRefs("```ts\n// Fixes #123\n```\n"), []);
+  // An unterminated fence runs to EOF.
+  assert.deepEqual(findSuspectRefs("```\nFixes #123\n"), []);
+});
+
+test("a tilde fence hides its references", () => {
+  assert.deepEqual(findSuspectRefs("~~~\nFixes #123\n~~~\n"), []);
+  // A backtick line inside a tilde fence is content, not a close.
+  assert.deepEqual(findSuspectRefs("~~~\n```\n#123\n~~~\n"), []);
+});
+
+test("markdown link syntax hides references in the label AND the destination", () => {
+  assert.deepEqual(findSuspectRefs("[issue #123](https://x.test)"), []);
+  // The destination arm needs a token the boundary rule would otherwise admit,
+  // or the `/` before it does the work and the skip goes untested.
+  assert.deepEqual(findSuspectRefs("[see it](x.test -#123)"), []);
+  assert.deepEqual(findSuspectRefs("see it: x.test -#123"), ["#123"]);
+});
+
+test("a URL fragment is not a reference", () => {
+  assert.deepEqual(findSuspectRefs("https://x.test/p#123"), []);
+});
+
+test("a word character before the trigger keeps it plain", () => {
+  assert.deepEqual(findSuspectRefs("abc#123"), []);
+});
+
+test("an HTML entity is not a reference", () => {
+  assert.deepEqual(findSuspectRefs("&#39;"), []);
+});
+
+test("no forge numbers an item 0", () => {
+  assert.deepEqual(findSuspectRefs("#0"), []);
+  assert.deepEqual(findSuspectRefs("#0123"), []);
+});
+
+test("the number grammar caps at ten digits", () => {
+  assert.deepEqual(findSuspectRefs("#1234567890"), ["#1234567890"]);
+  assert.deepEqual(findSuspectRefs("#12345678901"), []);
+});
+
+test("a trailing word character keeps the token plain", () => {
+  assert.deepEqual(findSuspectRefs("#12a"), []);
+});
+
+test("an indented code line hides its references", () => {
+  assert.deepEqual(findSuspectRefs("prose\n\n    Fixes #123\n"), []);
+  assert.deepEqual(findSuspectRefs("prose\n\n\tFixes #123\n"), []);
+  // Three spaces is prose, not code.
+  assert.deepEqual(findSuspectRefs("   Fixes #123\n"), ["#123"]);
+});
+
+test("the trigger set decides what counts", () => {
+  assert.deepEqual(findSuspectRefs("see !45", ["#", "!"]), ["!45"]);
+  assert.deepEqual(findSuspectRefs("see !45", ["#"]), []);
+  // Bitbucket autolinks nothing, so an empty trigger set finds nothing.
+  assert.deepEqual(findSuspectRefs("see #45 and !45", []), []);
+});
+
+test("repeats collapse to one entry and order is first appearance", () => {
+  assert.deepEqual(findSuspectRefs("#12 then again #12"), ["#12"]);
+  assert.deepEqual(findSuspectRefs("#12 then #45"), ["#12", "#45"]);
+  assert.deepEqual(findSuspectRefs("#45 then #12"), ["#45", "#12"]);
+});
+
+test("empty text finds nothing", () => {
+  assert.deepEqual(findSuspectRefs(""), []);
+  assert.deepEqual(findSuspectRefs("#"), []);
+});
+
+// ------------------------------------------------------ neutralizeSuspectRefs
+
+test("wrapping backticks the token only, never the surrounding punctuation", () => {
+  assert.equal(neutralizeSuspectRefs("Fixes #12 now").text, "Fixes `#12` now");
+  assert.equal(
+    neutralizeSuspectRefs("recorded decision (#10)").text,
+    "recorded decision (`#10`)",
+  );
+});
+
+test("the wrapped list carries the neutral form, distinct and in order", () => {
+  const out = neutralizeSuspectRefs("#12, #45, then #12 again");
+  assert.deepEqual(out.wrapped, ["`#12`", "`#45`"]);
+});
+
+test("neutralized output has nothing left to find", () => {
+  const out = neutralizeSuspectRefs("Fixes #12 and (#45)");
+  assert.deepEqual(findSuspectRefs(out.text), []);
+});
+
+test("neutralizing is idempotent", () => {
+  const once = neutralizeSuspectRefs("Fixes #12 and (#45)");
+  const twice = neutralizeSuspectRefs(once.text);
+  assert.equal(twice.text, once.text);
+  assert.deepEqual(twice.wrapped, []);
+});
+
+test("skipped regions come through byte-identical", () => {
+  const source = [
+    "```ts",
+    "// Fixes #123",
+    "```",
+    "",
+    "an inline `#7` span, a [link #8](https://x.test/#9), and",
+    "",
+    "    indented #10",
+    "",
+    "an entity &#39; plus abc#11",
+    "",
+  ].join("\n");
+  const out = neutralizeSuspectRefs(source);
+  assert.equal(out.text, source);
+  assert.deepEqual(out.wrapped, []);
+});
+
+test("text with no references comes through byte-identical", () => {
+  const source =
+    "No references here — just prose, a # alone, and !not-a-ref.\n";
+  const out = neutralizeSuspectRefs(source);
+  assert.equal(out.text, source);
+  assert.deepEqual(out.wrapped, []);
+});
+
+// ----------------------------------------------------------- formatRefList
+
+test("formatRefList joins one, two and three references", () => {
+  assert.equal(formatRefList([]), "");
+  assert.equal(formatRefList(["#12"]), "#12");
+  assert.equal(formatRefList(["#12", "#45"]), "#12 and #45");
+  assert.equal(formatRefList(["#12", "#45", "#103"]), "#12, #45, and #103");
+});
+
+test("formatRefList names five references and counts the rest", () => {
+  const five = ["#1", "#2", "#3", "#4", "#5"];
+  assert.equal(formatRefList(five), "#1, #2, #3, #4, and #5");
+  assert.equal(
+    formatRefList([...five, "#6"]),
+    "#1, #2, #3, #4, #5, and 1 more",
+  );
+  assert.equal(
+    formatRefList([...five, "#6", "#7", "#8"]),
+    "#1, #2, #3, #4, #5, and 3 more",
+  );
+});
+
+// -------------------------------------------------------- buildAiCommentBody
+
+/** The shipped template, spelled out rather than derived — a drift tripwire is
+ *  worthless if it recomputes the thing it is pinning. Both seams post this. */
+const GOLDEN =
+  "🤖 **GitDesktop AI review** · `sonnet` · automated\n" +
+  "\n" +
+  "---\n" +
+  "\n" +
+  "Looks good to me.\n" +
+  "\n" +
+  "---\n" +
+  "\n" +
+  "_Posted by [GitDesktop](https://gitdesktop.app) — AI output, verify before acting on it._";
+
+const PARTS = {
+  kind: "review",
+  model: "sonnet",
+  automated: true,
+  text: "Looks good to me.",
+};
+
+test("the comment body matches the shipped template", () => {
+  assert.equal(buildAiCommentBody(PARTS), GOLDEN);
+});
+
+test("a manual (non-automated) body drops the automated marker", () => {
+  assert.equal(
+    buildAiCommentBody({ ...PARTS, automated: false }),
+    GOLDEN.replace(" · automated", ""),
+  );
+});
+
+test("the neutralize flag changes nothing when there is nothing to wrap", () => {
+  assert.equal(buildAiCommentBody({ ...PARTS, neutralizeRefs: true }), GOLDEN);
+});
+
+test("the neutralize flag wraps the refs and discloses it once", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: "Recorded decision (#10) and Disclosure #11.",
+    neutralizeRefs: true,
+  });
+  assert.match(body, /Recorded decision \(`#10`\) and Disclosure `#11`\./);
+  const disclosures = body.match(/_References /g) ?? [];
+  assert.equal(disclosures.length, 1);
+  assert.ok(
+    body.endsWith(
+      "_References `#10` and `#11` are shown as plain text — this automated run could not confirm they were meant to link._",
+    ),
+    body,
+  );
+  // The disclosure names the NEUTRAL forms, so it cannot itself cross-reference.
+  assert.deepEqual(findSuspectRefs(body), []);
+});
+
+test("without the flag the refs are left exactly as written", () => {
+  const text = "Recorded decision (#10).";
+  const body = buildAiCommentBody({ ...PARTS, text });
+  assert.ok(body.includes(text), body);
+  assert.ok(!body.includes("_References "), body);
+});

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -582,6 +582,57 @@ const SPAN_FROM_HEADING_LINE = "## H ` x\n<span>\n#5\nb ` c";
 // belongs to another block and cannot pair — the reference between them is prose.
 const SPAN_STOPPED_BY_CONTAINER = "a ` open\n> q\n> <span>\n> #5\nb ` c";
 
+// A paragraph-interrupting line ends the paragraph the span opened in, so a closer
+// beyond it belongs to another block. Without the bound the span pairs across, the
+// stray tick below is never recorded, and the wrap it picks is stolen by that tick.
+const SPAN_ACROSS_HEADING = "a ` open\n## H\nb ` c #5";
+const SPAN_ACROSS_QUOTED_HEADING = "> a ` open\n> ## H\n> b ` c #5";
+const SPAN_CLOSER_ON_HEADING = "a ` open\n## H ` close\nb #5 c";
+const SPAN_ACROSS_THEMATIC = "a ` open\n***\nb #5 ` c";
+const SPAN_ACROSS_SETEXT = "a ` open\nH\n---\nb ` c #5";
+// Prose the renderer keeps whole: a line without letters is NOT a block start, and
+// `| a | b |` is a table only when a delimiter row follows. Splitting the paragraph
+// here would wrap a reference the renderer had already sealed inside a code span.
+const SPAN_OVER_EMOJI = "a ` open\n\u{1F916}\nb #5 ` c";
+const SPAN_OVER_BANGS = "a ` open\n!!!\nb #5 ` c";
+const SPAN_OVER_PIPES = "a ` open\n| x | y |\nb #5 ` c";
+
+test("a heading bounds the closer search", () => {
+  for (const source of [SPAN_ACROSS_HEADING, SPAN_ACROSS_QUOTED_HEADING]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    // Run TWO: the tick below the heading is a live stray once the span cannot
+    // form, and a single-tick wrap would have been stolen by it.
+    assert.deepEqual(neutralizeSuspectRefs(source).wrapped, ["``#5``"], label);
+  }
+});
+
+test("the bounding line's own tick cannot close the span", () => {
+  // The returned index is the bounding line's first character and the caller's
+  // window is half-open, so that line is never searched.
+  assert.deepEqual(findSuspectRefs(SPAN_CLOSER_ON_HEADING), ["#5"]);
+  assert.deepEqual(neutralizeSuspectRefs(SPAN_CLOSER_ON_HEADING).wrapped, [
+    "``#5``",
+  ]);
+});
+
+test("a thematic break or setext underline bounds the closer search", () => {
+  for (const source of [SPAN_ACROSS_THEMATIC, SPAN_ACROSS_SETEXT]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+  }
+});
+
+test("a paragraph the renderer keeps whole is not split", () => {
+  // These bound nothing: the span forms, the reference inside it is already inert,
+  // and wrapping there would put literal backticks into rendered code.
+  for (const source of [SPAN_OVER_EMOJI, SPAN_OVER_BANGS, SPAN_OVER_PIPES]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
 test("a block start after a heading bounds the closer search", () => {
   for (const source of [
     SPAN_THROUGH_HEADING_TYPE7,
@@ -1263,6 +1314,14 @@ const CORPUS = [
   SPAN_THROUGH_QUOTED_BLANK_TYPE7,
   SPAN_FROM_HEADING_LINE,
   SPAN_STOPPED_BY_CONTAINER,
+  SPAN_ACROSS_HEADING,
+  SPAN_ACROSS_QUOTED_HEADING,
+  SPAN_CLOSER_ON_HEADING,
+  SPAN_ACROSS_THEMATIC,
+  SPAN_ACROSS_SETEXT,
+  SPAN_OVER_EMOJI,
+  SPAN_OVER_BANGS,
+  SPAN_OVER_PIPES,
   HTML_TYPE7_CONTAINER_ALREADY_OPEN,
   HTML_TYPE7_AFTER_QUOTED_FENCE,
   INDENT_AFTER_HEADING,

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -280,6 +280,17 @@ const DEF_DEFERRED_HEADING = "[dest #5]:\n## H\n\nAlso [dest #5] here.\n";
  *  pinned directly regardless. */
 const ORACLE_EXCLUDED = new Set([DEF_DEFERRED_FENCE]);
 
+/** Also excluded, for a divergence isolated by differential measurement: marked
+ *  renders a wrap inside a LIST ITEM whose paragraph holds an UNCLOSED inline tag as
+ *  literal backticks, so the live count reads 1 before and 1 after. It forms the code
+ *  span for the same shape with a CLOSED tag, and in a plain paragraph with an
+ *  unclosed one — the item's paragraph content is `text\n<span>\n` + a code span, and
+ *  nothing in CommonMark lets an unclosed inline tag swallow the rest of the item.
+ *  The behaviour is pinned directly instead. */
+function excludeListTagQuirk(...sources) {
+  for (const source of sources) ORACLE_EXCLUDED.add(source);
+}
+
 test("a definition inside a code span defines nothing", () => {
   // Phase 0 runs the character scan for exactly this: without span state it would
   // collect a phantom label and phase 1 would skip the live use site below.
@@ -503,6 +514,196 @@ test("a tag alone on its line is a type-7 block, whatever the tag", () => {
 const HTML_TYPE7_MID_PARAGRAPH = "text\n<span>\n#5\n";
 const HTML_TYPE7_AFTER_BLANK = "text\n\n<span>\n#5\n";
 const HTML_TYPE6_MID_PARAGRAPH = "text\n<details>\n#5\n";
+
+// An inline tag is markup, not a text node: nothing inside it autolinks, and a wrap
+// there corrupts it — a quoted value becomes href="`#123`" and the link dies, an
+// unquoted one stops parsing as HTML at all. Its TEXT CONTENT is ordinary prose.
+const TAG_ATTR_DOUBLE = 'See <a href="#123">the section</a>.';
+const TAG_ATTR_SINGLE = "See <a href='#123'>x</a>.";
+const TAG_ATTR_TWO = 'See <a title="#1" href="#2">x</a>.';
+const TAG_ATTR_UNQUOTED = "See <a href=#123>x</a>.";
+const TAG_TEXT_CONTENT = "See <b>fixes #123</b> now.";
+const TAG_TEXT_AFTER = 'See <a href="/x">y</a> fixes #123.';
+const TAG_TICKS_INSIDE = '<a title="`x`">y</a> and #5';
+// Shapes the grammar must NOT swallow: no tag name, a digit start, an escape.
+const TAG_NOT_A_TAG_DIGIT = "a <3 and 5> #5";
+const TAG_NOT_A_TAG_BARE = "a < b and #5";
+const TAG_ESCAPED_ANGLE = 'a \\<a href="#1"> b';
+
+test("a reference in an attribute value is not scanned", () => {
+  for (const source of [
+    TAG_ATTR_DOUBLE,
+    TAG_ATTR_SINGLE,
+    TAG_ATTR_TWO,
+    TAG_ATTR_UNQUOTED,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+test("a reference in a tag's text content is still scanned", () => {
+  for (const source of [TAG_TEXT_CONTENT, TAG_TEXT_AFTER]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#123"], label);
+    assert.deepEqual(neutralizeSuspectRefs(source).wrapped, ["`#123`"], label);
+  }
+});
+
+test("something that only looks like a tag stays prose", () => {
+  // A tag name must start with a letter, and an escaped `<` is literal text.
+  for (const source of [
+    TAG_NOT_A_TAG_DIGIT,
+    TAG_NOT_A_TAG_BARE,
+    TAG_ESCAPED_ANGLE,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.equal(findSuspectRefs(source).length, 1, label);
+    assert.notEqual(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+test("a tag's own backticks are not strays", () => {
+  // Code spans and raw HTML have equal precedence and the leftmost wins. This arm
+  // only runs with no span open, so the tag starts first and its ticks are raw —
+  // they cannot steal a single-tick wrap after it.
+  const out = neutralizeSuspectRefs(TAG_TICKS_INSIDE);
+  assert.deepEqual(findSuspectRefs(TAG_TICKS_INSIDE), ["#5"]);
+  assert.deepEqual(out.wrapped, ["`#5`"]);
+});
+
+// A type-7 tag at a column the list marker's content had left is EITHER outside the
+// item (a block start, refs raw HTML) OR a lazy continuation of its paragraph (refs
+// prose). Both readings leave the reference live, so holding it is truthful either
+// way — which is what lets one boolean stand in for an indentation model here.
+const LIST_DEDENT_BULLET = "- text\n<span>\n#5";
+const LIST_DEDENT_ORDERED = "1. text\n<span>\n   #5";
+const LIST_DEDENT_AFTER_BODY = "- text\nmore\n<span>\n#5";
+const LIST_DEDENT_AFTER_INDENTED_BODY = "- text\n  more\n<span>\n#5";
+const LIST_DEDENT_AFTER_BLANK = "- text\n\n<span>\n#5";
+// Indented INTO the item's content column: not a dedent, so this arm ignores it.
+const LIST_TAG_INDENTED = "- text\n  <span>\n  #5";
+const LIST_TAG_INDENTED_ORDERED = "1. text\n   <span>\n   #5";
+excludeListTagQuirk(LIST_TAG_INDENTED, LIST_TAG_INDENTED_ORDERED);
+
+// A fence behind a list marker pairs against the ITEM's content column. Missing the
+// opener was never only cosmetic: the closer then opened a phantom fence that
+// swallowed everything after it, so the mangled code example came with a silently
+// missed reference below.
+const LIST_FENCE_CHAIN = "- ~~~\n  #5\n  ~~~\n\nSee #6";
+const LIST_FENCE_ORDERED = "1. ~~~\n   #5\n   ~~~\n\nSee #6";
+const LIST_FENCE_BACKTICK = "- ```\n  #5\n  ```\n\nSee #6";
+const LIST_FENCE_UNCLOSED = "- ~~~\n  #5\n\nSee #6";
+const LIST_FENCE_DEDENT_ENDS = "- ~~~\n  #5\nplain #6";
+const LIST_FENCE_INNER_BLANK = "- ~~~\n\n  #5\n  ~~~\n\nSee #6";
+const LIST_FENCE_CONTINUATION = "- text\n  ~~~\n  #5\n  ~~~\n\nSee #6";
+const LIST_FENCE_DEDENT_CLOSER = "- ~~~\n  #5\n~~~\n\nSee #6";
+
+test("a fence behind a list marker is a fence", () => {
+  // The reference inside stays untouched, and the one after the item is scanned.
+  for (const source of [
+    LIST_FENCE_CHAIN,
+    LIST_FENCE_ORDERED,
+    LIST_FENCE_BACKTICK,
+    LIST_FENCE_CONTINUATION,
+    LIST_FENCE_INNER_BLANK,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#6"], label);
+    assert.ok(neutralizeSuspectRefs(source).text.includes("#5"), label);
+    assert.ok(!neutralizeSuspectRefs(source).text.includes("`#5`"), label);
+  }
+});
+
+test("a list fence ends with its item", () => {
+  // Unclosed, it runs to the blank line that ends the item; a dedented line ends it
+  // too. Either way the reference below is scanned rather than swallowed.
+  for (const source of [LIST_FENCE_UNCLOSED, LIST_FENCE_DEDENT_ENDS]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#6"], label);
+  }
+});
+
+test("a list fence closer takes the three-space slack", () => {
+  // Measured against the renderer: the closer pairs from the item's column through
+  // column+3, and a fourth space makes it code content instead. The reference below
+  // it is item prose in the first case and inside the block in the second.
+  for (let indent = 2; indent <= 5; indent++) {
+    const source = `- ~~~\n  #5\n${" ".repeat(indent)}~~~\n  after #6`;
+    assert.deepEqual(findSuspectRefs(source), ["#6"], JSON.stringify(source));
+  }
+  const tooDeep = `- ~~~\n  #5\n${" ".repeat(6)}~~~\n  after #6`;
+  assert.deepEqual(findSuspectRefs(tooDeep), [], JSON.stringify(tooDeep));
+});
+
+test("a fence-shaped line inside the item does not re-open", () => {
+  // The closer-as-opener flip is what turned a mangle into a swallow: treating this
+  // line as content defers the item's end to the next ordinary line, which keeps the
+  // reference after it scannable.
+  assert.deepEqual(findSuspectRefs(LIST_FENCE_DEDENT_CLOSER), ["#6"]);
+});
+
+test("the fence arm leaves the list HTML shapes alone", () => {
+  // Round 4's `- <details>` and round 14's dedent hold both run through the same
+  // marker state, so they are pinned against this arm too.
+  assert.deepEqual(neutralizeSuspectRefs(HTML_IN_LIST).survived, ["`#123`"]);
+  assert.deepEqual(neutralizeSuspectRefs(LIST_DEDENT_BULLET).survived, [
+    "`#5`",
+  ]);
+});
+
+test("a tag that leaves a list item's indent holds its references", () => {
+  for (const source of [
+    LIST_DEDENT_BULLET,
+    LIST_DEDENT_ORDERED,
+    LIST_DEDENT_AFTER_BODY,
+    LIST_DEDENT_AFTER_INDENTED_BODY,
+    // A blank line clears the remembered column; the paragraph-start flag already
+    // opens the region here, so this path holds for its own reason.
+    LIST_DEDENT_AFTER_BLANK,
+  ]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, ["`#5`"], label);
+  }
+});
+
+test("a tag indented into the item is left to the ordinary arms", () => {
+  // Still inside the item, so the heuristic does not fire and the reference wraps.
+  for (const source of [LIST_TAG_INDENTED, LIST_TAG_INDENTED_ORDERED]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.deepEqual(neutralizeSuspectRefs(source).wrapped, ["`#5`"], label);
+  }
+});
+
+test("a list line that is not a tag is untouched by the heuristic", () => {
+  // The arm reads only the type-7 gate, so ordinary item prose still wraps.
+  const source = "- text\n- more #5\n";
+  assert.deepEqual(findSuspectRefs(source), ["#5"]);
+  assert.deepEqual(neutralizeSuspectRefs(source).wrapped, ["`#5`"]);
+  // And a type-6 tag on the marker's own line keeps its round-4 behaviour.
+  assert.deepEqual(neutralizeSuspectRefs(HTML_IN_LIST).survived, ["`#123`"]);
+});
+
+test("the held reference gets a disclosure that is true either way", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: LIST_DEDENT_BULLET,
+    neutralizeRefs: true,
+  });
+  assert.ok(body.includes(LIST_DEDENT_BULLET), body);
+  assert.ok(
+    body.endsWith(
+      "_This automated run could not neutralize `#5` — verify before trusting any links it created._",
+    ),
+    body,
+  );
+});
 
 test("a type-6 tag DOES interrupt a paragraph", () => {
   // The counterpart to the gate below: types 1 and 6 may interrupt, so this opener
@@ -1347,6 +1548,31 @@ const CORPUS = [
   HTML_TYPE7_MID_PARAGRAPH,
   HTML_TYPE7_AFTER_BLANK,
   HTML_TYPE6_MID_PARAGRAPH,
+  TAG_ATTR_DOUBLE,
+  TAG_ATTR_SINGLE,
+  TAG_ATTR_TWO,
+  TAG_ATTR_UNQUOTED,
+  TAG_TEXT_CONTENT,
+  TAG_TEXT_AFTER,
+  TAG_TICKS_INSIDE,
+  TAG_NOT_A_TAG_DIGIT,
+  TAG_NOT_A_TAG_BARE,
+  TAG_ESCAPED_ANGLE,
+  LIST_DEDENT_BULLET,
+  LIST_DEDENT_ORDERED,
+  LIST_DEDENT_AFTER_BODY,
+  LIST_DEDENT_AFTER_INDENTED_BODY,
+  LIST_DEDENT_AFTER_BLANK,
+  LIST_TAG_INDENTED,
+  LIST_TAG_INDENTED_ORDERED,
+  LIST_FENCE_CHAIN,
+  LIST_FENCE_ORDERED,
+  LIST_FENCE_BACKTICK,
+  LIST_FENCE_UNCLOSED,
+  LIST_FENCE_DEDENT_ENDS,
+  LIST_FENCE_INNER_BLANK,
+  LIST_FENCE_CONTINUATION,
+  LIST_FENCE_DEDENT_CLOSER,
   DEF_INSIDE_SPAN,
   DEF_DEFERRED_SETEXT,
   DEF_DEFERRED_BREAK,
@@ -1444,6 +1670,79 @@ test("the reported split is scanner-relative but never self-contradicting", () =
       );
     }
   }
+});
+
+/** The same document with Windows line endings. Written as a `\r` escape, never a
+ *  literal byte: this repo checks out CRLF, so a real CR in a fixture would be both
+ *  invisible in review and rewritten by the next checkout. */
+const toCrlf = (s) => s.replace(/\n/g, "\r\n");
+
+test("CRLF input classifies exactly as its LF twin", () => {
+  // The scan splits on `\n`, so every line would otherwise carry a trailing `\r` into
+  // tests anchored at `$` — a blank line stops reading blank, a closing fence's tail
+  // stops reading empty, and the fence swallows the rest of the comment.
+  for (const source of CORPUS) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(
+      findSuspectRefs(toCrlf(source)),
+      findSuspectRefs(source),
+      label,
+    );
+  }
+});
+
+test("CRLF output is its LF twin's output, transformed", () => {
+  // The invariant that holds for every entry: wrapping commutes with the line-ending
+  // transform. Wraps are inserted at offsets into the ORIGINAL text and never rewrite
+  // a line ending, so converting first and wrapping second gives the same bytes as
+  // wrapping first and converting second.
+  for (const source of CORPUS) {
+    const label = JSON.stringify(source);
+    const lf = neutralizeSuspectRefs(source);
+    const crlf = neutralizeSuspectRefs(toCrlf(source));
+    assert.equal(crlf.text, toCrlf(lf.text), label);
+    assert.deepEqual(crlf.wrapped, lf.wrapped, label);
+    assert.deepEqual(crlf.survived, lf.survived, label);
+  }
+});
+
+// Direct pins for the arms `\r` broke, each stated as its own shape rather than left
+// to the sweep above. The fence chain is the reported one: unclosed, it swallowed
+// every reference after it and posted them live with no disclosure.
+const CRLF_FENCE_CHAIN = "~~~\r\nexample\r\n~~~\r\nSee #123";
+const CRLF_BLANK_BOUND = "a ` open\r\n\r\nb #5 ` c";
+const CRLF_DEFINITION = "[dest]: /url\r\n\r\nSee [dest] and #5.\r\n";
+const CRLF_HTML_BLOCK = "<details>\r\nFixes #123\r\n</details>\r\n";
+// One document with both endings, to prove the strip is per-line and not global.
+const MIXED_EOL = "a ` open\r\n\nb #5 ` c\r\nSee #6\n";
+
+test("a CRLF fence closes and the text after it is scanned", () => {
+  assert.deepEqual(findSuspectRefs(CRLF_FENCE_CHAIN), ["#123"]);
+  assert.ok(
+    !neutralizeSuspectRefs(CRLF_FENCE_CHAIN).text.includes("`example`"),
+  );
+});
+
+test("a CRLF blank line still bounds a paragraph", () => {
+  assert.deepEqual(findSuspectRefs(CRLF_BLANK_BOUND), ["#5"]);
+});
+
+test("CRLF definition and HTML-block lines classify normally", () => {
+  assert.deepEqual(findSuspectRefs(CRLF_DEFINITION), ["#5"]);
+  const html = neutralizeSuspectRefs(CRLF_HTML_BLOCK);
+  assert.equal(html.text, CRLF_HTML_BLOCK);
+  assert.deepEqual(html.survived, ["`#123`"]);
+});
+
+test("a document with mixed line endings classifies per line", () => {
+  assert.deepEqual(findSuspectRefs(MIXED_EOL), ["#5", "#6"]);
+  // Every line ending is preserved exactly as it was. `#6` takes a run of two
+  // because the tick after `#5` is an unpaired stray in the same paragraph, and
+  // `#5` takes a run of one because the blank line above cleared the first tick.
+  assert.equal(
+    neutralizeSuspectRefs(MIXED_EOL).text,
+    "a ` open\r\n\nb `#5` ` c\r\nSee ``#6``\n",
+  );
 });
 
 test("neutralizing reaches a fixed point in one pass", () => {
@@ -1555,6 +1854,39 @@ test("a reference link still renders as a link afterwards", async (t) => {
     const out = neutralizeSuspectRefs(source);
     assert.match(md.parse(out.text), /<a href=/, label);
     assert.equal(md.parse(out.text), md.parse(source), label);
+  }
+});
+
+test("the renderer agrees about the CRLF corpus too", async (t) => {
+  let Marked;
+  try {
+    ({ Marked } = await import("marked"));
+  } catch {
+    t.skip(
+      "marked is not installed — the guards job runs with no install step",
+    );
+    return;
+  }
+  const md = new Marked();
+  // CommonMark accepts `\r\n`, so the same claim has to hold over the transformed
+  // corpus. Exclusions are keyed on the LF original — the divergence they name is
+  // about the parser's block model, not about line endings.
+  for (const source of CORPUS) {
+    if (ORACLE_EXCLUDED.has(source)) continue;
+    const crlf = toCrlf(source);
+    const out = neutralizeSuspectRefs(crlf);
+    if (out.wrapped.length === 0 && out.survived.length === 0) continue;
+    const after = outsideCode(md.parse(out.text));
+    const before = outsideCode(md.parse(crlf));
+    const label = JSON.stringify(crlf);
+    for (const form of out.wrapped) {
+      const token = stripTicks(form);
+      const beforeN = liveCount(before, token);
+      assert.ok(
+        liveCount(after, token) <= Math.max(beforeN - 1, 0),
+        `${token} still renders outside a code span for ${label}`,
+      );
+    }
   }
 });
 

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -95,6 +95,113 @@ test("an indented code line hides its references", () => {
   assert.deepEqual(findSuspectRefs("   Fixes #123\n"), ["#123"]);
 });
 
+// Backslash-parity fixtures; rule on `isEscaped`, guard below pins the counts.
+const ESC_1 = String.raw`\#123`;
+const ESC_2 = String.raw`\\#123`;
+const ESC_3 = String.raw`\\\#123`;
+const ESC_4 = String.raw`\\\\#123`;
+const ESCAPED_TICKS = "\\`#123\\`";
+
+test("the escape fixtures carry the backslash runs they claim", () => {
+  assert.deepEqual(
+    [ESC_1, ESC_2, ESC_3, ESC_4].map((s) => s.indexOf("#")),
+    [1, 2, 3, 4],
+  );
+});
+
+test("an odd backslash run escapes the trigger", () => {
+  assert.deepEqual(findSuspectRefs(ESC_1), []);
+  assert.deepEqual(findSuspectRefs(ESC_3), []);
+  assert.equal(neutralizeSuspectRefs(ESC_1).text, ESC_1);
+  assert.deepEqual(neutralizeSuspectRefs(ESC_1).wrapped, []);
+  assert.equal(neutralizeSuspectRefs(ESC_3).text, ESC_3);
+  assert.deepEqual(findSuspectRefs(String.raw`\!45`, ["#", "!"]), []);
+});
+
+test("an even backslash run leaves the reference live", () => {
+  assert.deepEqual(findSuspectRefs(ESC_2), ["#123"]);
+  assert.deepEqual(findSuspectRefs(ESC_4), ["#123"]);
+  const out = neutralizeSuspectRefs(ESC_2);
+  // The doubled backslash is self-escaped, so the code span still forms.
+  assert.equal(out.text, "\\\\`#123`");
+  assert.deepEqual(out.wrapped, ["`#123`"]);
+  assert.deepEqual(findSuspectRefs(out.text), []);
+});
+
+test("the backslash walk cannot cross a line boundary", () => {
+  // A trailing backslash is a markdown hard break, not an escape for the next line.
+  assert.deepEqual(findSuspectRefs("foo\\\n#123"), ["#123"]);
+});
+
+// Opener pins; why a false region is the dangerous direction is on `scanRefs`.
+test("an escaped backtick opens no code span", () => {
+  assert.equal(ESCAPED_TICKS.indexOf("#"), 2);
+  assert.deepEqual(findSuspectRefs(ESCAPED_TICKS), ["#123"]);
+});
+
+test("the fusion separator skips an escaped tick", () => {
+  // An escaped tick is a literal the renderer consumes with its backslash — it
+  // can't fuse with the wrap's opener, so no space is added beside it.
+  const out = neutralizeSuspectRefs("\\`#7");
+  assert.equal(out.text, "\\``#7`");
+  assert.deepEqual(out.wrapped, ["`#7`"]);
+  assert.deepEqual(findSuspectRefs(out.text), []);
+});
+
+test("an escaped bracket opens no link", () => {
+  assert.deepEqual(findSuspectRefs(String.raw`\[issue #123](https://x.test)`), [
+    "#123",
+  ]);
+});
+
+test("an unmatched backtick run is literal", () => {
+  assert.deepEqual(findSuspectRefs("a ` b #6"), ["#6"]);
+  // Inline syntax is parsed per paragraph, so a blank line bounds the search for a
+  // closing run and both ticks here stay literal.
+  assert.deepEqual(findSuspectRefs("` x\n\n#8 `"), ["#8"]);
+  // A blank line carrying whitespace is still a paragraph boundary.
+  assert.deepEqual(findSuspectRefs("` x\n \t \n#8 `"), ["#8"]);
+});
+
+test("a reference adjacent to a closed span is wrapped without fusing", () => {
+  assert.deepEqual(findSuspectRefs("`#7`#123"), ["#123"]);
+  const out = neutralizeSuspectRefs("`#7`#123");
+  // Without the separator the wrap's opener joins the span's closer into a run of
+  // two, and the renderer re-reads the whole thing as one longer span.
+  assert.equal(out.text, "`#7` `#123`");
+  assert.deepEqual(out.wrapped, ["`#123`"]);
+});
+
+test("a link label's ticks are live for pairing, so the wrap clears them", () => {
+  // Code spans parse before links, so a tick inside a link label can steal a
+  // single-tick wrap's opener and leave the reference outside the span.
+  const one = neutralizeSuspectRefs("[a ` b](c) #7");
+  assert.equal(one.text, "[a ` b](c) ``#7``");
+  assert.deepEqual(one.wrapped, ["``#7``"]);
+  assert.deepEqual(findSuspectRefs(one.text), []);
+  // A run of two in the label cannot pair with a run of one, so L stays 1.
+  const two = neutralizeSuspectRefs("[a `` b](c) #7");
+  assert.equal(two.text, "[a `` b](c) `#7`");
+  const pair = neutralizeSuspectRefs("[a ` b](c) #7 and #8");
+  assert.equal(pair.text, "[a ` b](c) ``#7`` and ``#8``");
+  assert.deepEqual(pair.wrapped, ["``#7``", "``#8``"]);
+});
+
+test("a fence bounds the search for a closing run", () => {
+  // The fence opens a block, so the paragraph's tick run never finds a closer and
+  // the refs inside the block are never reached.
+  assert.deepEqual(findSuspectRefs("note ``` a\n```\n#7\n"), []);
+  assert.equal(
+    neutralizeSuspectRefs("note ``` a\n```\n#7\n").text,
+    "note ``` a\n```\n#7\n",
+  );
+  // Same reason in the other direction: the paragraph's lone tick is literal, so
+  // the ref beside it is live and wraps clear of that stray.
+  const out = neutralizeSuspectRefs("prose ` #4\n```\ny `\n```\n");
+  assert.deepEqual(findSuspectRefs("prose ` #4\n```\ny `\n```\n"), ["#4"]);
+  assert.equal(out.text, "prose ` ``#4``\n```\ny `\n```\n");
+});
+
 test("the trigger set decides what counts", () => {
   assert.deepEqual(findSuspectRefs("see !45", ["#", "!"]), ["!45"]);
   assert.deepEqual(findSuspectRefs("see !45", ["#"]), []);
@@ -140,22 +247,39 @@ test("neutralizing is idempotent", () => {
   assert.deepEqual(twice.wrapped, []);
 });
 
+const SKIPPED_REGIONS = [
+  "```ts",
+  "// Fixes #123",
+  "```",
+  "",
+  "an inline `#7` span, a [link #8](https://x.test/#9), and",
+  "",
+  "    indented #10",
+  "",
+  "an entity &#39; plus abc#11",
+  "",
+].join("\n");
+
 test("skipped regions come through byte-identical", () => {
-  const source = [
-    "```ts",
-    "// Fixes #123",
-    "```",
-    "",
-    "an inline `#7` span, a [link #8](https://x.test/#9), and",
-    "",
-    "    indented #10",
-    "",
-    "an entity &#39; plus abc#11",
-    "",
-  ].join("\n");
-  const out = neutralizeSuspectRefs(source);
-  assert.equal(out.text, source);
+  const out = neutralizeSuspectRefs(SKIPPED_REGIONS);
+  assert.equal(out.text, SKIPPED_REGIONS);
   assert.deepEqual(out.wrapped, []);
+});
+
+test("a stray tick cannot steal the wrap's opener", () => {
+  // One unpaired tick in the paragraph makes a single-tick wrap stealable: the
+  // stray would pair with the wrap's opener, putting the reference OUTSIDE the
+  // resulting span, live, while the disclosure claimed otherwise.
+  const out = neutralizeSuspectRefs("a ` b #6");
+  assert.equal(out.text, "a ` b ``#6``");
+  assert.deepEqual(out.wrapped, ["``#6``"]);
+  assert.deepEqual(findSuspectRefs(out.text), []);
+});
+
+test("the wrap run length clears every stray length in the paragraph", () => {
+  const out = neutralizeSuspectRefs("a ` b `` c #6");
+  assert.equal(out.text, "a ` b `` c ```#6```");
+  assert.deepEqual(findSuspectRefs(out.text), []);
 });
 
 test("text with no references comes through byte-identical", () => {
@@ -164,6 +288,203 @@ test("text with no references comes through byte-identical", () => {
   const out = neutralizeSuspectRefs(source);
   assert.equal(out.text, source);
   assert.deepEqual(out.wrapped, []);
+});
+
+// ------------------------------------------------------- neutralizer property
+
+/** Every fixture string used above, plus geometries built to break the wrap. */
+const CORPUS = [
+  "",
+  "#",
+  "Fixes #123 now",
+  "See (#123) for detail",
+  "- fixes #7",
+  "the token `#123` stays plain",
+  "``a ` #123``",
+  "```\nFixes #123\n```\n",
+  "```ts\n// Fixes #123\n```\n",
+  "```\nFixes #123\n",
+  "~~~\nFixes #123\n~~~\n",
+  "~~~\n```\n#123\n~~~\n",
+  "[issue #123](https://x.test)",
+  "[see it](x.test -#123)",
+  "see it: x.test -#123",
+  "https://x.test/p#123",
+  "abc#123",
+  "&#39;",
+  "#0",
+  "#0123",
+  "#1234567890",
+  "#12345678901",
+  "#12a",
+  "prose\n\n    Fixes #123\n",
+  "prose\n\n\tFixes #123\n",
+  "   Fixes #123\n",
+  ESC_1,
+  ESC_2,
+  ESC_3,
+  ESC_4,
+  String.raw`\!45`,
+  "foo\\\n#123",
+  ESCAPED_TICKS,
+  String.raw`\[issue #123](https://x.test)`,
+  "a ` b #6",
+  "` x\n\n#8 `",
+  "`#7`#123",
+  "see !45",
+  "see #45 and !45",
+  "#12 then again #12",
+  "#12 then #45",
+  "#45 then #12",
+  "Fixes #12 now",
+  "recorded decision (#10)",
+  "#12, #45, then #12 again",
+  "Fixes #12 and (#45)",
+  SKIPPED_REGIONS,
+  "No references here — just prose, a # alone, and !not-a-ref.\n",
+  "Recorded decision (#10) and Disclosure #11.",
+  "Looks good to me.",
+  // Adversarial geometries.
+  "stray ` before #6",
+  "#6 then a stray `",
+  "a ` b `` c #6",
+  "``x`` paired, ` stray, #6",
+  `${ESCAPED_TICKS} then a stray \` and #6`,
+  "#1#2",
+  "#1 `` #2 ` #3",
+  "` open\nstill open\n#9",
+  "[a ` b](c) #7",
+  "[a `` b](c) #7",
+  "[a ` b](c) #7 and #8",
+  "[a ` b](c) [d ` e](f) #7",
+  "note ``` a\n```\n#7\n",
+  "prose ` #4\n```\ny `\n```\n",
+  "`#1``#2``#3``#4`#5",
+  "` a ` ` b #7",
+];
+
+/** The token inside an emitted wrap form, whatever run length it used. */
+function stripTicks(form) {
+  return form.replace(/^`+|`+$/g, "");
+}
+
+test("neutralizing partitions every found ref into wrapped or still-detectable", () => {
+  for (const source of CORPUS) {
+    const found = new Set(findSuspectRefs(source));
+    const out = neutralizeSuspectRefs(source);
+    const wrappedTokens = new Set(out.wrapped.map(stripTicks));
+    const survivors = new Set(findSuspectRefs(out.text));
+    const label = JSON.stringify(source);
+    for (const token of wrappedTokens) {
+      assert.ok(
+        !survivors.has(token),
+        `${token} claimed but survives in ${label}`,
+      );
+    }
+    for (const form of out.wrapped) {
+      assert.ok(
+        out.text.includes(form),
+        `${form} claimed but absent in ${label}`,
+      );
+    }
+    assert.deepEqual(
+      [...wrappedTokens, ...survivors].sort(),
+      [...found].sort(),
+      `partition mismatch for ${label}`,
+    );
+  }
+});
+
+test("the reported split is scanner-relative but never self-contradicting", () => {
+  for (const source of CORPUS) {
+    const out = neutralizeSuspectRefs(source);
+    const claimed = new Set(out.wrapped.map(stripTicks));
+    for (const form of out.survived) {
+      assert.ok(
+        !claimed.has(stripTicks(form)),
+        `${form} both claimed and disowned for ${JSON.stringify(source)}`,
+      );
+    }
+  }
+});
+
+test("neutralizing reaches a fixed point in one pass", () => {
+  for (const source of CORPUS) {
+    const once = neutralizeSuspectRefs(source).text;
+    assert.equal(
+      neutralizeSuspectRefs(once).text,
+      once,
+      `not idempotent for ${JSON.stringify(source)}`,
+    );
+  }
+});
+
+// ------------------------------------------------------------ renderer oracle
+
+/** Live-position occurrences of `token`, by the detector's own boundary grammar —
+ *  a preceding `[\w/&]` or a trailing word char keeps it plain. Counted, not
+ *  merely detected: the same token can appear more than once (an escaped copy the
+ *  wrap deliberately leaves alone, say), so only an INCREASE is a regression. */
+function liveCount(haystack, token) {
+  const esc = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`(^|[^\\w/&])${esc}(?!\\w)`, "g");
+  let n = 0;
+  while (re.exec(haystack) !== null) n++;
+  return n;
+}
+
+/** The HTML with every code region removed — what a forge autolinker would still
+ *  be free to linkify. `<pre>` first, so a fenced block's inner `<code>` goes with
+ *  it rather than leaving its wrapper behind. */
+function outsideCode(html) {
+  return html
+    .replace(/<pre[\s\S]*?<\/pre>/g, " ")
+    .replace(/<code[\s\S]*?<\/code>/g, " ");
+}
+
+// The only oracle here that is not the scanner itself: every other property test
+// proves self-consistency, this one puts the wrapped output through a real
+// CommonMark parser and asserts the claim holds in the RENDERED shape. It skips
+// when marked is absent because the CI guards job runs `node --test` with no
+// install step — locally it runs, and the session's forge-render probes are the
+// cross-check that marked's geometry matches the forges'.
+test("a wrapped ref never renders more exposed than it started", async (t) => {
+  let Marked;
+  try {
+    ({ Marked } = await import("marked"));
+  } catch {
+    t.skip(
+      "marked is not installed — the guards job runs with no install step",
+    );
+    return;
+  }
+  const md = new Marked();
+  for (const source of CORPUS) {
+    const out = neutralizeSuspectRefs(source);
+    if (out.wrapped.length === 0 && out.survived.length === 0) continue;
+    const after = outsideCode(md.parse(out.text));
+    const before = outsideCode(md.parse(source));
+    const label = JSON.stringify(source);
+    for (const form of out.wrapped) {
+      const token = stripTicks(form);
+      // Strictly-decreases with a floor, not === 0: an unrelated live-position
+      // copy of the same token (escaped elsewhere, or inside a link label) is
+      // not this wrap's to remove, and a hard zero would fail on correct output.
+      const beforeN = liveCount(before, token);
+      const afterN = liveCount(after, token);
+      assert.ok(
+        afterN <= Math.max(beforeN - 1, 0),
+        `${token} still renders outside a code span for ${label} (${beforeN}->${afterN})`,
+      );
+    }
+    for (const form of out.survived) {
+      const token = stripTicks(form);
+      assert.ok(
+        liveCount(after, token) <= liveCount(before, token),
+        `${token} renders MORE exposed after neutralizing ${label}`,
+      );
+    }
+  }
 });
 
 // ----------------------------------------------------------- formatRefList
@@ -249,4 +570,31 @@ test("without the flag the refs are left exactly as written", () => {
   const body = buildAiCommentBody({ ...PARTS, text });
   assert.ok(body.includes(text), body);
   assert.ok(!body.includes("_References "), body);
+});
+
+test("a body the guard cannot fully clear never claims more than it did", () => {
+  // The post-condition is the tripwire for a geometry the scan reads wrongly; no
+  // input reaches it today, so this pins the shape the footer must keep rather
+  // than a live case. Every corpus entry lands wholly in `wrapped` or in neither.
+  for (const source of CORPUS) {
+    const out = neutralizeSuspectRefs(source);
+    const body = buildAiCommentBody({
+      ...PARTS,
+      text: source,
+      neutralizeRefs: true,
+    });
+    if (out.survived.length === 0) {
+      assert.ok(!body.includes("could not neutralize"), body);
+      continue;
+    }
+    const named = formatRefList(out.survived);
+    assert.ok(
+      body.includes(
+        out.wrapped.length
+          ? ` It could not neutralize ${named}._`
+          : `_This automated run could not neutralize ${named} — verify before trusting any links it created._`,
+      ),
+      body,
+    );
+  }
 });

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -554,10 +554,10 @@ test("a type-7 tag opens inside a container that starts on its line", () => {
   }
 });
 
-// `paragraphLimit` inspects only lines AFTER the one a span opened on, so type 7 can
-// never open there. Passing that on keeps the closer search and the scan agreeing
-// about where the paragraph ends — otherwise the scan walks through a mid-paragraph
-// `<span>` line the limit stopped at, and the span it should have entered never opens.
+// `paragraphLimit` carries the same block state the scan does, so the two agree about
+// where the paragraph ends. A type-7 line only counts as a block start when something
+// makes it one; mid-paragraph, with no container opening and a paragraph still open
+// above it, it is inline HTML and the span closes straight across it.
 const SPAN_ACROSS_TYPE7 = "text ` open\n<span>\nstill ` closed\ncode #5 here\n";
 const SPAN_HIDING_A_DEFINITION =
   "text `\n<span>\n[d #5]: /u2\n`\n\nSee [d #5] now.\n";
@@ -570,6 +570,46 @@ const SPAN_THROUGH_QUOTE_TYPE7 = "text ` open\n> <span>\n> a ` b #5";
 const SPAN_THROUGH_LIST_TYPE7 = "text ` open\n- <span>\n  a ` b #5";
 const SPAN_THROUGH_NESTED_TYPE7 = "text ` open\n> - <span>\n>   a ` b #5";
 const SPAN_THROUGH_DEDENT_TYPE7 = "> text ` open\n<span>\n> a ` b #5";
+
+// A type-7 tag also opens where the line above it left no paragraph — after a
+// heading, or after a blockquote's own blank line. The closer search has to know
+// that too, or the span swallows a reference the renderer leaves as raw HTML.
+const SPAN_THROUGH_HEADING_TYPE7 = "a ` open\n## H\n<span>\n#5\nb ` c";
+const SPAN_THROUGH_QUOTED_BLANK_TYPE7 =
+  "> a ` open\n>\n> <span>\n> #5\n> b ` c";
+const SPAN_FROM_HEADING_LINE = "## H ` x\n<span>\n#5\nb ` c";
+// The paragraph the span opened in ends at the blockquote, so the closer inside it
+// belongs to another block and cannot pair — the reference between them is prose.
+const SPAN_STOPPED_BY_CONTAINER = "a ` open\n> q\n> <span>\n> #5\nb ` c";
+
+test("a block start after a heading bounds the closer search", () => {
+  for (const source of [
+    SPAN_THROUGH_HEADING_TYPE7,
+    SPAN_THROUGH_QUOTED_BLANK_TYPE7,
+    // The opener's OWN line can be the heading, so the walk seeds from it rather
+    // than assuming the line a span opened on leaves a paragraph behind.
+    SPAN_FROM_HEADING_LINE,
+  ]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.survived, ["`#5`"], label);
+  }
+});
+
+test("a container start bounds the closer search", () => {
+  // The depths are compared line to line, not against the opener: here the `<span>`
+  // sits at the same depth as the `> q` above it, so it opens nothing and the
+  // reference under it is ordinary quoted prose that wraps. The run is TWO because
+  // the unpaired tick above the blockquote is still counted as a stray — it sits in
+  // another block and could not have stolen a single-tick wrap, so this is the
+  // over-long-but-safe direction `strays` is documented to take.
+  const out = neutralizeSuspectRefs(SPAN_STOPPED_BY_CONTAINER);
+  assert.deepEqual(findSuspectRefs(SPAN_STOPPED_BY_CONTAINER), ["#5"]);
+  assert.deepEqual(out.wrapped, ["``#5``"]);
+  assert.deepEqual(out.survived, []);
+});
 
 test("a span candidate cannot run through a container-opening type-7 line", () => {
   for (const source of [
@@ -1219,6 +1259,10 @@ const CORPUS = [
   SPAN_THROUGH_LIST_TYPE7,
   SPAN_THROUGH_NESTED_TYPE7,
   SPAN_THROUGH_DEDENT_TYPE7,
+  SPAN_THROUGH_HEADING_TYPE7,
+  SPAN_THROUGH_QUOTED_BLANK_TYPE7,
+  SPAN_FROM_HEADING_LINE,
+  SPAN_STOPPED_BY_CONTAINER,
   HTML_TYPE7_CONTAINER_ALREADY_OPEN,
   HTML_TYPE7_AFTER_QUOTED_FENCE,
   INDENT_AFTER_HEADING,

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -597,6 +597,66 @@ const SPAN_OVER_EMOJI = "a ` open\n\u{1F916}\nb #5 ` c";
 const SPAN_OVER_BANGS = "a ` open\n!!!\nb #5 ` c";
 const SPAN_OVER_PIPES = "a ` open\n| x | y |\nb #5 ` c";
 
+// The opener's OWN line can be the block that ends: a heading may carry a backtick
+// and still close at its line end, so nothing below it can be that tick's closer.
+// (Only the heading arm is reachable here — a setext underline or thematic break
+// admits no backtick, so a span can never open on one.)
+const SPAN_OPENS_ON_HEADING = "## H ` x\nb #5 ` c";
+const SPAN_OPENS_ON_QUOTED_HEADING = "> ## H ` x\n> b #5 ` c";
+// A `>`-only line is the blockquote's blank line. `BLANK_LINE` never sees it — it
+// wants two newlines — and the depth is unchanged, so the gate has to test it.
+const SPAN_ACROSS_QUOTED_BLANK = "> a ` open\n>\n> b #5 ` c";
+// A shallower line under an OPEN paragraph is a lazy continuation the renderer folds
+// back, so the span really does reach across it and the reference inside is inert.
+const SPAN_OVER_LAZY_DEDENT = "> a ` open\nb #5 ` c";
+const SPAN_OVER_LAZY_DEDENT_OUTSIDE = "> a ` open\nb ` c #5";
+// Dedents that genuinely end the paragraph must still bound, via their own arms.
+const SPAN_DEDENT_TO_HEADING = "> a ` open\n## H\nb #5 ` c";
+const SPAN_DEDENT_TO_LIST = "> a ` open\n- item #5 ` c";
+
+test("a heading on the opener's own line caps the search", () => {
+  for (const source of [SPAN_OPENS_ON_HEADING, SPAN_OPENS_ON_QUOTED_HEADING]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+    assert.deepEqual(neutralizeSuspectRefs(source).wrapped, ["``#5``"], label);
+  }
+});
+
+test("a blockquote's own blank line bounds the closer search", () => {
+  assert.deepEqual(findSuspectRefs(SPAN_ACROSS_QUOTED_BLANK), ["#5"]);
+  assert.deepEqual(neutralizeSuspectRefs(SPAN_ACROSS_QUOTED_BLANK).wrapped, [
+    "``#5``",
+  ]);
+  // At depth zero `BLANK_LINE` already stops the walk before the blank line, so
+  // this arm changes nothing there.
+  assert.deepEqual(neutralizeSuspectRefs("a ` open\n\nb #5 ` c").wrapped, [
+    "`#5`",
+  ]);
+});
+
+test("a lazy continuation is not a container start", () => {
+  // The span reaches across the dedent, so this reference is already inert —
+  // wrapping it would put literal backticks inside the rendered code span.
+  assert.deepEqual(findSuspectRefs(SPAN_OVER_LAZY_DEDENT), []);
+  assert.equal(
+    neutralizeSuspectRefs(SPAN_OVER_LAZY_DEDENT).text,
+    SPAN_OVER_LAZY_DEDENT,
+  );
+  // With the reference past the closer the span leaves it live, and it wraps.
+  assert.deepEqual(findSuspectRefs(SPAN_OVER_LAZY_DEDENT_OUTSIDE), ["#5"]);
+});
+
+test("a dedent that really ends the paragraph still bounds", () => {
+  // Each of these leaves the quote AND starts something: the sibling arms catch
+  // them even though the depth drop alone no longer counts.
+  for (const source of [SPAN_DEDENT_TO_HEADING, SPAN_DEDENT_TO_LIST]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#5"], label);
+  }
+  // A fence dedent swallows the rest into code, so nothing is detected there.
+  assert.deepEqual(findSuspectRefs("> a ` open\n```\nb #5 ` c"), []);
+});
+
 test("a heading bounds the closer search", () => {
   for (const source of [SPAN_ACROSS_HEADING, SPAN_ACROSS_QUOTED_HEADING]) {
     const label = JSON.stringify(source);
@@ -1322,6 +1382,13 @@ const CORPUS = [
   SPAN_OVER_EMOJI,
   SPAN_OVER_BANGS,
   SPAN_OVER_PIPES,
+  SPAN_OPENS_ON_HEADING,
+  SPAN_OPENS_ON_QUOTED_HEADING,
+  SPAN_ACROSS_QUOTED_BLANK,
+  SPAN_OVER_LAZY_DEDENT,
+  SPAN_OVER_LAZY_DEDENT_OUTSIDE,
+  SPAN_DEDENT_TO_HEADING,
+  SPAN_DEDENT_TO_LIST,
   HTML_TYPE7_CONTAINER_ALREADY_OPEN,
   HTML_TYPE7_AFTER_QUOTED_FENCE,
   INDENT_AFTER_HEADING,

--- a/scripts/comment-refs.test.mjs
+++ b/scripts/comment-refs.test.mjs
@@ -95,6 +95,460 @@ test("an indented code line hides its references", () => {
   assert.deepEqual(findSuspectRefs("   Fixes #123\n"), ["#123"]);
 });
 
+// Raw-HTML-block fixtures. GitHub's reference filter runs INSIDE raw HTML, so a
+// `#N` there autolinks and must still be detected; a backtick wrap there is
+// literal text that mangles the block and neutralizes nothing, so the region is
+// left alone and its refs are disclosed instead. Region grammar on `scanRefs`.
+const HTML_DETAILS = "<details>\nFixes #123\n</details>";
+const HTML_DETAILS_SPACED = "<details>\n\nFixes #123\n\n</details>";
+const HTML_SUMMARY_INLINE = "<details><summary>x</summary> Fixes #12";
+const HTML_CLOSER_MID_TEXT = "prose #1\n</details>\nmore #2\n";
+const HTML_SPAN_INLINE = "<span>see #5</span> and more prose";
+const HTML_SPAN_ALONE = "<span>\nsee #5\n";
+const HTML_MIXED = "prose #7\n\n<details>\nFixes #8\n</details>";
+const HTML_SAME_TOKEN = "prose #7\n\n<details>\nFixes #7\n</details>";
+const HTML_TICK_INSIDE = "<details>\na ` b\n</details>\n\nFixes #6";
+
+// Region starts CommonMark reads at the container content column, a blank line it
+// defines as spaces and tabs only, a block start that beats an open code span, and
+// the type-1 end condition. Each of these wrapped a reference INSIDE raw HTML
+// before the region grammar learned the rule.
+const HTML_IN_QUOTE = "> <details>\n> Fixes #123\n> </details>\n";
+const HTML_IN_LIST = "- <details>\n  Fixes #123\n  </details>\n";
+const HTML_IN_ORDERED_LIST = "1. <details>\n   Fixes #3\n";
+// The middle line is one NBSP, spelled as an escape so it stays visible in the
+// source: whitespace to `String.trim`, CONTENT to CommonMark, so it must not end
+// the block. The guard below pins that the fixture really carries one.
+const HTML_NBSP_LINE = "<details>\n\u00a0\nFixes #123\n</details>\n";
+const HTML_ACROSS_SPAN =
+  "text ` open\n<details>\nstill ` closed\nFixes #123\n</details>\n";
+const HTML_QUOTED_STRAY = "> prose ` x\n> <details>\n> #9\n";
+const HTML_RAW_TEXT = "<pre>\nline one\n\nFixes #123\n</pre>\n";
+
+// Link reference definitions. A wrap on one of these lines is spliced into the URL
+// the definition supplies, so this region is skipped to prevent damage rather than a
+// false claim — and the ref was never live there either, so detecting it at the
+// manual seam was a false positive.
+const LINK_DEF_USED = "[jump][dest]\n\n[dest]: #123\n";
+const LINK_DEF_ALONE = "[dest]: #123\n";
+const LINK_DEF_SPLIT = "[dest]:\n#123\n";
+// Definition-SHAPED but continuing a paragraph, so CommonMark renders it as prose
+// and the reference really does link: detection must still fire here.
+const LINK_DEF_AS_PROSE = "see below\n[dest]: #123\n";
+
+test("a link reference definition is not scanned", () => {
+  for (const source of [LINK_DEF_USED, LINK_DEF_ALONE, LINK_DEF_SPLIT]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    const out = neutralizeSuspectRefs(source);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, [], label);
+  }
+});
+
+test("a definition-shaped line continuing a paragraph is prose", () => {
+  // The bound on the skip: only a line where a paragraph could START is a
+  // definition, so this one is scanned and wrapped like any other prose.
+  assert.deepEqual(findSuspectRefs(LINK_DEF_AS_PROSE), ["#123"]);
+  const out = neutralizeSuspectRefs(LINK_DEF_AS_PROSE);
+  assert.equal(out.text, "see below\n[dest]: `#123`\n");
+  assert.deepEqual(out.wrapped, ["`#123`"]);
+});
+
+// Reference-link USE sites. A wrap inside the label breaks the lookup (label matching
+// is case-fold and whitespace-collapse, nothing more), so the published link dies as
+// bracket text — and the ref renders inside the anchor, where no forge filter reaches
+// it, so detecting it was a false positive before the wrap broke anything.
+const LINK_REF_SHORTCUT = "[issue #5]\n\n[issue #5]: https://example.com\n";
+const LINK_REF_COLLAPSED = "[issue #5][]\n\n[issue #5]: /url\n";
+const LINK_REF_FULL = "[jump #5][dest]\n\n[dest]: /url\n";
+const LINK_REF_FOLDED = "[Issue   #5]\n\n[iSSUE #5]: /url\n";
+// No definition anywhere, so the brackets are prose and the ref really does link.
+const LINK_REF_NO_DEFINITION = "see [maybe #5] there\n";
+// A definition inside a fence is code, not a definition, so the label resolves
+// nothing and the use site below is prose.
+const LINK_REF_FENCED_DEF = "```\n[issue #5]: /url\n```\n\n[issue #5]\n";
+
+test("a resolving reference link is not scanned, in any of its forms", () => {
+  for (const source of [
+    LINK_REF_SHORTCUT,
+    LINK_REF_COLLAPSED,
+    LINK_REF_FULL,
+    LINK_REF_FOLDED,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    const out = neutralizeSuspectRefs(source);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, [], label);
+  }
+});
+
+test("a bracket span that resolves nothing is prose", () => {
+  // The bound on the skip. Skipping every bracket span instead would ship this
+  // reference live, which is the harm direction.
+  assert.deepEqual(findSuspectRefs(LINK_REF_NO_DEFINITION), ["#5"]);
+  assert.equal(
+    neutralizeSuspectRefs(LINK_REF_NO_DEFINITION).text,
+    "see [maybe `#5`] there\n",
+  );
+  // A full reference naming an undefined label is prose too.
+  const undefinedLabel = "[jump #5][nope]\n\n[dest]: /url\n";
+  assert.deepEqual(findSuspectRefs(undefinedLabel), ["#5"]);
+});
+
+test("a definition inside a fence defines nothing", () => {
+  // The pre-pass runs the same line classification as the scan, so a definition
+  // that is really code never enters the label set and its use site stays prose.
+  assert.deepEqual(findSuspectRefs(LINK_REF_FENCED_DEF), ["#5"]);
+  assert.equal(
+    neutralizeSuspectRefs(LINK_REF_FENCED_DEF).text,
+    "```\n[issue #5]: /url\n```\n\n[issue `#5`]\n",
+  );
+});
+
+// A label proves nothing on its own: `not a valid url` cannot be a bare destination,
+// so this whole line is a paragraph and BOTH its refs are live.
+const DEF_INVALID_TAIL = "[issue #5]: not a valid url\n\n[issue #5]\n";
+const DEF_DEFERRED_INVALID = "[dest]:\nnot a url #9\n";
+const DEF_ANGLE_DEST = "[issue #5]: <a url with spaces>\n\n[issue #5]\n";
+const DEF_TITLED = '[issue #5]: /url "A title"\n\n[issue #5]\n';
+const DEF_TITLED_PARENS = "[issue #5]: /url (A title)\n\n[issue #5]\n";
+
+test("a line whose tail is no destination is prose, label and all", () => {
+  // Registering the label would have silenced the use site below it too.
+  assert.deepEqual(findSuspectRefs(DEF_INVALID_TAIL), ["#5"]);
+  assert.equal(
+    neutralizeSuspectRefs(DEF_INVALID_TAIL).text,
+    "[issue `#5`]: not a valid url\n\n[issue `#5`]\n",
+  );
+});
+
+test("a deferred destination line is validated the same way", () => {
+  // `[dest]:` alone defers to the next line — but only if that line really is a
+  // destination, so this pair is a plain paragraph.
+  assert.deepEqual(findSuspectRefs(DEF_DEFERRED_INVALID), ["#9"]);
+  assert.equal(
+    neutralizeSuspectRefs(DEF_DEFERRED_INVALID).text,
+    "[dest]:\nnot a url `#9`\n",
+  );
+  // The valid shape still defers and still skips both lines.
+  assert.deepEqual(findSuspectRefs(LINK_DEF_SPLIT), []);
+});
+
+test("the valid destination forms are definitions", () => {
+  for (const source of [DEF_ANGLE_DEST, DEF_TITLED, DEF_TITLED_PARENS]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+test("a malformed definition line is prose", () => {
+  // A bracket that never closes, an all-whitespace label, and a missing colon are
+  // none of them definitions, so each stays scannable.
+  assert.deepEqual(findSuspectRefs("[dest #123\n"), ["#123"]);
+  assert.deepEqual(findSuspectRefs("[ ]: #123\n"), ["#123"]);
+  assert.deepEqual(findSuspectRefs("[dest] #123\n"), ["#123"]);
+  // An unescaped `]` inside the label ends it, so this is not a definition either.
+  assert.deepEqual(findSuspectRefs("[a]b]: #123\n"), ["#123"]);
+});
+
+/** A block opens at its container's content column, so the region is byte-identical
+ *  and the ref inside it is disclosed rather than wrapped. */
+function assertHeldWhole(source, form) {
+  const out = neutralizeSuspectRefs(source);
+  const label = JSON.stringify(source);
+  assert.equal(out.text, source, label);
+  assert.deepEqual(out.wrapped, [], label);
+  assert.deepEqual(out.survived, [form], label);
+}
+
+test("a blockquote's marker does not stop a block from opening", () => {
+  assertHeldWhole(HTML_IN_QUOTE, "`#123`");
+});
+
+test("a bullet list's marker does not stop a block from opening", () => {
+  assertHeldWhole(HTML_IN_LIST, "`#123`");
+});
+
+test("an ordered list's marker does not stop a block from opening", () => {
+  assertHeldWhole(HTML_IN_ORDERED_LIST, "`#3`");
+});
+
+test("a line of NBSP is content, not the blank line that ends a block", () => {
+  assert.equal(HTML_NBSP_LINE.split("\n")[1], "\u00a0");
+  const out = neutralizeSuspectRefs(HTML_NBSP_LINE);
+  assert.equal(out.text, HTML_NBSP_LINE);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#123`"]);
+});
+
+test("an open code span cannot reach across a block opener", () => {
+  // The opener is a block start and the block pass runs first, so the tick that
+  // would have closed the span is unreachable and the ref below it is held.
+  assertHeldWhole(HTML_ACROSS_SPAN, "`#123`");
+});
+
+test("a stray tick in a quoted paragraph cannot swallow the block below it", () => {
+  assertHeldWhole(HTML_QUOTED_STRAY, "`#9`");
+});
+
+test("a raw-text block ends at its closing tag, not at a blank line", () => {
+  // Type 1 ignores blank lines entirely, so `#123` two lines below one is still
+  // inside the `<pre>` and a wrap there would be visible backtick garbage.
+  const out = neutralizeSuspectRefs(HTML_RAW_TEXT);
+  assert.equal(out.text, HTML_RAW_TEXT);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#123`"]);
+  // The closing tag may share the opener's line, and the block ends there.
+  const oneLine = neutralizeSuspectRefs("<pre>see #1</pre>\n\nFixes #2");
+  assert.equal(oneLine.text, "<pre>see #1</pre>\n\nFixes `#2`");
+  assert.deepEqual(oneLine.wrapped, ["`#2`"]);
+  assert.deepEqual(oneLine.survived, ["`#1`"]);
+});
+
+test("a raw HTML block hides nothing from the detector", () => {
+  assert.deepEqual(findSuspectRefs(HTML_DETAILS), ["#123"]);
+  assert.deepEqual(findSuspectRefs(HTML_SUMMARY_INLINE), ["#12"]);
+  assert.deepEqual(findSuspectRefs(HTML_SPAN_ALONE), ["#5"]);
+  assert.deepEqual(findSuspectRefs(HTML_CLOSER_MID_TEXT), ["#1", "#2"]);
+});
+
+test("a reference in a raw HTML block is left alone and disclosed", () => {
+  const out = neutralizeSuspectRefs(HTML_DETAILS);
+  assert.equal(out.text, HTML_DETAILS);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#123`"]);
+});
+
+test("a blank line ends the block, so the reference below it wraps", () => {
+  const out = neutralizeSuspectRefs(HTML_DETAILS_SPACED);
+  assert.equal(out.text, "<details>\n\nFixes `#123`\n\n</details>");
+  assert.deepEqual(out.wrapped, ["`#123`"]);
+  assert.deepEqual(out.survived, []);
+});
+
+test("a type-6 opener covers the rest of its own line", () => {
+  const out = neutralizeSuspectRefs(HTML_SUMMARY_INLINE);
+  assert.equal(out.text, HTML_SUMMARY_INLINE);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#12`"]);
+});
+
+test("a lone closing tag opens a block and interrupts the paragraph", () => {
+  const out = neutralizeSuspectRefs(HTML_CLOSER_MID_TEXT);
+  assert.equal(out.text, "prose `#1`\n</details>\nmore #2\n");
+  assert.deepEqual(out.wrapped, ["`#1`"]);
+  assert.deepEqual(out.survived, ["`#2`"]);
+});
+
+test("a tag with trailing content on the line opens no block", () => {
+  // `span` is not a type-6 tag, and type 7 wants the tag alone on its line, so
+  // this is ordinary prose: the wrap must still fire.
+  const out = neutralizeSuspectRefs(HTML_SPAN_INLINE);
+  assert.equal(out.text, "<span>see `#5`</span> and more prose");
+  assert.deepEqual(out.wrapped, ["`#5`"]);
+  assert.deepEqual(out.survived, []);
+});
+
+test("a tag alone on its line is a type-7 block, whatever the tag", () => {
+  const out = neutralizeSuspectRefs(HTML_SPAN_ALONE);
+  assert.equal(out.text, HTML_SPAN_ALONE);
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#5`"]);
+});
+
+test("wrapped and held references are reported side by side", () => {
+  const out = neutralizeSuspectRefs(HTML_MIXED);
+  assert.equal(out.text, "prose `#7`\n\n<details>\nFixes #8\n</details>");
+  assert.deepEqual(out.wrapped, ["`#7`"]);
+  assert.deepEqual(out.survived, ["`#8`"]);
+});
+
+test("a token wrapped in one place and held in another is disowned", () => {
+  const out = neutralizeSuspectRefs(HTML_SAME_TOKEN);
+  assert.equal(out.text, "prose `#7`\n\n<details>\nFixes #7\n</details>");
+  assert.deepEqual(out.wrapped, []);
+  assert.deepEqual(out.survived, ["`#7`"]);
+});
+
+test("a tick inside a raw HTML block cannot lengthen a later wrap", () => {
+  // No inline syntax parses inside the block, and the blank line that ends one
+  // clears the paragraph's strays anyway, so that tick reaches nothing.
+  const out = neutralizeSuspectRefs(HTML_TICK_INSIDE);
+  assert.equal(out.text, "<details>\na ` b\n</details>\n\nFixes `#6`");
+  assert.deepEqual(out.wrapped, ["`#6`"]);
+});
+
+// Indented code cannot interrupt a paragraph, so these indented lines are prose
+// continuations whose refs really do link — skipping them was a silent live ref.
+const INDENT_PROSE_CONTINUATION = "Review notes:\n    Fixes #123\n";
+const INDENT_LIST_CONTINUATION = "- Finding\n    See #123\n";
+const INDENT_DEEP_LIST_CONTINUATION = "-   Finding\n        See #123\n";
+// A real indented code block: opened where a paragraph could start, and its later
+// lines stay inside it across a blank line.
+const INDENT_CODE_BLOCK = "p\n\n    a #1\n\n    Fixes #123\n";
+const INDENT_CODE_IN_LIST = "- Finding\n\n      See #123\n";
+
+test("an indented line continuing a paragraph is prose", () => {
+  for (const [source, wrapped] of [
+    [INDENT_PROSE_CONTINUATION, "Review notes:\n    Fixes `#123`\n"],
+    [INDENT_LIST_CONTINUATION, "- Finding\n    See `#123`\n"],
+    [INDENT_DEEP_LIST_CONTINUATION, "-   Finding\n        See `#123`\n"],
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), ["#123"], label);
+    assert.equal(neutralizeSuspectRefs(source).text, wrapped, label);
+  }
+});
+
+test("a real indented code block is still skipped", () => {
+  // No separate block state is needed: every skipped line leaves the paragraph-start
+  // flag true, so the block's later lines and the blank line inside it stay code.
+  for (const source of [
+    INDENT_CODE_BLOCK,
+    INDENT_CODE_IN_LIST,
+    "    Fixes #123\n",
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+// An unterminated fence inside a blockquote dies with its container. Without that it
+// swallows the rest of the comment, and those references post live and undisclosed.
+const FENCE_QUOTE_UNPAIRED_REPLY =
+  "> ```suggestion\n> const x = 1;\n\nThat still leaves the leak. Same root cause as #123, and it blocks !47.\n";
+const FENCE_QUOTE_UNPAIRED_MIN = "> ~~~\n> code\n\nFixes #123\n";
+const FENCE_QUOTE_LAZY = "> ~~~\nFixes #123\n";
+const FENCE_UNQUOTED_UNPAIRED = "```\nFixes #123\n";
+
+test("an unterminated fence in a blockquote ends with the blockquote", () => {
+  // A blank line ends the quote, and so does a line that drops below its depth.
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_UNPAIRED_REPLY, ["#", "!"]), [
+    "#123",
+    "!47",
+  ]);
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_UNPAIRED_MIN), ["#123"]);
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_LAZY), ["#123"]);
+});
+
+// A `>`-only line is a blank line INSIDE the blockquote, which a quoted fence
+// absorbs as a blank code line. Reading it as the end of the container kills the
+// fence early, and the real closer then opens a phantom fence over the rest.
+const FENCE_QUOTE_BLANK_INSIDE =
+  "> ```js\n> const a = 1;\n>\n> const b = 2;\n> ```\n> This fixes #123 as noted.";
+const FENCE_QUOTE_BLANK_CONTENT = "> ```\n> code #1\n>\n> more #2\n> ```";
+
+test("a quote-marker-only line does not end a quoted fence", () => {
+  // Live-ref direction: the fence really closes at its closer, so the prose after
+  // it inside the same quote is scanned.
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_BLANK_INSIDE), ["#123"]);
+  // Mangling direction: everything between the markers stays code, both sides of
+  // the blank line, so the neutralizer leaves it alone.
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_BLANK_CONTENT), []);
+  assert.equal(
+    neutralizeSuspectRefs(FENCE_QUOTE_BLANK_CONTENT).text,
+    FENCE_QUOTE_BLANK_CONTENT,
+  );
+});
+
+const FENCE_QUOTE_BLANK_THEN_PROSE =
+  "> ```\n> a #1\n>\n> b #2\n> ```\n\nAfter #9\n";
+const FENCE_NESTED_BLANK =
+  "> > ```\n> > a #1\n> >\n> > b #2\n> > ```\n> > tail #3\n";
+
+test("a quoted fence with an inner blank still ends at its own closer", () => {
+  // Both refs inside stay code and only what follows the closer is scanned —
+  // outside the quote entirely, and at a nested depth.
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_BLANK_THEN_PROSE), ["#9"]);
+  assert.deepEqual(findSuspectRefs(FENCE_NESTED_BLANK), ["#3"]);
+});
+
+const HTML_QUOTE_BLANK_INSIDE = "> <details>\n> #1\n>\n> #2\n";
+
+test("a quote-marker-only line DOES end a quoted HTML block", () => {
+  // The asymmetry the fence rule turns on: a fence absorbs `>` as a blank code
+  // line, a type-6 block ends at it. So the first ref is block content and held,
+  // and the second is an ordinary quoted paragraph and wraps.
+  const out = neutralizeSuspectRefs(HTML_QUOTE_BLANK_INSIDE);
+  assert.deepEqual(findSuspectRefs(HTML_QUOTE_BLANK_INSIDE), ["#1", "#2"]);
+  assert.deepEqual(out.survived, ["`#1`"]);
+  assert.deepEqual(out.wrapped, ["`#2`"]);
+});
+
+test("an unterminated fence at depth zero still runs to the end", () => {
+  // It has no container to lose, so this stays the pinned behaviour, and a properly
+  // closed quoted fence keeps suppressing its contents.
+  assert.deepEqual(findSuspectRefs(FENCE_UNQUOTED_UNPAIRED), []);
+  assert.deepEqual(findSuspectRefs(FENCE_IN_QUOTE), []);
+});
+
+// Indented code opens right after each of these leaf blocks, so a wrap there would
+// land inside rendered code while the footer claimed the reference was neutralized.
+const INDENT_AFTER_HEADING = "## Findings\n    // repro\n    fixes #123\n";
+const INDENT_AFTER_SETEXT = "Title\n---\n    fixes #123\n";
+const INDENT_AFTER_BREAK = "a\n\n***\n    fixes #123\n";
+const INDENT_AFTER_RAW_CLOSE = "<pre>\na\n</pre>\n    fixes #123\n";
+const INDENT_AFTER_TABLE = "| a | b |\n| - | - |\n    fixes #123\n";
+const INDENT_IN_QUOTE = "> intro\n>\n>     Fixes #123\n";
+const DEF_AFTER_HEADING = "## References\n[d]: #123\n\nsee [d]\n";
+const DEF_IN_QUOTE = "> intro\n>\n> [dest]: #123\n\nsee [dest]\n";
+
+test("a line that leaves no open paragraph lets indented code follow it", () => {
+  // Only recognizable paragraph content blocks the next line from starting a block;
+  // every other shape, modelled or not, falls back to treating the indent as code.
+  for (const source of [
+    INDENT_AFTER_HEADING,
+    INDENT_AFTER_SETEXT,
+    INDENT_AFTER_BREAK,
+    INDENT_AFTER_RAW_CLOSE,
+    INDENT_AFTER_TABLE,
+  ]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+test("a blockquote's own blank line and indent are read at its content column", () => {
+  // `>` alone is the blockquote's blank line, so what follows starts a block: an
+  // indented line is code, and a definition line registers instead of corrupting.
+  for (const source of [INDENT_IN_QUOTE, DEF_IN_QUOTE, DEF_AFTER_HEADING]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source), [], label);
+    assert.equal(neutralizeSuspectRefs(source).text, source, label);
+  }
+});
+
+// A fence opens at the blockquote content column, and pairs only at its own depth.
+const FENCE_IN_QUOTE = "> ~~~\n> #123\n> ~~~\n";
+const FENCE_DEPTH_MISMATCH = "> ```\n> a\n```\n#123\n";
+const FENCE_QUOTE_THEN_PROSE = "> ~~~\n> a\n> ~~~\n\n#123\n";
+
+test("a fence inside a blockquote is a fence", () => {
+  // The tilde form is the one that showed the damage: backticks in a quoted fence
+  // happen to open a code SPAN, which hid the refs by accident.
+  assert.deepEqual(findSuspectRefs(FENCE_IN_QUOTE), []);
+  assert.equal(neutralizeSuspectRefs(FENCE_IN_QUOTE).text, FENCE_IN_QUOTE);
+  // And it closes, so prose after the blockquote is scanned again.
+  assert.deepEqual(findSuspectRefs(FENCE_QUOTE_THEN_PROSE), ["#123"]);
+});
+
+test("a fence pairs only at its own container depth", () => {
+  // An unquoted ``` line cannot close a fence opened inside a blockquote, so the
+  // reference below stays inside code — which is where the renderer puts it too.
+  assert.deepEqual(findSuspectRefs(FENCE_DEPTH_MISMATCH), []);
+  assert.equal(
+    neutralizeSuspectRefs(FENCE_DEPTH_MISMATCH).text,
+    FENCE_DEPTH_MISMATCH,
+  );
+});
+
 // Backslash-parity fixtures; rule on `isEscaped`, guard below pins the counts.
 const ESC_1 = String.raw`\#123`;
 const ESC_2 = String.raw`\\#123`;
@@ -109,13 +563,82 @@ test("the escape fixtures carry the backslash runs they claim", () => {
   );
 });
 
-test("an odd backslash run escapes the trigger", () => {
-  assert.deepEqual(findSuspectRefs(ESC_1), []);
-  assert.deepEqual(findSuspectRefs(ESC_3), []);
-  assert.equal(neutralizeSuspectRefs(ESC_1).text, ESC_1);
-  assert.deepEqual(neutralizeSuspectRefs(ESC_1).wrapped, []);
-  assert.equal(neutralizeSuspectRefs(ESC_3).text, ESC_3);
-  assert.deepEqual(findSuspectRefs(String.raw`\!45`, ["#", "!"]), []);
+// The forges disagree about an escaped trigger, so the escape arm has two modes and
+// both are pinned. GitHub's reference filter runs after rendering, on text the escape
+// has already been consumed from, so `\#123` autolinks there; GitLab leaves it alone.
+test("an escaped trigger is a candidate by default, backslash run and all", () => {
+  assert.deepEqual(findSuspectRefs(ESC_1), [ESC_1]);
+  assert.deepEqual(findSuspectRefs(ESC_3), [ESC_3]);
+  assert.deepEqual(findSuspectRefs(String.raw`\!45`, ["#", "!"]), [
+    String.raw`\!45`,
+  ]);
+  // The wrap must ENCLOSE the backslashes. Opening the span after them would leave
+  // the span's own tick escaped, and the reference bare and live outside it.
+  const one = neutralizeSuspectRefs(ESC_1);
+  assert.equal(one.text, `\`${ESC_1}\``);
+  assert.deepEqual(one.wrapped, [`\`${ESC_1}\``]);
+  assert.equal(neutralizeSuspectRefs(ESC_3).text, `\`${ESC_3}\``);
+  // A word character before the run still keeps it plain: the boundary rule reads
+  // what ends up adjacent once the renderer consumes the backslash.
+  assert.deepEqual(findSuspectRefs(`a${ESC_1}`), []);
+});
+
+const ESCAPED_IN_HTML = `<details>\nFixes ${ESC_1}\n</details>`;
+
+test("an escaped reference inside a raw HTML block is held in BOTH modes", () => {
+  // No escape processing happens inside raw HTML, so the backslash is literal text
+  // and both forges linkify the reference beside it. The GitLab mode's reason for
+  // leaving an escape alone does not reach in here. The raw-HTML arm still refuses
+  // to rewrite, so it lands in `survived` carrying its backslash.
+  for (const live of [true, false]) {
+    const label = `escapedRefsLive=${live}`;
+    assert.deepEqual(
+      findSuspectRefs(ESCAPED_IN_HTML, ["#", "!"], live),
+      [ESC_1],
+      label,
+    );
+    const out = neutralizeSuspectRefs(ESCAPED_IN_HTML, ["#", "!"], live);
+    assert.equal(out.text, ESCAPED_IN_HTML, label);
+    assert.deepEqual(out.wrapped, [], label);
+    assert.deepEqual(out.survived, [`\`${ESC_1}\``], label);
+  }
+});
+
+test("the footer names an escaped reference held inside raw HTML", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: ESCAPED_IN_HTML,
+    neutralizeRefs: true,
+  });
+  assert.ok(body.includes(ESCAPED_IN_HTML), body);
+  assert.ok(
+    body.endsWith(
+      `_This automated run could not neutralize \`${ESC_1}\` — verify before trusting any links it created._`,
+    ),
+    body,
+  );
+});
+
+test("a fence recovers when a deeper quote drops a level", () => {
+  assert.deepEqual(findSuspectRefs("> > ~~~\n> > c\n> after #1\n"), ["#1"]);
+});
+
+test("the GitLab mode leaves an escaped trigger alone", () => {
+  for (const source of [ESC_1, ESC_3, String.raw`\!45`]) {
+    const label = JSON.stringify(source);
+    assert.deepEqual(findSuspectRefs(source, ["#", "!"], false), [], label);
+    const out = neutralizeSuspectRefs(source, ["#", "!"], false);
+    assert.equal(out.text, source, label);
+    assert.deepEqual(out.wrapped, [], label);
+  }
+  // An EVEN run is not an escape at all, so both modes agree about it.
+  for (const source of [ESC_2, ESC_4]) {
+    assert.deepEqual(
+      findSuspectRefs(source, ["#", "!"], false),
+      findSuspectRefs(source),
+      JSON.stringify(source),
+    );
+  }
 });
 
 test("an even backslash run leaves the reference live", () => {
@@ -361,6 +884,70 @@ const CORPUS = [
   "prose ` #4\n```\ny `\n```\n",
   "`#1``#2``#3``#4`#5",
   "` a ` ` b #7",
+  // Raw HTML blocks — the population that makes `survived` reachable.
+  HTML_DETAILS,
+  HTML_DETAILS_SPACED,
+  HTML_SUMMARY_INLINE,
+  HTML_CLOSER_MID_TEXT,
+  HTML_SPAN_INLINE,
+  HTML_SPAN_ALONE,
+  HTML_MIXED,
+  HTML_SAME_TOKEN,
+  HTML_TICK_INSIDE,
+  // Negative controls: each one wrapped a reference INSIDE raw HTML before the
+  // region grammar read container columns, CommonMark's blank line, and block
+  // starts that beat an open span. The renderer oracle below is what catches them.
+  HTML_IN_QUOTE,
+  HTML_IN_LIST,
+  HTML_IN_ORDERED_LIST,
+  HTML_NBSP_LINE,
+  HTML_ACROSS_SPAN,
+  HTML_QUOTED_STRAY,
+  HTML_RAW_TEXT,
+  // The oracle cannot see href corruption (a wrapped destination still renders as
+  // an anchor), so these are pinned by byte-identity above; here they only have to
+  // stay consistent with the partition and fixed-point properties.
+  LINK_DEF_USED,
+  LINK_DEF_ALONE,
+  LINK_DEF_SPLIT,
+  LINK_DEF_AS_PROSE,
+  LINK_REF_SHORTCUT,
+  LINK_REF_COLLAPSED,
+  LINK_REF_FULL,
+  LINK_REF_FOLDED,
+  LINK_REF_NO_DEFINITION,
+  LINK_REF_FENCED_DEF,
+  INDENT_PROSE_CONTINUATION,
+  INDENT_LIST_CONTINUATION,
+  INDENT_DEEP_LIST_CONTINUATION,
+  INDENT_CODE_BLOCK,
+  INDENT_CODE_IN_LIST,
+  FENCE_IN_QUOTE,
+  FENCE_DEPTH_MISMATCH,
+  FENCE_QUOTE_THEN_PROSE,
+  DEF_INVALID_TAIL,
+  DEF_DEFERRED_INVALID,
+  DEF_ANGLE_DEST,
+  DEF_TITLED,
+  DEF_TITLED_PARENS,
+  FENCE_QUOTE_UNPAIRED_REPLY,
+  FENCE_QUOTE_UNPAIRED_MIN,
+  FENCE_QUOTE_LAZY,
+  FENCE_UNQUOTED_UNPAIRED,
+  FENCE_QUOTE_BLANK_INSIDE,
+  FENCE_QUOTE_BLANK_CONTENT,
+  FENCE_QUOTE_BLANK_THEN_PROSE,
+  FENCE_NESTED_BLANK,
+  HTML_QUOTE_BLANK_INSIDE,
+  ESCAPED_IN_HTML,
+  INDENT_AFTER_HEADING,
+  INDENT_AFTER_SETEXT,
+  INDENT_AFTER_BREAK,
+  INDENT_AFTER_RAW_CLOSE,
+  INDENT_AFTER_TABLE,
+  INDENT_IN_QUOTE,
+  DEF_AFTER_HEADING,
+  DEF_IN_QUOTE,
 ];
 
 /** The token inside an emitted wrap form, whatever run length it used. */
@@ -479,11 +1066,66 @@ test("a wrapped ref never renders more exposed than it started", async (t) => {
     }
     for (const form of out.survived) {
       const token = stripTicks(form);
+      // Survivors sit outside the strictly-decreases arm above on purpose: a
+      // raw HTML block's ref is LEFT live and disclosed, so the only bar here
+      // is that neutralizing never made it more exposed than it was.
       assert.ok(
         liveCount(after, token) <= liveCount(before, token),
         `${token} renders MORE exposed after neutralizing ${label}`,
       );
     }
+  }
+});
+
+// The wrapped-arm oracle above cannot see this failure: a broken reference link still
+// renders, just as bracket text instead of an anchor, and its ref is not MORE exposed
+// than it started. So the link itself is what gets asserted.
+test("a reference link still renders as a link afterwards", async (t) => {
+  let Marked;
+  try {
+    ({ Marked } = await import("marked"));
+  } catch {
+    t.skip(
+      "marked is not installed — the guards job runs with no install step",
+    );
+    return;
+  }
+  const md = new Marked();
+  for (const source of [
+    LINK_REF_SHORTCUT,
+    LINK_REF_COLLAPSED,
+    LINK_REF_FULL,
+    LINK_REF_FOLDED,
+  ]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    assert.match(md.parse(out.text), /<a href=/, label);
+    assert.equal(md.parse(out.text), md.parse(source), label);
+  }
+});
+
+// The wrapped-arm oracle cannot speak for an escaped token: its own string carries a
+// backslash the renderer consumes, so its live count is zero before AND after and the
+// strictly-decreases assertion passes vacuously. What matters is the BARE reference
+// the forge filter would see post-render, so that is asserted directly.
+test("an escaped reference stops rendering live once wrapped", async (t) => {
+  let Marked;
+  try {
+    ({ Marked } = await import("marked"));
+  } catch {
+    t.skip(
+      "marked is not installed — the guards job runs with no install step",
+    );
+    return;
+  }
+  const md = new Marked();
+  for (const source of [ESC_1, ESC_3]) {
+    const label = JSON.stringify(source);
+    const out = neutralizeSuspectRefs(source);
+    // Before: marked consumes the escape, so `#123` is live body text — which is
+    // exactly what GitHub's post-render filter linkifies.
+    assert.equal(liveCount(outsideCode(md.parse(source)), "#123"), 1, label);
+    assert.equal(liveCount(outsideCode(md.parse(out.text)), "#123"), 0, label);
   }
 });
 
@@ -565,6 +1207,23 @@ test("the neutralize flag wraps the refs and discloses it once", () => {
   assert.deepEqual(findSuspectRefs(body), []);
 });
 
+test("the disclosure names the escaped form it actually shipped", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: `Fixes ${ESC_1} now`,
+    neutralizeRefs: true,
+  });
+  assert.ok(body.includes(`Fixes \`${ESC_1}\` now`), body);
+  assert.ok(
+    body.endsWith(
+      `_References \`${ESC_1}\` are shown as plain text — this automated run could not confirm they were meant to link._`,
+    ),
+    body,
+  );
+  // The footer's own copy sits in a code span, so it mints no reference either.
+  assert.deepEqual(findSuspectRefs(body), []);
+});
+
 test("without the flag the refs are left exactly as written", () => {
   const text = "Recorded decision (#10).";
   const body = buildAiCommentBody({ ...PARTS, text });
@@ -572,10 +1231,44 @@ test("without the flag the refs are left exactly as written", () => {
   assert.ok(!body.includes("_References "), body);
 });
 
+test("a body whose only refs sit in a raw HTML block still discloses them", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: HTML_DETAILS,
+    neutralizeRefs: true,
+  });
+  // The region is byte-identical in the shipped body, so the footer is the only
+  // thing standing between the reader and a live cross-reference.
+  assert.ok(body.includes(HTML_DETAILS), body);
+  assert.ok(!body.includes("_References "), body);
+  assert.ok(
+    body.endsWith(
+      "_This automated run could not neutralize `#123` — verify before trusting any links it created._",
+    ),
+    body,
+  );
+});
+
+test("a body with both outcomes names the wraps and the survivor", () => {
+  const body = buildAiCommentBody({
+    ...PARTS,
+    text: HTML_MIXED,
+    neutralizeRefs: true,
+  });
+  assert.ok(
+    body.endsWith(
+      "_References `#7` are shown as plain text — this automated run could not confirm they were meant to link. It could not neutralize `#8`._",
+    ),
+    body,
+  );
+});
+
 test("a body the guard cannot fully clear never claims more than it did", () => {
-  // The post-condition is the tripwire for a geometry the scan reads wrongly; no
-  // input reaches it today, so this pins the shape the footer must keep rather
-  // than a live case. Every corpus entry lands wholly in `wrapped` or in neither.
+  // The post-condition is the tripwire for a geometry the scan reads wrongly, and
+  // the corpus entries whose refs sit INSIDE a raw HTML block are its live
+  // producers, so both footer arms run against real output rather than a shape.
+  // The fixtures that deliberately open no block (the blank-line-spaced, inline
+  // `<span>`, and tick-inside variants) still wrap, and are the control.
   for (const source of CORPUS) {
     const out = neutralizeSuspectRefs(source);
     const body = buildAiCommentBody({

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -26,6 +26,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { openAutomationResult } from "@/lib/automations/results";
 import { displayLogin } from "@/lib/git/bot-login";
 import type { RemoteLens } from "@/lib/git/types";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
@@ -258,6 +259,8 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
       openRun({ repoPath: n.repoPath, repoName: n.repoName, runId: t.runId });
     } else if (t?.type === "agent") {
       openAgentTab({ repoPath: n.repoPath, repoName: n.repoName });
+    } else if (t?.type === "automation-result" && typeof t.id === "string") {
+      void openAutomationResult(n.repoPath, t.id);
     }
     onClose();
   };

--- a/src/features/automations/AutomationResultDialog.tsx
+++ b/src/features/automations/AutomationResultDialog.tsx
@@ -1,5 +1,6 @@
 import { Markdown } from "@/components/markdown/markdown";
 import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -9,12 +10,15 @@ import {
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAutomationResults } from "@/lib/automations/results";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { parseableDate } from "@/lib/time";
 import { useRetained } from "@/lib/use-retained";
 
 /**
- * Viewer for automation results that have no durable surface (commit
- * reviews). Opened from the completion toast; mounted once at the app root.
+ * Viewer for automated commit reviews, the one review target with no comment
+ * surface of its own. Opened from the completion toast or the result's inbox
+ * row (which reads the persisted copy after a restart); mounted once at the app
+ * root, so a cross-repo notification can open it without a repo switch.
  */
 export function AutomationResultDialog() {
   const openId = useAutomationResults((s) => s.openId);
@@ -37,6 +41,14 @@ export function AutomationResultDialog() {
             AI {shownResult?.mode === "security" ? "security audit" : "review"}
           </DialogTitle>
           <DialogDescription>
+            {shownResult?.hash && (
+              <>
+                <span className="font-mono">
+                  {shownResult.hash.slice(0, 7)}
+                </span>
+                {" · "}
+              </>
+            )}
             {shownResult?.subject}
             {shownResult && parseableDate(shownResult.createdAt) && (
               <>
@@ -46,6 +58,27 @@ export function AutomationResultDialog() {
             )}
           </DialogDescription>
         </DialogHeader>
+        {/* Says in words what the tone shows — kept output is not a review. */}
+        {shownResult?.phase === "error" && (
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="outline"
+              className="shrink-0 border-warning/40 bg-warning/10 text-warning"
+            >
+              {shownResult.timedOut === true
+                ? "Timed out — partial output"
+                : "Stopped early"}
+            </Badge>
+            {typeof shownResult.error === "string" && shownResult.error && (
+              <span
+                className="min-w-0 truncate text-muted-foreground text-sm"
+                onMouseEnter={clipTitleFromText}
+              >
+                {shownResult.error}
+              </span>
+            )}
+          </div>
+        )}
         <ScrollArea className="min-h-0 flex-1">
           {shownResult && <Markdown>{shownResult.text}</Markdown>}
         </ScrollArea>

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -357,6 +357,10 @@ export function PrReviewPanel({
             // it's unresolved the detector's both-trigger default applies —
             // over-warning in that window beats a missed live `!N`.
             forgeProvider ? REF_TRIGGERS[forgeProvider] : undefined,
+            // GitHub's reference filter runs post-render and links `\#N` anyway;
+            // GitLab honors the escape (measured on both) — so only GitLab gets
+            // escaped refs excused from the warning.
+            forgeProvider !== "gitlab",
           )
         : [];
     if (partial || suspectRefs.length > 0) {

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -347,13 +347,18 @@ export function PrReviewPanel({
     // would cancel the first (the confirm store keeps one request live), and the text
     // is never rewritten here — the user decides.
     const partial = phase === "error" || phase === "cancelled";
-    const refs = findSuspectRefs(
-      text,
-      // Absent on the local-PR / commit-review mounts, which have no forge lens;
-      // GitHub's single `#` space is the safe default there.
-      REF_TRIGGERS[context.provider ?? "github"],
-    );
-    if (partial || refs.length > 0) {
+    // A local PR is posted into app data, where no forge cross-reference or
+    // notification exists — the refs warning would be false there.
+    const suspectRefs =
+      prKind === "remote"
+        ? findSuspectRefs(
+            text,
+            // `context.provider` rides forge status, so it can still be unresolved
+            // here; GitHub's single `#` space is the safe default.
+            REF_TRIGGERS[context.provider ?? "github"],
+          )
+        : [];
+    if (partial || suspectRefs.length > 0) {
       const partialSentence =
         phase === "cancelled"
           ? "This run was cancelled before it finished, so the text may be incomplete."
@@ -361,11 +366,11 @@ export function PrReviewPanel({
             ? "This run failed before completing, so the text may be incomplete."
             : "";
       const refsTail =
-        refs.length === 1
+        suspectRefs.length === 1
           ? "it becomes a live cross-reference that notifies the thread it names. Backticks keep it plain."
-          : "each becomes a live cross-reference that notifies the thread it names. Backticks keep one plain.";
-      const refsSentence = refs.length
-        ? `The text mentions ${formatRefList(refs)} — posted as-is, ${refsTail}`
+          : "each becomes a live cross-reference that notifies the thread it names. Backticks keep them plain.";
+      const refsSentence = suspectRefs.length
+        ? `The text mentions ${formatRefList(suspectRefs)} — posted as-is, ${refsTail}`
         : "";
       const ok = await useConfirm.getState().ask({
         title: partial

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -36,7 +36,12 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { detectAgentCli, providerKind } from "@/lib/ai/agent";
 import { LOGIN_COMMAND } from "@/lib/ai/cli-client";
-import { buildAiCommentBody } from "@/lib/ai/comment-branding";
+import {
+  buildAiCommentBody,
+  findSuspectRefs,
+  formatRefList,
+  REF_TRIGGERS,
+} from "@/lib/ai/comment-branding";
 import { modelPickerEmptyText, useAvailableModels } from "@/lib/ai/models";
 import {
   defaultModelForProvider,
@@ -210,7 +215,8 @@ export function PrReviewPanel({
   const [ignoreNotes, setIgnoreNotes] = useState(false);
 
   // Review output cites `#N` constantly, so linkify it against the PR's own repo.
-  // `context.provider` is the AI provider — the FORGE one comes from forge status.
+  // `context.provider` is the FORGE provider too, but optional (absent on the
+  // local-PR mount); forge status is the resolved source for linkify.
   const forgeProvider = useForgeStatus(context.repoPath).data?.provider;
   const refs = forgeProvider
     ? {
@@ -335,16 +341,39 @@ export function PrReviewPanel({
 
   async function post() {
     if (!onPost || !text.trim() || posting || stale) return;
-    // A failed OR cancelled run keeps whatever streamed before it stopped, and that
-    // partial text stays postable — publishing an unfinished review is consequential,
-    // so confirm first, naming which way the run ended.
-    if (phase === "error" || phase === "cancelled") {
+    // Two reasons to stop and ask, merged into ONE dialog: a failed or cancelled run
+    // keeps whatever streamed before it stopped, and text carrying `#N`-style tokens
+    // posts as live cross-references that notify the threads they name. A second ask
+    // would cancel the first (the confirm store keeps one request live), and the text
+    // is never rewritten here — the user decides.
+    const partial = phase === "error" || phase === "cancelled";
+    const refs = findSuspectRefs(
+      text,
+      // Absent on the local-PR / commit-review mounts, which have no forge lens;
+      // GitHub's single `#` space is the safe default there.
+      REF_TRIGGERS[context.provider ?? "github"],
+    );
+    if (partial || refs.length > 0) {
+      const partialSentence =
+        phase === "cancelled"
+          ? "This run was cancelled before it finished, so the text may be incomplete."
+          : phase === "error"
+            ? "This run failed before completing, so the text may be incomplete."
+            : "";
+      const refsTail =
+        refs.length === 1
+          ? "it becomes a live cross-reference that notifies the thread it names. Backticks keep it plain."
+          : "each becomes a live cross-reference that notifies the thread it names. Backticks keep one plain.";
+      const refsSentence = refs.length
+        ? `The text mentions ${formatRefList(refs)} — posted as-is, ${refsTail}`
+        : "";
       const ok = await useConfirm.getState().ask({
-        title: "Post partial review?",
-        body:
-          phase === "cancelled"
-            ? "This run was cancelled before it finished, so the text may be incomplete. Post it as a comment anyway?"
-            : "This run failed before completing, so the text may be incomplete. Post it as a comment anyway?",
+        title: partial
+          ? "Post partial review?"
+          : "Post review with live references?",
+        body: [partialSentence, refsSentence, "Post it as a comment anyway?"]
+          .filter(Boolean)
+          .join(" "),
         confirmLabel: "Post anyway",
       });
       if (!ok) return;

--- a/src/features/pulls/PrReviewPanel.tsx
+++ b/src/features/pulls/PrReviewPanel.tsx
@@ -353,9 +353,10 @@ export function PrReviewPanel({
       prKind === "remote"
         ? findSuspectRefs(
             text,
-            // `context.provider` rides forge status, so it can still be unresolved
-            // here; GitHub's single `#` space is the safe default.
-            REF_TRIGGERS[context.provider ?? "github"],
+            // Keyed off the same resolved forge status the linkifier uses; while
+            // it's unresolved the detector's both-trigger default applies —
+            // over-warning in that window beats a missed live `!N`.
+            forgeProvider ? REF_TRIGGERS[forgeProvider] : undefined,
           )
         : [];
     if (partial || suspectRefs.length > 0) {

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -71,7 +71,7 @@ export const NotificationsSection = withForm({
             <form.AppField name="notifications.automations">
               {(field) => (
                 <field.CheckboxField
-                  label="Automation results (AI reviews posted or failed)"
+                  label="Automation results (AI reviews ready, posted, or failed)"
                   className="flex cursor-pointer items-center gap-2 text-xs"
                 />
               )}

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -168,6 +168,34 @@ const TABLE_ROW = /^ {0,3}\||\|[ \t]*$/;
  *  lines (setext underlines, thematic breaks) that are structure. */
 const HAS_TEXT = /[\p{L}\p{N}]/u;
 
+/** The two punctuation-only lines that really are block starts, as opposed to prose
+ *  that merely happens to carry no letters. */
+const THEMATIC_BREAK =
+  /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
+const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[ \t]*$/;
+
+/**
+ * Whether this line unconditionally ENDS the paragraph above it. A code span cannot
+ * cross a paragraph boundary, so {@link paragraphLimit} stops here: a closer beyond
+ * one of these belongs to another block and must never pair with an opener before it.
+ *
+ * Deliberately NARROWER than the inverse of {@link leavesOpenParagraph}, because the
+ * two answer for opposite polarities. That one may guess "no open paragraph" freely —
+ * its consumer then reads an indented line as code, which over-skips. This one may
+ * not: a wrong YES splits a paragraph the renderer keeps whole, so the span never
+ * opens and a reference the renderer had already made inert is wrapped inside
+ * rendered code and claimed neutralized. Hence prose without letters (a line of
+ * emoji, `!!!`) stays paragraph content here, and so does a `| a | b |` line, which
+ * is only a table when a delimiter row follows it.
+ */
+function breaksParagraph(quoted: string): boolean {
+  return (
+    ATX_HEADING.test(quoted) ||
+    THEMATIC_BREAK.test(quoted) ||
+    SETEXT_UNDERLINE.test(quoted)
+  );
+}
+
 /**
  * Whether this line leaves an OPEN PARAGRAPH behind it, which is the one thing that
  * stops the next line from starting a block. Only a line recognized as paragraph
@@ -409,11 +437,13 @@ function recordTicks(
   }
 }
 
-/** Where a code span opened at `from` must stop looking for its closer: the next
- *  blank line, fence line, or raw-HTML-block opener, whichever comes first. All
- *  three end the paragraph CommonMark parses the span within — a fence and an HTML
- *  block are block starts, and the block pass runs first — so reading past any of
- *  them would let a delimiter or another block's content pose as a closer. */
+/** Where a code span opened at `from` must stop looking for its closer: whichever
+ *  comes first of the next blank line, container start, paragraph-interrupting line
+ *  ({@link breaksParagraph}), fence line, or raw-HTML-block opener. Every one ends
+ *  the paragraph CommonMark parses the span within — the block pass runs before
+ *  inline parsing — so reading past any of them would let a delimiter or another
+ *  block's content pose as a closer. The bounding line itself is EXCLUDED: the index
+ *  returned is its first character, and the caller's window is half-open. */
 function paragraphLimit(text: string, from: number): number {
   BLANK_LINE.lastIndex = from;
   const blank = BLANK_LINE.exec(text);
@@ -442,14 +472,15 @@ function paragraphLimit(text: string, from: number): number {
     // start: the `span === 0` guard then suppresses the whole HTML arm there, and a
     // reference inside the raw block is either wrapped and falsely claimed or lost
     // to a span the renderer never opened.
-    const containerStart = opensContainer(line, prevDepth);
-    // A container start ends the paragraph outright, whatever follows its marker, so
-    // the search stops there: a closer beyond it sits in another block and cannot
-    // pair with this opener.
+    // Each arm ends the paragraph the opener sits in, so a closer past it belongs to
+    // another block. The container and paragraph-interrupting arms return outright;
+    // by the time the HTML arm is reached a container start has already returned, so
+    // its gate carries the paragraph half alone.
     if (
-      containerStart ||
+      opensContainer(line, prevDepth) ||
+      breaksParagraph(quoted) ||
       FENCE.test(quoted) ||
-      opensHtmlBlock(containerContent(line), !openParagraph || containerStart)
+      opensHtmlBlock(containerContent(line), !openParagraph)
     )
       return start;
     openParagraph = leavesOpenParagraph(quoted);
@@ -464,14 +495,14 @@ function paragraphLimit(text: string, from: number): number {
  *  opener without one is literal text — entering span state there would silently
  *  swallow every later reference.
  *
- *  APPROXIMATE, and NOT safely so. {@link paragraphLimit} bounds at blank lines,
- *  fences, container starts and HTML-block starts — but a HEADING is none of those,
- *  so content past one can pose as a closer and answer TRUE where markdown would
- *  not. Both failure arms are reachable there: a reference wrapped inside a region
- *  the renderer treats as code or raw HTML and then claimed neutralized, and a live
- *  reference swallowed by a span the renderer never opens and so never reported.
- *  Neither direction is safe; the remedy is bounding at every block that can
- *  interrupt a paragraph, which is tracked separately. */
+ *  APPROXIMATE in one narrow place. {@link paragraphLimit} bounds at blank lines,
+ *  container starts, headings, thematic breaks, setext underlines, fences and
+ *  HTML-block starts — every paragraph interruption recognizable from a single line.
+ *  What it cannot see is a GFM TABLE: `| a | b |` is ordinary prose until a delimiter
+ *  row follows it, and that lookahead is beyond a line-at-a-time model. A span can
+ *  therefore still pair across a real table and swallow a reference the renderer
+ *  leaves live in a cell — a silent miss, sharing its missing-lookahead root cause
+ *  with the table arm of {@link leavesOpenParagraph}. */
 function hasClosingRun(text: string, from: number, run: number): boolean {
   const limit = paragraphLimit(text, from);
   let i = from;

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -257,20 +257,37 @@ function opensDeferredDestination(line: string, depth: number): boolean {
   );
 }
 
-/** Whether `line` starts a container relative to `depth` — the notion the type-7 arm
- *  needs, shared by its two call sites so they cannot drift apart. Any CHANGE of
- *  blockquote depth ends the paragraph that was running (a rise enters a new one, a
- *  drop leaves it into lazy-continuation position) and a list marker begins a fresh
- *  item; in each case a type-7 tag may open where mid-paragraph it could not.
+/** Whether `line` starts a container relative to `depth`. A RISE always does, and so
+ *  does a list marker; a DROP depends on what the caller is asking, which is what
+ *  `lazyContinues` selects.
+ *
+ *  With `lazyContinues` false — the type-7 arm's reading, and the default — any
+ *  change counts, because that arm must fail OPEN: over-holding costs a truthful
+ *  disclosure while a missed block start costs a false claim.
+ *
+ *  With it true, a shallower line is a LAZY CONTINUATION that CommonMark folds back
+ *  into the paragraph above, so it starts nothing — the same rule
+ *  {@link opensDeferredDestination} follows. {@link paragraphLimit} passes its own
+ *  open-paragraph state here, since a span really does reach across such a line.
+ *
+ *  The two call sites therefore diverge ON PURPOSE, and only on drops. The scan may
+ *  then open a type-7 region inside a span the limit let form; the `span === 0` guard
+ *  shuts the HTML arm there, which is what the renderer does too.
  *
  *  KNOWN GAP: a list DEDENT is invisible here, because measuring it needs the item's
  *  content column and this scan has no indentation model. `- text` then `<span>`
  *  leaves the item, so the tag opens a block and the reference under it is raw HTML;
  *  the scan wraps it instead and claims it neutralized — the same false-claim class
  *  this function exists to prevent, narrowed to list dedents. */
-function opensContainer(line: string, depth: number): boolean {
+function opensContainer(
+  line: string,
+  depth: number,
+  lazyContinues = false,
+): boolean {
+  const lineDepth = quoteDepth(line);
   return (
-    quoteDepth(line) !== depth ||
+    lineDepth > depth ||
+    (!lazyContinues && lineDepth !== depth) ||
     LIST_MARKER.test(line.replace(QUOTE_PREFIX, ""))
   );
 }
@@ -443,7 +460,14 @@ function recordTicks(
  *  the paragraph CommonMark parses the span within — the block pass runs before
  *  inline parsing — so reading past any of them would let a delimiter or another
  *  block's content pose as a closer. The bounding line itself is EXCLUDED: the index
- *  returned is its first character, and the caller's window is half-open. */
+ *  returned is its first character, and the caller's window is half-open.
+ *
+ *  Two of those need spelling out. A `>`-only line is a blockquote's blank line, and
+ *  `BLANK_LINE` cannot see it — that pattern wants two newlines — so the gate tests
+ *  the quote-stripped line itself. And the OPENER's own line may be the block that
+ *  ends: a heading can carry a backtick and still close at its line end, so the
+ *  search is capped there before the walk begins. A drop in depth, by contrast, is a
+ *  lazy continuation while a paragraph is open, and does NOT bound. */
 function paragraphLimit(text: string, from: number): number {
   BLANK_LINE.lastIndex = from;
   const blank = BLANK_LINE.exec(text);
@@ -457,6 +481,11 @@ function paragraphLimit(text: string, from: number): number {
   let openerEnd = text.indexOf("\n", openerStart);
   if (openerEnd === -1) openerEnd = text.length;
   const opener = text.slice(openerStart, openerEnd);
+  // The opener's OWN line can be the block that ends here — a heading may carry a
+  // backtick and still close at its line end, so nothing after it can be the closer.
+  // `openerEnd` never exceeds `limit`: the earliest newline at or after `from` is the
+  // opener's own, and `BLANK_LINE` needs one before it can match.
+  if (breaksParagraph(opener.replace(QUOTE_PREFIX, ""))) return openerEnd;
   let prevDepth = quoteDepth(opener);
   let openParagraph = leavesOpenParagraph(opener.replace(QUOTE_PREFIX, ""));
   let nl = text.indexOf("\n", from);
@@ -466,18 +495,11 @@ function paragraphLimit(text: string, from: number): number {
     if (end === -1) end = text.length;
     const line = text.slice(start, end);
     const quoted = line.replace(QUOTE_PREFIX, "");
-    // The gate is read BEFORE the state advances, so this line is judged by what the
-    // one above it left behind — the same order the scan's arm uses. If the two
-    // disagree, a span candidate runs through a line the scan treats as a block
-    // start: the `span === 0` guard then suppresses the whole HTML arm there, and a
-    // reference inside the raw block is either wrapped and falsely claimed or lost
-    // to a span the renderer never opened.
-    // Each arm ends the paragraph the opener sits in, so a closer past it belongs to
-    // another block. The container and paragraph-interrupting arms return outright;
-    // by the time the HTML arm is reached a container start has already returned, so
-    // its gate carries the paragraph half alone.
+    // Read before the state advances, so each line is judged by what the one above it
+    // left behind — the same order the scan's arm uses.
     if (
-      opensContainer(line, prevDepth) ||
+      BLANK.test(quoted) ||
+      opensContainer(line, prevDepth, openParagraph) ||
       breaksParagraph(quoted) ||
       FENCE.test(quoted) ||
       opensHtmlBlock(containerContent(line), !openParagraph)
@@ -697,7 +719,10 @@ function scanRefs(
   // container from one that was already there.
   let prevDepth = 0;
   // Lengths of the unpaired literal runs seen so far in THIS paragraph; inline
-  // syntax is paragraph-scoped, so a blank line clears them.
+  // syntax is paragraph-scoped, so a blank line clears them. Only a blank line does,
+  // though a heading or container start also ends the paragraph for span purposes —
+  // so a tick above one still lengthens a wrap below it, which over-shoots in the
+  // direction this set is meant to over-shoot in.
   let strays = new Set<number>();
   let lineStart = 0;
   while (true) {

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -8,8 +8,9 @@
  * It also owns the forge-reference detector both seams share. A bare `#N` in
  * posted text is a live cross-reference that backlinks and notifies whatever
  * thread it names, so the manual seam confirms with the user before posting and
- * never rewrites the text, while the automated seam — where nobody is present to
- * confirm — neutralizes the refs and says so, via {@link AiCommentParts.neutralizeRefs}.
+ * never rewrites the text, while the automated seam (where nobody is present to
+ * confirm) neutralizes what it can and names what it could not, via
+ * {@link AiCommentParts.neutralizeRefs}.
  *
  * The output is pure Markdown: it renders on every forge (GitHub / GitLab /
  * Bitbucket) AND in the app's own `Markdown` component, so it uses no raw HTML
@@ -40,8 +41,11 @@ export interface AiCommentParts {
  */
 export const GD_COMMENT_ANCHOR = "https://gitdesktop.app";
 
-/** Trigger characters that autolink per provider — mirrors the app's renderer
- *  (Bitbucket autolinks neither, so it detects nothing there by design). */
+/** Trigger characters that autolink per provider — mirrors the NUMERIC triggers of
+ *  the app's renderer (`src/components/markdown/markdown-refs.ts`), whose `@`
+ *  user-mention trigger is deliberately out of scope here: a mention notifies a
+ *  person, not a thread, and neither seam rewrites one. Bitbucket autolinks
+ *  neither number trigger, so it detects nothing there by design. */
 export const REF_TRIGGERS = {
   github: ["#"],
   gitlab: ["#", "!"],
@@ -71,6 +75,148 @@ const FENCE = /^ {0,3}(`{3,}|~{3,})/;
 /** Indented code: four spaces or a tab of leading whitespace. */
 const INDENTED = /^(?: {4}|\t)/;
 
+/** A blank line, CommonMark's own definition: spaces and tabs only. `String.trim`
+ *  is NOT the same test — it also strips NBSP, U+2028 and the rest of Unicode
+ *  whitespace, and a line the renderer treats as content while this scan treats it
+ *  as a boundary is exactly how a wrap lands inside a region that never closed. */
+const BLANK = /^[ \t]*$/;
+
+/** Container markers CommonMark strips before a leaf block ever sees its line:
+ *  blockquote first, then at most one list marker. An HTML block opens at that
+ *  CONTENT column, so `> <details>` starts one just as a bare `<details>` does. */
+const QUOTE_PREFIX = /^(?: {0,3}> ?)+/;
+const LIST_MARKER = /^ {0,3}(?:[-+*]|\d{1,9}[.)])(?:[ \t]+|$)/;
+
+/** CommonMark's type-6 HTML-block tag list (spec 0.31.2), verbatim and in the
+ *  spec's order. A line whose first non-space run is `<` or `</` plus one of these
+ *  opens a RAW block that runs to the next blank line, and unlike a fence it may
+ *  interrupt a paragraph. Written as one split string because the only consumer is
+ *  the alternation below, which a 62-line literal would bury. */
+const HTML_BLOCK_TAGS =
+  "address article aside base basefont blockquote body caption center col colgroup dd details dialog dir div dl dt fieldset figcaption figure footer form frame frameset h1 h2 h3 h4 h5 h6 head header hr html iframe legend li link main menu menuitem nav noframes ol optgroup option p param search section summary table tbody td tfoot th thead title tr track ul".split(
+    " ",
+  );
+
+/** Type 6: a known block tag closed by whitespace, `>`, `/>`, or the line's end —
+ *  so a single-line `<details><summary>x</summary> text` opens one too. Tag names
+ *  are case-insensitive. */
+const HTML_BLOCK_TYPE_6 = new RegExp(
+  `^ {0,3}</?(?:${HTML_BLOCK_TAGS.join("|")})(?:[ \\t]|/?>|$)`,
+  "i",
+);
+
+const HTML_TAG_NAME = "[A-Za-z][A-Za-z0-9-]*";
+const HTML_ATTR = `[ \\t]+[a-zA-Z_:][\\w.:-]*(?:[ \\t]*=[ \\t]*(?:[^ \\t"'=<>\`]+|'[^']*'|"[^"]*"))?`;
+
+/** Type 7: one COMPLETE open or closing tag alone on a line, any tag name. The one
+ *  deliberate over-approximation left here is paragraph state: CommonMark forbids a
+ *  type-7 block from interrupting a paragraph, and this scan does not track which
+ *  lines are inside one. */
+const HTML_BLOCK_TYPE_7 = new RegExp(
+  `^ {0,3}(?:<${HTML_TAG_NAME}(?:${HTML_ATTR})*[ \\t]*/?>|</${HTML_TAG_NAME}[ \\t]*>)[ \\t]*$`,
+);
+
+/** Type 1, the raw-text tags. Their block ignores blank lines entirely and ends only
+ *  at {@link RAW_TEXT_CLOSE} — which CommonMark takes as ANY of the four closing tags
+ *  anywhere on a line, the opener's own line included. Note the start condition
+ *  admits no `/>`, per the spec. */
+const RAW_TEXT_OPEN = /^ {0,3}<(?:pre|script|style|textarea)(?:[ \t]|>|$)/i;
+const RAW_TEXT_CLOSE = /<\/(?:pre|script|style|textarea)>/i;
+
+/** Whether `line` (at its content column) opens a raw HTML block — see
+ *  {@link scanRefs} for why the region suppresses wrapping without suppressing
+ *  detection. */
+function opensHtmlBlock(line: string): boolean {
+  return (
+    RAW_TEXT_OPEN.test(line) ||
+    HTML_BLOCK_TYPE_6.test(line) ||
+    HTML_BLOCK_TYPE_7.test(line)
+  );
+}
+
+/** The two raw-block starts CommonMark lets INTERRUPT a paragraph (types 1 and 6);
+ *  type 7 needs a blank line before it. The block pass runs before inline parsing,
+ *  so one of these beats an open code span rather than sitting inside it. */
+function interruptsParagraph(line: string): boolean {
+  return RAW_TEXT_OPEN.test(line) || HTML_BLOCK_TYPE_6.test(line);
+}
+
+/** A link reference definition's opening: `[label]:` at the content column, where the
+ *  label holds no unescaped bracket. The capture exists to reject an all-whitespace
+ *  label, which CommonMark does not accept. This matches the OPENING only; whether
+ *  the line is really a definition is {@link DEFINITION_TAIL}'s call, and a line that
+ *  fails there is a paragraph whose references stay scannable. */
+const LINK_DEFINITION = /^ {0,3}\[((?:[^\\[\]]|\\.)*)\]:/;
+
+/** What must follow that `]:` for the line to BE a definition: a destination, then
+ *  the line's end or a title. `[issue #5]: not a valid url` fails it — a bare
+ *  destination cannot hold spaces — and CommonMark renders that line as a paragraph
+ *  whose refs are live, so a prefix-only test would silence them. Control characters
+ *  are not excluded from the bare form (biome bans them in a class, and they cannot
+ *  occur meaningfully here); that over-accepts, which only ever over-skips. */
+const DEFINITION_TAIL =
+  /^[ \t]*(?:<(?:[^<>\\]|\\.)*>|(?:[^\s\\]|\\.)+)(?:[ \t]+(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\((?:[^()\\]|\\.)*\)))?[ \t]*$/;
+
+/** An ATX heading, and the two shapes a GFM table row takes. Both are leaf blocks
+ *  that close any paragraph above them. */
+const ATX_HEADING = /^ {0,3}#{1,6}([ \t]|$)/;
+const TABLE_ROW = /^ {0,3}\||\|[ \t]*$/;
+
+/** A letter or a digit, in any script — what tells prose from the punctuation-only
+ *  lines (setext underlines, thematic breaks) that are structure. */
+const HAS_TEXT = /[\p{L}\p{N}]/u;
+
+/**
+ * Whether this line leaves an OPEN PARAGRAPH behind it, which is the one thing that
+ * stops the next line from starting a block. Only a line recognized as paragraph
+ * content answers YES; everything else — a blank line, a heading, a table row, and
+ * any punctuation-only line, including shapes not modelled here — answers NO, so an
+ * indented line after it stays code and stays skipped.
+ *
+ * The polarity is the point. Guessing YES for an unmodelled leaf would let the next
+ * indented line be wrapped inside rendered code while the footer claimed it was
+ * neutralized; guessing NO merely over-skips, which is the status quo. The
+ * approximations lean that way too: a line of pure punctuation reads as structure
+ * even when it is really prose, and so does any line ending in a pipe, since
+ * {@link TABLE_ROW}'s trailing alternative is unanchored. Both cost a detection
+ * after such a line, never a false claim.
+ *
+ * TABLE_ROW is deliberately left loose. Tightening it to "a leading pipe, or two
+ * pipes" would recover `a table |` as prose, but `use a || b` would then read as a
+ * table row and lose ITS following line instead — one missed reference traded for
+ * another. The honest fix is GFM's actual rule, where a table exists only when the
+ * NEXT line is a delimiter row, and that is a lookahead this line-at-a-time model
+ * does not have.
+ *
+ * KNOWN DEPTH-BLINDNESS, left as it is: this reads the line's CONTENT and never its
+ * container depth, so an open paragraph carries across a depth INCREASE — in
+ * `intro\n>     #5` the flag survives into the blockquote and the indented line
+ * there is scanned as prose, wrapping a reference inside quoted indented code.
+ * Mangling only, since indented code never autolinks; fixing it means tracking the
+ * container stack, not another line test.
+ */
+function leavesOpenParagraph(quoted: string): boolean {
+  if (BLANK.test(quoted)) return false;
+  const inner = quoted.replace(LIST_MARKER, "");
+  if (ATX_HEADING.test(inner) || TABLE_ROW.test(inner)) return false;
+  return HAS_TEXT.test(quoted);
+}
+
+/** How many blockquote markers a line opens with. A fence must pair at the SAME
+ *  depth: an unquoted ``` line does not close one opened inside a blockquote. */
+function quoteDepth(line: string): number {
+  const marker = QUOTE_PREFIX.exec(line);
+  if (!marker) return 0;
+  let depth = 0;
+  for (const ch of marker[0]) if (ch === ">") depth++;
+  return depth;
+}
+
+/** The line as its innermost leaf block sees it, container markers removed. */
+function containerContent(line: string): string {
+  return line.replace(QUOTE_PREFIX, "").replace(LIST_MARKER, "");
+}
+
 /** How many references a formatted list names before it counts the rest. */
 const REF_LIST_CAP = 5;
 
@@ -95,6 +241,9 @@ interface RefOccurrence {
   /** Backtick run length a wrap here must use to be un-stealable — see
    *  {@link wrapRunLength}. */
   wrapRun: number;
+  /** Inside a raw HTML block, where a wrap would emit literal backticks and
+   *  neutralize nothing. Reported, never rewritten — see {@link scanRefs}. */
+  htmlBlock: boolean;
 }
 
 /** The shortest backtick run a wrap can use without a live literal run in the same
@@ -128,6 +277,55 @@ function linkEnd(text: string, open: number, limit: number): number {
     else if (ch === ")" && --parens === 0) return i + 1;
   }
   return open;
+}
+
+/** A link label reduced to its matching key, per CommonMark: internal whitespace runs
+ *  collapse to one space, the ends are trimmed, and case folds away. `toLowerCase` is
+ *  a near-fold rather than the spec's full Unicode one — but the definition and the
+ *  use site both come through HERE, so any divergence only fails to resolve a pair,
+ *  which lands on the status quo of scanning the brackets as prose. */
+function normalizeLabel(label: string): string {
+  return label
+    .replace(/[ \t\r\n\f]+/g, " ")
+    .replace(/^ | $/g, "")
+    .toLowerCase();
+}
+
+/** Index of the `]` closing the bracket span opened at `open`, or -1 when none does
+ *  before `limit`. An escaped bracket is content, not structure. */
+function bracketEnd(text: string, open: number, limit: number): number {
+  let depth = 0;
+  for (let i = open; i < limit; i++) {
+    if (isEscaped(text, i)) continue;
+    const ch = text[i];
+    if (ch === "[") depth++;
+    else if (ch === "]" && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/** The end index (exclusive) of a REFERENCE link opening at `open` whose label one of
+ *  `labels` defines, or `open` when nothing resolves. All three forms: shortcut
+ *  `[label]`, collapsed `[label][]`, and full `[text][label]` — the last resolves on
+ *  the SECOND bracket, and skipping from `open` covers the text's own refs, which
+ *  render inside the anchor where no forge filter reaches them. */
+function referenceEnd(
+  text: string,
+  open: number,
+  limit: number,
+  labels: ReadonlySet<string>,
+): number {
+  if (labels.size === 0) return open;
+  const close = bracketEnd(text, open, limit);
+  if (close === -1) return open;
+  const first = normalizeLabel(text.slice(open + 1, close));
+  if (text[close + 1] !== "[") return labels.has(first) ? close + 1 : open;
+  const second = bracketEnd(text, close + 1, limit);
+  if (second === -1) return open;
+  const inner = text.slice(close + 2, second);
+  return labels.has(inner === "" ? first : normalizeLabel(inner))
+    ? second + 1
+    : open;
 }
 
 /** Whether the character at `i` is markdown-escaped: an ODD run of immediately
@@ -167,9 +365,10 @@ function recordTicks(
 }
 
 /** Where a code span opened at `from` must stop looking for its closer: the next
- *  blank line or the next fence line, whichever comes first. Both end the paragraph
- *  CommonMark parses the span within — a fence interrupts one, and reading past
- *  either would let a delimiter or a fenced line's content pose as a closer. */
+ *  blank line, fence line, or raw-HTML-block opener, whichever comes first. All
+ *  three end the paragraph CommonMark parses the span within — a fence and an HTML
+ *  block are block starts, and the block pass runs first — so reading past any of
+ *  them would let a delimiter or another block's content pose as a closer. */
 function paragraphLimit(text: string, from: number): number {
   BLANK_LINE.lastIndex = from;
   const blank = BLANK_LINE.exec(text);
@@ -179,7 +378,12 @@ function paragraphLimit(text: string, from: number): number {
     const start = nl + 1;
     let end = text.indexOf("\n", start);
     if (end === -1) end = text.length;
-    if (FENCE.test(text.slice(start, end))) return start;
+    const line = text.slice(start, end);
+    if (
+      FENCE.test(line.replace(QUOTE_PREFIX, "")) ||
+      opensHtmlBlock(containerContent(line))
+    )
+      return start;
     nl = end < text.length ? end : -1;
   }
   return limit;
@@ -216,72 +420,317 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * both {@link findSuspectRefs} and {@link neutralizeSuspectRefs} consume, so the
  * warning and the rewrite can never disagree about what counts.
  *
- * The scan never fires inside four REGIONS: fenced blocks, inline code spans,
- * markdown link syntax, and indented code. Their boundaries are approximate and
- * deliberately over-skip at the margins (a lazy paragraph continuation indented
- * four spaces, say), failing toward the status quo — no warning, no rewrite — the
- * safe direction for both callers.
+ * The scan never fires inside five SKIP regions: fenced blocks, inline code spans,
+ * markdown link syntax (inline `[text](dest)` plus the three reference forms —
+ * shortcut `[label]`, collapsed `[label][]`, and full `[text][label]`), indented
+ * code, and link reference definition lines. Their boundaries are approximate, but
+ * NOT uniformly in one direction any more, so each arm states its own:
+ *   - fence: over-skips, and its container-depth model is why (see below);
+ *   - indented code and definitions: gated on where a block may START, so they can
+ *     under-skip a line the renderer would have treated as a block;
+ *   - code spans: the closer search over-reaches past blocks it does not model,
+ *     which opens a span the renderer never opens and under-detects;
+ *   - link syntax: over-skips, since a resolving label need not be a link.
+ * Where an arm can go either way the choice is spelled out at its own site; nothing
+ * here silently assumes over-skipping is always the outcome.
  *
- * Backslash parity is an EXACT rule, not an approximation, and it gates all three
- * syntax-recognizing sites: the trigger character, a span's opening backtick run,
- * and a link's opening bracket. An escape-blind opener is the dangerous direction —
- * it would enter a region that markdown never enters and hide the refs after it.
+ * Two of those regions are gated on where a block may START, because CommonMark
+ * forbids both from interrupting a paragraph: an indented line is code only at a
+ * paragraph start (`Review notes:\n    Fixes #123` is prose with a LIVE reference,
+ * not a code block), and a definition line likewise. That gate needs no block state
+ * of its own — a skipped line leaves the paragraph-start flag set, so a real
+ * indented block keeps its later lines, blank lines included. What COUNTS as a
+ * paragraph start is {@link leavesOpenParagraph}'s call, and it answers
+ * conservatively: any line it cannot recognize as paragraph content leaves the next
+ * indented line skipped, because the opposite guess wraps inside rendered code and
+ * claims the reference was neutralized.
+ *
+ * A reference form only skips when its label actually RESOLVES against a definition
+ * this text carries, which is why {@link scanRefs} walks the lines twice: phase 0
+ * collects the labels, phase 1 scans. Both walks run the same classification, so a
+ * definition inside a fence, an indent, or raw HTML is code and defines nothing, and
+ * its use site stays prose — matching what the renderer does with it. Resolution has
+ * to be the gate: skipping every bracket span would ship a live `#N` out of `see
+ * [maybe #5] there`, while skipping none breaks real links, because a wrap inside a
+ * label defeats a lookup that only case-folds and collapses whitespace. Where a
+ * resolving span is not a link after all (a code span crossing the bracket), the
+ * skip is an over-skip — status quo, and the safe side.
+ *
+ * ONE STRUCTURAL CLASS IS LEFT: every inline construct here is recognized within a
+ * single LINE, while CommonMark lets these run across a newline. Three known
+ * instances, all renderer-verified:
+ *   - a reference label — `[a\n#5]` against a matching definition wraps and the
+ *     link dies as bracket text;
+ *   - an inline destination — `[see](\n#123\n)` wraps and the href becomes
+ *     `%60#123%60`;
+ *   - a definition TITLE on its own continuation line, which the definition arm
+ *     does not follow — the href survives and only the tooltip gains backticks.
+ * Closing the class means a character scan that can consume across line
+ * boundaries, which the line-driven block model this function is built on cannot
+ * express — a structural change rather than another region rule.
+ *
+ * The definition line is the one region skipped to prevent DAMAGE rather than a
+ * false claim. It renders nothing: the label is consumed and the destination
+ * becomes an href, which no forge's reference filter rewrites, so a `#N` there was
+ * never live and warning about it is a false positive. Worse, a wrap would land
+ * INSIDE the URL — the renderer percent-encodes the backticks into the
+ * destination — so the automated seam would corrupt a working link. Recognition is
+ * bounded to lines where a paragraph could start, CommonMark's own rule, because a
+ * definition-shaped line that merely continues a paragraph really does render as
+ * prose. A malformed definition at a genuine start is skipped anyway; that is an
+ * under-detect, the status-quo direction.
+ *
+ * A fifth region, the raw HTML block (CommonMark types 1, 6 and 7), is DETECTED
+ * but never rewritten. A forge's reference filter runs inside raw HTML, so a `#N`
+ * there really does autolink and the manual seam must still warn about it; a
+ * backtick wrap there, though, is literal text that mangles the block while the
+ * reference stays live. So its occurrences carry `htmlBlock` and
+ * {@link neutralizeSuspectRefs} routes them into `survived` for the footer to
+ * name. Region starts are read at the CONTAINER CONTENT COLUMN, since a `> ` or a
+ * list marker does not stop a block from opening. The fence arm reads blockquote
+ * markers too, pairs a fence only at the depth it opened at, and ends one when the
+ * line's depth drops below that — which closes the lazy continuation as well. What
+ * remains there is the LIST case: `- ~~~` opens a fence this scan does not see, so
+ * its content is scanned. That mangles at worst, since fenced content never
+ * autolinks either way.
+ *
+ * The remaining approximation is paragraph state, which this scan does not track,
+ * so a type-7 opener CommonMark would read as a lazy paragraph continuation opens
+ * a region here. That costs a wrap, and usually gains an honest disclosure — but
+ * not always: where the stranded ref sits somewhere the forge would not have
+ * linked anyway (inside a link label, say, as in a `<span>` line followed by
+ * `[issue #123](url)`, or in `<a href="#123">` alone on a line), the disclosure
+ * names a reference that was never live. Over-warning is the tolerable failure;
+ * a false claim of neutralization is not.
+ *
+ * That phantom-disclosure arm has one cosmetic sibling and one that is not. A `#N`
+ * inside an inline HTML ATTRIBUTE is inert — no reference filter rewrites attribute
+ * values — so a wrap there only adds noise. A `#N` in an inline element's TEXT
+ * (`<span>see #5</span>` mid-paragraph) is LIVE: the filter walks text nodes, and
+ * that one is a text node. It is detected and wrapped like any other prose
+ * reference, which is correct; only the attribute case is the harmless one.
+ *
+ * Backslash parity is an EXACT rule, not an approximation. It still GATES the two
+ * region openers, a span's opening backtick run and a link's opening bracket, where
+ * an escape-blind opener is the dangerous direction: it would enter a region
+ * markdown never enters and hide every reference after it. At the TRIGGER it no
+ * longer gates but decides — an escaped trigger is a candidate whenever
+ * `escapedRefsLive` says the forge would link it anyway, and the occurrence then
+ * begins at the backslash run so the wrap encloses it rather than being escaped by
+ * it. {@link findSuspectRefs} carries the forge split behind that flag.
  *
  * Each occurrence also carries the wrap run length the neutralizer must use there,
  * derived from the literal backtick runs this scan believes are live for pairing.
- * Which skipped regions contribute those: fence content NO and indented code NO
- * (both are blocks, their ticks never pair), span content NO (the span consumed
- * them), link regions YES (spans parse before links) — so the link arm alone feeds
- * `strays` on skip. Every claim built on that set is SCANNER-RELATIVE; the
- * marked-oracle test in `scripts/comment-refs.test.mjs` is what grounds it against
- * a real parser.
+ * Which regions contribute those: fence content NO and indented code NO (both are
+ * blocks, their ticks never pair), span content NO (the span consumed them), raw
+ * HTML block content NO (a block parses no inline syntax at all, so its ticks are
+ * ordinary characters that no code span outside the block can ever pair with),
+ * link regions YES, inline and reference alike (spans parse before links, so a tick
+ * inside a label is still live for pairing), definition lines YES — a valid one
+ * renders nothing and could pair with nothing, but the INVALID lines this arm also
+ * skips are prose whose ticks are live, and over-recording only lengthens a wrap —
+ * so the link arm alone feeds `strays`. Every claim built on that set is
+ * SCANNER-RELATIVE; the marked-oracle test in `scripts/comment-refs.test.mjs` is
+ * what grounds it against a real parser.
  */
-function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
+function scanRefs(
+  text: string,
+  triggers: readonly string[],
+  escapedRefsLive: boolean,
+): RefOccurrence[] {
   const out: RefOccurrence[] = [];
   if (triggers.length === 0) return out;
-  let fence: { char: string; len: number } | null = null;
+  // A reference link resolves against a definition that may sit ANYWHERE in the
+  // document, so phase 0 walks the lines first and collects the labels. Both phases
+  // run this one classification, so the pre-pass honours the same regions the scan
+  // does and no definition inside a fence, an indent, or raw HTML is ever collected.
+  const labels = new Set<string>();
+  let phase = 0;
+  let fence: { char: string; len: number; depth: number } | null = null;
   // The open code span's backtick-run length; 0 when none. A run of N backticks
   // closes at the next run of exactly N (CommonMark), and a span may cross lines.
   let span = 0;
+  // Whether an open raw HTML block covers this line, and whether that block is a
+  // type-1 raw-text one (ends at its closing tag, never at a blank line).
+  let htmlBlock = false;
+  let rawText = false;
+  // A link reference definition is only parsed where a PARAGRAPH could start —
+  // otherwise the line is a lazy continuation and renders as ordinary prose. Only a
+  // preceding open paragraph line takes this false. `definitionTail` carries the
+  // one continuation CommonMark allows without re-stating the label: a destination
+  // on the line after a `]:` that ended its own line.
+  let atParagraphStart = true;
+  let definitionTail = false;
   // Lengths of the unpaired literal runs seen so far in THIS paragraph; inline
   // syntax is paragraph-scoped, so a blank line clears them.
   let strays = new Set<number>();
   let lineStart = 0;
-  while (lineStart <= text.length) {
+  while (true) {
+    if (lineStart > text.length) {
+      if (phase === 1) break;
+      // Rewind for the scanning pass with every piece of block state reset, so the
+      // two walks classify identically and the label set is complete before use.
+      phase = 1;
+      fence = null;
+      span = 0;
+      htmlBlock = false;
+      rawText = false;
+      atParagraphStart = true;
+      definitionTail = false;
+      strays = new Set();
+      lineStart = 0;
+      continue;
+    }
     let lineEnd = text.indexOf("\n", lineStart);
     if (lineEnd === -1) lineEnd = text.length;
     const line = text.slice(lineStart, lineEnd);
-    if (line.trim() === "") strays = new Set();
-    // Block structure is only readable outside a code span: an open span swallows
-    // whatever it crosses, fence lines included.
+    // A blockquote's content column is where its leaf blocks live; the list-marker
+    // strip is for the opener test only, since a lone `-` would otherwise strip to
+    // nothing and read as the blank line that ends an open block.
+    const quoted = line.replace(QUOTE_PREFIX, "");
+    const inner = quoted.replace(LIST_MARKER, "");
+    // Closing a type-1 block is deferred past this line's scan: the line carrying
+    // the closing tag is the block's LAST line, content included.
+    let closeAfterLine = false;
+    // Consumed here whatever this line turns out to be, so a definition whose next
+    // line is a fence or a block opener cannot leak the skip past that block.
+    const tailPending = definitionTail;
+    definitionTail = false;
+    if (BLANK.test(line)) strays = new Set();
+    // A block start beats inline parsing, so an open span cannot reach across one
+    // that may interrupt a paragraph — and while a span is open, block structure
+    // is otherwise unreadable, since the span swallows fence lines and all.
+    if (span > 0 && interruptsParagraph(inner)) span = 0;
     if (span === 0) {
-      const fenced = FENCE.exec(line);
-      if (fence) {
-        if (
-          fenced &&
-          fenced[1][0] === fence.char &&
-          fenced[1].length >= fence.len &&
-          line.slice(fenced[0].length).trim() === ""
-        ) {
-          fence = null;
+      if (htmlBlock) {
+        if (rawText) {
+          if (RAW_TEXT_CLOSE.test(line)) closeAfterLine = true;
+        } else if (BLANK.test(quoted)) {
+          // A blank line is the only thing that ends a type-6/7 block: a fence or
+          // an indent inside one is raw content, so the checks below must not run.
+          htmlBlock = false;
         }
-        lineStart = lineEnd + 1;
-        continue;
-      }
-      if (fenced) {
-        fence = { char: fenced[1][0], len: fenced[1].length };
-        lineStart = lineEnd + 1;
-        continue;
-      }
-      if (INDENTED.test(line)) {
-        lineStart = lineEnd + 1;
-        continue;
+      } else {
+        // Fences are read at the blockquote content column — `> ~~~` opens one, and
+        // a wrap inside it would corrupt a displayed code example. List markers are
+        // deliberately NOT stripped here: a blockquote marker repeats on every line,
+        // so opener and closer stay at the same depth, while a list marker appears
+        // only on the item's first line and its block's continuation is indentation
+        // this scanner does not model, so the two ends would pair at different
+        // depths. A fence opened by `- ~~~` therefore stays unrecognized, which is
+        // today's behaviour and mangles at worst — fenced content never autolinks.
+        const fenced = FENCE.exec(quoted);
+        const depth = quoteDepth(line);
+        if (fence) {
+          if (
+            fenced &&
+            fenced[1][0] === fence.char &&
+            fenced[1].length >= fence.len &&
+            depth === fence.depth &&
+            BLANK.test(quoted.slice(fenced[0].length))
+          ) {
+            fence = null;
+            atParagraphStart = true;
+            lineStart = lineEnd + 1;
+            continue;
+          }
+          // A fence dies with its CONTAINER, and DEPTH is the whole test: a line
+          // that drops below the fence's depth has left the blockquote, and a truly
+          // blank line is depth 0, so it is already covered. Testing the
+          // quote-stripped line for blankness instead would kill the fence on a
+          // `>`-only line — which CommonMark keeps INSIDE the quoted block as a
+          // blank code line — and the real closer would then open a phantom fence
+          // over the rest of the quote. Without any of this an unterminated `> ~~~`
+          // swallows the rest of the comment and posts its references live and
+          // undisclosed. A depth-0 fence has no container to lose, so it keeps
+          // running to the end — the pinned behaviour for an unterminated fence.
+          if (fence.depth >= 1 && depth < fence.depth) {
+            // This line is OUTSIDE the fence, so it falls through to be scanned.
+            fence = null;
+          } else {
+            atParagraphStart = true;
+            lineStart = lineEnd + 1;
+            continue;
+          }
+        }
+        if (fenced) {
+          fence = { char: fenced[1][0], len: fenced[1].length, depth };
+          atParagraphStart = true;
+          lineStart = lineEnd + 1;
+          continue;
+        }
+        // Indented code CANNOT interrupt a paragraph, so an indented line is code
+        // only where a paragraph could start; anywhere else it is a continuation
+        // whose refs are live prose. A real block's later lines stay skipped without
+        // any extra state, because every skipped line leaves this flag true — and a
+        // blank line inside the block leaves it true as well. The column is measured
+        // at the blockquote content, like the fence and definition arms; list markers
+        // stay unstripped for the same reason they do there — a marker appears only
+        // on the item's first line, so stripping it would measure the item's own
+        // indentation against nothing.
+        if (atParagraphStart && INDENTED.test(quoted)) {
+          lineStart = lineEnd + 1;
+          continue;
+        }
+        // A link reference definition renders NOTHING: its label is consumed and its
+        // destination becomes an href, which no forge's reference filter rewrites. A
+        // wrap here would be spliced into the URL itself, so the whole line is
+        // skipped — including a destination that spilled onto the next line.
+        if (tailPending) {
+          atParagraphStart = true;
+          recordTicks(text, lineStart, lineEnd, strays);
+          lineStart = lineEnd + 1;
+          continue;
+        }
+        const definition = atParagraphStart
+          ? LINK_DEFINITION.exec(inner)
+          : null;
+        // A label alone proves nothing: the tail has to parse as a destination, or
+        // the line is a paragraph whose refs are live and must stay scannable.
+        let deferred = false;
+        let defines = false;
+        if (definition && /\S/.test(definition[1])) {
+          const tail = inner.slice(definition[0].length);
+          defines = DEFINITION_TAIL.test(tail);
+          if (!defines && BLANK.test(tail)) {
+            // The destination may sit on the next line — but only if THAT line is
+            // one, so it is validated here rather than trusted on arrival.
+            let nextEnd = text.indexOf("\n", lineEnd + 1);
+            if (nextEnd === -1) nextEnd = text.length;
+            const next = containerContent(text.slice(lineEnd + 1, nextEnd));
+            defines = lineEnd < text.length && DEFINITION_TAIL.test(next);
+            deferred = defines;
+          }
+        }
+        if (defines && definition) {
+          // Collected in phase 0 only, so the set is frozen while phase 1 resolves
+          // against it and a use site cannot depend on where it sits in the text.
+          if (phase === 0) labels.add(normalizeLabel(definition[1]));
+          definitionTail = deferred;
+          atParagraphStart = true;
+          recordTicks(text, lineStart, lineEnd, strays);
+          lineStart = lineEnd + 1;
+          continue;
+        }
+        // The opener line is itself inside the block, so a ref after the tag on
+        // that same line is covered.
+        if (RAW_TEXT_OPEN.test(inner)) {
+          htmlBlock = true;
+          rawText = true;
+          if (RAW_TEXT_CLOSE.test(line)) closeAfterLine = true;
+        } else if (opensHtmlBlock(inner)) {
+          htmlBlock = true;
+        }
       }
     }
     let i = lineStart;
-    while (i < lineEnd) {
+    // Phase 0 classifies lines and nothing else — the character scan belongs to the
+    // pass that has the whole label set in hand.
+    while (phase === 1 && i < lineEnd) {
       const ch = text[i];
-      if (ch === "`") {
+      // A raw HTML block parses no inline syntax, so its backticks and brackets
+      // are ordinary characters and only the trigger scan runs inside one.
+      if (ch === "`" && !htmlBlock) {
         // An escaped backtick is a literal character the renderer consumes with its
         // backslash, so it neither opens a span nor joins the run that follows it.
         if (span === 0 && isEscaped(text, i)) {
@@ -304,8 +753,12 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
         i++;
         continue;
       }
-      if (ch === "[" && !isEscaped(text, i)) {
-        const skip = linkEnd(text, i, lineEnd);
+      if (ch === "[" && !htmlBlock && !isEscaped(text, i)) {
+        // Inline syntax first, then the reference forms. A label that resolves to no
+        // definition is prose, and its refs stay detected — the alternative, skipping
+        // every bracket span, would ship a live `#N` from `see [maybe #5] there`.
+        let skip = linkEnd(text, i, lineEnd);
+        if (skip === i) skip = referenceEnd(text, i, lineEnd, labels);
         if (skip > i) {
           // Code spans parse BEFORE links, so a tick inside the region this arm
           // jumps is still live for pairing and must not be missed by `strays`.
@@ -316,39 +769,83 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
         }
         continue;
       }
-      if (
-        triggers.includes(ch) &&
-        !(i > 0 && BLOCKED_BEFORE.test(text[i - 1])) &&
-        !isEscaped(text, i)
-      ) {
-        const num = REF_NUMBER.exec(text.slice(i + 1, i + 1 + REF_NUMBER_SPAN));
-        if (num) {
-          const end = i + 1 + num[0].length;
-          out.push({
-            start: i,
-            end,
-            token: text.slice(i, end),
-            wrapRun: wrapRunLength(strays),
-          });
-          i = end;
-          continue;
+      if (triggers.includes(ch)) {
+        const escaped = isEscaped(text, i);
+        // The occurrence starts at the BACKSLASH RUN, not at the trigger. A wrap
+        // opened after the backslash would have its own opening tick escaped, and
+        // the reference would sit bare and live outside a span that never formed;
+        // enclosing the run puts the tick where nothing escapes it. The boundary
+        // rule then reads the character before the run, since that is what ends up
+        // adjacent to the reference once the renderer consumes the backslash.
+        let start = i;
+        if (escaped) while (start > 0 && text[start - 1] === "\\") start--;
+        // A raw HTML block processes no escapes at all, so the backslash there is
+        // literal text and BOTH forges still linkify the reference beside it. That
+        // makes it a candidate whatever `escapedRefsLive` says — the GitLab excuse
+        // for leaving an escape alone only holds outside raw HTML. It still cannot
+        // be wrapped, so it routes to `survived` like any other block reference.
+        if (
+          (escapedRefsLive || !escaped || htmlBlock) &&
+          !(start > 0 && BLOCKED_BEFORE.test(text[start - 1]))
+        ) {
+          const num = REF_NUMBER.exec(
+            text.slice(i + 1, i + 1 + REF_NUMBER_SPAN),
+          );
+          if (num) {
+            const end = i + 1 + num[0].length;
+            out.push({
+              start,
+              end,
+              token: text.slice(start, end),
+              wrapRun: wrapRunLength(strays),
+              htmlBlock,
+            });
+            i = end;
+            continue;
+          }
         }
       }
       i++;
+    }
+    // Only an open paragraph line can make the NEXT line a continuation; every
+    // other path above restores the flag before its own `continue`. A raw HTML
+    // block's lines leave no paragraph either, the one that closes it included —
+    // so this reads `htmlBlock` BEFORE the close below clears it.
+    atParagraphStart = htmlBlock || !leavesOpenParagraph(quoted);
+    if (closeAfterLine) {
+      htmlBlock = false;
+      rawText = false;
     }
     lineStart = lineEnd + 1;
   }
   return out;
 }
 
-/** Distinct suspect reference tokens ("#12", "!4") in first-appearance order. */
+/**
+ * Distinct suspect reference tokens ("#12", "!4") in first-appearance order. An
+ * escaped token keeps its backslashes ("\\#12"), because that is the text a caller
+ * would have to show or rewrite.
+ *
+ * `escapedRefsLive` says whether `\#12` still autolinks on the target forge, and the
+ * forges disagree: GitHub runs its reference filter AFTER rendering, on text the
+ * escape has already been consumed from, so the anchor is minted anyway; GitLab
+ * wraps the escaped character and leaves it alone. Defaulting to TRUE is the safe
+ * direction — a caller that knows it is posting to GitLab passes false and gets the
+ * old behaviour, while a caller that knows nothing over-wraps rather than shipping a
+ * live reference it promised to neutralize.
+ *
+ * GitLab's exemption stops at raw HTML: no escape is processed inside an HTML block
+ * on either forge, so the backslash is literal text and the reference beside it
+ * links regardless. Those occurrences are candidates in BOTH modes.
+ */
 export function findSuspectRefs(
   text: string,
   triggers: readonly string[] = ["#", "!"],
+  escapedRefsLive = true,
 ): string[] {
   const seen = new Set<string>();
   const refs: string[] = [];
-  for (const hit of scanRefs(text, triggers)) {
+  for (const hit of scanRefs(text, triggers, escapedRefsLive)) {
     if (seen.has(hit.token)) continue;
     seen.add(hit.token);
     refs.push(hit.token);
@@ -371,19 +868,39 @@ export function findSuspectRefs(
  * un-neutralized rather than silently claimed. The text keeps every attempted wrap
  * either way. `survived` carries run-1 forms because its reader renders it in the
  * footer's own fresh paragraph, where no stray from the body can reach it.
+ *
+ * Occurrences inside a raw HTML block are the one case never even attempted: a
+ * wrap there emits literal backticks around a reference that autolinks anyway, so
+ * the region comes through byte-identical and its tokens go straight to
+ * `survived`. A token appearing both inside and outside such a block is wrapped
+ * where it can be, and the post-condition still lands it in `survived` because
+ * the copy in the block survives the rescan.
  */
 export function neutralizeSuspectRefs(
   text: string,
   triggers: readonly string[] = ["#", "!"],
+  escapedRefsLive = true,
 ): { text: string; wrapped: string[]; survived: string[] } {
   const forms = new Map<string, string>();
+  // Tokens every occurrence of which sat in a raw HTML block on the first pass —
+  // detected, deliberately not rewritten, and owed a disclosure. Pass 0 alone is
+  // enough because a wrap never changes a line's leading column: the one character
+  // this rewrite adds is a separator before a backtick-adjacent wrap, and a wrap is
+  // always preceded by its own trigger, so no later pass can move a line into or
+  // out of a region.
+  const held = new Set<string>();
   let out = text;
   for (let pass = 0; pass < NEUTRALIZE_PASSES; pass++) {
-    const hits = scanRefs(out, triggers);
+    const hits = scanRefs(out, triggers, escapedRefsLive);
     if (hits.length === 0) break;
     const parts: string[] = [];
     let cursor = 0;
     for (const hit of hits) {
+      if (hit.htmlBlock) {
+        // Leaving `cursor` where it is keeps the region byte-identical.
+        if (pass === 0) held.add(hit.token);
+        continue;
+      }
       const ticks = "`".repeat(hit.wrapRun);
       // A wrap tick touching a literal one FUSES into a longer run, so the chosen
       // length is no longer what the renderer sees and the two ends stop pairing.
@@ -411,15 +928,24 @@ export function neutralizeSuspectRefs(
       }
     }
     parts.push(out.slice(cursor));
-    out = parts.join("");
+    const next = parts.join("");
+    // A pass that wrapped nothing (every hit was held) cannot change the text, and
+    // re-running it would only re-derive the same hits.
+    if (next === out) break;
+    out = next;
   }
-  if (out === text) return { text, wrapped: [], survived: [] };
-  const survivors = new Set(findSuspectRefs(out, triggers));
+  if (out === text && held.size === 0) {
+    return { text, wrapped: [], survived: [] };
+  }
+  const survivors = new Set(findSuspectRefs(out, triggers, escapedRefsLive));
   const wrapped: string[] = [];
   const survived: string[] = [];
   for (const [token, form] of forms) {
     if (survivors.has(token)) survived.push(`\`${token}\``);
     else wrapped.push(form);
+  }
+  for (const token of held) {
+    if (!forms.has(token)) survived.push(`\`${token}\``);
   }
   return { text: out, wrapped, survived };
 }
@@ -445,7 +971,10 @@ export function buildAiCommentBody({
 }: AiCommentParts): string {
   const meta = automated ? " · automated" : "";
   // Both triggers deliberately, no provider: this seam has none in hand, and a
-  // wrapped `!N` on GitHub is a literal that never linked anyway.
+  // wrapped `!N` on GitHub is a literal that never linked anyway. The escape default
+  // rides the same reasoning: `\#N` autolinks on GitHub and does not on GitLab, so
+  // treating it as live costs a visible `\#N` in a code span on GitLab and saves a
+  // live cross-reference on GitHub. Cosmetic against undisclosed — no contest.
   const neutralized = neutralizeRefs ? neutralizeSuspectRefs(text) : null;
   // The wraps stay in the body whatever the guard concluded; only the CLAIM is
   // gated, so an unverifiable wrap ships silently rather than as a false promise.

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -5,15 +5,30 @@
  * posted AI review is unmistakably machine-authored and byte-identical across
  * both paths. Do not hand-roll the header/footer in either seam again.
  *
+ * It also owns the forge-reference detector both seams share. A bare `#N` in
+ * posted text is a live cross-reference that backlinks and notifies whatever
+ * thread it names, so the manual seam confirms with the user before posting and
+ * never rewrites the text, while the automated seam — where nobody is present to
+ * confirm — neutralizes the refs and says so, via {@link AiCommentParts.neutralizeRefs}.
+ *
  * The output is pure Markdown: it renders on every forge (GitHub / GitLab /
  * Bitbucket) AND in the app's own `Markdown` component, so it uses no raw HTML
  * and no `<details>`.
+ *
+ * DEPENDENCY-FREE, ERASABLE TS ONLY: `scripts/comment-refs.test.mjs` imports this
+ * module directly under Node's default type stripping, which resolves no bundler
+ * aliases and erases types rather than compiling them. Keep it at zero runtime
+ * imports, and to syntax that erases (interfaces, plain functions, `as const`).
  */
 export interface AiCommentParts {
   kind: "review" | "security audit";
   model: string;
   automated: boolean;
   text: string;
+  /** Backtick-wrap any `#N`-style reference in `text` and disclose that in the
+   *  footer. For the automated seam only: nobody is there to confirm intent, so
+   *  the stray cross-reference is prevented outright. */
+  neutralizeRefs?: boolean;
 }
 
 /**
@@ -25,13 +40,221 @@ export interface AiCommentParts {
  */
 export const GD_COMMENT_ANCHOR = "https://gitdesktop.app";
 
+/** Trigger characters that autolink per provider — mirrors the app's renderer
+ *  (Bitbucket autolinks neither, so it detects nothing there by design). */
+export const REF_TRIGGERS = {
+  github: ["#"],
+  gitlab: ["#", "!"],
+  bitbucket: [],
+} as const;
+
+/** A reference only opens at a boundary: a word char keeps `word#123` plain, `/`
+ *  keeps a URL fragment plain, and `&` keeps entities like `&#39;` unlinkified.
+ *  Cross-module contract: the same set as `BLOCKED_BEFORE` in
+ *  `src/components/markdown/markdown-refs.ts`, so this detector and the app's own
+ *  autolinker agree on what is prose. */
+const BLOCKED_BEFORE = /[\w/&]/;
+
+/** No forge numbers an item 0, and the value caps at ten digits — the grammar the
+ *  renderer's `NUMBER_SRC` emits. */
+const REF_NUMBER = /^[1-9]\d{0,9}(?!\w)/;
+
+/** How far past a trigger the number grammar can possibly reach: ten digits plus
+ *  the one character the boundary lookahead reads. */
+const REF_NUMBER_SPAN = 12;
+
+/** Opens or closes a fenced block. */
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/** Indented code: four spaces or a tab of leading whitespace. */
+const INDENTED = /^(?: {4}|\t)/;
+
+/** How many references a formatted list names before it counts the rest. */
+const REF_LIST_CAP = 5;
+
+/** One suspect token's position in the scanned text. */
+interface RefOccurrence {
+  start: number;
+  end: number;
+  token: string;
+}
+
+/** The end index (exclusive) of a `[label](destination)` opening at `open`, or
+ *  `open` when what's there isn't one. Both halves skip whole — a number in
+ *  either belongs to the link. Bounded to `limit` (the line), so a link split
+ *  across lines is not recognized. */
+function linkEnd(text: string, open: number, limit: number): number {
+  let depth = 0;
+  let i = open;
+  for (; i < limit; i++) {
+    const ch = text[i];
+    if (ch === "[") depth++;
+    else if (ch === "]" && --depth === 0) break;
+  }
+  if (i >= limit || text[i + 1] !== "(") return open;
+  let parens = 0;
+  for (i += 1; i < limit; i++) {
+    const ch = text[i];
+    if (ch === "(") parens++;
+    else if (ch === ")" && --parens === 0) return i + 1;
+  }
+  return open;
+}
+
+/**
+ * Every suspect reference occurrence in `text`, in source order — the ONE scan
+ * both {@link findSuspectRefs} and {@link neutralizeSuspectRefs} consume, so the
+ * warning and the rewrite can never disagree about what counts.
+ *
+ * Regions the scan never fires inside: fenced blocks, inline code spans, markdown
+ * link syntax, and indented code. Each of those over-skips at the margins (a lazy
+ * paragraph continuation indented four spaces, say), which fails toward the
+ * status quo — no warning, no rewrite — the safe direction for both callers.
+ */
+function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
+  const out: RefOccurrence[] = [];
+  if (triggers.length === 0) return out;
+  let fence: { char: string; len: number } | null = null;
+  // The open code span's backtick-run length; 0 when none. A run of N backticks
+  // closes at the next run of exactly N (CommonMark), and a span may cross lines.
+  let span = 0;
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    let lineEnd = text.indexOf("\n", lineStart);
+    if (lineEnd === -1) lineEnd = text.length;
+    // Block structure is only readable outside a code span: an open span swallows
+    // whatever it crosses, fence lines included.
+    if (span === 0) {
+      const fenced = FENCE.exec(text.slice(lineStart, lineEnd));
+      if (fence) {
+        if (
+          fenced &&
+          fenced[1][0] === fence.char &&
+          fenced[1].length >= fence.len &&
+          text.slice(lineStart + fenced[0].length, lineEnd).trim() === ""
+        ) {
+          fence = null;
+        }
+        lineStart = lineEnd + 1;
+        continue;
+      }
+      if (fenced) {
+        fence = { char: fenced[1][0], len: fenced[1].length };
+        lineStart = lineEnd + 1;
+        continue;
+      }
+      if (INDENTED.test(text.slice(lineStart, lineEnd))) {
+        lineStart = lineEnd + 1;
+        continue;
+      }
+    }
+    let i = lineStart;
+    while (i < lineEnd) {
+      const ch = text[i];
+      if (ch === "`") {
+        let run = 1;
+        while (i + run < lineEnd && text[i + run] === "`") run++;
+        if (span === 0) span = run;
+        else if (span === run) span = 0;
+        i += run;
+        continue;
+      }
+      if (span > 0) {
+        i++;
+        continue;
+      }
+      if (ch === "[") {
+        const skip = linkEnd(text, i, lineEnd);
+        i = skip > i ? skip : i + 1;
+        continue;
+      }
+      if (
+        triggers.includes(ch) &&
+        !(i > 0 && BLOCKED_BEFORE.test(text[i - 1]))
+      ) {
+        const num = REF_NUMBER.exec(text.slice(i + 1, i + 1 + REF_NUMBER_SPAN));
+        if (num) {
+          const end = i + 1 + num[0].length;
+          out.push({ start: i, end, token: text.slice(i, end) });
+          i = end;
+          continue;
+        }
+      }
+      i++;
+    }
+    lineStart = lineEnd + 1;
+  }
+  return out;
+}
+
+/** Distinct suspect reference tokens ("#12", "!4") in first-appearance order. */
+export function findSuspectRefs(
+  text: string,
+  triggers: readonly string[] = ["#", "!"],
+): string[] {
+  const seen = new Set<string>();
+  const refs: string[] = [];
+  for (const hit of scanRefs(text, triggers)) {
+    if (seen.has(hit.token)) continue;
+    seen.add(hit.token);
+    refs.push(hit.token);
+  }
+  return refs;
+}
+
+/** Backtick-wraps every suspect occurrence; everything else stays byte-identical.
+ *  `wrapped` lists the distinct NEUTRALIZED forms (`` `#12` ``), not the bare
+ *  tokens: its only consumer is a disclosure line inside the same comment body,
+ *  and naming the bare token there would create the very cross-reference the
+ *  wrapping prevents. */
+export function neutralizeSuspectRefs(
+  text: string,
+  triggers: readonly string[] = ["#", "!"],
+): { text: string; wrapped: string[] } {
+  const hits = scanRefs(text, triggers);
+  if (hits.length === 0) return { text, wrapped: [] };
+  const seen = new Set<string>();
+  const wrapped: string[] = [];
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const hit of hits) {
+    parts.push(text.slice(cursor, hit.start), "`", hit.token, "`");
+    cursor = hit.end;
+    const form = `\`${hit.token}\``;
+    if (seen.has(form)) continue;
+    seen.add(form);
+    wrapped.push(form);
+  }
+  parts.push(text.slice(cursor));
+  return { text: parts.join(""), wrapped };
+}
+
+/** "#12" | "#12 and #45" | "#12, #45, and #103" | caps at 5 then "and N more". */
+export function formatRefList(refs: string[]): string {
+  const shown = refs.slice(0, REF_LIST_CAP);
+  const extra = refs.length - shown.length;
+  const items = extra > 0 ? [...shown, `${extra} more`] : shown;
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
 /** Wraps raw AI review text in the branded GitDesktop AI-comment body. */
 export function buildAiCommentBody({
   kind,
   model,
   automated,
   text,
+  neutralizeRefs,
 }: AiCommentParts): string {
   const meta = automated ? " · automated" : "";
-  return `🤖 **GitDesktop AI ${kind}** · \`${model}\`${meta}\n\n---\n\n${text}\n\n---\n\n_Posted by [GitDesktop](${GD_COMMENT_ANCHOR}) — AI output, verify before acting on it._`;
+  // Both triggers deliberately, no provider: this seam has none in hand, and a
+  // wrapped `!N` on GitHub is a literal that never linked anyway.
+  const neutralized = neutralizeRefs ? neutralizeSuspectRefs(text) : null;
+  const body = neutralized?.wrapped.length ? neutralized.text : text;
+  const disclosure = neutralized?.wrapped.length
+    ? `\n\n_References ${formatRefList(neutralized.wrapped)} are shown as plain text — this automated run could not confirm they were meant to link._`
+    : "";
+  return `🤖 **GitDesktop AI ${kind}** · \`${model}\`${meta}\n\n---\n\n${body}\n\n---\n\n_Posted by [GitDesktop](${GD_COMMENT_ANCHOR}) — AI output, verify before acting on it._${disclosure}`;
 }

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -108,10 +108,13 @@ const HTML_BLOCK_TYPE_6 = new RegExp(
 const HTML_TAG_NAME = "[A-Za-z][A-Za-z0-9-]*";
 const HTML_ATTR = `[ \\t]+[a-zA-Z_:][\\w.:-]*(?:[ \\t]*=[ \\t]*(?:[^ \\t"'=<>\`]+|'[^']*'|"[^"]*"))?`;
 
-/** Type 7: one COMPLETE open or closing tag alone on a line, any tag name. The one
- *  deliberate over-approximation left here is paragraph state: CommonMark forbids a
- *  type-7 block from interrupting a paragraph, and this scan does not track which
- *  lines are inside one. */
+/** Type 7: one COMPLETE open or closing tag alone on a line, any tag name. Unlike
+ *  types 1 and 6 it cannot interrupt a paragraph, so its opener is gated on the
+ *  paragraph-start flag OR {@link opensContainer} — a gate of its own, since the
+ *  indented and definition arms read the flag alone. Without it a `<span>` line
+ *  mid-paragraph opened a region and the reference below it became a phantom "could
+ *  not neutralize"; without the container half, a `> <span>` line failed to open one
+ *  and the reference inside the raw block was wrapped and falsely claimed. */
 const HTML_BLOCK_TYPE_7 = new RegExp(
   `^ {0,3}(?:<${HTML_TAG_NAME}(?:${HTML_ATTR})*[ \\t]*/?>|</${HTML_TAG_NAME}[ \\t]*>)[ \\t]*$`,
 );
@@ -126,11 +129,11 @@ const RAW_TEXT_CLOSE = /<\/(?:pre|script|style|textarea)>/i;
 /** Whether `line` (at its content column) opens a raw HTML block — see
  *  {@link scanRefs} for why the region suppresses wrapping without suppressing
  *  detection. */
-function opensHtmlBlock(line: string): boolean {
+function opensHtmlBlock(line: string, atParagraphStart = true): boolean {
   return (
     RAW_TEXT_OPEN.test(line) ||
     HTML_BLOCK_TYPE_6.test(line) ||
-    HTML_BLOCK_TYPE_7.test(line)
+    (atParagraphStart && HTML_BLOCK_TYPE_7.test(line))
   );
 }
 
@@ -200,6 +203,49 @@ function leavesOpenParagraph(quoted: string): boolean {
   const inner = quoted.replace(LIST_MARKER, "");
   if (ATX_HEADING.test(inner) || TABLE_ROW.test(inner)) return false;
   return HAS_TEXT.test(quoted);
+}
+
+/** Whether `line` can serve as a definition's DEFERRED destination — the line after a
+ *  `]:` that ended its own line, where `depth` is that line's own blockquote depth.
+ *  CommonMark settles BLOCK STRUCTURE before it looks for link reference
+ *  definitions, so any line that STARTS a block ends the definition instead of
+ *  supplying its destination: a fence, a raw-HTML or ATX opener, a setext underline
+ *  or thematic break (both punctuation-only, hence the text test), and any container
+ *  that opens here. A container already open is a different matter — a quoted
+ *  definition's destination carries the same `>` its label did — so the depths are
+ *  compared rather than required to be zero. */
+function opensDeferredDestination(line: string, depth: number): boolean {
+  // Only a container that OPENS ends the definition. A shallower line is a lazy
+  // continuation, which CommonMark folds back into the same paragraph, so the
+  // destination still belongs to the definition and rewriting it corrupts the URL.
+  if (quoteDepth(line) > depth) return false;
+  const content = line.replace(QUOTE_PREFIX, "");
+  return (
+    DEFINITION_TAIL.test(content) &&
+    HAS_TEXT.test(content) &&
+    !FENCE.test(content) &&
+    !ATX_HEADING.test(content) &&
+    !interruptsParagraph(content) &&
+    !LIST_MARKER.test(content)
+  );
+}
+
+/** Whether `line` starts a container relative to `depth` — the notion the type-7 arm
+ *  needs, shared by its two call sites so they cannot drift apart. Any CHANGE of
+ *  blockquote depth ends the paragraph that was running (a rise enters a new one, a
+ *  drop leaves it into lazy-continuation position) and a list marker begins a fresh
+ *  item; in each case a type-7 tag may open where mid-paragraph it could not.
+ *
+ *  KNOWN GAP: a list DEDENT is invisible here, because measuring it needs the item's
+ *  content column and this scan has no indentation model. `- text` then `<span>`
+ *  leaves the item, so the tag opens a block and the reference under it is raw HTML;
+ *  the scan wraps it instead and claims it neutralized — the same false-claim class
+ *  this function exists to prevent, narrowed to list dedents. */
+function opensContainer(line: string, depth: number): boolean {
+  return (
+    quoteDepth(line) !== depth ||
+    LIST_MARKER.test(line.replace(QUOTE_PREFIX, ""))
+  );
 }
 
 /** How many blockquote markers a line opens with. A fence must pair at the SAME
@@ -373,15 +419,26 @@ function paragraphLimit(text: string, from: number): number {
   BLANK_LINE.lastIndex = from;
   const blank = BLANK_LINE.exec(text);
   const limit = blank ? blank.index : text.length;
+  // The container the span opened inside, so the lines below can be judged against it.
+  const openerStart = text.lastIndexOf("\n", from - 1) + 1;
+  let openerEnd = text.indexOf("\n", openerStart);
+  if (openerEnd === -1) openerEnd = text.length;
+  const fromDepth = quoteDepth(text.slice(openerStart, openerEnd));
   let nl = text.indexOf("\n", from);
   while (nl !== -1 && nl + 1 < limit) {
     const start = nl + 1;
     let end = text.indexOf("\n", start);
     if (end === -1) end = text.length;
     const line = text.slice(start, end);
+    // A line after the opener is paragraph-continuation text, where a type-7 tag
+    // cannot open a block — UNLESS it starts a container, which ends that paragraph
+    // and lets one open after all. The scan's own arm reads exactly the same notion;
+    // if these two disagree, a span candidate runs through a line the scan treats as
+    // a block start, the `span === 0` guard suppresses the whole HTML arm there, and
+    // a reference inside the raw block gets wrapped and falsely claimed.
     if (
       FENCE.test(line.replace(QUOTE_PREFIX, "")) ||
-      opensHtmlBlock(containerContent(line))
+      opensHtmlBlock(containerContent(line), opensContainer(line, fromDepth))
     )
       return start;
     nl = end < text.length ? end : -1;
@@ -394,11 +451,19 @@ function paragraphLimit(text: string, from: number): number {
  *  opener without one is literal text — entering span state there would silently
  *  swallow every later reference.
  *
- *  APPROXIMATE in one direction still: another block that can interrupt a paragraph
- *  (a heading, a list) is not bounded here, so its content can pose as a closer and
- *  answer TRUE where markdown would not. That arm opens a span the renderer never
- *  opens, which under-detects — the status quo — and produces no wrap, so the
- *  post-condition in {@link neutralizeSuspectRefs} keeps the disclosure honest. */
+ *  APPROXIMATE, and NOT safely so: {@link paragraphLimit} bounds at blank lines,
+ *  fences and HTML-block starts, but not at every block that can interrupt a
+ *  paragraph — a heading or a list start is not bounded, so its content can pose as
+ *  a closer and answer TRUE where markdown would not.
+ *
+ *  The old claim here was that such an arm "produces no wrap, so the post-condition
+ *  keeps the disclosure honest". That is FALSE for spans crossing a blockquote or
+ *  list start: fuzzing the shape found both arms of the failure — a reference
+ *  wrapped inside a region the renderer treats as code or raw HTML and then claimed
+ *  neutralized, and a live reference swallowed by a span the renderer never opens
+ *  and so never reported. The class predates the HTML-region work and closing it
+ *  means bounding this search at container starts as well, which is a larger change
+ *  than a region rule; it is tracked separately rather than patched here. */
 function hasClosingRun(text: string, from: number, run: number): boolean {
   const limit = paragraphLimit(text, from);
   let i = from;
@@ -480,7 +545,23 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * prose. A malformed definition at a genuine start is skipped anyway; that is an
  * under-detect, the status-quo direction.
  *
- * A fifth region, the raw HTML block (CommonMark types 1, 6 and 7), is DETECTED
+ * A deferred destination must not be a BLOCK START — see
+ * {@link opensDeferredDestination}. Block structure is settled before definitions
+ * are looked for, so `[d]:` over `---`, `***`, a fence, a type-1/6 tag, or any
+ * container marker leaves both references live rather than minting a definition.
+ * `## H` needs no rule of its own: a space makes it an invalid bare destination and
+ * {@link DEFINITION_TAIL} already rejects it.
+ *
+ * ORACLE DIVERGENCE, worth knowing before trusting a test here: marked 18.0.11
+ * disagrees on the leaf shapes — it swallows `---`, `***`, a type-6 tag or a fence
+ * line into the destination and renders the pair as an empty definition. GitHub
+ * renders `[d #5]:` over `---` as a HEADING carrying a live linked reference
+ * (probed 2026-09-08), which is what CommonMark's two-phase parse predicts. Where
+ * the two disagree the FORGE wins, since predicting the forge is this module's whole
+ * job; the suite pins those shapes directly and excludes them from its
+ * marked-oracle sweep.
+ *
+ * A sixth region, the raw HTML block (CommonMark types 1, 6 and 7), is DETECTED
  * but never rewritten. A forge's reference filter runs inside raw HTML, so a `#N`
  * there really does autolink and the manual seam must still warn about it; a
  * backtick wrap there, though, is literal text that mangles the block while the
@@ -494,14 +575,13 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * its content is scanned. That mangles at worst, since fenced content never
  * autolinks either way.
  *
- * The remaining approximation is paragraph state, which this scan does not track,
- * so a type-7 opener CommonMark would read as a lazy paragraph continuation opens
- * a region here. That costs a wrap, and usually gains an honest disclosure — but
- * not always: where the stranded ref sits somewhere the forge would not have
- * linked anyway (inside a link label, say, as in a `<span>` line followed by
- * `[issue #123](url)`, or in `<a href="#123">` alone on a line), the disclosure
- * names a reference that was never live. Over-warning is the tolerable failure;
- * a false claim of neutralization is not.
+ * Paragraph state IS tracked ({@link leavesOpenParagraph}), and the type-7 arm reads
+ * it alongside {@link opensContainer}. What remains is that pair answering YES too
+ * readily: `text` then `2. <span>` looks like a container start, but an ordered list
+ * beginning at 2 cannot interrupt a paragraph, so no block opens and the reference
+ * below stays ordinary prose. The scan holds it and discloses it — an over-hold with
+ * a TRUTHFUL disclosure, which is the polarity this arm is built for. Over-warning
+ * is the tolerable failure; a false claim of neutralization is not.
  *
  * That phantom-disclosure arm has one cosmetic sibling and one that is not. A `#N`
  * inside an inline HTML ATTRIBUTE is inert — no reference filter rewrites attribute
@@ -529,9 +609,10 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * inside a label is still live for pairing), definition lines YES — a valid one
  * renders nothing and could pair with nothing, but the INVALID lines this arm also
  * skips are prose whose ticks are live, and over-recording only lengthens a wrap —
- * so the link arm alone feeds `strays`. Every claim built on that set is
- * SCANNER-RELATIVE; the marked-oracle test in `scripts/comment-refs.test.mjs` is
- * what grounds it against a real parser.
+ * so the link and definition arms are what feed `strays`. Every claim built on that
+ * set is SCANNER-RELATIVE; the marked-oracle test in `scripts/comment-refs.test.mjs`
+ * is what grounds it against a real parser, except where marked itself diverges from
+ * the forges — those fixtures are pinned directly instead.
  */
 function scanRefs(
   text: string,
@@ -542,8 +623,20 @@ function scanRefs(
   if (triggers.length === 0) return out;
   // A reference link resolves against a definition that may sit ANYWHERE in the
   // document, so phase 0 walks the lines first and collects the labels. Both phases
-  // run this one classification, so the pre-pass honours the same regions the scan
-  // does and no definition inside a fence, an indent, or raw HTML is ever collected.
+  // run the same line classification AND the same character scan, so the pre-pass
+  // honours every region the scan does — no definition inside a fence, an indent,
+  // raw HTML, or a multi-line code span is ever collected.
+  //
+  // The one thing phase 0 lacks is the label set it is building, so a `[` it cannot
+  // resolve is walked into rather than skipped. NO COUNTEREXAMPLE HAS BEEN FOUND to
+  // the claim that this only ever shrinks the label set: the subset argument is
+  // solid for the reference lookups themselves, but the span-state divergence it can
+  // cause has not been proven monotonic, so treat the direction as observed rather
+  // than guaranteed. That divergence can open a code span phase 1
+  // never opens, which suppresses a definition line phase 0 would otherwise have
+  // collected — a SMALLER label set, so fewer use sites are skipped and more
+  // references are reported. Under-collecting is the safe direction here, and two
+  // passes settle it: nothing feeds back into phase 0.
   const labels = new Set<string>();
   let phase = 0;
   let fence: { char: string; len: number; depth: number } | null = null;
@@ -561,6 +654,9 @@ function scanRefs(
   // on the line after a `]:` that ended its own line.
   let atParagraphStart = true;
   let definitionTail = false;
+  // The previous line's blockquote depth, so the HTML arm can tell an opening
+  // container from one that was already there.
+  let prevDepth = 0;
   // Lengths of the unpaired literal runs seen so far in THIS paragraph; inline
   // syntax is paragraph-scoped, so a blank line clears them.
   let strays = new Set<number>();
@@ -568,8 +664,9 @@ function scanRefs(
   while (true) {
     if (lineStart > text.length) {
       if (phase === 1) break;
-      // Rewind for the scanning pass with every piece of block state reset, so the
-      // two walks classify identically and the label set is complete before use.
+      // Rewind for the scanning pass with every piece of block state reset — the
+      // stray set included, so phase 0's tick bookkeeping cannot leak into the wrap
+      // lengths phase 1 computes — and with the label set now built.
       phase = 1;
       fence = null;
       span = 0;
@@ -577,6 +674,7 @@ function scanRefs(
       rawText = false;
       atParagraphStart = true;
       definitionTail = false;
+      prevDepth = 0;
       strays = new Set();
       lineStart = 0;
       continue;
@@ -589,6 +687,16 @@ function scanRefs(
     // nothing and read as the blank line that ends an open block.
     const quoted = line.replace(QUOTE_PREFIX, "");
     const inner = quoted.replace(LIST_MARKER, "");
+    const depth = quoteDepth(line);
+    // A container that starts on this line begins a fresh block context, so a type-7
+    // tag may open inside it even while the outer paragraph is still going. Only the
+    // HTML arm reads this, and it fails OPEN on purpose: over-holding costs an honest
+    // disclosure, whereas wrapping inside raw HTML is a false claim of
+    // neutralization — the opposite polarity from the indent arm, which fails closed.
+    const containerOpens = opensContainer(line, prevDepth);
+    // Updated here rather than at the loop's foot, so the block arms' `continue`
+    // paths cannot leave it stale.
+    prevDepth = depth;
     // Closing a type-1 block is deferred past this line's scan: the line carrying
     // the closing tag is the block's LAST line, content included.
     let closeAfterLine = false;
@@ -620,7 +728,6 @@ function scanRefs(
         // depths. A fence opened by `- ~~~` therefore stays unrecognized, which is
         // today's behaviour and mangles at worst — fenced content never autolinks.
         const fenced = FENCE.exec(quoted);
-        const depth = quoteDepth(line);
         if (fence) {
           if (
             fenced &&
@@ -697,8 +804,9 @@ function scanRefs(
             // one, so it is validated here rather than trusted on arrival.
             let nextEnd = text.indexOf("\n", lineEnd + 1);
             if (nextEnd === -1) nextEnd = text.length;
-            const next = containerContent(text.slice(lineEnd + 1, nextEnd));
-            defines = lineEnd < text.length && DEFINITION_TAIL.test(next);
+            const next = text.slice(lineEnd + 1, nextEnd);
+            defines =
+              lineEnd < text.length && opensDeferredDestination(next, depth);
             deferred = defines;
           }
         }
@@ -718,15 +826,17 @@ function scanRefs(
           htmlBlock = true;
           rawText = true;
           if (RAW_TEXT_CLOSE.test(line)) closeAfterLine = true;
-        } else if (opensHtmlBlock(inner)) {
+        } else if (opensHtmlBlock(inner, atParagraphStart || containerOpens)) {
           htmlBlock = true;
         }
       }
     }
     let i = lineStart;
-    // Phase 0 classifies lines and nothing else — the character scan belongs to the
-    // pass that has the whole label set in hand.
-    while (phase === 1 && i < lineEnd) {
+    // BOTH phases run the character scan. Phase 0 needs it for its side effects, not
+    // its output: code-span state is derived here, and without it a definition line
+    // sitting inside a multi-line span would register a phantom label that phase 1
+    // then resolves a live reference against. Only the recording is phase-gated.
+    while (i < lineEnd) {
       const ch = text[i];
       // A raw HTML block parses no inline syntax, so its backticks and brackets
       // are ordinary characters and only the trigger scan runs inside one.
@@ -793,13 +903,16 @@ function scanRefs(
           );
           if (num) {
             const end = i + 1 + num[0].length;
-            out.push({
-              start,
-              end,
-              token: text.slice(start, end),
-              wrapRun: wrapRunLength(strays),
-              htmlBlock,
-            });
+            if (phase === 1) {
+              out.push({
+                start,
+                end,
+                token: text.slice(start, end),
+                wrapRun: wrapRunLength(strays),
+                htmlBlock,
+              });
+            }
+            // Advanced in both phases, so the two walks stay in step.
             i = end;
             continue;
           }

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -109,12 +109,11 @@ const HTML_TAG_NAME = "[A-Za-z][A-Za-z0-9-]*";
 const HTML_ATTR = `[ \\t]+[a-zA-Z_:][\\w.:-]*(?:[ \\t]*=[ \\t]*(?:[^ \\t"'=<>\`]+|'[^']*'|"[^"]*"))?`;
 
 /** Type 7: one COMPLETE open or closing tag alone on a line, any tag name. Unlike
- *  types 1 and 6 it cannot interrupt a paragraph, so its opener is gated on the
- *  paragraph-start flag OR {@link opensContainer} — a gate of its own, since the
- *  indented and definition arms read the flag alone. Without it a `<span>` line
- *  mid-paragraph opened a region and the reference below it became a phantom "could
- *  not neutralize"; without the container half, a `> <span>` line failed to open one
- *  and the reference inside the raw block was wrapped and falsely claimed. */
+ *  types 1 and 6 it cannot interrupt a paragraph, so it needs a BLOCK START under
+ *  it: either a line whose predecessor left no open paragraph, or a container
+ *  opening on the line itself ({@link opensContainer}). Both halves are load-bearing
+ *  and the gate is this arm's own — the indented and definition arms read the
+ *  paragraph flag alone. */
 const HTML_BLOCK_TYPE_7 = new RegExp(
   `^ {0,3}(?:<${HTML_TAG_NAME}(?:${HTML_ATTR})*[ \\t]*/?>|</${HTML_TAG_NAME}[ \\t]*>)[ \\t]*$`,
 );
@@ -419,28 +418,42 @@ function paragraphLimit(text: string, from: number): number {
   BLANK_LINE.lastIndex = from;
   const blank = BLANK_LINE.exec(text);
   const limit = blank ? blank.index : text.length;
-  // The container the span opened inside, so the lines below can be judged against it.
+  // The block state the scan's own arm would carry, walked line by line from the one
+  // the span opened on. Both halves matter: a type-7 tag needs a block start, which
+  // is EITHER a line whose predecessor left no open paragraph OR a container opening
+  // here. Seeding from the opener rather than assuming it is paragraph content keeps
+  // a heading (which can hold a backtick and yet ends the paragraph) honest.
   const openerStart = text.lastIndexOf("\n", from - 1) + 1;
   let openerEnd = text.indexOf("\n", openerStart);
   if (openerEnd === -1) openerEnd = text.length;
-  const fromDepth = quoteDepth(text.slice(openerStart, openerEnd));
+  const opener = text.slice(openerStart, openerEnd);
+  let prevDepth = quoteDepth(opener);
+  let openParagraph = leavesOpenParagraph(opener.replace(QUOTE_PREFIX, ""));
   let nl = text.indexOf("\n", from);
   while (nl !== -1 && nl + 1 < limit) {
     const start = nl + 1;
     let end = text.indexOf("\n", start);
     if (end === -1) end = text.length;
     const line = text.slice(start, end);
-    // A line after the opener is paragraph-continuation text, where a type-7 tag
-    // cannot open a block — UNLESS it starts a container, which ends that paragraph
-    // and lets one open after all. The scan's own arm reads exactly the same notion;
-    // if these two disagree, a span candidate runs through a line the scan treats as
-    // a block start, the `span === 0` guard suppresses the whole HTML arm there, and
-    // a reference inside the raw block gets wrapped and falsely claimed.
+    const quoted = line.replace(QUOTE_PREFIX, "");
+    // The gate is read BEFORE the state advances, so this line is judged by what the
+    // one above it left behind — the same order the scan's arm uses. If the two
+    // disagree, a span candidate runs through a line the scan treats as a block
+    // start: the `span === 0` guard then suppresses the whole HTML arm there, and a
+    // reference inside the raw block is either wrapped and falsely claimed or lost
+    // to a span the renderer never opened.
+    const containerStart = opensContainer(line, prevDepth);
+    // A container start ends the paragraph outright, whatever follows its marker, so
+    // the search stops there: a closer beyond it sits in another block and cannot
+    // pair with this opener.
     if (
-      FENCE.test(line.replace(QUOTE_PREFIX, "")) ||
-      opensHtmlBlock(containerContent(line), opensContainer(line, fromDepth))
+      containerStart ||
+      FENCE.test(quoted) ||
+      opensHtmlBlock(containerContent(line), !openParagraph || containerStart)
     )
       return start;
+    openParagraph = leavesOpenParagraph(quoted);
+    prevDepth = quoteDepth(line);
     nl = end < text.length ? end : -1;
   }
   return limit;
@@ -451,19 +464,14 @@ function paragraphLimit(text: string, from: number): number {
  *  opener without one is literal text — entering span state there would silently
  *  swallow every later reference.
  *
- *  APPROXIMATE, and NOT safely so: {@link paragraphLimit} bounds at blank lines,
- *  fences and HTML-block starts, but not at every block that can interrupt a
- *  paragraph — a heading or a list start is not bounded, so its content can pose as
- *  a closer and answer TRUE where markdown would not.
- *
- *  The old claim here was that such an arm "produces no wrap, so the post-condition
- *  keeps the disclosure honest". That is FALSE for spans crossing a blockquote or
- *  list start: fuzzing the shape found both arms of the failure — a reference
- *  wrapped inside a region the renderer treats as code or raw HTML and then claimed
- *  neutralized, and a live reference swallowed by a span the renderer never opens
- *  and so never reported. The class predates the HTML-region work and closing it
- *  means bounding this search at container starts as well, which is a larger change
- *  than a region rule; it is tracked separately rather than patched here. */
+ *  APPROXIMATE, and NOT safely so. {@link paragraphLimit} bounds at blank lines,
+ *  fences, container starts and HTML-block starts — but a HEADING is none of those,
+ *  so content past one can pose as a closer and answer TRUE where markdown would
+ *  not. Both failure arms are reachable there: a reference wrapped inside a region
+ *  the renderer treats as code or raw HTML and then claimed neutralized, and a live
+ *  reference swallowed by a span the renderer never opens and so never reported.
+ *  Neither direction is safe; the remedy is bounding at every block that can
+ *  interrupt a paragraph, which is tracked separately. */
 function hasClosingRun(text: string, from: number, run: number): boolean {
   const limit = paragraphLimit(text, from);
   let i = from;

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -25,9 +25,9 @@ export interface AiCommentParts {
   model: string;
   automated: boolean;
   text: string;
-  /** Backtick-wrap any `#N`-style reference in `text` and disclose that in the
-   *  footer. For the automated seam only: nobody is there to confirm intent, so
-   *  the stray cross-reference is prevented outright. */
+  /** Backtick-wrap what it can of the `#N`-style references in `text`, disclose
+   *  exactly what was neutralized, and name what it could not. For the automated
+   *  seam only, where nobody is present to confirm intent. */
   neutralizeRefs?: boolean;
 }
 
@@ -63,7 +63,9 @@ const REF_NUMBER = /^[1-9]\d{0,9}(?!\w)/;
  *  the one character the boundary lookahead reads. */
 const REF_NUMBER_SPAN = 12;
 
-/** Opens or closes a fenced block. */
+/** Opens or closes a fenced block. The `^ {0,3}` anchor admits only spaces before
+ *  the run, so a leading backslash already breaks the match — fences need no
+ *  separate escape check. */
 const FENCE = /^ {0,3}(`{3,}|~{3,})/;
 
 /** Indented code: four spaces or a tab of leading whitespace. */
@@ -72,11 +74,38 @@ const INDENTED = /^(?: {4}|\t)/;
 /** How many references a formatted list names before it counts the rest. */
 const REF_LIST_CAP = 5;
 
+/** Rewrite passes the neutralizer may take. Wrapping can UNBLOCK a trigger that the
+ *  wrapped token's own trailing digit was shielding (`#1#2` → `` `#1` ``#2), so one
+ *  pass can mint the very thing it removes; repeating settles it. The cap keeps a
+ *  geometry neither pass converges on from looping — the post-condition in
+ *  {@link neutralizeSuspectRefs} then withholds the claim instead. */
+const NEUTRALIZE_PASSES = 4;
+
+/** Matches a blank line — CommonMark's paragraph boundary, which a line of spaces
+ *  or tabs satisfies just as well as an empty one. Sticky-ish by `lastIndex` so the
+ *  lookahead below needs no tail slice; every use MUST set `lastIndex` first, since
+ *  the flag makes that position shared state between calls. */
+const BLANK_LINE = /\n[ \t]*\n/g;
+
 /** One suspect token's position in the scanned text. */
 interface RefOccurrence {
   start: number;
   end: number;
   token: string;
+  /** Backtick run length a wrap here must use to be un-stealable — see
+   *  {@link wrapRunLength}. */
+  wrapRun: number;
+}
+
+/** The shortest backtick run a wrap can use without a live literal run in the same
+ *  paragraph stealing its opener. A stray run pairs only with a run of ITS OWN
+ *  length, so a length outside `strays` leaves the wrap's own two runs to pair with
+ *  each other. Only as complete as `strays` is — see {@link scanRefs}, whose skip
+ *  regions decide which literal runs get recorded at all. */
+function wrapRunLength(strays: ReadonlySet<number>): number {
+  let len = 1;
+  while (strays.has(len)) len++;
+  return len;
 }
 
 /** The end index (exclusive) of a `[label](destination)` opening at `open`, or
@@ -101,15 +130,111 @@ function linkEnd(text: string, open: number, limit: number): number {
   return open;
 }
 
+/** Whether the character at `i` is markdown-escaped: an ODD run of immediately
+ *  preceding backslashes (a backslash escapes any ASCII punctuation; an even run is
+ *  self-escaped backslashes). The neutralizer needs this too — a backslash before
+ *  the wrap's opening backtick escapes it, leaving a bare live reference. */
+function isEscaped(text: string, i: number): boolean {
+  let slashes = 0;
+  while (i - slashes - 1 >= 0 && text[i - slashes - 1] === "\\") slashes++;
+  return slashes % 2 === 1;
+}
+
+/** Records every backtick run in `[from, to)` as a stray, counting runs the way the
+ *  main scan does (an escaped tick is a literal that joins no run). For a region the
+ *  scan SKIPS whose ticks markdown still parses. */
+function recordTicks(
+  text: string,
+  from: number,
+  to: number,
+  strays: Set<number>,
+): void {
+  let i = from;
+  while (i < to) {
+    if (text[i] !== "`") {
+      i++;
+      continue;
+    }
+    if (isEscaped(text, i)) {
+      i++;
+      continue;
+    }
+    let run = 1;
+    while (i + run < to && text[i + run] === "`") run++;
+    strays.add(run);
+    i += run;
+  }
+}
+
+/** Where a code span opened at `from` must stop looking for its closer: the next
+ *  blank line or the next fence line, whichever comes first. Both end the paragraph
+ *  CommonMark parses the span within — a fence interrupts one, and reading past
+ *  either would let a delimiter or a fenced line's content pose as a closer. */
+function paragraphLimit(text: string, from: number): number {
+  BLANK_LINE.lastIndex = from;
+  const blank = BLANK_LINE.exec(text);
+  const limit = blank ? blank.index : text.length;
+  let nl = text.indexOf("\n", from);
+  while (nl !== -1 && nl + 1 < limit) {
+    const start = nl + 1;
+    let end = text.indexOf("\n", start);
+    if (end === -1) end = text.length;
+    if (FENCE.test(text.slice(start, end))) return start;
+    nl = end < text.length ? end : -1;
+  }
+  return limit;
+}
+
+/** Whether a run of exactly `run` backticks appears at or after `from` within the
+ *  paragraph. CommonMark closes a code span only on an equal-length run, so an
+ *  opener without one is literal text — entering span state there would silently
+ *  swallow every later reference.
+ *
+ *  APPROXIMATE in one direction still: another block that can interrupt a paragraph
+ *  (a heading, a list) is not bounded here, so its content can pose as a closer and
+ *  answer TRUE where markdown would not. That arm opens a span the renderer never
+ *  opens, which under-detects — the status quo — and produces no wrap, so the
+ *  post-condition in {@link neutralizeSuspectRefs} keeps the disclosure honest. */
+function hasClosingRun(text: string, from: number, run: number): boolean {
+  const limit = paragraphLimit(text, from);
+  let i = from;
+  while (i < limit) {
+    if (text[i] !== "`") {
+      i++;
+      continue;
+    }
+    let n = 1;
+    while (i + n < limit && text[i + n] === "`") n++;
+    if (n === run) return true;
+    i += n;
+  }
+  return false;
+}
+
 /**
  * Every suspect reference occurrence in `text`, in source order — the ONE scan
  * both {@link findSuspectRefs} and {@link neutralizeSuspectRefs} consume, so the
  * warning and the rewrite can never disagree about what counts.
  *
- * Regions the scan never fires inside: fenced blocks, inline code spans, markdown
- * link syntax, and indented code. Each of those over-skips at the margins (a lazy
- * paragraph continuation indented four spaces, say), which fails toward the
- * status quo — no warning, no rewrite — the safe direction for both callers.
+ * The scan never fires inside four REGIONS: fenced blocks, inline code spans,
+ * markdown link syntax, and indented code. Their boundaries are approximate and
+ * deliberately over-skip at the margins (a lazy paragraph continuation indented
+ * four spaces, say), failing toward the status quo — no warning, no rewrite — the
+ * safe direction for both callers.
+ *
+ * Backslash parity is an EXACT rule, not an approximation, and it gates all three
+ * syntax-recognizing sites: the trigger character, a span's opening backtick run,
+ * and a link's opening bracket. An escape-blind opener is the dangerous direction —
+ * it would enter a region that markdown never enters and hide the refs after it.
+ *
+ * Each occurrence also carries the wrap run length the neutralizer must use there,
+ * derived from the literal backtick runs this scan believes are live for pairing.
+ * Which skipped regions contribute those: fence content NO and indented code NO
+ * (both are blocks, their ticks never pair), span content NO (the span consumed
+ * them), link regions YES (spans parse before links) — so the link arm alone feeds
+ * `strays` on skip. Every claim built on that set is SCANNER-RELATIVE; the
+ * marked-oracle test in `scripts/comment-refs.test.mjs` is what grounds it against
+ * a real parser.
  */
 function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
   const out: RefOccurrence[] = [];
@@ -118,20 +243,25 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
   // The open code span's backtick-run length; 0 when none. A run of N backticks
   // closes at the next run of exactly N (CommonMark), and a span may cross lines.
   let span = 0;
+  // Lengths of the unpaired literal runs seen so far in THIS paragraph; inline
+  // syntax is paragraph-scoped, so a blank line clears them.
+  let strays = new Set<number>();
   let lineStart = 0;
   while (lineStart <= text.length) {
     let lineEnd = text.indexOf("\n", lineStart);
     if (lineEnd === -1) lineEnd = text.length;
+    const line = text.slice(lineStart, lineEnd);
+    if (line.trim() === "") strays = new Set();
     // Block structure is only readable outside a code span: an open span swallows
     // whatever it crosses, fence lines included.
     if (span === 0) {
-      const fenced = FENCE.exec(text.slice(lineStart, lineEnd));
+      const fenced = FENCE.exec(line);
       if (fence) {
         if (
           fenced &&
           fenced[1][0] === fence.char &&
           fenced[1].length >= fence.len &&
-          text.slice(lineStart + fenced[0].length, lineEnd).trim() === ""
+          line.slice(fenced[0].length).trim() === ""
         ) {
           fence = null;
         }
@@ -143,7 +273,7 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
         lineStart = lineEnd + 1;
         continue;
       }
-      if (INDENTED.test(text.slice(lineStart, lineEnd))) {
+      if (INDENTED.test(line)) {
         lineStart = lineEnd + 1;
         continue;
       }
@@ -152,10 +282,21 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
     while (i < lineEnd) {
       const ch = text[i];
       if (ch === "`") {
+        // An escaped backtick is a literal character the renderer consumes with its
+        // backslash, so it neither opens a span nor joins the run that follows it.
+        if (span === 0 && isEscaped(text, i)) {
+          i++;
+          continue;
+        }
         let run = 1;
         while (i + run < lineEnd && text[i + run] === "`") run++;
-        if (span === 0) span = run;
-        else if (span === run) span = 0;
+        // Escapes do not work inside a code span, so the closing arm is unguarded;
+        // a run that never meets its match stays literal and can steal a wrap.
+        if (span === run) span = 0;
+        else if (span === 0) {
+          if (hasClosingRun(text, i + run, run)) span = run;
+          else strays.add(run);
+        }
         i += run;
         continue;
       }
@@ -163,19 +304,32 @@ function scanRefs(text: string, triggers: readonly string[]): RefOccurrence[] {
         i++;
         continue;
       }
-      if (ch === "[") {
+      if (ch === "[" && !isEscaped(text, i)) {
         const skip = linkEnd(text, i, lineEnd);
-        i = skip > i ? skip : i + 1;
+        if (skip > i) {
+          // Code spans parse BEFORE links, so a tick inside the region this arm
+          // jumps is still live for pairing and must not be missed by `strays`.
+          recordTicks(text, i, skip, strays);
+          i = skip;
+        } else {
+          i++;
+        }
         continue;
       }
       if (
         triggers.includes(ch) &&
-        !(i > 0 && BLOCKED_BEFORE.test(text[i - 1]))
+        !(i > 0 && BLOCKED_BEFORE.test(text[i - 1])) &&
+        !isEscaped(text, i)
       ) {
         const num = REF_NUMBER.exec(text.slice(i + 1, i + 1 + REF_NUMBER_SPAN));
         if (num) {
           const end = i + 1 + num[0].length;
-          out.push({ start: i, end, token: text.slice(i, end) });
+          out.push({
+            start: i,
+            end,
+            token: text.slice(i, end),
+            wrapRun: wrapRunLength(strays),
+          });
           i = end;
           continue;
         }
@@ -202,31 +356,72 @@ export function findSuspectRefs(
   return refs;
 }
 
-/** Backtick-wraps every suspect occurrence; everything else stays byte-identical.
- *  `wrapped` lists the distinct NEUTRALIZED forms (`` `#12` ``), not the bare
- *  tokens: its only consumer is a disclosure line inside the same comment body,
- *  and naming the bare token there would create the very cross-reference the
- *  wrapping prevents. */
+/**
+ * Backtick-wraps every suspect occurrence; the rest of the text stays byte-identical
+ * apart from a separating space where a wrap would otherwise fuse with an adjacent
+ * literal backtick. The run length is per-occurrence rather than always one tick,
+ * because a stray unpaired tick earlier in the paragraph would otherwise pair with
+ * the wrap's OPENER and leave the reference bare and live outside the resulting span.
+ *
+ * Both `wrapped` and `survived` list backticked forms (`` `#12` ``), never bare
+ * tokens: their only consumers are disclosure lines inside the same comment body,
+ * and naming a bare token there would create the very cross-reference the wrapping
+ * prevents. The split is the post-condition — re-scanning the output decides which
+ * list a ref lands in, so a geometry this scan approximates wrongly is REPORTED as
+ * un-neutralized rather than silently claimed. The text keeps every attempted wrap
+ * either way. `survived` carries run-1 forms because its reader renders it in the
+ * footer's own fresh paragraph, where no stray from the body can reach it.
+ */
 export function neutralizeSuspectRefs(
   text: string,
   triggers: readonly string[] = ["#", "!"],
-): { text: string; wrapped: string[] } {
-  const hits = scanRefs(text, triggers);
-  if (hits.length === 0) return { text, wrapped: [] };
-  const seen = new Set<string>();
-  const wrapped: string[] = [];
-  const parts: string[] = [];
-  let cursor = 0;
-  for (const hit of hits) {
-    parts.push(text.slice(cursor, hit.start), "`", hit.token, "`");
-    cursor = hit.end;
-    const form = `\`${hit.token}\``;
-    if (seen.has(form)) continue;
-    seen.add(form);
-    wrapped.push(form);
+): { text: string; wrapped: string[]; survived: string[] } {
+  const forms = new Map<string, string>();
+  let out = text;
+  for (let pass = 0; pass < NEUTRALIZE_PASSES; pass++) {
+    const hits = scanRefs(out, triggers);
+    if (hits.length === 0) break;
+    const parts: string[] = [];
+    let cursor = 0;
+    for (const hit of hits) {
+      const ticks = "`".repeat(hit.wrapRun);
+      // A wrap tick touching a literal one FUSES into a longer run, so the chosen
+      // length is no longer what the renderer sees and the two ends stop pairing.
+      // A separating space is the only added character this rewrite ever makes.
+      const before =
+        hit.start > 0 &&
+        out[hit.start - 1] === "`" &&
+        !isEscaped(out, hit.start - 1)
+          ? " "
+          : "";
+      const after = out[hit.end] === "`" ? " " : "";
+      parts.push(
+        out.slice(cursor, hit.start),
+        before,
+        ticks,
+        hit.token,
+        ticks,
+        after,
+      );
+      cursor = hit.end;
+      // Pass 0 fixes WHICH refs the caller may be told about; later passes only
+      // refresh a form they re-wrapped, so the disclosure names what shipped.
+      if (pass === 0 || forms.has(hit.token)) {
+        forms.set(hit.token, `${ticks}${hit.token}${ticks}`);
+      }
+    }
+    parts.push(out.slice(cursor));
+    out = parts.join("");
   }
-  parts.push(text.slice(cursor));
-  return { text: parts.join(""), wrapped };
+  if (out === text) return { text, wrapped: [], survived: [] };
+  const survivors = new Set(findSuspectRefs(out, triggers));
+  const wrapped: string[] = [];
+  const survived: string[] = [];
+  for (const [token, form] of forms) {
+    if (survivors.has(token)) survived.push(`\`${token}\``);
+    else wrapped.push(form);
+  }
+  return { text: out, wrapped, survived };
 }
 
 /** "#12" | "#12 and #45" | "#12, #45, and #103" | caps at 5 then "and N more". */
@@ -252,9 +447,21 @@ export function buildAiCommentBody({
   // Both triggers deliberately, no provider: this seam has none in hand, and a
   // wrapped `!N` on GitHub is a literal that never linked anyway.
   const neutralized = neutralizeRefs ? neutralizeSuspectRefs(text) : null;
-  const body = neutralized?.wrapped.length ? neutralized.text : text;
-  const disclosure = neutralized?.wrapped.length
-    ? `\n\n_References ${formatRefList(neutralized.wrapped)} are shown as plain text — this automated run could not confirm they were meant to link._`
+  // The wraps stay in the body whatever the guard concluded; only the CLAIM is
+  // gated, so an unverifiable wrap ships silently rather than as a false promise.
+  const body = neutralized?.text ?? text;
+  const done = neutralized?.wrapped.length
+    ? formatRefList(neutralized.wrapped)
     : "";
+  const missed = neutralized?.survived.length
+    ? formatRefList(neutralized.survived)
+    : "";
+  let disclosure = "";
+  if (done) {
+    const couldNot = missed ? ` It could not neutralize ${missed}.` : "";
+    disclosure = `\n\n_References ${done} are shown as plain text — this automated run could not confirm they were meant to link.${couldNot}_`;
+  } else if (missed) {
+    disclosure = `\n\n_This automated run could not neutralize ${missed} — verify before trusting any links it created._`;
+  }
   return `🤖 **GitDesktop AI ${kind}** · \`${model}\`${meta}\n\n---\n\n${body}\n\n---\n\n_Posted by [GitDesktop](${GD_COMMENT_ANCHOR}) — AI output, verify before acting on it._${disclosure}`;
 }

--- a/src/lib/ai/comment-branding.ts
+++ b/src/lib/ai/comment-branding.ts
@@ -118,6 +118,35 @@ const HTML_BLOCK_TYPE_7 = new RegExp(
   `^ {0,3}(?:<${HTML_TAG_NAME}(?:${HTML_ATTR})*[ \\t]*/?>|</${HTML_TAG_NAME}[ \\t]*>)[ \\t]*$`,
 );
 
+/** A COMPLETE inline tag starting here — the type-7 shapes without the line anchors.
+ *  Sticky, so it can be tried at a position without slicing; the caller still has to
+ *  reject a match that ran past the line, since a quoted attribute value may hold a
+ *  newline. */
+const INLINE_TAG = new RegExp(
+  `(?:<${HTML_TAG_NAME}(?:${HTML_ATTR})*[ \\t]*/?>|</${HTML_TAG_NAME}[ \\t]*>)`,
+  "y",
+);
+
+/**
+ * The end index (exclusive) of a complete inline tag opening at `open`, or `open` when
+ * what is there is not one. The WHOLE tag is skipped, attribute values and all: it is
+ * raw-HTML markup rather than a text node, so no reference inside it is live and a
+ * wrap there corrupts the tag — a quoted `href="#123"` becomes ``href="`#123`"`` and
+ * the link breaks, while an unquoted one stops parsing as HTML altogether.
+ *
+ * Ticks inside the tag are NOT recorded as strays. CommonMark gives code spans and raw
+ * HTML equal precedence and lets the leftmost win; this arm is only reached with no
+ * span open, so the tag genuinely starts first and its backticks are raw. A tick
+ * BEFORE the tag wins instead, and the scan is already in span state by then.
+ */
+function inlineTagEnd(text: string, open: number, limit: number): number {
+  INLINE_TAG.lastIndex = open;
+  const tag = INLINE_TAG.exec(text);
+  if (!tag) return open;
+  const end = open + tag[0].length;
+  return end <= limit && !tag[0].includes("\n") ? end : open;
+}
+
 /** Type 1, the raw-text tags. Their block ignores blank lines entirely and ends only
  *  at {@link RAW_TEXT_CLOSE} — which CommonMark takes as ANY of the four closing tags
  *  anywhere on a line, the opener's own line included. Note the start condition
@@ -274,11 +303,14 @@ function opensDeferredDestination(line: string, depth: number): boolean {
  *  then open a type-7 region inside a span the limit let form; the `span === 0` guard
  *  shuts the HTML arm there, which is what the renderer does too.
  *
- *  KNOWN GAP: a list DEDENT is invisible here, because measuring it needs the item's
- *  content column and this scan has no indentation model. `- text` then `<span>`
- *  leaves the item, so the tag opens a block and the reference under it is raw HTML;
- *  the scan wraps it instead and claims it neutralized — the same false-claim class
- *  this function exists to prevent, narrowed to list dedents. */
+ *  A list DEDENT is invisible to this function — measuring one needs the item's
+ *  content column — so the type-7 gate carries a separate stand-in for it: a tag at a
+ *  column the last list marker's content had left counts as a transition there. That
+ *  heuristic can only ever HOLD a reference, and holding is truthful under both
+ *  readings of the shape (outside the item its refs are raw HTML; inside it they are
+ *  prose), so it cannot produce a false claim. What it costs is the occasional
+ *  over-hold, disclosed honestly; and it deliberately ignores a tag indented INTO the
+ *  item, which the ordinary arms handle. */
 function opensContainer(
   line: string,
   depth: number,
@@ -321,7 +353,25 @@ const NEUTRALIZE_PASSES = 4;
  *  or tabs satisfies just as well as an empty one. Sticky-ish by `lastIndex` so the
  *  lookahead below needs no tail slice; every use MUST set `lastIndex` first, since
  *  the flag makes that position shared state between calls. */
-const BLANK_LINE = /\n[ \t]*\n/g;
+const BLANK_LINE = /\r?\n[ \t]*\r?\n/g;
+
+/**
+ * A line's text for CLASSIFICATION, with the CR of a CRLF pair removed.
+ *
+ * The scan splits on `\n`, so under CRLF every line would otherwise carry a trailing
+ * `\r` — and each line test is anchored at `$`, so a blank line would not read blank,
+ * a closing fence's tail would not read empty, and the fence would run to the end of
+ * the comment swallowing every reference after it. Stripping at EXTRACTION fixes all
+ * of them at once.
+ *
+ * Offsets are never derived from this string. The raw text keeps feeding `lineStart`
+ * / `lineEnd`, so wraps still land at positions in the original and every untouched
+ * region stays byte-identical — which is why the input is not normalized instead.
+ */
+function classifyLine(text: string, start: number, end: number): string {
+  const stop = end > start && text[end - 1] === "\r" ? end - 1 : end;
+  return text.slice(start, stop);
+}
 
 /** One suspect token's position in the scanned text. */
 interface RefOccurrence {
@@ -480,7 +530,7 @@ function paragraphLimit(text: string, from: number): number {
   const openerStart = text.lastIndexOf("\n", from - 1) + 1;
   let openerEnd = text.indexOf("\n", openerStart);
   if (openerEnd === -1) openerEnd = text.length;
-  const opener = text.slice(openerStart, openerEnd);
+  const opener = classifyLine(text, openerStart, openerEnd);
   // The opener's OWN line can be the block that ends here — a heading may carry a
   // backtick and still close at its line end, so nothing after it can be the closer.
   // `openerEnd` never exceeds `limit`: the earliest newline at or after `from` is the
@@ -493,7 +543,7 @@ function paragraphLimit(text: string, from: number): number {
     const start = nl + 1;
     let end = text.indexOf("\n", start);
     if (end === -1) end = text.length;
-    const line = text.slice(start, end);
+    const line = classifyLine(text, start, end);
     const quoted = line.replace(QUOTE_PREFIX, "");
     // Read before the state advances, so each line is judged by what the one above it
     // left behind — the same order the scan's arm uses.
@@ -629,12 +679,12 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * reference stays live. So its occurrences carry `htmlBlock` and
  * {@link neutralizeSuspectRefs} routes them into `survived` for the footer to
  * name. Region starts are read at the CONTAINER CONTENT COLUMN, since a `> ` or a
- * list marker does not stop a block from opening. The fence arm reads blockquote
- * markers too, pairs a fence only at the depth it opened at, and ends one when the
- * line's depth drops below that — which closes the lazy continuation as well. What
- * remains there is the LIST case: `- ~~~` opens a fence this scan does not see, so
- * its content is scanned. That mangles at worst, since fenced content never
- * autolinks either way.
+ * list marker does not stop a block from opening. The fence arm reads both kinds of
+ * marker, and pairs each fence against the container it opened in: a quoted one by
+ * blockquote depth, a `- ~~~` one by the item's content column. An unrecognized
+ * opener was never merely cosmetic — its own closer would go on to open a PHANTOM
+ * fence that swallowed the rest of the comment, so the wrap inside the code example
+ * came with a silently missed reference after it.
  *
  * Paragraph state IS tracked ({@link leavesOpenParagraph}), and the type-7 arm reads
  * it alongside {@link opensContainer}. What remains is that pair answering YES too
@@ -644,12 +694,14 @@ function hasClosingRun(text: string, from: number, run: number): boolean {
  * a TRUTHFUL disclosure, which is the polarity this arm is built for. Over-warning
  * is the tolerable failure; a false claim of neutralization is not.
  *
- * That phantom-disclosure arm has one cosmetic sibling and one that is not. A `#N`
- * inside an inline HTML ATTRIBUTE is inert — no reference filter rewrites attribute
- * values — so a wrap there only adds noise. A `#N` in an inline element's TEXT
- * (`<span>see #5</span>` mid-paragraph) is LIVE: the filter walks text nodes, and
- * that one is a text node. It is detected and wrapped like any other prose
- * reference, which is correct; only the attribute case is the harmless one.
+ * The inline-HTML family splits two ways, and both are handled. A `#N` inside a
+ * complete inline TAG is markup: no filter rewrites it, and wrapping it corrupts the
+ * tag, so {@link inlineTagEnd} skips the whole thing. A `#N` in an element's TEXT
+ * (`<span>see #5</span>`) is LIVE — the filter walks text nodes and that is one — so
+ * it is detected and wrapped like any other prose. What is left of the family is a
+ * tag this line-local grammar cannot complete: one split across lines, or a
+ * malformed one. Those fall through to being scanned as prose, which is where the
+ * cross-line class below already leaves them.
  *
  * Backslash parity is an EXACT rule, not an approximation. It still GATES the two
  * region openers, a span's opening backtick run and a link's opening bracket, where
@@ -700,7 +752,12 @@ function scanRefs(
   // passes settle it: nothing feeds back into phase 0.
   const labels = new Set<string>();
   let phase = 0;
-  let fence: { char: string; len: number; depth: number } | null = null;
+  let fence: {
+    char: string;
+    len: number;
+    depth: number;
+    column: number;
+  } | null = null;
   // The open code span's backtick-run length; 0 when none. A run of N backticks
   // closes at the next run of exactly N (CommonMark), and a span may cross lines.
   let span = 0;
@@ -718,6 +775,9 @@ function scanRefs(
   // The previous line's blockquote depth, so the HTML arm can tell an opening
   // container from one that was already there.
   let prevDepth = 0;
+  // Content column of the most recent list marker, or -1 when none is in play; a
+  // blank line clears it. Read ONLY by the type-7 gate — see `leftListIndent`.
+  let listColumn = -1;
   // Lengths of the unpaired literal runs seen so far in THIS paragraph; inline
   // syntax is paragraph-scoped, so a blank line clears them. Only a blank line does,
   // though a heading or container start also ends the paragraph for span purposes —
@@ -745,7 +805,7 @@ function scanRefs(
     }
     let lineEnd = text.indexOf("\n", lineStart);
     if (lineEnd === -1) lineEnd = text.length;
-    const line = text.slice(lineStart, lineEnd);
+    const line = classifyLine(text, lineStart, lineEnd);
     // A blockquote's content column is where its leaf blocks live; the list-marker
     // strip is for the opener test only, since a lone `-` would otherwise strip to
     // nothing and read as the blank line that ends an open block.
@@ -758,9 +818,20 @@ function scanRefs(
     // disclosure, whereas wrapping inside raw HTML is a false claim of
     // neutralization — the opposite polarity from the indent arm, which fails closed.
     const containerOpens = opensContainer(line, prevDepth);
+    // A type-7 tag sitting at a column the list marker's content had left is either
+    // outside the item (a block start, its refs raw HTML) or a lazy continuation of
+    // the item's paragraph (its refs prose). Both readings leave the reference LIVE,
+    // so holding it is truthful either way — which is what makes this one-boolean
+    // stand-in for an indentation model safe. Over-tripping only ever over-holds.
+    const leftListIndent =
+      listColumn >= 0 &&
+      quoted.length - quoted.replace(/^[ \t]*/, "").length < listColumn;
     // Updated here rather than at the loop's foot, so the block arms' `continue`
     // paths cannot leave it stale.
     prevDepth = depth;
+    const marker = LIST_MARKER.exec(quoted);
+    if (BLANK.test(quoted)) listColumn = -1;
+    else if (marker) listColumn = marker[0].length;
     // Closing a type-1 block is deferred past this line's scan: the line carrying
     // the closing tag is the block's LAST line, content included.
     let closeAfterLine = false;
@@ -783,28 +854,76 @@ function scanRefs(
           htmlBlock = false;
         }
       } else {
-        // Fences are read at the blockquote content column — `> ~~~` opens one, and
-        // a wrap inside it would corrupt a displayed code example. List markers are
-        // deliberately NOT stripped here: a blockquote marker repeats on every line,
-        // so opener and closer stay at the same depth, while a list marker appears
-        // only on the item's first line and its block's continuation is indentation
-        // this scanner does not model, so the two ends would pair at different
-        // depths. A fence opened by `- ~~~` therefore stays unrecognized, which is
-        // today's behaviour and mangles at worst — fenced content never autolinks.
+        // Fences are read at their CONTAINER's content column. A blockquote marker
+        // repeats on every line, so `quoted` carries opener and closer alike; a list
+        // marker appears only on the item's first line, so a fence behind one records
+        // the item's column and its later lines are matched against that instead.
         const fenced = FENCE.exec(quoted);
+        const indent = quoted.length - quoted.replace(/^[ \t]*/, "").length;
+        // Inside a list fence the closer sits at the item's column, plus CommonMark's
+        // usual three-space slack; `quoted` still carries that indentation.
+        const listClose =
+          fence && fence.column > 0 && indent >= fence.column
+            ? FENCE.exec(quoted.slice(fence.column))
+            : null;
+        const closer = fence && fence.column > 0 ? listClose : fenced;
         if (fence) {
           if (
-            fenced &&
-            fenced[1][0] === fence.char &&
-            fenced[1].length >= fence.len &&
+            closer &&
+            closer[1][0] === fence.char &&
+            closer[1].length >= fence.len &&
             depth === fence.depth &&
-            BLANK.test(quoted.slice(fenced[0].length))
+            BLANK.test(quoted.slice(fence.column + closer[0].length))
           ) {
             fence = null;
             atParagraphStart = true;
             lineStart = lineEnd + 1;
             continue;
           }
+          // A list fence dies with its ITEM. A non-blank line short of the column has
+          // left it; a blank line ends it too unless the next non-blank line is still
+          // indented into the item, which CommonMark keeps as code content.
+          //
+          // A fence-shaped line that is NOT this fence's closer is treated as content
+          // instead, deferring the death to the next ordinary line. That is the arm
+          // that keeps later references scannable: ending the item here would let the
+          // very same line re-open a fence at column 0 and swallow everything after
+          // it. Every judgment call in here is settled that way — an item ended too
+          // soon only exposes more text to the scan, while one left open hides it.
+          if (fence.column > 0 && !fenced) {
+            let ends = false;
+            if (BLANK.test(quoted)) {
+              let at = lineEnd + 1;
+              while (at <= text.length) {
+                let to = text.indexOf("\n", at);
+                if (to === -1) to = text.length;
+                const ahead = classifyLine(text, at, to).replace(
+                  QUOTE_PREFIX,
+                  "",
+                );
+                if (!BLANK.test(ahead)) {
+                  ends =
+                    ahead.length - ahead.replace(/^[ \t]*/, "").length <
+                    fence.column;
+                  break;
+                }
+                at = to + 1;
+              }
+              if (at > text.length) ends = true;
+            } else if (indent < fence.column) {
+              ends = true;
+            }
+            if (ends) {
+              // Outside the item now, so this line falls through to be classified.
+              fence = null;
+            } else {
+              atParagraphStart = true;
+              lineStart = lineEnd + 1;
+              continue;
+            }
+          }
+        }
+        if (fence) {
           // A fence dies with its CONTAINER, and DEPTH is the whole test: a line
           // that drops below the fence's depth has left the blockquote, and a truly
           // blank line is depth 0, so it is already covered. Testing the
@@ -824,8 +943,19 @@ function scanRefs(
             continue;
           }
         }
-        if (fenced) {
-          fence = { char: fenced[1][0], len: fenced[1].length, depth };
+        // A fence behind a list marker opens at the item's content column; one
+        // anywhere else opens at column 0 and keeps the blockquote-depth rules.
+        const markerFence = marker ? FENCE.exec(inner) : null;
+        if (fenced || markerFence) {
+          const open = fenced ?? markerFence;
+          if (open) {
+            fence = {
+              char: open[1][0],
+              len: open[1].length,
+              depth,
+              column: fenced ? 0 : (marker?.[0].length ?? 0),
+            };
+          }
           atParagraphStart = true;
           lineStart = lineEnd + 1;
           continue;
@@ -868,7 +998,7 @@ function scanRefs(
             // one, so it is validated here rather than trusted on arrival.
             let nextEnd = text.indexOf("\n", lineEnd + 1);
             if (nextEnd === -1) nextEnd = text.length;
-            const next = text.slice(lineEnd + 1, nextEnd);
+            const next = classifyLine(text, lineEnd + 1, nextEnd);
             defines =
               lineEnd < text.length && opensDeferredDestination(next, depth);
             deferred = defines;
@@ -890,7 +1020,12 @@ function scanRefs(
           htmlBlock = true;
           rawText = true;
           if (RAW_TEXT_CLOSE.test(line)) closeAfterLine = true;
-        } else if (opensHtmlBlock(inner, atParagraphStart || containerOpens)) {
+        } else if (
+          opensHtmlBlock(
+            inner,
+            atParagraphStart || containerOpens || leftListIndent,
+          )
+        ) {
           htmlBlock = true;
         }
       }
@@ -926,6 +1061,16 @@ function scanRefs(
       if (span > 0) {
         i++;
         continue;
+      }
+      // An inline tag is markup, not text: nothing in it autolinks, and a wrap there
+      // breaks the tag. Its TEXT CONTENT is a different matter and keeps being
+      // scanned — a reference between the tags is live prose.
+      if (ch === "<" && !htmlBlock && !isEscaped(text, i)) {
+        const skip = inlineTagEnd(text, i, lineEnd);
+        if (skip > i) {
+          i = skip;
+          continue;
+        }
       }
       if (ch === "[" && !htmlBlock && !isEscaped(text, i)) {
         // Inline syntax first, then the reference forms. A label that resolves to no

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -25,10 +25,12 @@ Do not wrap the message in markdown fences. Do not add commentary before or afte
 
 /** Reference-syntax rule for every prompt whose output can be posted to a forge:
  *  a bare `#N` there is a live cross-reference that notifies the thread it names,
- *  so enumeration must not use it. Only the `(1)` form is offered — a leading
- *  `1)` renders as an ordered list in the app's own markdown. */
+ *  so it names three things that must not use it — enumeration, internal labels,
+ *  and items numbered in another document — and states the prohibition on the `#`
+ *  character itself, since parenthesizing it changes nothing. Only the `(1)` form
+ *  is offered — a leading `1)` renders as an ordered list in the app's own markdown. */
 const REFERENCE_RULE =
-  "Write #N (or !N) only when deliberately referencing a real issue or pull request in this repository — on the forge it becomes a live cross-reference and notifies that thread. For enumeration or internal labels write (1), (2), never #1. To mention a reference without linking it, wrap it in backticks.";
+  "Reference syntax: write #N (or !N) only when deliberately referencing a real issue or pull request in this repository — on the forge it becomes a live cross-reference and notifies that thread. The # character itself is what links, and parentheses do not neutralize it: (#10) is still a live reference. For enumeration or internal labels write (1), (2) — never #1, never (#1). For numbered items in ANOTHER document (the PR description's list, a linked doc, a finding in an earlier review) name or quote the item — \"the description's item 11\" — never #11, never (#11). To mention a reference without linking it, wrap it in backticks.";
 
 // KEEP IN SYNC: src-tauri/src/mcp_server/generate.rs mirrors this for the MCP recipe tools.
 export function buildCommitPrompt(input: CommitPromptInput): {

--- a/src/lib/automations/results.ts
+++ b/src/lib/automations/results.ts
@@ -1,7 +1,21 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { toast } from "sonner";
 import { create } from "zustand";
 import type { ReviewMode } from "@/lib/ai/types";
+import {
+  identityKeyFor,
+  mergeById,
+  repoIdentity,
+} from "@/lib/git/repo-identity";
+import { storeName } from "@/lib/test-mode";
 
+/**
+ * A finished automated COMMIT review — the one review target with no comment
+ * surface to deliver into, so this store is the output's only home. Persisted so
+ * the text survives a restart and its notification stays clickable.
+ */
 export interface AutomationRunResult {
+  schemaVersion: 1;
   id: string;
   repoPath: string;
   /** What was reviewed — a commit subject or PR title. */
@@ -9,21 +23,198 @@ export interface AutomationRunResult {
   mode: ReviewMode;
   text: string;
   createdAt: string;
+  /** Commit sha the review covered; "" when unknown. */
+  hash: string;
+  /** Present only on a kept PARTIAL run (mirrors PersistedReview's vocabulary). */
+  phase?: "error";
+  error?: string;
+  timedOut?: boolean;
+}
+
+/** Records kept per repo, pruned on every write so the file stays bounded.
+ *  Completed reviews and kept partials share the cap — commit-review traffic is
+ *  low, so a split (as the PR history store has) would buy nothing. */
+const MAX_PER_REPO = 20;
+
+/** In-session rows, across all repos — the toast's View button reads this list. */
+const MAX_IN_SESSION = 20;
+
+// Personal app-data, keyed by the repo's worktree-stable identity — never written
+// into the repo itself (the text quotes user source + may contain AI false
+// positives). Routed through storeName() so cold-start/test mode never pollutes
+// real results.
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("automation-results.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write through one in-process queue: autoSave persists
+// on a ~100ms debounce, so two overlapping writes would both reload the same
+// pre-flush disk snapshot and the later would drop the earlier's record (two review
+// modes of the same commit settle back to back). With the force-save in writeAll,
+// each reload sees fresh state.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  // Tolerate a missing store file: `load()` tolerates one but `reload()` rejects with
+  // a raw io error (os error 2) until the first `save()` creates the file — without
+  // this guard the first-ever write throws before reaching `save()` and the store can
+  // never bootstrap. Fall back to the loaded in-memory state on ANY reload failure.
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing file — the next save() creates it.
+  }
+}
+
+/** Shape-guard one record out of untrusted store JSON: a hand-edited (or older)
+ *  `automation-results.json` reaches the dialog verbatim, so a malformed record is
+ *  dropped rather than blanking the list or throwing mid-render. `phase` /
+ *  `timedOut` are compared by exact value elsewhere, never coerced. */
+function isStoredResult(x: unknown): x is AutomationRunResult {
+  if (typeof x !== "object" || x === null) return false;
+  const r = x as Record<string, unknown>;
+  return (
+    typeof r.id === "string" &&
+    typeof r.text === "string" &&
+    typeof r.subject === "string" &&
+    typeof r.createdAt === "string" &&
+    typeof r.hash === "string"
+  );
+}
+
+async function readByKey(key: string): Promise<AutomationRunResult[]> {
+  const store = await getStore();
+  const raw = await store.get<unknown>(key);
+  return Array.isArray(raw) ? raw.filter(isStoredResult) : [];
+}
+
+/** Reads a repo's records, merging in any still under a legacy checkout-path key
+ *  (folded onto the identity by the next write via `keyFor`). */
+async function readMerged(repo: string): Promise<AutomationRunResult[]> {
+  const id = await repoIdentity(repo);
+  const primary = await readByKey(id);
+  const legacy = id === repo ? [] : await readByKey(repo);
+  return mergeById(primary, legacy);
+}
+
+/** The identity store key for `repo`, folding any legacy checkout-path-keyed records
+ *  onto it once. Called inside the serialized queue (after `reloadRaw`) so the fold
+ *  is ordered with the write. */
+async function keyFor(repo: string): Promise<string> {
+  const store = await getStore();
+  return identityKeyFor<AutomationRunResult[]>(
+    store,
+    "automation-results",
+    repo,
+    mergeById,
+  );
+}
+
+/** Newest {@link MAX_PER_REPO} by `createdAt`. A record whose stamp doesn't parse
+ *  can't be ordered, so those sort after the dated ones and keep their insertion
+ *  order — a junk stamp costs its own position, never someone else's. */
+function prune(records: AutomationRunResult[]): AutomationRunResult[] {
+  return records
+    .map((record, index) => {
+      const ts = new Date(record.createdAt).getTime();
+      return { record, index, ts: Number.isNaN(ts) ? null : ts };
+    })
+    .sort((a, b) => {
+      if (a.ts === null || b.ts === null) {
+        if (a.ts !== b.ts) return a.ts === null ? 1 : -1;
+        return a.index - b.index;
+      }
+      return b.ts - a.ts;
+    })
+    .slice(0, MAX_PER_REPO)
+    .map((x) => x.record);
+}
+
+/** Upserts a record by id under its repo's identity key, then prunes. */
+async function persist(result: AutomationRunResult): Promise<void> {
+  return serialize(async () => {
+    await reloadRaw();
+    const store = await getStore();
+    const key = await keyFor(result.repoPath);
+    const all = await readByKey(key);
+    const without = all.filter((r) => r.id !== result.id);
+    await store.set(key, prune([result, ...without]));
+    // Flush now instead of on autoSave's debounce, so the next serialized reload
+    // can't re-read a pre-write disk snapshot and drop this record.
+    await store.save();
+  });
 }
 
 interface AutomationResultsState {
-  /** Newest first, capped — results are session-scoped, not persisted. */
+  /** Newest first, capped — this session's results; the durable copy is the store
+   *  file, which {@link openAutomationResult} reads on a miss. */
   results: AutomationRunResult[];
   /** Result shown in the viewer dialog, if any. */
   openId: string | null;
-  add: (result: AutomationRunResult) => void;
+  /** Inserts synchronously (so the completion toast's View button works at once);
+   *  the returned promise settles with the DURABLE write — it rejects when the
+   *  record didn't reach disk, so a caller can tell the user what was kept. */
+  add: (result: AutomationRunResult) => Promise<void>;
+  /** Puts a record read back from disk into the session list WITHOUT re-persisting
+   *  it. Internal to {@link openAutomationResult}; a re-persist would rewrite the
+   *  file on every restored open. */
+  hydrate: (result: AutomationRunResult) => void;
   setOpen: (id: string | null) => void;
 }
 
 export const useAutomationResults = create<AutomationResultsState>()((set) => ({
   results: [],
   openId: null,
-  add: (result) =>
-    set((s) => ({ results: [result, ...s.results].slice(0, 20) })),
+  add: (result) => {
+    set((s) => ({ results: [result, ...s.results].slice(0, MAX_IN_SESSION) }));
+    return persist(result);
+  },
+  hydrate: (result) =>
+    set((s) => ({
+      results: [result, ...s.results.filter((r) => r.id !== result.id)].slice(
+        0,
+        MAX_IN_SESSION,
+      ),
+    })),
   setOpen: (id) => set({ openId: id }),
 }));
+
+/**
+ * Opens a stored automation result in the viewer dialog — the click-through of an
+ * automated commit review's notification, which outlives the session that produced
+ * it. Reads the persisted copy when the session list doesn't hold the record, and
+ * says so when it's gone (pruned, or cleared with the repo's app data) rather than
+ * leaving a dead click.
+ */
+export async function openAutomationResult(
+  repoPath: string,
+  id: string,
+): Promise<void> {
+  const state = useAutomationResults.getState();
+  if (state.results.some((r) => r.id === id)) {
+    state.setOpen(id);
+    return;
+  }
+  const stored = await readMerged(repoPath).catch(
+    (): AutomationRunResult[] => [],
+  );
+  const found = stored.find((r) => r.id === id);
+  if (!found) {
+    toast.info("This review result is no longer available.");
+    return;
+  }
+  useAutomationResults.getState().hydrate(found);
+  useAutomationResults.getState().setOpen(id);
+}

--- a/src/lib/automations/results.ts
+++ b/src/lib/automations/results.ts
@@ -56,7 +56,10 @@ function getStore(): Promise<Store> {
 // on a ~100ms debounce, so two overlapping writes would both reload the same
 // pre-flush disk snapshot and the later would drop the earlier's record (two review
 // modes of the same commit settle back to back). With the force-save in writeAll,
-// each reload sees fresh state.
+// each reload sees fresh state. Cross-INSTANCE overlap (two app instances delivering
+// different runs) still races last-writer-wins like the sibling plugin stores — the
+// automation claim only keeps instances off the SAME run; cross-process locking for
+// this store class is a recorded deferral.
 let opChain: Promise<unknown> = Promise.resolve();
 function serialize<T>(op: () => Promise<T>): Promise<T> {
   const run = opChain.then(op, op);

--- a/src/lib/automations/results.ts
+++ b/src/lib/automations/results.ts
@@ -18,7 +18,7 @@ export interface AutomationRunResult {
   schemaVersion: 1;
   id: string;
   repoPath: string;
-  /** What was reviewed — a commit subject or PR title. */
+  /** What was reviewed: the commit's subject. */
   subject: string;
   mode: ReviewMode;
   text: string;
@@ -55,7 +55,7 @@ function getStore(): Promise<Store> {
 // Serialize every read-modify-write through one in-process queue: autoSave persists
 // on a ~100ms debounce, so two overlapping writes would both reload the same
 // pre-flush disk snapshot and the later would drop the earlier's record (two review
-// modes of the same commit settle back to back). With the force-save in writeAll,
+// modes of the same commit settle back to back). With the force-save in `persist`,
 // each reload sees fresh state. Cross-INSTANCE overlap (two app instances delivering
 // different runs) still races last-writer-wins like the sibling plugin stores — the
 // automation claim only keeps instances off the SAME run; cross-process locking for
@@ -83,8 +83,11 @@ async function reloadRaw(): Promise<void> {
 
 /** Shape-guard one record out of untrusted store JSON: a hand-edited (or older)
  *  `automation-results.json` reaches the dialog verbatim, so a malformed record is
- *  dropped rather than blanking the list or throwing mid-render. `phase` /
- *  `timedOut` are compared by exact value elsewhere, never coerced. */
+ *  dropped rather than blanking the list or throwing mid-render. Every field left
+ *  unchecked is guarded at its consumer instead: `mode` / `phase` / `timedOut` are
+ *  compared by exact value in `AutomationResultDialog` and `error` is typeof-guarded
+ *  at its render site there, `repoPath` is dereferenced only on the write path
+ *  (`persist`, whose caller is runner-typed), and `schemaVersion` is write-only. */
 function isStoredResult(x: unknown): x is AutomationRunResult {
   if (typeof x !== "object" || x === null) return false;
   const r = x as Record<string, unknown>;
@@ -210,9 +213,13 @@ export async function openAutomationResult(
     state.setOpen(id);
     return;
   }
-  const stored = await readMerged(repoPath).catch(
-    (): AutomationRunResult[] => [],
-  );
+  // Read through the write queue after a fresh reload: `getStore()` memoizes the
+  // first `load()`, so a record another instance wrote since then is absent from
+  // the cached snapshot and would read as pruned.
+  const stored = await serialize(async () => {
+    await reloadRaw();
+    return readMerged(repoPath);
+  }).catch((): AutomationRunResult[] => []);
   const found = stored.find((r) => r.id === id);
   if (!found) {
     toast.info("This review result is no longer available.");

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -26,6 +26,8 @@ import {
   forgePrDiff,
   forgeStatus,
   gitBranchDiff,
+  gitBranches,
+  gitBranchTips,
   gitCommitDiff,
   readRepoInstructions,
 } from "@/lib/git/api";
@@ -43,7 +45,10 @@ import {
 } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { effectiveReviewAi, loadSettings } from "@/lib/settings/api";
-import { pushNotification } from "@/lib/stores/notifications";
+import {
+  type NotificationTarget,
+  pushNotification,
+} from "@/lib/stores/notifications";
 import {
   type ReviewTarget,
   registerAutomationRun,
@@ -56,7 +61,7 @@ import {
   getDismissedHeadMap,
   setDismissedHead,
 } from "./dismissals";
-import { useAutomationResults } from "./results";
+import { type AutomationRunResult, useAutomationResults } from "./results";
 import { loadAutomations, repoAutomationsFor } from "./store";
 import { sameSha } from "./sync";
 import { branchConditionsPass, effectiveActions } from "./types";
@@ -549,6 +554,9 @@ async function run(
         kind: label,
         model: reviewCfg.model,
         automated: true,
+        // Unattended seam: suspect `#N` refs are backtick-wrapped with a disclosure
+        // line (owner ruling) — the manual panel confirms with the user instead.
+        neutralizeRefs: true,
         text,
       });
       await deliver(event, action, body, text, notify);
@@ -587,6 +595,9 @@ async function run(
       // Coverage stays safe for free: a PARTIAL is dropped by `listReviews`, so the
       // pr-sync gate still sees this head as un-reviewed and re-reviews it.
       let keptPartial = false;
+      // A kept COMMIT partial's record id — the failure row's click target, since a
+      // commit review has no panel to restore the output into.
+      let partialResultId = "";
       if (
         progress.timedOut &&
         progress.text.trim() !== "" &&
@@ -605,6 +616,31 @@ async function run(
           .then(() => true)
           .catch(() => false);
       }
+      if (
+        event.kind === "commit" &&
+        progress.timedOut &&
+        progress.text.trim() !== ""
+      ) {
+        const partial: AutomationRunResult = {
+          schemaVersion: 1,
+          id: crypto.randomUUID(),
+          repoPath: event.repoPath,
+          subject: event.title,
+          mode: action,
+          text: progress.text,
+          createdAt: new Date().toISOString(),
+          hash: event.hash,
+          phase: "error",
+          error: message,
+          timedOut: true,
+        };
+        partialResultId = partial.id;
+        keptPartial = await useAutomationResults
+          .getState()
+          .add(partial)
+          .then(() => true)
+          .catch(() => false);
+      }
       toast.error(`AI ${label} failed: ${message}`);
       // Inbox parity with manual runs (reviews.ts's notifyReviewDone): a genuine failure
       // records an inbox row too, gated on the same automations pref.
@@ -616,15 +652,38 @@ async function run(
             ? `"${event.hash.slice(0, 7)}"`
             : `"${event.title}"`;
         const reason = message.trim() ? `${subject} — ${message}` : subject;
+        // Where the kept output waits differs by event: a PR partial is restored into
+        // the review panel, a commit partial only through this row.
+        const partialNote =
+          event.kind === "commit"
+            ? "Partial output is kept — open it from this notification."
+            : "Partial output is kept under Previous reviews.";
         // The inbox row is where a kept partial gets discovered — a durable failure that
         // doesn't mention it reads as a run with nothing to show for it.
         const subtitle = keptPartial
-          ? `${reason}${reason.endsWith(".") ? "" : "."} Partial output is kept under Previous reviews.`
+          ? `${reason}${reason.endsWith(".") ? "" : "."} ${partialNote}`
           : reason;
         // Local alias for the loop's `action: ReviewMode` — the Re-run closure's
         // `run` body sees the outer `action` fine, but aliasing keeps the object
         // literal (which also has a field named `action`) unambiguous to read.
         const mode = action;
+        // A commit row navigates only when a partial actually landed — that record
+        // is the whole click-through. PR rows always land on their PR: automations
+        // run against the fork's own PRs (the poll that feeds them pins the origin
+        // slug deliberately), so the lens rides along.
+        let target: NotificationTarget | undefined;
+        if (event.kind === "commit") {
+          if (keptPartial) {
+            target = { type: "automation-result", id: partialResultId };
+          }
+        } else {
+          target = {
+            type: "pr",
+            kind: event.target.type,
+            ref: targetRef(event),
+            lens: "origin",
+          };
+        }
         pushNotification({
           kind: "review-failed",
           tone: "danger",
@@ -632,19 +691,7 @@ async function run(
           subtitle,
           repoPath: event.repoPath,
           repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
-          ...(event.kind === "commit"
-            ? {}
-            : {
-                target: {
-                  type: "pr",
-                  kind: event.target.type,
-                  ref: targetRef(event),
-                  // Automations run against the fork's own PRs: the poll that
-                  // feeds them pins the origin slug deliberately, so the
-                  // click-through lands there too.
-                  lens: "origin",
-                },
-              }),
+          target,
           // This run's stopped dock row; passing a dismissed key is safe (resetReview
           // no-ops on a gone key).
           action: {
@@ -782,25 +829,55 @@ async function resolveDiff(
     return { text, truncated: false, files: filesFromDiff(text) };
   }
   if (event.target.type === "remote") {
-    // Remote pr-open: prefer the local branch diff (it carries numstat), but the head
-    // branch isn't guaranteed local — catch-up / ready-flip events cover PRs opened
-    // elsewhere that reach this machine before any fetch lands the ref (observed live:
-    // `git diff` fails on an unfetched head). Fall back to the provider's PR diff.
-    try {
-      return await gitBranchDiff(
-        event.repoPath,
-        event.base,
-        event.head,
-        DIFF_MAX_BYTES,
-      );
-    } catch {
-      const text = await forgePrDiff(
-        event.repoPath,
-        event.target.number,
-        "origin",
-      );
+    // Remote pr-open: the local branches are only a shortcut (they carry numstat) and
+    // are trusted ONLY when provably fresh — a stale-but-present local ref returns a
+    // clean but WRONG diff, which is worse than the unfetched-head case that merely
+    // throws. Head freshness is the event's headSha against the local tip; the poll
+    // payload carries no base OID, so the base's own upstream tracking is the
+    // strongest local signal there is. Everything unverifiable — no headSha, an
+    // unfetched or moved head, a base that is untracked/gone/diverged, a probe that
+    // throws, or an empty local diff (inconclusive for a remote target) — reads the
+    // provider's PR diff, the source of truth this review needs for delivery anyway.
+    // Deliberately no fetch: a review must not mutate refs, and it would still race.
+    // Hoisted: the narrowing to the remote target doesn't flow into the closures.
+    const prNumber = event.target.number;
+    const { repoPath, base, head } = event;
+    const headSha = event.headSha ?? "";
+    // Origin-pinned — the poller is origin-scoped, so this tracks the fork's own PRs.
+    const providerDiff = async () => {
+      const text = await forgePrDiff(repoPath, prNumber, "origin");
       return { text, truncated: false, files: filesFromDiff(text) };
-    }
+    };
+    const localRefsFresh = async (): Promise<boolean> => {
+      if (!headSha) return false;
+      try {
+        const [tips, branches] = await Promise.all([
+          gitBranchTips(repoPath, [head]),
+          gitBranches(repoPath),
+        ]);
+        const tip = tips[head];
+        if (!tip || !sameSha(tip, headSha)) return false;
+        const baseBranch = branches.find((b) => b.name === base);
+        return (
+          baseBranch !== undefined &&
+          baseBranch.upstream !== null &&
+          !baseBranch.upstreamGone &&
+          baseBranch.upstreamAhead === 0 &&
+          baseBranch.upstreamBehind === 0
+        );
+      } catch {
+        return false;
+      }
+    };
+    if (!(await localRefsFresh())) return providerDiff();
+    const local = await gitBranchDiff(
+      repoPath,
+      base,
+      head,
+      DIFF_MAX_BYTES,
+    ).catch(() => null);
+    if (!local || !local.text.trim()) return providerDiff();
+    return local;
   }
   // Local PR targets: both branches are inherently local.
   return gitBranchDiff(event.repoPath, event.base, event.head, DIFF_MAX_BYTES);
@@ -1049,17 +1126,25 @@ async function deliver(
   const osPing = notify && !(await loadSettings().catch(() => null))?.hideAi;
 
   if (event.kind === "commit") {
-    // Commits have no comment surface — keep the result in-session and let
-    // the toast open it.
-    const result = {
+    // Commits have no comment surface — the results store is this review's only
+    // home, so the record is persisted before the toast and the inbox row that
+    // both point at it.
+    const result: AutomationRunResult = {
+      schemaVersion: 1,
       id: crypto.randomUUID(),
       repoPath: event.repoPath,
       subject: event.title,
       mode,
       text: rawText,
       createdAt: new Date().toISOString(),
+      hash: event.hash,
     };
-    useAutomationResults.getState().add(result);
+    // The session insert is synchronous; only the durable write is awaited, and a
+    // store failure must never break delivery (the toast still opens the result).
+    await useAutomationResults
+      .getState()
+      .add(result)
+      .catch(() => undefined);
     toast.success(`AI ${label} of ${event.hash.slice(0, 7)} ready`, {
       duration: 15_000,
       action: {
@@ -1067,6 +1152,21 @@ async function deliver(
         onClick: () => useAutomationResults.getState().setOpen(result.id),
       },
     });
+    // Inbox parity with the failure path (and with manual runs): the row is gated on
+    // the automations pref ALONE, never on hideAi — the dock filters AI rows at
+    // render time, so hiding AI mutes the ping without losing the history.
+    if (notify) {
+      pushNotification({
+        kind: "review-ready",
+        tone: "success",
+        title: `AI ${label} of ${event.hash.slice(0, 7)} ready`,
+        subtitle: event.title,
+        repoPath: event.repoPath,
+        repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
+        target: { type: "automation-result", id: result.id },
+        dedupeKey: `automation-review:${event.repoPath}:commit:${event.hash}:${mode}`,
+      });
+    }
     if (osPing) {
       void notifyIfUnfocused(
         `AI ${label} ready`,
@@ -1093,6 +1193,27 @@ async function deliver(
       queryKey: ["repo", event.repoPath, "pr", "origin", event.target.number],
     });
     toast.success(`AI ${label} posted on #${event.target.number}`);
+    // Gated on the automations pref alone — see the commit arm.
+    if (notify) {
+      const prNumber = event.target.number;
+      pushNotification({
+        kind: "review-ready",
+        tone: "success",
+        title: `AI ${label} posted on #${prNumber}`,
+        subtitle: `"${event.title}"`,
+        repoPath: event.repoPath,
+        repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
+        // The lens rides both the target and the dedupe key: a fork's origin and
+        // upstream PRs share a number, and automations are origin-pinned.
+        target: {
+          type: "pr",
+          kind: "remote",
+          ref: String(prNumber),
+          lens: "origin",
+        },
+        dedupeKey: `automation-review:${event.repoPath}:remote:origin:${prNumber}:${mode}`,
+      });
+    }
     if (osPing) {
       void notifyIfUnfocused(
         `AI ${label} posted on #${event.target.number}`,
@@ -1126,6 +1247,18 @@ async function deliver(
     queryKey: ["local-prs", event.repoPath],
   });
   toast.success(`AI ${label} added to "${pr.title}"`);
+  // Gated on the automations pref alone — see the commit arm.
+  if (notify) {
+    pushNotification({
+      kind: "review-ready",
+      tone: "success",
+      title: `AI ${label} added to "${pr.title}"`,
+      repoPath: event.repoPath,
+      repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
+      target: { type: "pr", kind: "local", ref: targetId, lens: "origin" },
+      dedupeKey: `automation-review:${event.repoPath}:local:origin:${targetId}:${mode}`,
+    });
+  }
   if (osPing) {
     void notifyIfUnfocused(`AI ${label} finished`, `Local PR "${pr.title}"`);
   }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -554,8 +554,9 @@ async function run(
         kind: label,
         model: reviewCfg.model,
         automated: true,
-        // Unattended seam: suspect `#N` refs are backtick-wrapped with a disclosure
-        // line (owner ruling) — the manual panel confirms with the user instead.
+        // Unattended seam: suspect `#N` refs are backtick-wrapped — or, where a
+        // wrap can't neutralize (raw HTML), left alone — with a disclosure line
+        // naming each (owner ruling); the manual panel confirms with the user.
         neutralizeRefs: true,
         text,
       });

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -78,6 +78,7 @@ const IDENTITY_STORES: IdentityStore[] = [
   { file: "local-prs.json", merge: "id-merge" },
   { file: "local-issues.json", merge: "id-merge" },
   { file: "pr-reviews.json", merge: "id-merge" },
+  { file: "automation-results.json", merge: "id-merge" },
   { file: "pr-review-drafts.json", merge: "inner-key" },
   { file: "review-notes.json", merge: "inner-key" },
   { file: "automation-dismissals.json", merge: "inner-key" },

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -68,6 +68,11 @@ export type NotificationTarget =
       reviewId?: string;
     }
   | { type: "run"; runId: number }
+  | {
+      type: "automation-result";
+      /** Persisted AutomationRunResult id — opens the app-root result dialog. */
+      id: string;
+    }
   | { type: "agent" }
   | { type: "repo" };
 


### PR DESCRIPTION
Automated commit reviews previously lived only in session memory and left no inbox row, so a restart lost the text and the completion toast was the only way to reach it. This persists those results per repo, gives every finished automated review a click-through notification, stops posted review text from minting stray `#N` cross-references, and keeps remote PR reviews from diffing stale local branches.

### Durable commit-review results

- Rewrites `src/lib/automations/results.ts` around a persisted `automation-results.json` plugin store: records gain `schemaVersion`, `hash`, and the partial-run fields (`phase`, `error`, `timedOut`), keyed by worktree-stable repo identity via `repoIdentity`/`identityKeyFor` with legacy checkout-path records folded in through `mergeById`.
- Serializes every read-modify-write through a single `opChain` queue with a forced `store.save()`, since `autoSave`'s debounce would otherwise let two overlapping writes reload the same pre-flush snapshot and drop a record; `reloadRaw` tolerates the missing-file case so the first write can bootstrap.
- Adds `isStoredResult` shape-guarding, `prune` to `MAX_PER_REPO` newest-first (unparseable stamps sort last and keep insertion order), and `hydrate` so a disk-restored record enters the session list without re-persisting.
- Adds `openAutomationResult(repoPath, id)`, which serves from the session list, falls back to the persisted copy, and toasts "This review result is no longer available." rather than leaving a dead click.
- Registers `automation-results.json` in `IDENTITY_STORES` in `src/lib/repo-data-migration.ts` so results follow a relocated repo.

### Notification click-through

- Adds the `automation-result` variant to `NotificationTarget` in `src/lib/stores/notifications.ts`, and routes it in `ActivityDock.tsx` to `openAutomationResult`.
- `src/lib/automations/runner.ts` now pushes a `review-ready` row on all three delivery arms (commit, remote PR, local PR), gated on the automations pref alone rather than `hideAi`, each with a lens-aware `dedupeKey`.
- The failure path persists a kept commit partial as an `AutomationRunResult` and points the row's target at it; the subtitle's `partialNote` now differs by event kind ("open it from this notification" for commits, "Previous reviews" for PRs). PR rows keep their origin-pinned `pr` target, hoisted out of the old inline spread into a `target` variable.
- `AutomationResultDialog.tsx` shows the short hash in the description and a warning `Badge` ("Timed out — partial output" / "Stopped early") plus the error text for records with `phase: "error"`.

### Forge-reference guard

- `src/lib/ai/comment-branding.ts` grows a shared detector: `REF_TRIGGERS` per provider, a single `scanRefs` pass that skips fenced blocks, inline code spans, markdown link syntax, and indented code, plus `findSuspectRefs`, `neutralizeSuspectRefs`, and `formatRefList`. The module is kept dependency-free and erasable-syntax-only so the test can import it under Node's type stripping.
- `buildAiCommentBody` accepts `neutralizeRefs`, backtick-wrapping suspect tokens and appending a one-line disclosure that names only the neutralized forms — so the disclosure itself can't cross-reference.
- `PrReviewPanel.tsx` merges the partial-run confirm and the new live-reference warning into one `useConfirm` dialog (a second ask would cancel the first), never rewriting the text; it resolves triggers from `context.provider`, defaulting to GitHub's single `#`.
- `runner.ts` passes `neutralizeRefs: true` on the unattended seam, and `src/lib/ai/prompt.ts` tightens `REFERENCE_RULE` to state that `#` itself is what links and that `(#1)` is not neutralized.

### Stale-diff fix and tests

- `resolveDiff` in `runner.ts` now trusts local branches for a remote PR only when provably fresh — the event's `headSha` must match the local tip (`gitBranchTips`) and the base branch must be tracked, present, and neither ahead nor behind (`gitBranches`) — otherwise it reads the provider's PR diff. An empty local diff also falls back. No fetch is issued, so the review never mutates refs.
- Adds `scripts/comment-refs.test.mjs`, a `node:test` suite (no dev dependency, runnable via `node --test "scripts/*.test.mjs"`) covering the detector's skip regions, number grammar, trigger sets, idempotent neutralization, `formatRefList` capping, and a spelled-out golden comment body as a template-drift tripwire.
- Adds four changelog fragments under `changelog.d/` covering reference confirmation, inbox rows, the stale diff, and commit-review durability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated review results now appear in Notifications with click-through access.
  - Commit review results persist between sessions, including partial output from timed-out runs.
  - Result details show commit identifiers and clearer timeout or early-stop status.
  - Remote pull request reviews use the latest available changes when local branches are outdated.

- **Bug Fixes**
  - AI-generated comments now warn about potentially unintended references and safely neutralize them during automated posting.
  - Interactive review posting combines reference and partial-output warnings into one confirmation.
  - Automation notifications now include ready, posted, and failed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->