### PR TITLE
fix(lists,branches,history,sessions): key virtual rows and tighten gates

### DIFF
--- a/changelog.d/changed-stash-offer-reapply.md
+++ b/changelog.d/changed-stash-offer-reapply.md
@@ -1,0 +1,4 @@
+- When bringing uncommitted changes to another branch isn't possible, the stash
+  offer that follows now leads with **Stash and switch** and comes with **Reapply
+  after switching** already ticked for that switch, so your changes still land on
+  the new branch. Your saved preference stays as you set it.

--- a/changelog.d/changed-stash-offer-reapply.md
+++ b/changelog.d/changed-stash-offer-reapply.md
@@ -1,4 +1,5 @@
 - When bringing uncommitted changes to another branch isn't possible, the stash
   offer that follows now leads with **Stash and switch** and comes with **Reapply
-  after switching** already ticked for that switch, so your changes still land on
-  the new branch. Your saved preference stays as you set it.
+  after switching** already ticked for that switch (unless you unticked it
+  yourself), so your changes still land on the new branch. Your saved preference
+  stays as you set it.

--- a/changelog.d/fixed-amend-rules-settling.md
+++ b/changelog.d/fixed-amend-rules-settling.md
@@ -1,2 +1,3 @@
-- Amending a pushed commit now checks your branch protection rules before
-  offering the force-push, and again when you confirm it.
+- Amending a pushed commit now waits for branch protection rules to finish
+  loading before offering the force-push, and re-checks them when you confirm
+  it.

--- a/changelog.d/fixed-amend-rules-settling.md
+++ b/changelog.d/fixed-amend-rules-settling.md
@@ -1,0 +1,2 @@
+- Amending a pushed commit now checks your branch protection rules before
+  offering the force-push, and again when you confirm it.

--- a/changelog.d/fixed-branch-rules-offline.md
+++ b/changelog.d/fixed-branch-rules-offline.md
@@ -1,0 +1,2 @@
+- Committing, cleaning up branches, and editing branch rules keep working while
+  you're offline — branch rules load from disk without waiting for a connection.

--- a/changelog.d/fixed-narration-file-links.md
+++ b/changelog.d/fixed-narration-file-links.md
@@ -1,0 +1,2 @@
+- File paths in a session transcript stay clickable for the life of the message,
+  and middle-clicking one opens it in your editor just like a left click.

--- a/changelog.d/fixed-virtualized-list-keys.md
+++ b/changelog.d/fixed-virtualized-list-keys.md
@@ -1,0 +1,4 @@
+- Long lists stay cleanly laid out while you filter them — the clone and Explore
+  repository browsers, **Repository files**, and **Code TODOs** keep every row at its
+  own height as results narrow, and switching tabs brings each list back in at the
+  top.

--- a/changelog.d/fixed-virtualized-list-keys.md
+++ b/changelog.d/fixed-virtualized-list-keys.md
@@ -1,4 +1,4 @@
 - Long lists stay cleanly laid out while you filter them — the clone and Explore
   repository browsers, **Repository files**, and **Code TODOs** keep every row at its
-  own height as results narrow, and switching tabs brings each list back in at the
-  top.
+  own height as results narrow, and switching provider or file tabs brings that list
+  back in at the top.

--- a/src/features/code-todos/CodeTodosPanel.tsx
+++ b/src/features/code-todos/CodeTodosPanel.tsx
@@ -5,7 +5,7 @@ import {
   ListChecksIcon,
 } from "@phosphor-icons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -35,6 +35,12 @@ type FlatRow =
 /** DOM key for an item row (also its selection identity). */
 function itemKey(item: TodoScanItem): string {
   return `${item.path}:${item.line}`;
+}
+
+/** Row identity, shared by the virtualizer's size cache and the React key so the
+ *  two can't disagree about which row an index holds. */
+function rowKeyOf(row: FlatRow): string {
+  return row.type === "header" ? `h:${row.path}` : `i:${itemKey(row.item)}`;
 }
 
 export function CodeTodosPanel({
@@ -122,10 +128,24 @@ export function CodeTodosPanel({
     return { flatRows: rows, navItems: nav };
   }, [visibleItems, collapsed]);
 
+  // The virtualizer keys its measurement projection on `getItemKey`'s IDENTITY,
+  // so this is re-minted per row sequence rather than per render — `flatRows` is
+  // memo-stable, making it the sequence's only input.
+  const getItemKey = useCallback(
+    (index: number) => {
+      const row = flatRows[index];
+      return row ? rowKeyOf(row) : index;
+    },
+    [flatRows],
+  );
   const virtualizer = useVirtualizer({
     count: flatRows.length,
     getScrollElement: () => scrollEl,
     estimateSize: (i) => (flatRows[i].type === "header" ? 28 : 32),
+    // Key by row identity, not index: the filter and collapsing a group permute
+    // headers and items through the same indexes, and an index key hands a 28px
+    // header the height measured for the 32px item row that sat there before.
+    getItemKey,
     overscan: 16,
   });
 
@@ -301,11 +321,7 @@ export function CodeTodosPanel({
                   const row = flatRows[vi.index];
                   return (
                     <div
-                      key={
-                        row.type === "header"
-                          ? `header:${row.path}`
-                          : itemKey(row.item)
-                      }
+                      key={rowKeyOf(row)}
                       data-index={vi.index}
                       ref={virtualizer.measureElement}
                       className="absolute top-0 left-0 w-full"

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -322,6 +322,10 @@ function YoursResults({
   }
   return (
     <ResultsList
+      // A cached provider resolves synchronously, so the list never unmounts
+      // between providers — key it or the surviving virtualizer carries one
+      // account's scroll offset onto the other's repositories.
+      key={provider}
       rows={rows}
       selected={selected}
       onSelect={onSelect}
@@ -349,10 +353,17 @@ function SearchResults({
 }) {
   const search = useForgeSearchRepos(provider, query, sort, true);
 
-  const repos = useMemo<ForgeSearchRepo[]>(
-    () => search.data?.pages.flatMap((p) => p.repos) ?? [],
-    [search.data],
-  );
+  // Dedupe by full name: the forge's index can shift between page fetches and
+  // repeat a repo, which the content-derived row keys would collide on — one
+  // React key and one measurement entry for two rows.
+  const repos = useMemo<ForgeSearchRepo[]>(() => {
+    const seen = new Set<string>();
+    return (search.data?.pages.flatMap((p) => p.repos) ?? []).filter((r) => {
+      if (seen.has(r.fullName)) return false;
+      seen.add(r.fullName);
+      return true;
+    });
+  }, [search.data]);
   // Search results are already provider-ranked (best/stars/updated), so present
   // them flat — no owner grouping, which would fight the ranking.
   const rows = useMemo<ExploreRow[]>(

--- a/src/features/explore/ExploreScreen.tsx
+++ b/src/features/explore/ExploreScreen.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -373,6 +374,10 @@ function SearchResults({
   }
   return (
     <ResultsList
+      // A cached search resolves synchronously, so the list never unmounts
+      // between queries — key it on the search's identity (this hook's query-key
+      // axes) or the surviving virtualizer paints new rows at the old offset.
+      key={`${provider}:${sort}:${query}`}
       rows={rows}
       selected={selected}
       onSelect={onSelect}
@@ -423,10 +428,27 @@ function ResultsList({
   footer?: React.ReactNode;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
+  // The virtualizer keys its measurement projection on `getItemKey`'s IDENTITY,
+  // so this is re-minted per row sequence rather than per render — `rows` is
+  // memo-stable, making it the sequence's only input.
+  const getItemKey = useCallback(
+    (index: number) => {
+      const row = rows[index];
+      if (!row) return index;
+      return row.kind === "header"
+        ? `h:${row.owner}`
+        : `r:${row.repo.fullName}`;
+    },
+    [rows],
+  );
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (i) => (rows[i].kind === "header" ? 26 : 46),
+    // Key by row identity, not index: a new query replaces the rows wholesale
+    // and Load more appends, and an index key hands a 26px header the height
+    // measured for the 46px repo row that sat there before.
+    getItemKey,
     overscan: 12,
   });
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -655,8 +655,11 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 {{/ai}}- Switching with **uncommitted changes** prompts you to bring them along or stash
   and switch. Tick **Reapply after switching** on that prompt to have the stashed changes
   put back for you once the switch lands; leave it unticked and they stay in the stash until
-  you pop them. If reapplying them hits conflicts, the files appear in **Changes** to resolve
-  and the stash is kept as a backup. Your choice is remembered for next time.
+  you pop them. If bringing changes along doesn't work, the prompt returns with **Reapply
+  after switching** already ticked for that switch; your saved choice changes only when you
+  tick or untick it yourself. If reapplying them hits conflicts, the files appear in
+  **Changes** to resolve and the stash is kept as a backup. Your choice is remembered for
+  next time.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it
   from the default branch** ({{kbd:update-from-default}}) — the last *without* checking it
   out. On a branch listed under **Promotion branches** in *Branch rules*, that update offer

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -656,10 +656,10 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
   and switch. Tick **Reapply after switching** on that prompt to have the stashed changes
   put back for you once the switch lands; leave it unticked and they stay in the stash until
   you pop them. If bringing changes along doesn't work, the prompt returns with **Reapply
-  after switching** already ticked for that switch; your saved choice changes only when you
-  tick or untick it yourself. If reapplying them hits conflicts, the files appear in
-  **Changes** to resolve and the stash is kept as a backup. Your choice is remembered for
-  next time.
+  after switching** already ticked for that switch (an untick you made yourself stands);
+  your saved choice changes only when you tick or untick it yourself. If reapplying them
+  hits conflicts, the files appear in **Changes** to resolve and the stash is kept as a
+  backup. Your choice is remembered for next time.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it
   from the default branch** ({{kbd:update-from-default}}) — the last *without* checking it
   out. On a branch listed under **Promotion branches** in *Branch rules*, that update offer

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -655,11 +655,12 @@ The branch name in the header opens the **branch switcher** ({{kbd:show-branches
 {{/ai}}- Switching with **uncommitted changes** prompts you to bring them along or stash
   and switch. Tick **Reapply after switching** on that prompt to have the stashed changes
   put back for you once the switch lands; leave it unticked and they stay in the stash until
-  you pop them. If bringing changes along doesn't work, the prompt returns with **Reapply
-  after switching** already ticked for that switch (an untick you made yourself stands);
-  your saved choice changes only when you tick or untick it yourself. If reapplying them
-  hits conflicts, the files appear in **Changes** to resolve and the stash is kept as a
-  backup. Your choice is remembered for next time.
+  you pop them. If bringing changes along doesn't work, the prompt returns suggesting
+  **Stash and switch**, with **Bring changes** set aside and its reason on hover, and
+  **Reapply after switching** already ticked for that switch (an untick you made yourself
+  stands). Your saved choice changes only when you tick or untick it yourself. If reapplying
+  them hits conflicts, the files appear in **Changes** to resolve and the stash is kept as a
+  backup.
 - {{Secondaryclick}} a branch to **merge**, **squash and merge**, **rebase**, or **update it
   from the default branch** ({{kbd:update-from-default}}) — the last *without* checking it
   out. On a branch listed under **Promotion branches** in *Branch rules*, that update offer

--- a/src/features/history/useAmendCommit.ts
+++ b/src/features/history/useAmendCommit.ts
@@ -1,7 +1,10 @@
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { isForcePushBlocked } from "@/lib/branch-rules/match";
-import { useEffectiveBranchRules } from "@/lib/branch-rules/queries";
+import {
+  useEffectiveBranchRules,
+  useEffectiveBranchRulesSettling,
+} from "@/lib/branch-rules/queries";
 import { gitCommitDetails } from "@/lib/git/api";
 import { useRepoStatus } from "@/lib/git/queries";
 import { useSettings } from "@/lib/settings/queries";
@@ -29,6 +32,12 @@ export function useAmendCommit(repoPath: string) {
   );
 }
 
+const RULES_SETTLING_MESSAGE =
+  "Branch rules are still loading — try again in a moment";
+
+const protectedBranchMessage = (name: string) =>
+  `${name} is protected: force-pushing (amending a pushed commit) is blocked by a branch rule`;
+
 /**
  * Amend, gated by a force-push confirmation when the commit is already on the
  * remote (an upstream exists and HEAD isn't ahead of it). Returns the request
@@ -39,6 +48,11 @@ export function useAmendWithConfirm(repoPath: string) {
   const status = useRepoStatus(repoPath);
   const settings = useSettings();
   const rulesConfig = useEffectiveBranchRules(repoPath);
+  // While either rules scope is on its FIRST read the effective config stands in
+  // as empty, so `isForcePushBlocked` is vacuously false — the force-push arm
+  // holds on this instead. A plain amend never consults the rules, so it never
+  // holds.
+  const rulesSettling = useEffectiveBranchRulesSettling(repoPath);
   const amend = useAmendCommit(repoPath);
   const [pendingHash, setPendingHash] = useState<string | null>(null);
 
@@ -50,19 +64,23 @@ export function useAmendWithConfirm(repoPath: string) {
   const needsForcePush =
     upstream !== null && !branch?.upstreamGone && (branch?.ahead ?? 0) === 0;
 
-  function requestAmend(hash: string) {
-    // Amending an already-pushed commit means force-pushing it. If a branch
-    // rule blocks force-pushes here, refuse outright rather than confirm.
-    if (
-      needsForcePush &&
-      branch?.name &&
-      isForcePushBlocked(rulesConfig, branch.name)
-    ) {
-      toast.error(
-        `${branch.name} is protected: force-pushing (amending a pushed commit) is blocked by a branch rule`,
-      );
-      return;
+  // Amending an already-pushed commit means force-pushing it. Shared by request
+  // and confirm so the two refusal paths can't drift.
+  function forcePushRefused(): boolean {
+    if (!needsForcePush) return false;
+    if (rulesSettling) {
+      toast.error(RULES_SETTLING_MESSAGE);
+      return true;
     }
+    if (branch?.name && isForcePushBlocked(rulesConfig, branch.name)) {
+      toast.error(protectedBranchMessage(branch.name));
+      return true;
+    }
+    return false;
+  }
+
+  function requestAmend(hash: string) {
+    if (forcePushRefused()) return;
     if (needsForcePush && (settings.data?.confirmAmendForcePush ?? true)) {
       setPendingHash(hash);
     } else {
@@ -73,6 +91,9 @@ export function useAmendWithConfirm(repoPath: string) {
   function confirmAmend() {
     const hash = pendingHash;
     setPendingHash(null);
+    // The gate can flip under an open dialog: the rules may have settled to
+    // blocked, or may still be settling.
+    if (forcePushRefused()) return;
     if (hash) amend(hash).catch(toastError);
   }
 

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -346,6 +346,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   // "Reapply after switching" — seeded from the saved preference each time the
   // dialog opens fresh, and persisted back when the user changes it.
   const [reapplyOnSwitch, setReapplyOnSwitch] = useState(false);
+  // Whether the user touched that checkbox since the dialog last opened. A ref
+  // because the dirty-tree refusal branch reads it after an await. It gates two
+  // things: the auto-tick there (an explicit untick is the user's call and is
+  // never overridden) and the persist below, so an auto-tick stays session-only.
+  const reapplyTouchedRef = useRef(false);
   // Why a first switch attempt didn't work, shown when the dialog re-opens.
   const [switchHint, setSwitchHint] = useState<string | null>(null);
   // The worktree pending a "Promote to main workspace" confirm — set by the
@@ -921,6 +926,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (hasChangesRef.current) {
       setSwitchHint(null);
       setReapplyOnSwitch(settings.data?.reapplyStashOnSwitch ?? false);
+      reapplyTouchedRef.current = false;
       setSwitchTarget({ name, remote });
       return;
     }
@@ -930,15 +936,26 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
   function bringAndSwitch() {
     if (!switchTarget) return;
     const target = switchTarget;
+    // Captured with the target: the refusal branch below runs after an await and
+    // must decide from the checkbox (and its touched flag) as they stood when
+    // THIS switch started — a dialog reopened mid-checkout owns the live values.
+    const reapply = reapplyOnSwitch;
+    const touched = reapplyTouchedRef.current;
     setSwitchTarget(null);
     void runCheckout(target, {
       onError: (e) => {
         // git refused to carry the changes over rather than failing outright —
         // re-open the choice with stashing pointed out, instead of a dead-end
-        // toast. The checkbox keeps whatever the user already set.
+        // toast. Reapply is auto-ticked for this switch alone (session-only: the
+        // persist below stays gated on an explicit toggle) so the changes still
+        // come along — unless the user unticked it here, which stands.
         if (isDirtyTreeRefusal(e)) {
+          const willReapply = !touched || reapply;
+          if (!touched) setReapplyOnSwitch(true);
           setSwitchHint(
-            "Bringing changes didn't work — git would overwrite them. Stash and switch instead.",
+            willReapply
+              ? "Bringing changes didn't work — git would overwrite them. Stash and switch instead: Reapply is set, so your changes still come along."
+              : "Bringing changes didn't work — git would overwrite them. Stash and switch instead.",
           );
           setSwitchTarget(target);
           return;
@@ -955,7 +972,11 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     const target = switchTarget;
     const reapply = reapplyOnSwitch;
     setSwitchTarget(null);
-    if (settings.data && settings.data.reapplyStashOnSwitch !== reapply) {
+    if (
+      reapplyTouchedRef.current &&
+      settings.data &&
+      settings.data.reapplyStashOnSwitch !== reapply
+    ) {
       // Fire-and-forget, and deliberately silent: a preference that didn't
       // persist must neither delay the switch nor report over its outcome.
       void saveSettings
@@ -2963,7 +2984,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         currentLabel={currentLabel}
         hint={switchHint}
         reapply={reapplyOnSwitch}
-        onReapplyChange={setReapplyOnSwitch}
+        onReapplyChange={(v) => {
+          reapplyTouchedRef.current = true;
+          setReapplyOnSwitch(v);
+        }}
         onCancel={() => setSwitchTarget(null)}
         onBringChanges={bringAndSwitch}
         onStashAndSwitch={stashAndSwitch}

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -937,9 +937,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     if (!switchTarget) return;
     const target = switchTarget;
     // Captured with the target: the refusal branch below runs after an await and
-    // must decide from the checkbox (and its touched flag) as they stood when
-    // THIS switch started — a dialog reopened mid-checkout owns the live values.
-    const reapply = reapplyOnSwitch;
+    // must decide from the touched flag as it stood when THIS switch started — a
+    // dialog reopened mid-checkout owns the live values.
     const touched = reapplyTouchedRef.current;
     setSwitchTarget(null);
     void runCheckout(target, {
@@ -950,12 +949,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
         // persist below stays gated on an explicit toggle) so the changes still
         // come along — unless the user unticked it here, which stands.
         if (isDirtyTreeRefusal(e)) {
-          const willReapply = !touched || reapply;
           if (!touched) setReapplyOnSwitch(true);
           setSwitchHint(
-            willReapply
-              ? "Bringing changes didn't work — git would overwrite them. Stash and switch instead: Reapply is set, so your changes still come along."
-              : "Bringing changes didn't work — git would overwrite them. Stash and switch instead.",
+            "Bringing changes didn't work — git would overwrite them. Stash and switch instead.",
           );
           setSwitchTarget(target);
           return;

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type KeyboardEvent,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -801,6 +802,10 @@ export function RepositoryFilesDialog({
             </p>
           ) : (
             <FileList
+              // One FileList serves all three tabs, so a switch is a wholesale
+              // content swap: remount it, or the surviving virtualizer reuses
+              // the previous tab's measured row heights and scroll offset.
+              key={tab}
               paths={filtered}
               rowInfo={tab === "ai" ? aiRowInfo : ignoredRowInfo}
               rowSuffix={tab === "ai" ? aiRowSuffix : undefined}
@@ -1107,10 +1112,21 @@ function FileList({
   onKeyDown: (e: KeyboardEvent) => void;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
+  // The virtualizer keys its measurement projection on `getItemKey`'s IDENTITY,
+  // so this is re-minted per path sequence rather than per render — `paths` is
+  // memo-stable, making it the sequence's only input.
+  const getItemKey = useCallback(
+    (index: number) => paths[index] ?? index,
+    [paths],
+  );
   const virtualizer = useVirtualizer({
     count: paths.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => rowHeight,
+    // Key by path, not index: the rule and text filters permute the sequence,
+    // and rows carrying a second line are taller than those without — an index
+    // key hands a row the height measured for whatever sat there before.
+    getItemKey,
     overscan: 12,
   });
 

--- a/src/features/repository/SwitchWithChangesDialog.tsx
+++ b/src/features/repository/SwitchWithChangesDialog.tsx
@@ -1,4 +1,5 @@
 import { WarningIcon } from "@phosphor-icons/react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -29,7 +30,11 @@ export function SwitchWithChangesDialog({
 }: {
   target: { name: string; remote: string | null } | null;
   currentLabel: string;
-  /** One-line note above the choices, e.g. why a first attempt didn't work. */
+  /**
+   * One-line note above the choices. Set only when a bring-changes attempt was
+   * refused — the switcher clears it on every fresh open — so its presence is
+   * also what puts the footer in its refusal state below.
+   */
   hint?: string | null;
   reapply: boolean;
   onReapplyChange: (reapply: boolean) => void;
@@ -38,6 +43,10 @@ export function SwitchWithChangesDialog({
   onStashAndSwitch: () => void;
 }) {
   const shownTarget = useRetained(target);
+  // Bringing the changes has already been refused, so it can only fail again:
+  // stashing takes the primary and the dead offer stays visible but inert,
+  // rather than reading as the recommended action beside a hint saying it lost.
+  const refused = Boolean(hint);
   return (
     <Dialog
       open={target !== null}
@@ -81,10 +90,24 @@ export function SwitchWithChangesDialog({
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button variant="outline" onClick={onStashAndSwitch}>
+          <Button
+            variant={refused ? "default" : "outline"}
+            onClick={onStashAndSwitch}
+          >
             Stash and switch
           </Button>
-          <Button onClick={onBringChanges}>Bring changes</Button>
+          <DisabledReasonButton
+            disabled={refused}
+            reason={
+              refused
+                ? "Git would overwrite your changes — stash and switch instead"
+                : null
+            }
+            variant={refused ? "outline" : "default"}
+            onClick={onBringChanges}
+          >
+            Bring changes
+          </DisabledReasonButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/repository/SwitchWithChangesDialog.tsx
+++ b/src/features/repository/SwitchWithChangesDialog.tsx
@@ -33,7 +33,8 @@ export function SwitchWithChangesDialog({
   /**
    * One-line note above the choices. Set only when a bring-changes attempt was
    * refused — the switcher clears it on every fresh open — so its presence is
-   * also what puts the footer in its refusal state below.
+   * also what puts the footer in its refusal state below, and what the reapply
+   * clause is appended to.
    */
   hint?: string | null;
   reapply: boolean;
@@ -76,7 +77,14 @@ export function SwitchWithChangesDialog({
             className="flex items-start gap-1.5 text-xs text-warning"
           >
             <WarningIcon className="size-4 shrink-0" />
-            <span>{hint}</span>
+            {/* The reapply clause is appended here rather than baked into the
+                hint: the checkbox stays live while this note shows. */}
+            <span>
+              {hint}
+              {refused && reapply
+                ? " Reapply is set, so your changes still come along."
+                : null}
+            </span>
           </p>
         )}
         <label className="flex cursor-pointer items-center gap-2 text-xs">

--- a/src/features/repository/SwitchWithChangesDialog.tsx
+++ b/src/features/repository/SwitchWithChangesDialog.tsx
@@ -105,6 +105,9 @@ export function SwitchWithChangesDialog({
             Stash and switch
           </Button>
           <DisabledReasonButton
+            // Below `sm` the footer stacks and stretches the wrapper span; the
+            // Button fills it to match the plain siblings beside it.
+            className="w-full"
             disabled={refused}
             reason={
               refused

--- a/src/features/sessions/AgentNarration.tsx
+++ b/src/features/sessions/AgentNarration.tsx
@@ -1,5 +1,6 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useSyncExternalStore } from "react";
 import { Markdown } from "@/components/markdown/markdown";
+import { hljsUpgradeStore } from "@/components/markdown/markdown-hljs";
 import { useOpenFile } from "./useOpenFile";
 
 // Extensions we treat as file references when they appear in an inline-code
@@ -70,6 +71,20 @@ const KNOWN_EXT = new Set([
   "pl",
 ]);
 
+// The marks a qualifying span carries. Listed once because the walk both adds
+// and removes them: an unmark that misses one leaves a span that still looks or
+// reads as a link.
+const MARK_ATTRS = ["data-gd-file", "role", "tabindex", "aria-label"];
+const MARK_CLASSES = [
+  "cursor-pointer",
+  "underline",
+  "decoration-dotted",
+  "underline-offset-2",
+  "hover:text-foreground",
+  "focus-visible:outline-1",
+  "focus-visible:outline-ring",
+];
+
 /** Strip a trailing `:line[:col]` or `#Lx` locator before resolving the path. */
 function filePathOf(raw: string): string {
   return raw.trim().replace(/[:#].*$/, "");
@@ -101,36 +116,46 @@ export function AgentNarration({
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const openFile = useOpenFile();
+  // The shared renderer re-injects its whole innerHTML when the lazy
+  // highlight.js upgrade bumps this snapshot, discarding every mark below while
+  // `text` stays value-identical.
+  const hljsVersion = useSyncExternalStore(
+    hljsUpgradeStore.subscribe,
+    hljsUpgradeStore.getSnapshot,
+    hljsUpgradeStore.getServerSnapshot,
+  );
 
   // After each render, turn inline-code spans that look like file paths into
   // real, keyboard-operable links (button role + tab stop) — using a layout
   // effect so the styling lands before paint (no flicker while streaming) and
-  // without modifying the shared Markdown renderer. Re-runs whenever the text
-  // changes; Markdown replaces its innerHTML on each delta, so spans are fresh.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-mark on each streamed update
+  // without modifying the shared Markdown renderer. Marking is two-directional
+  // for symmetry: an identical re-parse preserves these nodes, so a future
+  // non-DOM input to the decision could otherwise strand marks.
+  // Neither dep is read inside the effect — `text` and `hljsVersion` are
+  // deliberate re-walk triggers for the DOM they rebuild.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text and hljsVersion are intentional re-walk triggers
   useLayoutEffect(() => {
     const root = ref.current;
     if (!root) return;
     for (const el of root.querySelectorAll("code")) {
-      if (el.closest("pre")) continue; // fenced code blocks aren't file refs
-      const raw = el.textContent ?? "";
-      if (!isFilePath(raw)) continue;
-      const path = filePathOf(raw);
+      // A fenced block isn't a file ref, and a code span inside a link label
+      // belongs to the link — marking it would double-dispatch on activation.
+      // The `||` short-circuits past the text read for both.
+      if (el.closest("pre, a") || !isFilePath(el.textContent ?? "")) {
+        if (el.hasAttribute("data-gd-file")) {
+          for (const attr of MARK_ATTRS) el.removeAttribute(attr);
+          el.classList.remove(...MARK_CLASSES);
+        }
+        continue;
+      }
+      const path = filePathOf(el.textContent ?? "");
       el.setAttribute("data-gd-file", path);
       el.setAttribute("role", "button");
       el.setAttribute("tabindex", "0");
       el.setAttribute("aria-label", `Open ${path}`);
-      el.classList.add(
-        "cursor-pointer",
-        "underline",
-        "decoration-dotted",
-        "underline-offset-2",
-        "hover:text-foreground",
-        "focus-visible:outline-1",
-        "focus-visible:outline-ring",
-      );
+      el.classList.add(...MARK_CLASSES);
     }
-  }, [text]);
+  }, [text, hljsVersion]);
 
   const activate = (target: EventTarget | null) => {
     const el = (target as HTMLElement | null)?.closest<HTMLElement>(
@@ -145,13 +170,25 @@ export function AgentNarration({
     if (activate(e.target)) e.preventDefault();
   };
 
+  // A middle click rides `auxclick` and never fires `click`, so the dispatch has
+  // to be reachable from here too or the third button is dead on a marked span.
+  const onAuxClick = (e: React.MouseEvent) => {
+    if (e.button !== 1) return;
+    if (activate(e.target)) e.preventDefault();
+  };
+
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== "Enter" && e.key !== " ") return;
     if (activate(e.target)) e.preventDefault();
   };
 
   return (
-    <div ref={ref} onClick={onClick} onKeyDown={onKeyDown}>
+    <div
+      ref={ref}
+      onClick={onClick}
+      onAuxClick={onAuxClick}
+      onKeyDown={onKeyDown}
+    >
       <Markdown className="px-0.5">{text}</Markdown>
     </div>
   );

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -7,7 +7,14 @@ import {
 import { useSelector } from "@tanstack/react-store";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -263,6 +270,10 @@ export function CloneRepoDialog({
               </div>
               <div className="h-72 rounded-none border">
                 <RepoBrowser
+                  // One RepoBrowser serves every provider tab, so remount it per
+                  // provider or the surviving virtualizer carries its scroll
+                  // offset onto another account's repositories.
+                  key={provider}
                   provider={provider}
                   repos={repos}
                   rows={rows}
@@ -379,10 +390,27 @@ function RepoBrowser({
 }) {
   const openSettings = useUiStore((s) => s.openSettings);
   const parentRef = useRef<HTMLDivElement>(null);
+  // The virtualizer keys its measurement projection on `getItemKey`'s IDENTITY,
+  // so this is re-minted per row sequence rather than per render — `rows` is
+  // memo-stable, making it the sequence's only input.
+  const getItemKey = useCallback(
+    (index: number) => {
+      const row = rows[index];
+      if (!row) return index;
+      return row.kind === "header"
+        ? `h:${row.owner}`
+        : `r:${row.repo.fullName}`;
+    },
+    [rows],
+  );
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (i) => (rows[i].kind === "header" ? 26 : 30),
+    // Key by row identity, not index: the filter permutes headers and repos
+    // through the same indexes, and an index key hands a 26px header the height
+    // measured for the 30px repo row that sat there before.
+    getItemKey,
     overscan: 12,
   });
 

--- a/src/lib/branch-rules/queries.ts
+++ b/src/lib/branch-rules/queries.ts
@@ -29,6 +29,8 @@ export function useSaveBranchRules(repo: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (config: BranchRulesConfig) => saveBranchRules(repo, config),
+    // Local write — see useBranchRules: "online" mode would park it offline.
+    networkMode: "always",
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: branchRulesKey(repo) }),
   });
@@ -53,6 +55,8 @@ export function useSaveSharedBranchRules(repo: string) {
   return useMutation({
     mutationFn: (config: BranchRulesConfig) =>
       saveSharedBranchRules(repo, config),
+    // Local write — see useBranchRules: "online" mode would park it offline.
+    networkMode: "always",
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: sharedBranchRulesKey(repo) }),
   });

--- a/src/lib/branch-rules/queries.ts
+++ b/src/lib/branch-rules/queries.ts
@@ -19,6 +19,9 @@ export function useBranchRules(repo: string) {
     queryKey: branchRulesKey(repo),
     queryFn: () => loadBranchRules(repo),
     staleTime: Number.POSITIVE_INFINITY,
+    // Local read: the default "online" mode parks it while the OS reports no
+    // connection, which would hold every rules-settling gate closed forever.
+    networkMode: "always",
   });
 }
 
@@ -40,6 +43,8 @@ export function useSharedBranchRules(repo: string) {
     // The file can change out from under us (pull, branch switch), so let it
     // refetch on focus rather than caching forever.
     staleTime: 30_000,
+    // Local read — see useBranchRules: "online" mode would park it offline.
+    networkMode: "always",
   });
 }
 


### PR DESCRIPTION
Virtualized lists in this repo shared one root defect: they let TanStack Virtual key rows by index, so a filter or tab switch handed a short header the height measured for the tall row that previously sat at that index, and a surviving virtualizer carried its scroll offset into unrelated content. This batch fixes that across all four list surfaces and, while in the neighborhood, closes three unrelated correctness gaps in branch switching, amend gating, and session narration.

### Virtualized list identity

- Adds a `getItemKey` derived from row identity (not index) to the virtualizers in `src/features/code-todos/CodeTodosPanel.tsx`, `src/features/explore/ExploreScreen.tsx`, `src/features/repository/RepositoryFilesDialog.tsx`, and `src/features/welcome/CloneRepoDialog.tsx`. Each is wrapped in `useCallback` over the memo-stable row array, since the virtualizer keys its measurement projection on the callback's identity.
- Extracts `rowKeyOf(row: FlatRow)` in `CodeTodosPanel.tsx` so the virtualizer's size cache and the React `key` on the rendered row can't disagree about which row an index holds.
- Remounts lists whose content is swapped wholesale rather than re-filtered: `key={tab}` on `FileList` in `RepositoryFilesDialog.tsx` (one list serves all three tabs), `key={provider}` on `RepoBrowser` in `CloneRepoDialog.tsx`, and `key={`${provider}:${sort}:${query}`}` on `ResultsList` in `ExploreScreen.tsx`, where a cached search resolves synchronously and never unmounts the list between queries.

### Branch switcher — stash offer after a refused bring

- Tracks whether the user touched **Reapply after switching** via a new `reapplyTouchedRef` in `src/features/repository/BranchSwitcher.tsx`, reset on each fresh open. `bringAndSwitch` captures the checkbox and its touched flag alongside the target so the post-`await` refusal branch decides from the values as they stood when that switch started.
- On a dirty-tree refusal, auto-ticks reapply for that switch alone (an explicit untick by the user stands) and extends the hint to say the changes still come along. The persist in `stashAndSwitch` is now gated on `reapplyTouchedRef`, so an auto-tick stays session-only and never rewrites the saved preference.
- Reworks the footer in `src/features/repository/SwitchWithChangesDialog.tsx`: presence of `hint` marks the refused state, promoting **Stash and switch** to the primary variant and rendering **Bring changes** through `DisabledReasonButton` — visible but inert, with "Git would overwrite your changes — stash and switch instead" as the reason. The `hint` prop doc now records that it also drives this state.

### Amend force-push gating

- Consumes `useEffectiveBranchRulesSettling` in `src/features/history/useAmendCommit.ts`. While either rules scope is on its first read the effective config stands in as empty, making `isForcePushBlocked` vacuously false; the force-push arm now holds on the settling flag instead (a plain amend never consults the rules, so it never holds).
- Factors the refusal into a shared `forcePushRefused()` used by both `requestAmend` and `confirmAmend`, with the toast copy hoisted to `RULES_SETTLING_MESSAGE` and `protectedBranchMessage`. `confirmAmend` re-checks because the gate can flip under an open dialog — rules may have settled to blocked, or may still be settling.

### Session narration file links

- Subscribes `src/features/sessions/AgentNarration.tsx` to `hljsUpgradeStore` via `useSyncExternalStore`, adding the snapshot as a re-walk trigger: the shared renderer re-injects its whole `innerHTML` when the lazy highlight.js upgrade lands, discarding every mark while `text` stays value-identical.
- Makes the marking walk two-directional — `MARK_ATTRS` and `MARK_CLASSES` are listed once and both applied and removed, so a span that stops qualifying can't be left looking or reading as a link. The skip condition now also excludes `code` inside an `a`, where marking would double-dispatch on activation.
- Adds an `onAuxClick` handler on the wrapper so middle-click opens a marked path; it rides `auxclick` and never fires `click`.

### Docs

- Four fragments under `changelog.d/`: `fixed-virtualized-list-keys.md`, `changed-stash-offer-reapply.md`, `fixed-amend-rules-settling.md`, and `fixed-narration-file-links.md`.
- Updates the branch-switching section of `src/features/help/content.ts` to describe the returning prompt with **Reapply after switching** pre-ticked and to state that the saved choice changes only on an explicit toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Branch rules now load from disk while offline, allowing commits, branch cleanup, and rule edits without a network connection.
  - Amending pushed commits now waits for branch protection checks before offering a force-push and revalidates before confirmation.
  - Long filtered lists retain correct row sizing and reset appropriately when switching providers, tabs, or searches.
  - Session transcript file links remain clickable, including middle-click support for opening files in the editor.

- **Improvements**
  - Stash-and-switch now prioritizes reapplying changes after switching without overwriting saved preferences.
  - Help content now explains the updated stash behavior and preference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->