### PR TITLE
fix(pulls,issues,branches,clone): keep disabled triggers reachable

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -17,7 +17,8 @@ paths:
 - Destructive paths confirm via the shared `useConfirm`/`ConfirmDialogHost` primitive;
   commit-level prompts share wording through `src/features/history/commit-confirms.ts`.
 - Disabled actions explain why: `DisabledReasonButton`, or `useDisabledReason` +
-  `ARIA_DISABLED_CLASS` on raw-button sites — never hide, never a bare `disabled`.
+  `ARIA_DISABLED_CLASS` on raw-button and form-wrapped-Button (`form.SubmitButton`)
+  sites — never hide, never a bare `disabled`.
 - Truncated user/repo content: `clipTitle`/`clipTitleFromText` only-when-clipped; Base UI
   Select rows via `SelectClipText` as the row's SOLE child.
 - Semantic state tokens (`--success`, `--warning`, `--info`, `--merged`, `--destructive`)

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -152,7 +152,12 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   explain via the field's `warning` hint. Raw-`<button>` sites the vendored
   Button can't size (reaction chips, the discussion upvote chip) take the SAME
   contract from the shared `useDisabledReason` hook + `ARIA_DISABLED_CLASS`
-  (`src/lib/use-disabled-reason.ts`) — never hand-rolled.
+  (`src/lib/use-disabled-reason.ts`) — never hand-rolled. A vendored Button the
+  render composition can't reach because a form component wraps it
+  (`form.SubmitButton`, which forwards props but isn't itself a Trigger) takes
+  the same hook directly: `focusableWhenDisabled`/`aria-describedby`/
+  `wrapperTitle` passed straight through, plus its own sr-only reason span
+  alongside (`src/features/welcome/CloneRepoDialog.tsx` is the reference).
 - A conversation surface's own actions sit before the submit button via
   `CommentComposer`'s `leadingActions` slot when submit is the row's last
   action (the issue views); a surface whose right-slot action is itself a

--- a/changelog.d/fixed-disabled-trigger-keyboard-reach.md
+++ b/changelog.d/fixed-disabled-trigger-keyboard-reach.md
@@ -1,7 +1,7 @@
-- The Projects picker, the discussions category filter, issue close and
-  more-actions menus, pull-request merge menus, the branch-update options
-  caret, the branch switcher, and the clone dialog's Clone button now explain
-  why they're unavailable to keyboard and screen-reader users too: the
-  disabled control stays focusable, announces its reason, and shows it on
-  hover. A pull-request merge held only by another operation in flight now
-  says so, instead of showing the ordinary "Merge this pull request" hint.
+- The Projects picker, the discussions category filter and New-discussion
+  button, issue close and more-actions menus, pull-request merge and review
+  controls, the branch-update options caret, the branch switcher, and the
+  clone dialog's Clone button now explain why they're unavailable to keyboard
+  and screen-reader users too: the disabled control stays focusable,
+  announces its reason, and shows it on hover. A held pull-request merge and
+  the discussions controls now name what's actually holding them.

--- a/changelog.d/fixed-disabled-trigger-keyboard-reach.md
+++ b/changelog.d/fixed-disabled-trigger-keyboard-reach.md
@@ -1,0 +1,5 @@
+- The Projects picker, the discussions category filter, issue close and
+  more-actions menus, pull-request merge menus, the branch switcher, and the
+  clone dialog's Clone button now explain why they're unavailable to keyboard
+  and screen-reader users too: the disabled control stays focusable,
+  announces its reason, and shows it on hover.

--- a/changelog.d/fixed-disabled-trigger-keyboard-reach.md
+++ b/changelog.d/fixed-disabled-trigger-keyboard-reach.md
@@ -3,5 +3,5 @@
   caret, the branch switcher, and the clone dialog's Clone button now explain
   why they're unavailable to keyboard and screen-reader users too: the
   disabled control stays focusable, announces its reason, and shows it on
-  hover. Pull-request merge buttons also keep their normal hover hint again
-  once nothing is blocking them.
+  hover. A pull-request merge held only by another operation in flight now
+  says so, instead of showing the ordinary "Merge this pull request" hint.

--- a/changelog.d/fixed-disabled-trigger-keyboard-reach.md
+++ b/changelog.d/fixed-disabled-trigger-keyboard-reach.md
@@ -1,5 +1,7 @@
 - The Projects picker, the discussions category filter, issue close and
-  more-actions menus, pull-request merge menus, the branch switcher, and the
-  clone dialog's Clone button now explain why they're unavailable to keyboard
-  and screen-reader users too: the disabled control stays focusable,
-  announces its reason, and shows it on hover.
+  more-actions menus, pull-request merge menus, the branch-update options
+  caret, the branch switcher, and the clone dialog's Clone button now explain
+  why they're unavailable to keyboard and screen-reader users too: the
+  disabled control stays focusable, announces its reason, and shows it on
+  hover. Pull-request merge buttons also keep their normal hover hint again
+  once nothing is blocking them.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -304,8 +304,9 @@ const CONTEXT_MENU_SUPPRESS_RE =
 // room for a tooltip), so neither is ever wrapped in one. Sub/Submenu triggers
 // are excluded by name as well, pinning that idiom rather than resting on the
 // absence of a wrapper. Discriminating on a `Reason`-suffixed value instead
-// would miss the live sites whose hint is a bare conditional string rather than
-// a named reason (the discussions category menu, the branch trigger).
+// would have missed sites whose hint was a bare conditional string rather
+// than a named reason (the discussions category menu and the branch trigger,
+// both converted at #326).
 // The tempered `(?!</)` steps hold the match inside one unclosed element chain,
 // so a titled span that already closed cannot pair with a later sibling's
 // trigger; the `DisabledReasonButton` step makes the FIXED composition

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -788,28 +788,10 @@ export const CHECKS = [
     name: "titled-disabled-trigger",
     appliesTo: notVendoredUi,
     scan: perFile(TITLED_TRIGGER_DISABLED_RE),
-    // DEFERRED, not exempt: every entry is a residual site of the class the
-    // pickers were converted out of, held back because each needs its own live
-    // keyboard pass. The gate blocks NEW sites; these come off the list as they
-    // convert, and the stale-entry rule turns each conversion into a required
-    // edit here.
-    allowlist: [
-      // The projects picker — the direct twin of the converted labels picker.
-      "src/features/conversations/ProjectsPopover.tsx",
-      // Category menu; its hint is a bare sign-in string rather than a reason
-      // prop, so the conversion has to introduce the reason first.
-      "src/features/discussions/DiscussionsPanel.tsx",
-      // Two menus (close options, more actions) whose `disabled` sits inside the
-      // render Button rather than on the trigger.
-      "src/features/issues/RemoteIssueView.tsx",
-      // Merge menus: the wrapper is what refuses the click a disabled Button
-      // drops, so converting them wants the live merge-gate pass.
-      "src/features/pulls/LocalPrView.tsx",
-      "src/features/pulls/RemotePrView.tsx",
-      // The branch trigger's wrapper also owns the header shrink cascade, so a
-      // conversion has to move those classes to wrapperClassName.
-      "src/features/repository/BranchSwitcher.tsx",
-    ],
+    // Every residual site of the class the pickers were converted out of has
+    // now converted too — the allowlist is empty on purpose, not pruned away:
+    // a fresh violation here is a NEW instance of the class, not a returning one.
+    allowlist: [],
     message:
       "a menu/popover trigger that carries its disabled reason on a titled wrapper is hover-only — a natively disabled trigger leaves the tab order, so keyboard and screen-reader users reach neither the control nor the reason; compose `<Trigger render={<DisabledReasonButton disabled reason/>}>` instead (src/components/disabled-reason-button.tsx), which holds the reason on a focusable aria-disabled button whose own useButton swallows activation; a site that genuinely cannot take the primitive needs an allowlist entry with rationale",
   },

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -306,7 +306,7 @@ const CONTEXT_MENU_SUPPRESS_RE =
 // absence of a wrapper. Discriminating on a `Reason`-suffixed value instead
 // would have missed sites whose hint was a bare conditional string rather
 // than a named reason (the discussions category menu and the branch trigger,
-// both converted at #326).
+// both since converted).
 // The tempered `(?!</)` steps hold the match inside one unclosed element chain,
 // so a titled span that already closed cannot pair with a later sibling's
 // trigger; the `DisabledReasonButton` step makes the FIXED composition

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -311,8 +311,11 @@ const CONTEXT_MENU_SUPPRESS_RE =
 // trigger; the `DisabledReasonButton` step makes the FIXED composition
 // unmatchable even where a wrapper survives to carry layout classes. Both
 // windows are PAIR_GAP with ~1.4x headroom: across the live sites the widest
-// title→trigger run measures 113 normalized chars, the widest trigger→disabled
-// 84. Accepted evasions, all zero-instance today: a hint delivered by something
+// title→trigger run measured 113 normalized chars, the widest trigger→disabled
+// 84 (measured at #305, before every one of those sites converted — #326
+// converted the last of them, so the figure is no longer re-checkable against
+// a live site and stands on that record instead). Accepted evasions, all
+// zero-instance today: a hint delivered by something
 // other than `title`, a wrapper that is a component rather than a tag, and a
 // `disabled` computed too far from the tag.
 const TITLED_TRIGGER_DISABLED_RE = new RegExp(

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -312,12 +312,10 @@ const CONTEXT_MENU_SUPPRESS_RE =
 // unmatchable even where a wrapper survives to carry layout classes. Both
 // windows are PAIR_GAP with ~1.4x headroom: across the live sites the widest
 // title→trigger run measured 113 normalized chars, the widest trigger→disabled
-// 84 (measured at #305, before every one of those sites converted — #326
-// converted the last of them, so the figure is no longer re-checkable against
-// a live site and stands on that record instead). Accepted evasions, all
-// zero-instance today: a hint delivered by something
-// other than `title`, a wrapper that is a component rather than a tag, and a
-// `disabled` computed too far from the tag.
+// 84 (measured at #305, before those sites converted). Accepted evasions, all
+// zero-instance today: a hint delivered by something other than `title`, a
+// wrapper that is a component rather than a tag, and a `disabled` computed
+// too far from the tag.
 const TITLED_TRIGGER_DISABLED_RE = new RegExp(
   `title\\s*=(?:(?!</|DisabledReasonButton)[\\s\\S]){0,${PAIR_GAP}}?` +
     `<(?![A-Za-z][\\w.]*Sub(?:menu)?Trigger\\b)[A-Za-z][\\w.]*Trigger\\b` +
@@ -793,7 +791,11 @@ export const CHECKS = [
     scan: perFile(TITLED_TRIGGER_DISABLED_RE),
     // Every residual site of the class the pickers were converted out of has
     // now converted too — the allowlist is empty on purpose, not pruned away:
-    // a fresh violation here is a NEW instance of the class, not a returning one.
+    // a fresh violation here is a NEW instance of the class, not a returning
+    // one. The regex's own blind spot still stands, though: a disabled branch
+    // that swaps out the whole trigger for a plain non-`*Trigger` element (the
+    // shape `PrMergeabilityBanner`'s update-branch caret used to take) carries
+    // no `*Trigger` tag for the pattern to anchor on.
     allowlist: [],
     message:
       "a menu/popover trigger that carries its disabled reason on a titled wrapper is hover-only — a natively disabled trigger leaves the tab order, so keyboard and screen-reader users reach neither the control nor the reason; compose `<Trigger render={<DisabledReasonButton disabled reason/>}>` instead (src/components/disabled-reason-button.tsx), which holds the reason on a focusable aria-disabled button whose own useButton swallows activation; a site that genuinely cannot take the primitive needs an allowlist entry with rationale",

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1233,7 +1233,7 @@ test("titled-disabled-trigger leaves the primitive and the non-trigger wrappers 
   assert.deepEqual(titledDisabledTrigger(stacked), []);
 });
 
-test("titled-disabled-trigger allowlists the residual sites per file", () => {
+test("titled-disabled-trigger reports every site now that the allowlist is empty", () => {
   const check = CHECKS.find((c) => c.name === "titled-disabled-trigger");
   const row = [
     '<span title={heldReason} className="inline-flex">',
@@ -1250,8 +1250,11 @@ test("titled-disabled-trigger allowlists the residual sites per file", () => {
     "src/features/issues/SomeNewPicker.tsx",
   ];
   const views = new Map(files.map((f) => [f, view(row)]));
-  // A deferred residual stays quiet; the same markup in a fresh picker reports.
+  // Every residual site converted, so the allowlist is empty: the same
+  // hover-only shape reports wherever it appears, the old site or a new one —
+  // proving there is no silent gap left behind.
   assert.deepEqual(runCheck(check, files, views).violations, [
+    "src/features/conversations/ProjectsPopover.tsx:1",
     "src/features/issues/SomeNewPicker.tsx:1",
   ]);
 });

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1250,9 +1250,10 @@ test("titled-disabled-trigger reports every site now that the allowlist is empty
     "src/features/issues/SomeNewPicker.tsx",
   ];
   const views = new Map(files.map((f) => [f, view(row)]));
-  // Every residual site converted, so the allowlist is empty: the same
-  // hover-only shape reports wherever it appears, the old site or a new one —
-  // proving there is no silent gap left behind.
+  // Every residual site converted, so the allowlist is empty: this ONE former
+  // entry's path reports again alongside a fresh one, rather than staying
+  // quiet as it did before. The separate stale-allowlist test is what pins
+  // the general mechanism for every entry, past or future.
   assert.deepEqual(runCheck(check, files, views).violations, [
     "src/features/conversations/ProjectsPopover.tsx:1",
     "src/features/issues/SomeNewPicker.tsx:1",

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -2,6 +2,7 @@ import { Popover } from "@base-ui/react/popover";
 import { CopyIcon, KanbanIcon } from "@phosphor-icons/react";
 import { type ReactNode, useEffect, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { MetaValueCell } from "@/components/meta-field-cells";
 import { usePanelPortalContainer } from "@/components/panel-portal";
 import { Button } from "@/components/ui/button";
@@ -271,32 +272,29 @@ export function ProjectsPopover({
     }
   }
 
-  // Trigger first, so it never shifts as chips come and go. A natively disabled
-  // button swallows `title`, so the reason rides a wrapping span.
+  // Trigger first, so it never shifts as chips come and go.
   const trigger = (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <span
-        title={heldReason}
-        className={
-          heldReason ? "inline-flex cursor-not-allowed" : "inline-flex"
+      <Popover.Trigger
+        disabled={!!heldReason}
+        render={
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit projects"
+            reason={heldReason}
+          />
         }
       >
-        <Popover.Trigger
-          disabled={!!heldReason}
-          render={
-            <Button variant="ghost" size="xs" aria-label="Edit projects" />
-          }
-        >
-          {/* size-3 explicitly: the Button's own icon rule skips a sized
-              element, and a 16px swap would widen the label column mid-write. */}
-          {editProjects.isPending ? (
-            <Spinner className="size-3" data-icon="inline-start" />
-          ) : (
-            <KanbanIcon data-icon="inline-start" />
-          )}
-          Projects
-        </Popover.Trigger>
-      </span>
+        {/* size-3 explicitly: the Button's own icon rule skips a sized
+            element, and a 16px swap would widen the label column mid-write. */}
+        {editProjects.isPending ? (
+          <Spinner className="size-3" data-icon="inline-start" />
+        ) : (
+          <KanbanIcon data-icon="inline-start" />
+        )}
+        Projects
+      </Popover.Trigger>
       <Popover.Portal container={portalContainer}>
         <Popover.Positioner
           align="start"

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -276,12 +276,12 @@ export function ProjectsPopover({
   const trigger = (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
       <Popover.Trigger
-        disabled={!!heldReason}
         render={
           <DisabledReasonButton
             variant="ghost"
             size="xs"
             aria-label="Edit projects"
+            disabled={!!heldReason}
             reason={heldReason}
           />
         }

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -45,6 +45,29 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
   const meta = useDiscussionMeta(repoPath, ghReady && supportsDiscussions);
   const enabled = meta.data?.hasDiscussionsEnabled ?? false;
   const listEnabled = ghReady && supportsDiscussions && enabled;
+  // `listEnabled` folds four distinct states into one boolean; the trigger's
+  // reason has to name the one that's actually true, in the same order the
+  // body below checks them, or it reads as a permanent "sign in" hint even
+  // for a GitLab host, a discussions-off repo, or a still-loading probe.
+  // `meta` is gated on `ghReady && supportsDiscussions`, so its query stays
+  // permanently "pending" while disabled — checking it before those two would
+  // read every not-ready/unsupported state as "loading" instead.
+  const listDisabledReason = (() => {
+    switch (true) {
+      case gh.isPending:
+        return "Loading discussions…";
+      case !ghReady:
+        return "Sign in to GitHub to browse discussions";
+      case !supportsDiscussions:
+        return "Discussions aren't available on this repository's host";
+      case meta.isPending:
+        return "Loading discussions…";
+      case meta.isError:
+        return "Couldn't load discussions for this repository";
+      default:
+        return "Discussions aren't enabled for this repository";
+    }
+  })();
   const [categoryId, setCategoryId] = useState<string | null>(null);
   // How many discussions to load; "Load more" bumps it by PAGE_SIZE. A category
   // switch resets it so a filtered view starts from the first page again.
@@ -124,11 +147,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
                 variant="outline"
                 size="xs"
                 disabled={!listEnabled}
-                reason={
-                  listEnabled
-                    ? undefined
-                    : "Sign in to GitHub to browse discussions"
-                }
+                reason={listEnabled ? undefined : listDisabledReason}
               />
             }
           >

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -45,19 +45,21 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
   const meta = useDiscussionMeta(repoPath, ghReady && supportsDiscussions);
   const enabled = meta.data?.hasDiscussionsEnabled ?? false;
   const listEnabled = ghReady && supportsDiscussions && enabled;
-  // `listEnabled` folds four distinct states into one boolean; the trigger's
+  // `listEnabled` folds four distinct states into one boolean; each control's
   // reason has to name the one that's actually true, in the same order the
   // body below checks them, or it reads as a permanent "sign in" hint even
   // for a GitLab host, a discussions-off repo, or a still-loading probe.
   // `meta` is gated on `ghReady && supportsDiscussions`, so its query stays
   // permanently "pending" while disabled — checking it before those two would
-  // read every not-ready/unsupported state as "loading" instead.
-  const listDisabledReason = (() => {
+  // read every not-ready/unsupported state as "loading" instead. The sign-in
+  // sentence is the only part that differs between callers (each names its
+  // own action), so it's the one parameter.
+  const discussionsDisabledReason = (signedOutReason: string) => {
     switch (true) {
       case gh.isPending:
         return "Loading discussions…";
       case !ghReady:
-        return "Sign in to GitHub to browse discussions";
+        return signedOutReason;
       case !supportsDiscussions:
         return "Discussions aren't available on this repository's host";
       case meta.isPending:
@@ -67,7 +69,7 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
       default:
         return "Discussions aren't enabled for this repository";
     }
-  })();
+  };
   const [categoryId, setCategoryId] = useState<string | null>(null);
   // How many discussions to load; "Load more" bumps it by PAGE_SIZE. A category
   // switch resets it so a filtered view starts from the first page again.
@@ -147,7 +149,13 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
                 variant="outline"
                 size="xs"
                 disabled={!listEnabled}
-                reason={listEnabled ? undefined : listDisabledReason}
+                reason={
+                  listEnabled
+                    ? undefined
+                    : discussionsDisabledReason(
+                        "Sign in to GitHub to browse discussions",
+                      )
+                }
               />
             }
           >
@@ -182,7 +190,13 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
           size="xs"
           wrapperClassName="ml-auto"
           disabled={!listEnabled}
-          reason="Sign in to GitHub to start a discussion"
+          reason={
+            listEnabled
+              ? undefined
+              : discussionsDisabledReason(
+                  "Sign in to GitHub to start a discussion",
+                )
+          }
           title="New discussion"
           onClick={() => setCreateOpen(true)}
         >

--- a/src/features/discussions/DiscussionsPanel.tsx
+++ b/src/features/discussions/DiscussionsPanel.tsx
@@ -5,7 +5,6 @@ import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { RelativeTime } from "@/components/relative-time";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -119,25 +118,23 @@ export function DiscussionsPanel({ repoPath }: { repoPath: string }) {
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-1 border-b p-2">
         <DropdownMenu>
-          {/* A trigger can't take the disabled-reason primitive — a `render`
-              target can't carry its wrapper — so the reason rides a span around
-              the trigger, whose own `disabled` keeps the button inert. */}
-          <span
-            className={cn("inline-flex", !listEnabled && "cursor-not-allowed")}
-            title={
-              listEnabled
-                ? undefined
-                : "Sign in to GitHub to browse discussions"
+          <DropdownMenuTrigger
+            render={
+              <DisabledReasonButton
+                variant="outline"
+                size="xs"
+                disabled={!listEnabled}
+                reason={
+                  listEnabled
+                    ? undefined
+                    : "Sign in to GitHub to browse discussions"
+                }
+              />
             }
           >
-            <DropdownMenuTrigger
-              disabled={!listEnabled}
-              render={<Button variant="outline" size="xs" />}
-            >
-              {categoryLabel}
-              <CaretDownIcon data-icon="inline-end" />
-            </DropdownMenuTrigger>
-          </span>
+            {categoryLabel}
+            <CaretDownIcon data-icon="inline-end" />
+          </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="min-w-52">
             <DropdownMenuItem
               onClick={() => chooseCategory(null)}

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -349,8 +349,10 @@ export function RemoteIssueView({
     closeIssue.isPending ||
     reopenIssue.isPending ||
     detailsStale;
-  // Which term of `busy` the composer names, ranked: the switch window outranks a
-  // write the viewer started, being the hold they can't have caused themselves.
+  // Which term of `busy` to name, ranked: the switch window outranks a write the
+  // viewer started, being the hold they can't have caused themselves. Shared by
+  // the composer and the close/reopen controls below — every one of them holds
+  // for exactly these same terms.
   const composerReason = (() => {
     switch (true) {
       case detailsStale:
@@ -764,7 +766,7 @@ export function RemoteIssueView({
               variant="outline"
               size="sm"
               disabled={busy || triageBlocked}
-              reason={triageReason ?? staleReason}
+              reason={triageReason ?? composerReason}
               onClick={() => doClose("completed")}
               title={
                 draftRidesStateChange
@@ -784,7 +786,7 @@ export function RemoteIssueView({
                       size="icon-sm"
                       aria-label="Other close options"
                       disabled={busy || triageBlocked}
-                      reason={triageReason ?? staleReason}
+                      reason={triageReason ?? composerReason}
                     />
                   }
                 >
@@ -809,7 +811,7 @@ export function RemoteIssueView({
             variant="outline"
             size="sm"
             disabled={busy || triageBlocked}
-            reason={triageReason ?? staleReason}
+            reason={triageReason ?? composerReason}
             onClick={doReopen}
             title={
               draftRidesStateChange

--- a/src/features/issues/RemoteIssueView.tsx
+++ b/src/features/issues/RemoteIssueView.tsx
@@ -774,29 +774,22 @@ export function RemoteIssueView({
             >
               {draftRidesStateChange ? "Close with comment" : "Close issue"}
             </DisabledReasonButton>
-            {/* Close reasons are a GitHub concept; GitLab has none. The caret is
-                a menu TRIGGER: native `disabled` holds the menu shut, and the
-                hint rides a wrapping span since a disabled Button swallows
-                `title` (house trigger idiom). */}
+            {/* Close reasons are a GitHub concept; GitLab has none. */}
             {canWrite && (
               <DropdownMenu>
-                <span
-                  title={triageReason ?? staleReason}
-                  className="inline-flex"
+                <DropdownMenuTrigger
+                  render={
+                    <DisabledReasonButton
+                      variant="outline"
+                      size="icon-sm"
+                      aria-label="Other close options"
+                      disabled={busy || triageBlocked}
+                      reason={triageReason ?? staleReason}
+                    />
+                  }
                 >
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        variant="outline"
-                        size="icon-sm"
-                        aria-label="Other close options"
-                        disabled={busy || triageBlocked}
-                      />
-                    }
-                  >
-                    <CaretDownIcon />
-                  </DropdownMenuTrigger>
-                </span>
+                  <CaretDownIcon />
+                </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="min-w-52">
                   {/* A menu item drops pointer events when disabled and has no
                       room for a title, so the draft promise rides the label —
@@ -887,22 +880,20 @@ export function RemoteIssueView({
             <DropdownMenu>
               {/* Every item but Transfer is withheld while the rendered issue is
                   the previous one, so hold the menu shut rather than open a near-
-                  empty popup; the reason rides a wrapping span since a disabled
-                  Button swallows `title` (house trigger idiom). */}
-              <span title={staleReason} className="inline-flex">
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      aria-label="More actions"
-                      disabled={detailsStale}
-                    />
-                  }
-                >
-                  <DotsThreeIcon className="size-4" weight="bold" />
-                </DropdownMenuTrigger>
-              </span>
+                  empty popup. */}
+              <DropdownMenuTrigger
+                render={
+                  <DisabledReasonButton
+                    variant="outline"
+                    size="xs"
+                    aria-label="More actions"
+                    disabled={detailsStale}
+                    reason={staleReason}
+                  />
+                }
+              >
+                <DotsThreeIcon className="size-4" weight="bold" />
+              </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-52">
                 {/* Absent while a placeholder is served: the verb comes from the
                     rendered issue's pin state while the write addresses

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -77,7 +77,6 @@ import { useLocalPrs, useUpdateLocalPr } from "@/lib/pulls/queries";
 import { useAiEnabled } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { toastError } from "@/lib/toast";
-import { cn } from "@/lib/utils";
 import { LinkedIssuesField } from "./LinkedIssuesField";
 import { LocalPrLifecycleRow } from "./LocalPrTimeline";
 import { PROMOTION_REASON, type PromotionKind } from "./PrMergeabilityBanner";
@@ -1151,26 +1150,19 @@ export function LocalPrView({
               </DisabledReasonButton>
             )}
             <DropdownMenu>
-              {/* A natively-disabled Button swallows `title`, so the refusal
-                  rides a wrapping span (house idiom) — outside the trigger,
-                  which carries `disabled` itself so a blocked merge can't open
-                  the menu. */}
-              <span
-                title={mergeReason}
-                className={cn(
-                  "inline-flex",
-                  mergeBlocked && "cursor-not-allowed",
-                )}
+              <DropdownMenuTrigger
+                render={
+                  <DisabledReasonButton
+                    size="sm"
+                    disabled={mergeBlocked}
+                    reason={mergeReason}
+                  />
+                }
               >
-                <DropdownMenuTrigger
-                  disabled={mergeBlocked}
-                  render={<Button size="sm" />}
-                >
-                  <GitMergeIcon data-icon="inline-start" />
-                  Merge
-                  <CaretDownIcon data-icon="inline-end" />
-                </DropdownMenuTrigger>
-              </span>
+                <GitMergeIcon data-icon="inline-start" />
+                Merge
+                <CaretDownIcon data-icon="inline-end" />
+              </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
                 <DropdownMenuItem
                   disabled={

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -657,15 +657,18 @@ export function LocalPrView({
   // DisabledReasonButton, never the trigger — its own inner useButton swallows
   // activation while blocked, which is what actually keeps the menu shut.
   const mergeBlocked = !canMerge || merge.isPending || dirtyBlocks;
-  // This same string doubles as the hover title while nothing blocks.
+  // This same string doubles as the hover title while nothing blocks. The
+  // active merge outranks `dirtyBlocks`: a merge already in flight can't be
+  // unblocked by committing or stashing, so a dirty tree that shows up mid-merge
+  // must not override "Merging…" with a remedy that doesn't apply.
   const mergeReason = (() => {
     switch (true) {
       case !canMerge:
         return "Approve the PR before merging";
-      case dirtyBlocks:
-        return "Commit or stash your changes before merging into the current branch";
       case merge.isPending:
         return "Merging…";
+      case dirtyBlocks:
+        return "Commit or stash your changes before merging into the current branch";
       default:
         return `Merge ${pr.head} into ${pr.base}`;
     }
@@ -1142,6 +1145,10 @@ export function LocalPrView({
                 }
                 reason={(() => {
                   switch (true) {
+                    case updateBranchFrom.isPending:
+                      return "Updating this branch…";
+                    case recovery.pending:
+                      return "Another git operation is running.";
                     case defaultBranch.isPending:
                       return "Checking which branch is the default…";
                     case rulesSettling:

--- a/src/features/pulls/LocalPrView.tsx
+++ b/src/features/pulls/LocalPrView.tsx
@@ -653,15 +653,23 @@ export function LocalPrView({
     );
   }
 
-  // The Merge control's state. Hoisted because the refusal has to sit on the
-  // wrapping span while `disabled` sits on the trigger — a disabled trigger is
-  // what actually keeps the menu shut.
+  // The Merge control's state. `disabled`/`reason` land on the rendered
+  // DisabledReasonButton, never the trigger — its own inner useButton swallows
+  // activation while blocked, which is what actually keeps the menu shut.
   const mergeBlocked = !canMerge || merge.isPending || dirtyBlocks;
-  const mergeReason = !canMerge
-    ? "Approve the PR before merging"
-    : dirtyBlocks
-      ? "Commit or stash your changes before merging into the current branch"
-      : `Merge ${pr.head} into ${pr.base}`;
+  // This same string doubles as the hover title while nothing blocks.
+  const mergeReason = (() => {
+    switch (true) {
+      case !canMerge:
+        return "Approve the PR before merging";
+      case dirtyBlocks:
+        return "Commit or stash your changes before merging into the current branch";
+      case merge.isPending:
+        return "Merging…";
+      default:
+        return `Merge ${pr.head} into ${pr.base}`;
+    }
+  })();
 
   return (
     <div className="flex h-full flex-col">
@@ -1156,6 +1164,7 @@ export function LocalPrView({
                     size="sm"
                     disabled={mergeBlocked}
                     reason={mergeReason}
+                    title={mergeReason}
                   />
                 }
               >

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -557,44 +557,30 @@ export function PrMergeabilityBanner({
               )}
               Update branch
             </DisabledReasonButton>
-            {/* A span-wrapped `render` would swallow the caret's disabled state — the
-              vendored Button's `pointer-events-none` routes the click to the span,
-              which IS the trigger — so a refused update renders no trigger at all. */}
-            {updateDisabled ? (
-              <span className="inline-flex" title={updateDisabledReason}>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Update branch options"
-                  disabled
-                >
-                  <CaretDownIcon />
-                </Button>
-              </span>
-            ) : (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label="Update branch options"
-                      title={updateOptionsLabel}
-                    />
-                  }
-                >
-                  <CaretDownIcon />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-48">
-                  <DropdownMenuItem
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <DisabledReasonButton
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Update branch options"
                     disabled={updateDisabled}
-                    onClick={onUpdateWithRebase}
-                  >
-                    Update with rebase…
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                    reason={updateDisabledReason}
+                    title={updateOptionsLabel}
+                  />
+                }
+              >
+                <CaretDownIcon />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-48">
+                <DropdownMenuItem
+                  disabled={updateDisabled}
+                  onClick={onUpdateWithRebase}
+                >
+                  Update with rebase…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         )}
 

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -296,6 +296,11 @@ function isServerMergeDisabled(pr: PrDetails, s: MergeStrategy): boolean {
   return SERVER_MERGE_FLAG[s](pr) === false;
 }
 
+/** Defensive fallback for a `busy` hold whose term `composerReason` doesn't
+ *  (yet) name — coverage holds today, but this keeps the four sites that
+ *  guard against it in step rather than re-typing the sentence. */
+const MERGE_BUSY_FALLBACK_REASON = "Another operation is in progress";
+
 export function RemotePrView({
   repoPath,
   number,
@@ -2368,7 +2373,7 @@ export function RemotePrView({
       case staleReason !== undefined:
         return staleReason;
       case busy:
-        return composerReason ?? "Another operation is in progress";
+        return composerReason ?? MERGE_BUSY_FALLBACK_REASON;
       case pr.isDraft:
         return `Mark the ${prNoun} ready before merging`;
       case mergeGuardMissing:
@@ -3077,7 +3082,7 @@ export function RemotePrView({
                       // would open against the previously rendered PR;
                       // `composerReason` names whichever term is in flight so the
                       // hold is never mute.
-                      reason={composerReason}
+                      reason={composerReason ?? MERGE_BUSY_FALLBACK_REASON}
                       onClick={() => setSubmitOpen(true)}
                       title="Submit a review (verdict, summary, and any pending comments)"
                     >
@@ -3104,7 +3109,9 @@ export function RemotePrView({
                             case approvals.isError:
                               return "Couldn't load approval state";
                             case busy:
-                              return composerReason;
+                              return (
+                                composerReason ?? MERGE_BUSY_FALLBACK_REASON
+                              );
                             case approvals.isPending:
                               return "Checking approval state…";
                             default:
@@ -3168,7 +3175,7 @@ export function RemotePrView({
                           case approvals.isError:
                             return "Couldn't load review state";
                           case busy:
-                            return composerReason;
+                            return composerReason ?? MERGE_BUSY_FALLBACK_REASON;
                           case approvals.isPending:
                             return "Checking review state…";
                           default:

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2358,8 +2358,8 @@ export function RemotePrView({
   // Permission outranks the availability hints: a viewer who can't push can't
   // act on any of them. The wait outranks them in turn — every hint below reads
   // the RENDERED pr, which through a switch is the previous one, so each would
-  // describe a pull request the viewer didn't pick. `busy` alone (an unrelated
-  // mutation in flight) gets its own line rather than falling through to the
+  // describe a pull request the viewer didn't pick. `busy` alone names the term
+  // in flight (`composerReason`) rather than falling through to the
   // enabled-state hint, which would misdescribe what's actually holding it —
   // this same string doubles as the hover title while nothing blocks.
   const mergeReason = (() => {
@@ -2375,7 +2375,7 @@ export function RemotePrView({
       case allMergeMethodsBlocked:
         return "No merge method is enabled by both this repository's settings and its branch rules";
       case busy:
-        return "Another operation is in progress";
+        return composerReason ?? "Another operation is in progress";
       default:
         return `Merge this ${prNoun}`;
     }
@@ -3295,7 +3295,7 @@ export function RemotePrView({
               variant="outline"
               size="sm"
               disabled={busy || writeBlocked}
-              reason={writeReason ?? staleReason}
+              reason={writeReason ?? composerReason}
               onClick={() => void markReadyForReview()}
             >
               Ready for review
@@ -3306,7 +3306,7 @@ export function RemotePrView({
               variant="ghost"
               size="sm"
               disabled={busy || writeBlocked}
-              reason={writeReason ?? staleReason}
+              reason={writeReason ?? composerReason}
               title="Turn this pull request back into a draft"
               onClick={() => void convertToDraft()}
             >
@@ -3350,7 +3350,7 @@ export function RemotePrView({
                 variant="outline"
                 size="sm"
                 disabled={busy || writeBlocked}
-                reason={writeReason ?? staleReason}
+                reason={writeReason ?? composerReason}
                 onClick={() => void doCancelAutoMerge()}
               >
                 Cancel auto-merge
@@ -3365,7 +3365,7 @@ export function RemotePrView({
               variant="outline"
               size="sm"
               disabled={busy || triageBlocked}
-              reason={triageReason ?? staleReason}
+              reason={triageReason ?? composerReason}
               onClick={doClose}
               title={
                 draftRidesStateChange
@@ -3465,7 +3465,7 @@ export function RemotePrView({
             variant="outline"
             size="sm"
             disabled={busy || triageBlocked}
-            reason={triageReason ?? staleReason}
+            reason={triageReason ?? composerReason}
             onClick={doReopen}
             title={
               draftRidesStateChange

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2357,16 +2357,10 @@ export function RemotePrView({
     allMergeMethodsBlocked;
   // Permission outranks the availability hints: a viewer who can't push can't
   // act on any of them. The wait outranks them in turn — every hint below reads
-  // the RENDERED pr, which through a switch is the previous one, so each would
-  // describe a pull request the viewer didn't pick. `busy` ranks above the
-  // static availability hints too: `pr.isDraft` (and the other two) still read
-  // true while a term of `busy` is in flight FOR THIS SAME PR — e.g.
-  // `setDraft.isPending` on a draft PR, mid-flip to ready — so checking them
-  // first would tell the viewer to do the exact thing already in progress.
-  // `busy` alone names the term in flight (`composerReason`) rather than
-  // falling through to the enabled-state hint, which would misdescribe what's
-  // actually holding it — this same string doubles as the hover title while
-  // nothing blocks.
+  // the RENDERED pr, which through a switch is the previous one. `busy` also
+  // outranks the static hints: `pr.isDraft` and the rest can stay true while a
+  // term of `busy` is in flight for this same PR, and `composerReason` names
+  // it — this same string doubles as the hover title while nothing blocks.
   const mergeReason = (() => {
     switch (true) {
       case writeReason !== undefined:

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -3080,9 +3080,10 @@ export function RemotePrView({
                       size="sm"
                       disabled={busy}
                       // `busy` folds in the placeholder window, where the review
-                      // would open against the previously rendered PR. The pending
-                      // arms carry no reason here, as on the neighbours.
-                      reason={staleReason}
+                      // would open against the previously rendered PR;
+                      // `composerReason` names whichever term is in flight so the
+                      // hold is never mute.
+                      reason={composerReason}
                       onClick={() => setSubmitOpen(true)}
                       title="Submit a review (verdict, summary, and any pending comments)"
                     >
@@ -3099,14 +3100,23 @@ export function RemotePrView({
                         // Approve that would fire the wrong direction on click. The
                         // failed read has no other surface, so it rides `reason` —
                         // hoverable and announced while the button is unavailable.
+                        // Every term of `disabled` gets words this way, `busy`'s via
+                        // `composerReason`, so the hold is never mute.
                         disabled={
                           busy || approvals.isPending || approvals.isError
                         }
-                        reason={
-                          approvals.isError
-                            ? "Couldn't load approval state"
-                            : staleReason
-                        }
+                        reason={(() => {
+                          switch (true) {
+                            case approvals.isError:
+                              return "Couldn't load approval state";
+                            case busy:
+                              return composerReason;
+                            case approvals.isPending:
+                              return "Checking approval state…";
+                            default:
+                              return undefined;
+                          }
+                        })()}
                         // Unknown state is announced as unknown: a failed read
                         // must not claim "not pressed" while the reason says the
                         // state couldn't be loaded.
@@ -3154,15 +3164,23 @@ export function RemotePrView({
                       // posture as the approve toggle: `reason` carries the read
                       // failure nothing else reports, and DisabledReasonButton keeps
                       // the disabled button focusable so that reason is announced
-                      // rather than lost.
+                      // rather than lost. Every term of `disabled` gets words this
+                      // way, `busy`'s via `composerReason`.
                       disabled={
                         busy || approvals.isPending || approvals.isError
                       }
-                      reason={
-                        approvals.isError
-                          ? "Couldn't load review state"
-                          : staleReason
-                      }
+                      reason={(() => {
+                        switch (true) {
+                          case approvals.isError:
+                            return "Couldn't load review state";
+                          case busy:
+                            return composerReason;
+                          case approvals.isPending:
+                            return "Checking review state…";
+                          default:
+                            return undefined;
+                        }
+                      })()}
                       // Unknown state is announced as unknown (same as approve).
                       aria-pressed={
                         approvals.isError

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -3366,27 +3366,19 @@ export function RemotePrView({
           )}
           {canMerge && (
             <DropdownMenu>
-              {/* A natively-disabled Button swallows `title`, so the hint rides a
-                  wrapping span (house idiom). The span stays OUTSIDE the trigger:
-                  as the trigger it would take the click the disabled button
-                  refuses and open the menu anyway — merging past every gate,
-                  including GitLab's stale-head guard. */}
-              <span
-                title={mergeReason}
-                className={cn(
-                  "inline-flex",
-                  mergeBlocked && "cursor-not-allowed",
-                )}
+              <DropdownMenuTrigger
+                render={
+                  <DisabledReasonButton
+                    size="sm"
+                    disabled={mergeBlocked}
+                    reason={mergeReason}
+                  />
+                }
               >
-                <DropdownMenuTrigger
-                  disabled={mergeBlocked}
-                  render={<Button size="sm" />}
-                >
-                  <GitMergeIcon data-icon="inline-start" />
-                  Merge
-                  <CaretDownIcon data-icon="inline-end" />
-                </DropdownMenuTrigger>
-              </span>
+                <GitMergeIcon data-icon="inline-start" />
+                Merge
+                <CaretDownIcon data-icon="inline-end" />
+              </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
                 {/* Branch-rule gating is GitHub branch-protection data, so it
                     never applies to GitLab/Bitbucket. */}

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2358,24 +2358,29 @@ export function RemotePrView({
   // Permission outranks the availability hints: a viewer who can't push can't
   // act on any of them. The wait outranks them in turn — every hint below reads
   // the RENDERED pr, which through a switch is the previous one, so each would
-  // describe a pull request the viewer didn't pick. `busy` alone names the term
-  // in flight (`composerReason`) rather than falling through to the
-  // enabled-state hint, which would misdescribe what's actually holding it —
-  // this same string doubles as the hover title while nothing blocks.
+  // describe a pull request the viewer didn't pick. `busy` ranks above the
+  // static availability hints too: `pr.isDraft` (and the other two) still read
+  // true while a term of `busy` is in flight FOR THIS SAME PR — e.g.
+  // `setDraft.isPending` on a draft PR, mid-flip to ready — so checking them
+  // first would tell the viewer to do the exact thing already in progress.
+  // `busy` alone names the term in flight (`composerReason`) rather than
+  // falling through to the enabled-state hint, which would misdescribe what's
+  // actually holding it — this same string doubles as the hover title while
+  // nothing blocks.
   const mergeReason = (() => {
     switch (true) {
       case writeReason !== undefined:
         return writeReason;
       case staleReason !== undefined:
         return staleReason;
+      case busy:
+        return composerReason ?? "Another operation is in progress";
       case pr.isDraft:
         return `Mark the ${prNoun} ready before merging`;
       case mergeGuardMissing:
         return "Reload to merge — couldn't load the head commit to guard the merge";
       case allMergeMethodsBlocked:
         return "No merge method is enabled by both this repository's settings and its branch rules";
-      case busy:
-        return composerReason ?? "Another operation is in progress";
       default:
         return `Merge this ${prNoun}`;
     }

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -299,7 +299,7 @@ function isServerMergeDisabled(pr: PrDetails, s: MergeStrategy): boolean {
 /** Defensive fallback for a `busy` hold whose term `composerReason` doesn't
  *  (yet) name — coverage holds today, but this keeps the four sites that
  *  guard against it in step rather than re-typing the sentence. */
-const MERGE_BUSY_FALLBACK_REASON = "Another operation is in progress";
+const BUSY_HOLD_FALLBACK_REASON = "Another operation is in progress";
 
 export function RemotePrView({
   repoPath,
@@ -2373,7 +2373,7 @@ export function RemotePrView({
       case staleReason !== undefined:
         return staleReason;
       case busy:
-        return composerReason ?? MERGE_BUSY_FALLBACK_REASON;
+        return composerReason ?? BUSY_HOLD_FALLBACK_REASON;
       case pr.isDraft:
         return `Mark the ${prNoun} ready before merging`;
       case mergeGuardMissing:
@@ -3082,7 +3082,7 @@ export function RemotePrView({
                       // would open against the previously rendered PR;
                       // `composerReason` names whichever term is in flight so the
                       // hold is never mute.
-                      reason={composerReason ?? MERGE_BUSY_FALLBACK_REASON}
+                      reason={composerReason ?? BUSY_HOLD_FALLBACK_REASON}
                       onClick={() => setSubmitOpen(true)}
                       title="Submit a review (verdict, summary, and any pending comments)"
                     >
@@ -3110,7 +3110,7 @@ export function RemotePrView({
                               return "Couldn't load approval state";
                             case busy:
                               return (
-                                composerReason ?? MERGE_BUSY_FALLBACK_REASON
+                                composerReason ?? BUSY_HOLD_FALLBACK_REASON
                               );
                             case approvals.isPending:
                               return "Checking approval state…";
@@ -3175,7 +3175,7 @@ export function RemotePrView({
                           case approvals.isError:
                             return "Couldn't load review state";
                           case busy:
-                            return composerReason ?? MERGE_BUSY_FALLBACK_REASON;
+                            return composerReason ?? BUSY_HOLD_FALLBACK_REASON;
                           case approvals.isPending:
                             return "Checking review state…";
                           default:

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2345,9 +2345,10 @@ export function RemotePrView({
     );
   }
 
-  // The Merge control's state. Hoisted because the refusal has to sit on the
-  // wrapping span while `disabled` sits on the trigger — a disabled trigger is
-  // what actually keeps the menu (and with it an unguarded merge) shut.
+  // The Merge control's state. `disabled`/`reason` land on the rendered
+  // DisabledReasonButton, never the trigger — its own inner useButton swallows
+  // activation while blocked, which is what actually keeps an unguarded merge
+  // from firing.
   const mergeBlocked =
     busy ||
     writeBlocked ||
@@ -2357,17 +2358,28 @@ export function RemotePrView({
   // Permission outranks the availability hints: a viewer who can't push can't
   // act on any of them. The wait outranks them in turn — every hint below reads
   // the RENDERED pr, which through a switch is the previous one, so each would
-  // describe a pull request the viewer didn't pick.
-  const mergeReason =
-    writeReason ??
-    staleReason ??
-    (pr.isDraft
-      ? `Mark the ${prNoun} ready before merging`
-      : mergeGuardMissing
-        ? "Reload to merge — couldn't load the head commit to guard the merge"
-        : allMergeMethodsBlocked
-          ? "No merge method is enabled by both this repository's settings and its branch rules"
-          : `Merge this ${prNoun}`);
+  // describe a pull request the viewer didn't pick. `busy` alone (an unrelated
+  // mutation in flight) gets its own line rather than falling through to the
+  // enabled-state hint, which would misdescribe what's actually holding it —
+  // this same string doubles as the hover title while nothing blocks.
+  const mergeReason = (() => {
+    switch (true) {
+      case writeReason !== undefined:
+        return writeReason;
+      case staleReason !== undefined:
+        return staleReason;
+      case pr.isDraft:
+        return `Mark the ${prNoun} ready before merging`;
+      case mergeGuardMissing:
+        return "Reload to merge — couldn't load the head commit to guard the merge";
+      case allMergeMethodsBlocked:
+        return "No merge method is enabled by both this repository's settings and its branch rules";
+      case busy:
+        return "Another operation is in progress";
+      default:
+        return `Merge this ${prNoun}`;
+    }
+  })();
 
   // The header's meta fields, row-major, as label/value pairs for the grid
   // below: an editable field emits its trigger as the label cell and its chips
@@ -3372,6 +3384,7 @@ export function RemotePrView({
                     size="sm"
                     disabled={mergeBlocked}
                     reason={mergeReason}
+                    title={mergeReason}
                   />
                 }
               >

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -15,9 +15,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -2463,50 +2463,50 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         }}
       >
-        {/* The reason rides the wrapper (a disabled trigger drops pointer
-            events, so its own `title` never surfaces), and the wrapper is the
-            header's flex item, so it owns the shrink-20 that makes the branch
-            label collapse before the CI badge (4); the inner Button needs
-            `shrink` to undo the vendored `shrink-0`, or nothing truncates. */}
-        <span
-          className={cn(
-            "inline-flex min-w-0 shrink-20",
-            amending && "cursor-not-allowed",
-          )}
-          title={
-            amending ? "Finish or stop amending to switch branches" : undefined
-          }
-        >
-          <Popover.Trigger
-            disabled={busy || amending}
-            render={
-              <Button
-                variant="ghost"
-                size="sm"
-                // overflow-hidden clips the box the shrink cascade squeezes;
-                // without it the icons (shrink-0) spill out both sides into the
-                // separator and the repository menu on a narrow header.
-                className="min-w-0 shrink overflow-hidden"
+        {/* The wrapper is the header's flex item, so it owns the shrink-20
+            that makes the branch label collapse before the CI badge (4); the
+            inner Button needs `shrink` to undo the vendored `shrink-0`, or
+            nothing truncates. */}
+        <Popover.Trigger
+          disabled={busy || amending}
+          render={
+            <DisabledReasonButton
+              variant="ghost"
+              size="sm"
+              wrapperClassName="min-w-0 shrink-20"
+              reason={(() => {
+                switch (true) {
+                  case amending:
+                    return "Finish or stop amending to switch branches";
+                  case busy:
+                    return "Another git operation is running.";
+                  default:
+                    return undefined;
+                }
+              })()}
+              // overflow-hidden clips the box the shrink cascade squeezes;
+              // without it the icons (shrink-0) spill out both sides into the
+              // separator and the repository menu on a narrow header.
+              className="min-w-0 shrink overflow-hidden"
+            >
+              <GitBranchIcon data-icon="inline-start" />
+              <span
+                className="min-w-0 truncate"
+                // Sits under the wrapper's conditional title — a static or
+                // blanked title here would suppress that tooltip.
+                onMouseEnter={clipTitle(currentLabel)}
               >
-                <GitBranchIcon data-icon="inline-start" />
-                <span
-                  className="min-w-0 truncate"
-                  // Sits under the wrapper's conditional (amending) title — a
-                  // static or blanked title here would suppress that tooltip.
-                  onMouseEnter={clipTitle(currentLabel)}
-                >
-                  {currentLabel}
-                </span>
-                {head?.detached && (
-                  <Badge variant="secondary" className="ml-1 shrink-0">
-                    detached
-                  </Badge>
-                )}
-                <CaretDownIcon data-icon="inline-end" />
-              </Button>
-            }
-          />
-        </span>
+                {currentLabel}
+              </span>
+              {head?.detached && (
+                <Badge variant="secondary" className="ml-1 shrink-0">
+                  detached
+                </Badge>
+              )}
+              <CaretDownIcon data-icon="inline-end" />
+            </DisabledReasonButton>
+          }
+        />
         <Popover.Portal>
           <Popover.Positioner
             align="start"

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -2463,17 +2463,15 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
           }
         }}
       >
-        {/* The wrapper is the header's flex item, so it owns the shrink-20
-            that makes the branch label collapse before the CI badge (4); the
-            inner Button needs `shrink` to undo the vendored `shrink-0`, or
-            nothing truncates. */}
         <Popover.Trigger
-          disabled={busy || amending}
           render={
             <DisabledReasonButton
               variant="ghost"
               size="sm"
+              // The wrapper is the header's flex item, so it owns the shrink-20
+              // that makes the branch label collapse before the CI badge (4).
               wrapperClassName="min-w-0 shrink-20"
+              disabled={busy || amending}
               reason={(() => {
                 switch (true) {
                   case amending:
@@ -2484,9 +2482,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     return undefined;
                 }
               })()}
-              // overflow-hidden clips the box the shrink cascade squeezes;
-              // without it the icons (shrink-0) spill out both sides into the
-              // separator and the repository menu on a narrow header.
+              // overflow-hidden clips the box the shrink cascade squeezes; the
+              // shrink undoes the vendored Button's own shrink-0, or nothing
+              // truncates — without either, the icons spill out both sides
+              // into the separator and the repository menu on a narrow header.
               className="min-w-0 shrink overflow-hidden"
             >
               <GitBranchIcon data-icon="inline-start" />

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -40,6 +40,10 @@ import { useAddRecentRepo, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { errorMessage, isAppError } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
+import {
+  ARIA_DISABLED_CLASS,
+  useDisabledReason,
+} from "@/lib/use-disabled-reason";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 import { nameFromUrl, parentDir } from "./clone-utils";
@@ -200,6 +204,15 @@ export function CloneRepoDialog({
   const canClone =
     values.destination.trim().length > 0 &&
     (tab === "url" ? values.url.trim().length > 0 : selected !== null);
+  const cloneDisabledReason = canClone
+    ? undefined
+    : !values.destination.trim()
+      ? "Choose a local path to clone into"
+      : tab === "url"
+        ? "Enter a repository URL to clone"
+        : "Select a repository to clone";
+  const { blockedReason, reasonId, wrapperTitle, describedBy } =
+    useDisabledReason({ disabled: !canClone, reason: cloneDisabledReason });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -346,24 +359,26 @@ export function CloneRepoDialog({
               Cancel
             </Button>
             <form.AppForm>
-              {/* Wrap so the disabled reason still shows on hover — a
-                  native-disabled button swallows its `title` (vendored Button's
-                  pointer-events-none). */}
               <span
-                className="inline-flex"
-                title={
-                  canClone
-                    ? undefined
-                    : !values.destination.trim()
-                      ? "Choose a local path to clone into"
-                      : tab === "url"
-                        ? "Enter a repository URL to clone"
-                        : "Select a repository to clone"
-                }
+                className={cn(
+                  "inline-flex",
+                  blockedReason && "cursor-not-allowed",
+                )}
+                title={wrapperTitle}
               >
-                <form.SubmitButton disabled={!canClone}>
+                <form.SubmitButton
+                  focusableWhenDisabled={!!blockedReason}
+                  disabled={!canClone}
+                  aria-describedby={describedBy}
+                  className={ARIA_DISABLED_CLASS}
+                >
                   Clone
                 </form.SubmitButton>
+                {blockedReason ? (
+                  <span id={reasonId} className="sr-only">
+                    {blockedReason}
+                  </span>
+                ) : null}
               </span>
             </form.AppForm>
           </DialogFooter>

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -204,13 +204,18 @@ export function CloneRepoDialog({
   const canClone =
     values.destination.trim().length > 0 &&
     (tab === "url" ? values.url.trim().length > 0 : selected !== null);
-  const cloneDisabledReason = canClone
-    ? undefined
-    : !values.destination.trim()
-      ? "Choose a local path to clone into"
-      : tab === "url"
-        ? "Enter a repository URL to clone"
-        : "Select a repository to clone";
+  const cloneDisabledReason = (() => {
+    switch (true) {
+      case canClone:
+        return undefined;
+      case !values.destination.trim():
+        return "Choose a local path to clone into";
+      case tab === "url":
+        return "Enter a repository URL to clone";
+      default:
+        return "Select a repository to clone";
+    }
+  })();
   const { blockedReason, reasonId, wrapperTitle, describedBy } =
     useDisabledReason({ disabled: !canClone, reason: cloneDisabledReason });
 


### PR DESCRIPTION
Converts the last remaining menu and popover triggers that carried their disabled reason on a titled wrapper over to the `DisabledReasonButton` primitive, so a blocked control stays in the tab order and announces why it's unavailable instead of only revealing the reason on hover. With every residual site converted, the `titled-disabled-trigger` gate's deferral allowlist empties out and any future violation is a genuinely new instance of the class.

### Trigger conversions

- `src/features/repository/BranchSwitcher.tsx`: the branch trigger now renders a `DisabledReasonButton`, moving the header's `min-w-0 shrink-20` flex sizing onto `wrapperClassName` so the label still collapses before the CI badge; the reason is computed per state and now also covers the `busy` case ("Another git operation is running.") that the previous wrapper title left unexplained.
- `src/features/pulls/RemotePrView.tsx` and `src/features/pulls/LocalPrView.tsx`: the Merge menu triggers drop the titled `<span>` wrapper and put `disabled`/`reason` directly on the rendered `DisabledReasonButton`, keeping the blocked merge inert while surfacing `mergeReason`.
- `src/features/issues/RemoteIssueView.tsx`: both the "Other close options" caret and the "More actions" menu convert, carrying `triageReason ?? staleReason` and `staleReason` respectively.
- `src/features/conversations/ProjectsPopover.tsx`: the Projects trigger takes `reason={heldReason}` directly; the stale comment about a disabled button swallowing `title` goes away.
- `src/features/discussions/DiscussionsPanel.tsx`: the category filter trigger now passes the sign-in hint as a `reason` prop rather than a bare title string on a wrapping span.

### Clone dialog

- `src/features/welcome/CloneRepoDialog.tsx`: the Clone button can't take the primitive (it's `form.SubmitButton`), so it wires the pieces by hand via `useDisabledReason` — `focusableWhenDisabled`, `aria-describedby` pointing at an `sr-only` reason node, `ARIA_DISABLED_CLASS`, and the wrapper title. The reason text itself is hoisted into a `cloneDisabledReason` binding.

### Gate and docs

- `scripts/check-banned-patterns.mjs`: empties the `titled-disabled-trigger` allowlist and replaces the deferral rationale with a note explaining the empty list is deliberate.
- Adds `changelog.d/fixed-disabled-trigger-keyboard-reach.md` covering the picker, filter, issue menus, merge menus, branch switcher, and Clone button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and screen-reader access to disabled controls across project, discussion, issue, pull request, branch, and repository workflows.
  * Disabled controls now explain why they are unavailable through accessible announcements and hover hints.
* **Bug Fixes**
  * Added clearer status messages while merges, branch updates, and other operations are in progress.
  * Pull-request merge controls now identify when another operation is in progress instead of showing a generic merge prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->