### PR TITLE
fix(paths,notifications): middle-truncate every path display

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -20,7 +20,8 @@ paths:
   `ARIA_DISABLED_CLASS` on raw-button and form-wrapped-Button (`form.SubmitButton`)
   sites — never hide, never a bare `disabled`.
 - Truncated user/repo content: `clipTitle`/`clipTitleFromText` only-when-clipped; Base UI
-  Select rows via `SelectClipText` as the row's SOLE child.
+  Select rows via `SelectClipText` as the row's SOLE child; file/directory paths
+  middle-truncate via `PathText` (`src/components/path-text.tsx`), never hand-rolled.
 - Semantic state tokens (`--success`, `--warning`, `--info`, `--merged`, `--destructive`)
   — no hardcoded green/amber/red classes; never meaning by color alone.
 - Per-variant copy/labels/glyphs are `Record` lookups, never ternary chains.

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -133,6 +133,13 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   an item-level handler is dead once the row span self-bounds (the
   `select-item-clip-title` guard fails on both); the closed field takes
   `onMouseEnter={clipTitleFromText}` on its `SelectValue`.
+- File/directory paths middle-truncate through `PathText`
+  (`src/components/path-text.tsx`) — head context and the filename both
+  survive. It owns its only-when-clipped tooltip (allowlisted in
+  `inline-clip-title`: the outer span it titles never overflows itself). A
+  new path display hand-rolling `truncate` re-mints the inconsistency this
+  fixed. Label composites (`Saved to <PathText/>`) space via `gap-*` on the
+  flex row, never a trailing space in the label — flex line boxes trim it.
 - A `SelectControl`/`SelectField` `items` Record silently reorders integer-like
   keys to the front (JS object semantics) — any picker whose option values are
   user-supplied identifiers that can be all-digits (logins, slugs) must pass

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -140,6 +140,8 @@ Inner-clause drift between two dispatchers is the regression this prevents; the
   new path display hand-rolling `truncate` re-mints the inconsistency this
   fixed. Label composites (`Saved to <PathText/>`) space via `gap-*` on the
   flex row, never a trailing space in the label — flex line boxes trim it.
+  Non-flex-item text is exempt: the absolutely-positioned `sr-only` badge
+  spans keep their trailing announcement space.
 - A `SelectControl`/`SelectField` `items` Record silently reorders integer-like
   keys to the front (JS object semantics) — any picker whose option values are
   user-supplied identifiers that can be all-digits (logins, slugs) must pass

--- a/changelog.d/changed-path-middle-truncation.md
+++ b/changelog.d/changed-path-middle-truncation.md
@@ -1,0 +1,3 @@
+- File and directory paths now truncate in the middle: the filename and its
+  leading context stay visible when space runs short, across the Changes list,
+  diff headers, worktree rows, and every other path display.

--- a/changelog.d/changed-path-middle-truncation.md
+++ b/changelog.d/changed-path-middle-truncation.md
@@ -1,3 +1,3 @@
 - File and directory paths now truncate in the middle: the filename and its
   leading context stay visible when space runs short, across the Changes list,
-  diff headers, worktree rows, and every other path display.
+  diff headers, worktree rows, and dozens of other path displays.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -228,14 +228,11 @@ const INLINE_CLIP_TITLE_RE = new RegExp(
 // a same-tag [^>] bound, because prop expressions carry `=>` arrows; the
 // tempered `(?!</SelectItem\b)` step stops each scan at the item's closing
 // tag, so an adjacent picker's trigger handler can never pair across items.
-// Known false positive left open: a legal SELF-BOUNDED clip span inside an
-// item (TaskDialog's `max-w-64 truncate` interpreter-path sub-span — its own
-// width bound keeps the handler live) sits ~2× outside the window today; a
-// compacted row would fire loudly, with the allowlist as remedy. Accepted
-// evasions: an aliased or wrapped handler, a reordered/interleaved class
-// string, a wrapper component around SelectItem — and a bare text child with
-// no affordance at all, the shape most converted sites had, which no arm can
-// see.
+// Accepted evasions: an aliased or wrapped handler, a reordered/interleaved
+// class string, a wrapper component around SelectItem — the only in-item path
+// row now routes through PathText, whose classes live in path-text.tsx and
+// are invisible to these patterns — and a bare text child with no affordance
+// at all, the shape most converted sites had, which no arm can see.
 const SELECT_ITEM_CLIP_TITLE_RE = new RegExp(
   `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP}}?\\bclipTitle`,
   "g",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -229,10 +229,10 @@ const INLINE_CLIP_TITLE_RE = new RegExp(
 // tempered `(?!</SelectItem\b)` step stops each scan at the item's closing
 // tag, so an adjacent picker's trigger handler can never pair across items.
 // Accepted evasions: an aliased or wrapped handler, a reordered/interleaved
-// class string, a wrapper component around SelectItem — the only in-item path
-// row now routes through PathText, whose classes live in path-text.tsx and
-// are invisible to these patterns — and a bare text child with no affordance
-// at all, the shape most converted sites had, which no arm can see.
+// class string, a wrapper component around SelectItem, and a bare text child
+// with no affordance at all, the shape most converted sites had, which no arm
+// can see. The only in-item path row now routes through PathText, whose
+// classes live in path-text.tsx and are invisible to these patterns.
 const SELECT_ITEM_CLIP_TITLE_RE = new RegExp(
   `<SelectItem\\b(?:(?!</SelectItem\\b)[\\s\\S]){0,${PAIR_GAP}}?\\bclipTitle`,
   "g",

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -522,7 +522,12 @@ export const CHECKS = [
     appliesTo: (file) =>
       file !== "src/lib/clip-title.ts" && notVendoredUi(file),
     scan: perFile(INLINE_CLIP_TITLE_RE),
-    allowlist: [],
+    allowlist: [
+      // PathText measures its two inner spans and titles the outer one, which
+      // never overflows itself — clipTitle can't serve that shape. It keeps
+      // the helper's remove-don't-blank contract.
+      "src/components/path-text.tsx",
+    ],
     message:
       "clip-measured tooltips route through clipTitle/clipTitleFromText (src/lib/clip-title.ts) — an inline rewrite re-opens the blank-title ancestor-suppression class; if the pairing is a false positive, add an allowlist entry with rationale",
   },

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -226,11 +226,10 @@ test("select-item-clip-title flags the superseded item-level handler, wrapped or
     "</SelectItem>",
   ].join("\n");
   assert.deepEqual(selectItemClipTitle(deadSpan), [1]);
-  // A SELF-BOUNDED span (explicit max-w) keeps its handler LIVE — TaskDialog's
-  // interpreter-path sub-span. At close range it still pairs: the guard cannot
-  // see width bounds, so this is the known false positive the allowlist
-  // remedies. In the real tree the row's markup holds it ~2× outside the
-  // window.
+  // A synthetic SELF-BOUNDED span (an explicit max-w keeps its handler live).
+  // At close range it still pairs — the guard cannot see width bounds — so a
+  // real one would need the allowlist. No in-tree site carries this shape
+  // today: in-item path rows route through PathText.
   const bounded = [
     "<SelectItem key={i.id} value={i.id}>",
     "  <span",

--- a/src/components/path-text.tsx
+++ b/src/components/path-text.tsx
@@ -1,0 +1,64 @@
+import type { MouseEvent } from "react";
+import { cn } from "@/lib/utils";
+
+const isSep = (ch: string) => ch === "/" || ch === "\\";
+
+/**
+ * The app's one file/directory path display: middle truncation via two flex
+ * spans, so the filename survives at every width with no measurement, and DOM
+ * order fixes visual order (bidi can't reorder across the split). Every path
+ * renders through this — hand-rolling `truncate` on one re-mints the
+ * inconsistent-truncation class. The only-when-clipped tooltip lives here (same
+ * remove-don't-blank contract as `clipTitle`): the outer span never overflows
+ * once a child truncates, so a handler on it would be dead.
+ */
+export function PathText({
+  path,
+  line,
+  className,
+}: {
+  path: string;
+  /** Optional line number rendered as `:{line}` in the protected tail. */
+  line?: number | null;
+  className?: string;
+}) {
+  // Trailing separators belong to the tail, so `a/b/` splits at `a` | `/b/`;
+  // concatenating the two spans always reproduces `path` exactly.
+  let end = path.length;
+  while (end > 0 && isSep(path[end - 1])) end--;
+  let cut = -1;
+  for (let i = end - 1; i >= 0; i--) {
+    if (isSep(path[i])) {
+      cut = i;
+      break;
+    }
+  }
+  const dir = cut > 0 ? path.slice(0, cut) : "";
+  const base = cut >= 0 ? path.slice(cut) : path;
+  const full = line != null ? `${path}:${line}` : path;
+
+  const onMouseEnter = (e: MouseEvent<HTMLElement>) => {
+    const el = e.currentTarget;
+    let clipped = false;
+    for (const child of el.children) {
+      if (child.scrollWidth > child.clientWidth) clipped = true;
+    }
+    const v = full.trim();
+    if (clipped && v) el.title = v;
+    else el.removeAttribute("title");
+  };
+
+  return (
+    <span className={cn("flex min-w-0", className)} onMouseEnter={onMouseEnter}>
+      {/* min-w-0 is mandatory: a flex item's `min-width: auto` floors it at
+          content width, and `truncate` silently never engages without it. */}
+      {dir ? <span className="min-w-0 truncate">{dir}</span> : null}
+      {/* max-w-full + truncate is the degradation path for a lone filename with
+          no head to give: it end-ellipses instead of overflowing the row. */}
+      <span className="max-w-full shrink-0 truncate">
+        {base}
+        {line != null ? `:${line}` : null}
+      </span>
+    </span>
+  );
+}

--- a/src/components/path-text.tsx
+++ b/src/components/path-text.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from "react";
+import { type MouseEvent, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 const isSep = (ch: string) => ch === "/" || ch === "\\";
@@ -10,16 +10,23 @@ const isSep = (ch: string) => ch === "/" || ch === "\\";
  * renders through this — hand-rolling `truncate` on one re-mints the
  * inconsistent-truncation class. The only-when-clipped tooltip lives here (same
  * remove-don't-blank contract as `clipTitle`): the outer span never overflows
- * once a child truncates, so a handler on it would be dead.
+ * once a child truncates, so a handler on it would be dead. The tooltip keeps
+ * the path's own leading/trailing whitespace — those are identity characters
+ * in a git path.
  */
 export function PathText({
   path,
   line,
+  title,
   className,
 }: {
   path: string;
   /** Optional line number rendered as `:{line}` in the protected tail. */
   line?: number | null;
+  /** Tooltip value when clipped, for a rendered path that is a relativized
+   *  form of a longer canonical one (e.g. a transcript target) — the richer
+   *  string wins where the truncation already hides text. */
+  title?: string;
   className?: string;
 }) {
   // Trailing separators belong to the tail, so `a/b/` splits at `a` | `/b/`;
@@ -33,9 +40,19 @@ export function PathText({
       break;
     }
   }
-  const dir = cut > 0 ? path.slice(0, cut) : "";
+  const dir = cut >= 0 ? path.slice(0, cut) : "";
   const base = cut >= 0 ? path.slice(cut) : path;
   const full = line != null ? `${path}:${line}` : path;
+  const tip = title ?? full;
+
+  const ref = useRef<HTMLSpanElement>(null);
+  // The title is set imperatively, so React never clears it: a reused element
+  // (navigated header, windowed row) would keep the PREVIOUS path's tooltip
+  // until the next hover. Drop it the moment it no longer matches the content.
+  useEffect(() => {
+    const el = ref.current;
+    if (el && el.title && el.title !== tip) el.removeAttribute("title");
+  }, [tip]);
 
   const onMouseEnter = (e: MouseEvent<HTMLElement>) => {
     const el = e.currentTarget;
@@ -43,15 +60,20 @@ export function PathText({
     for (const child of el.children) {
       if (child.scrollWidth > child.clientWidth) clipped = true;
     }
-    const v = full.trim();
-    if (clipped && v) el.title = v;
+    if (clipped && tip.trim()) el.title = tip;
     else el.removeAttribute("title");
   };
 
   return (
-    <span className={cn("flex min-w-0", className)} onMouseEnter={onMouseEnter}>
-      {/* min-w-0 is mandatory: a flex item's `min-width: auto` floors it at
-          content width, and `truncate` silently never engages without it. */}
+    // min-w-0 here is the load-bearing one: without it the outer span floors
+    // at content width in ITS flex row and the children never shrink. (The
+    // dir span's copy is belt-and-braces — `truncate`'s overflow:hidden
+    // already zeroes a flex item's automatic minimum size.)
+    <span
+      ref={ref}
+      className={cn("flex min-w-0", className)}
+      onMouseEnter={onMouseEnter}
+    >
       {dir ? <span className="min-w-0 truncate">{dir}</span> : null}
       {/* max-w-full + truncate is the degradation path for a lone filename with
           no head to give: it end-ellipses instead of overflowing the row. */}

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -650,6 +650,7 @@ const TONE_CLASS: Record<NotificationTone, string> = {
  *  (e.g. `ci-run`, whose success/failure lives in the tone). */
 const KIND_GLYPH: Partial<Record<NotificationKind, typeof CheckCircleIcon>> = {
   "review-ready": SparkleIcon,
+  "review-posted": SparkleIcon,
   "review-failed": SparkleIcon,
   "checks-passed": CheckCircleIcon,
   "checks-failed": XCircleIcon,
@@ -672,10 +673,14 @@ const KIND_GLYPH: Partial<Record<NotificationKind, typeof CheckCircleIcon>> = {
  *  is therefore already on screen from every section. A `review-failed` from an
  *  *automation* still points at Review even though the panel shows idle: those
  *  runs use a separate `auto:<n>` key namespace, but Review is where the Run
- *  button lives. Read with a row's plain-string kind — a hydrated row can carry
- *  a kind from an older build, so a lookup must miss, never fail. */
+ *  button lives. `review-posted` means the automation already posted the review
+ *  as a PR comment, so it lives in the Conversation timeline; `review-ready` is
+ *  saved to the review panel un-posted, so Review is its landing. Read with a
+ *  row's plain-string kind — a hydrated row can carry a kind from an older
+ *  build, so a lookup must miss, never fail. */
 const KIND_SECTION: Partial<Record<NotificationKind, PrSection>> = {
   "review-ready": "review",
+  "review-posted": "conversation",
   "review-failed": "review",
   "pr-opened": "conversation",
   "pr-merged": "conversation",

--- a/src/features/code-todos/CodeTodoDetailView.tsx
+++ b/src/features/code-todos/CodeTodoDetailView.tsx
@@ -6,6 +6,7 @@ import {
 import hljs from "highlight.js/lib/common";
 import { useState } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -154,9 +155,11 @@ export function CodeTodoDetailView({
             )}
           </p>
         </div>
-        <p className="mt-1 font-mono text-xs text-muted-foreground">
-          {path}:{line}
-        </p>
+        <PathText
+          path={path}
+          line={line}
+          className="mt-1 font-mono text-xs text-muted-foreground"
+        />
         {/* Attribution line for the TODO's blame — hidden while stale/absent. */}
         {todoLine && isRealCommit(todoLine.hash) && (
           <p className="mt-2 text-xs text-muted-foreground">

--- a/src/features/code-todos/CodeTodosPanel.tsx
+++ b/src/features/code-todos/CodeTodosPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from "@phosphor-icons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
@@ -339,10 +340,10 @@ export function CodeTodosPanel({
                           ) : (
                             <CaretDownIcon className="size-3 shrink-0" />
                           )}
-                          <span className="truncate font-mono" title={row.path}>
-                            {row.path}
+                          <PathText path={row.path} className="font-mono" />
+                          <span className="shrink-0 tabular-nums">
+                            ({row.count})
                           </span>
-                          <span className="tabular-nums">({row.count})</span>
                         </button>
                       ) : (
                         <TodoRow

--- a/src/features/commit/CommitDialog.tsx
+++ b/src/features/commit/CommitDialog.tsx
@@ -1,6 +1,7 @@
 import { InfoIcon, SparkleIcon } from "@phosphor-icons/react";
 import { DiffStat } from "@/components/diff-stat";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -14,7 +15,6 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { clipTitle } from "@/lib/clip-title";
 import { KIND_BADGE } from "@/lib/git/change-kind-badge";
 import { useWorkingLineStats } from "@/lib/git/queries";
 import type { FileEntry } from "@/lib/git/types";
@@ -216,12 +216,21 @@ export function CommitDialog({ repoPath }: { repoPath: string }) {
                           announced first, and its trailing space keeps the two
                           from fusing. */}
                       <span className="sr-only">{badge.label} </span>
-                      <span
-                        className="min-w-0 flex-1 truncate"
-                        onMouseEnter={clipTitle(label)}
-                      >
-                        {label}
-                      </span>
+                      {entry.origPath ? (
+                        // A rename is two paths and an arrow: the composite
+                        // can't ride PathText's only-when-clipped measurement,
+                        // so the row keeps a static title for the whole label.
+                        <span
+                          className="flex min-w-0 flex-1 items-center gap-1"
+                          title={label}
+                        >
+                          <PathText path={entry.origPath} />
+                          <span className="shrink-0">→</span>
+                          <PathText path={entry.path} />
+                        </span>
+                      ) : (
+                        <PathText path={entry.path} className="flex-1" />
+                      )}
                       {stat ? (
                         <DiffStat
                           added={stat.added}

--- a/src/features/compare/BranchDiffView.tsx
+++ b/src/features/compare/BranchDiffView.tsx
@@ -1,6 +1,7 @@
 import { useDeferredValue, useState } from "react";
 import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
+import { PathText } from "@/components/path-text";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -151,11 +152,8 @@ export function BranchDiffView({
                       : "hover:bg-muted/60",
                   )}
                   onClick={() => setSelectedPath(file.path)}
-                  title={file.path}
                 >
-                  <span className="min-w-0 flex-1 truncate font-mono">
-                    {file.path}
-                  </span>
+                  <PathText path={file.path} className="flex-1 font-mono" />
                   <DiffStat
                     added={file.added}
                     deleted={file.deleted}

--- a/src/features/diff/DiffSurface.tsx
+++ b/src/features/diff/DiffSurface.tsx
@@ -23,6 +23,7 @@ import {
   useState,
 } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { decodeBase64Utf8 } from "@/lib/git/api";
@@ -1314,12 +1315,10 @@ export function DiffContent({
       className="ph-no-capture @container/diff-pane flex h-full flex-col"
     >
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
-        <span
-          className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
-          title={filePath}
-        >
-          {filePath}
-        </span>
+        <PathText
+          path={filePath}
+          className="flex-1 font-mono text-xs text-muted-foreground"
+        />
         {/* ~200px of unshrinkable text, so it shows only where the pane has the
             room; the sr-only twin carries it at every width, and `aria-hidden`
             on the visible copy keeps the two from announcing twice. Hidden in

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -410,12 +411,10 @@ function WorkingTreeDiff({
           selection && "bg-primary/10",
         )}
       >
-        <span
-          className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
-          title={file.path}
-        >
-          {file.path}
-        </span>
+        <PathText
+          path={file.path}
+          className="flex-1 font-mono text-xs text-muted-foreground"
+        />
         {/* min-h-7 pins the cluster to the language picker's h-7 trigger: the
             xs (h-6) selection buttons — and an extensionless file, where the
             picker renders nothing — would otherwise shrink the row by 4px.

--- a/src/features/diff/ImageDiff.tsx
+++ b/src/features/diff/ImageDiff.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PathText } from "@/components/path-text";
 import {
   ImageLightbox,
   type LightboxImage,
@@ -254,9 +255,10 @@ export function ImageDiff({
     // ph-no-capture: user image content + path — block from session replay.
     <div className="ph-no-capture flex h-full flex-col">
       <div className="border-b px-3 py-1.5">
-        <p className="truncate font-mono text-xs text-muted-foreground">
-          {filePath}
-        </p>
+        <PathText
+          path={filePath}
+          className="font-mono text-xs text-muted-foreground"
+        />
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
         <ImagePanes repoPath={repoPath} filePath={filePath} revs={revs} />

--- a/src/features/explore/ExploreCloneDialog.tsx
+++ b/src/features/explore/ExploreCloneDialog.tsx
@@ -131,8 +131,7 @@ export function ExploreCloneDialog({
               </Button>
             </div>
             {values.destination.trim() && target && (
-              // gap-1, not a trailing space in the label: a flex line box
-              // trims a trailing collapsible space, fusing the two items.
+              // gap-1, not a trailing label space — flex line boxes trim those.
               <p className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
                 <span className="shrink-0">Clones into</span>
                 <PathText

--- a/src/features/explore/ExploreCloneDialog.tsx
+++ b/src/features/explore/ExploreCloneDialog.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useEffectEvent } from "react";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -130,13 +131,16 @@ export function ExploreCloneDialog({
               </Button>
             </div>
             {values.destination.trim() && target && (
-              <p className="truncate text-[11px] text-muted-foreground">
-                Clones into{" "}
-                <span className="font-mono">
-                  {values.destination.trim().replace(/[\\/]$/, "")}
-                  {values.destination.includes("/") ? "/" : "\\"}
-                  {target.name}
-                </span>
+              // gap-1, not a trailing space in the label: a flex line box
+              // trims a trailing collapsible space, fusing the two items.
+              <p className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
+                <span className="shrink-0">Clones into</span>
+                <PathText
+                  path={`${values.destination.trim().replace(/[\\/]$/, "")}${
+                    values.destination.includes("/") ? "/" : "\\"
+                  }${target.name}`}
+                  className="font-mono"
+                />
               </p>
             )}
           </div>

--- a/src/features/history/BlameDialog.tsx
+++ b/src/features/history/BlameDialog.tsx
@@ -2,6 +2,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import hljs from "highlight.js/lib/common";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -113,8 +114,8 @@ export function BlameDialog({
           <DialogTitle className="truncate">
             {shortRev ? `Blame: ${name} @ ${shortRev}` : `Blame: ${name}`}
           </DialogTitle>
-          <DialogDescription className="truncate font-mono">
-            {path}
+          <DialogDescription>
+            <PathText path={path} className="font-mono" />
           </DialogDescription>
         </DialogHeader>
 

--- a/src/features/history/BlameFilePickerDialog.tsx
+++ b/src/features/history/BlameFilePickerDialog.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { PathText } from "@/components/path-text";
 import {
   Dialog,
   DialogContent,
@@ -213,9 +214,7 @@ function FileList({
                   path === activePath && "bg-accent text-accent-foreground",
                 )}
               >
-                <span className="block truncate font-mono" title={path}>
-                  {path}
-                </span>
+                <PathText path={path} className="flex-1 font-mono" />
               </button>
             </div>
           );

--- a/src/features/history/CommitDetailView.tsx
+++ b/src/features/history/CommitDetailView.tsx
@@ -5,6 +5,7 @@ import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
 import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
 import type { MarkdownRefs } from "@/components/markdown/markdown-refs";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -448,11 +449,8 @@ export function CommitDetailView({
                   onMouseEnter={() =>
                     hoverPrefetch(() => prefetchFileDiff(hash, file.path))
                   }
-                  title={file.path}
                 >
-                  <span className="min-w-0 flex-1 truncate font-mono">
-                    {file.path}
-                  </span>
+                  <PathText path={file.path} className="flex-1 font-mono" />
                   <DiffStat
                     added={file.added}
                     deleted={file.deleted}

--- a/src/features/history/FileHistoryDialog.tsx
+++ b/src/features/history/FileHistoryDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { CommitAuthorAvatar } from "@/components/commit-author-avatar";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import {
   Dialog,
@@ -65,8 +66,8 @@ export function FileHistoryDialog({
       <DialogContent className="flex h-[80vh] flex-col sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle className="truncate">History of {name}</DialogTitle>
-          <DialogDescription className="truncate font-mono">
-            {path}
+          <DialogDescription>
+            <PathText path={path} className="font-mono" />
           </DialogDescription>
         </DialogHeader>
 

--- a/src/features/pulls/PrCommitDetail.tsx
+++ b/src/features/pulls/PrCommitDetail.tsx
@@ -2,6 +2,7 @@ import { CopyIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -240,11 +241,8 @@ export function PrCommitDetail({
                         : "hover:bg-muted/60",
                     )}
                     onClick={() => setSelectedPath(file.path)}
-                    title={file.path}
                   >
-                    <span className="min-w-0 flex-1 truncate font-mono">
-                      {file.path}
-                    </span>
+                    <PathText path={file.path} className="flex-1 font-mono" />
                     <DiffStat
                       added={file.added}
                       deleted={file.deleted}

--- a/src/features/pulls/PrMergeabilityBanner.tsx
+++ b/src/features/pulls/PrMergeabilityBanner.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -417,8 +418,8 @@ export function PrMergeabilityBanner({
   const fileList = conflictFiles.length > 0 && (
     <ul className="basis-full pl-5 text-muted-foreground">
       {shownFiles.map((path) => (
-        <li key={path} className="truncate font-mono" title={path}>
-          {path}
+        <li key={path}>
+          <PathText path={path} className="font-mono" />
         </li>
       ))}
       {extraFiles > 0 && (

--- a/src/features/pulls/RemotePrViewParts.tsx
+++ b/src/features/pulls/RemotePrViewParts.tsx
@@ -2,6 +2,7 @@ import { ClockIcon } from "@phosphor-icons/react";
 import { type ComponentProps, useMemo, useState } from "react";
 import { DetailRail, DetailRailRow } from "@/components/detail-rail";
 import { DiffStat } from "@/components/diff-stat";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -263,9 +264,8 @@ export function PrFilesPane({
           : "hover:bg-muted/60",
       )}
       onClick={() => onSelectPath(file.path)}
-      title={file.path}
     >
-      <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
+      <PathText path={file.path} className="flex-1 font-mono" />
       <DiffStat added={file.additions} deleted={file.deletions} />
     </button>
   ));

--- a/src/features/pulls/ReviewThreads.tsx
+++ b/src/features/pulls/ReviewThreads.tsx
@@ -11,12 +11,12 @@ import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { Markdown } from "@/components/markdown/markdown";
 import { MarkdownEditor } from "@/components/markdown-editor";
+import { PathText } from "@/components/path-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Thread } from "@/features/conversations/Thread";
 import type { MentionSource } from "@/features/conversations/useMentionCandidates";
-import { clipTitle } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import type {
   ApplyLinesResult,
@@ -1010,12 +1010,10 @@ export function ReviewThreadList({
         const resolvedOpen = openResolvedGroups.has(path);
         return (
           <div key={path} className="space-y-1.5">
-            <p
-              className="truncate font-mono text-xs text-muted-foreground"
-              onMouseEnter={clipTitle(path)}
-            >
-              {path}
-            </p>
+            <PathText
+              path={path}
+              className="font-mono text-xs text-muted-foreground"
+            />
             <div className="space-y-1.5">
               {unresolved.map((t) => (
                 <ReviewThreadCard

--- a/src/features/repository/ConflictFileView.tsx
+++ b/src/features/repository/ConflictFileView.tsx
@@ -1,6 +1,7 @@
 import { SparkleIcon } from "@phosphor-icons/react";
 import { useMemo } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { HighlightedCode } from "@/features/diff/HighlightedCode";
@@ -420,11 +421,10 @@ export function ConflictFileView({
     <div className="ph-no-capture flex h-full flex-col">
       {/* Header toolbar — calm, neutral; whole-file + AI actions */}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate font-mono text-xs text-muted-foreground">
-            {path}
-          </span>
-        </span>
+        <PathText
+          path={path}
+          className="font-mono text-xs text-muted-foreground"
+        />
         <span className="flex shrink-0 items-center gap-1.5">
           <Button size="xs" variant="ghost" onClick={openInEditor}>
             Open in editor

--- a/src/features/repository/ConflictResolveView.tsx
+++ b/src/features/repository/ConflictResolveView.tsx
@@ -7,6 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Spinner } from "@/components/ui/spinner";
@@ -256,9 +257,10 @@ export function ConflictResolveView({
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="flex min-w-0 items-center gap-1.5">
           <SparkleIcon className="size-3.5 shrink-0 text-primary" />
-          <span className="truncate font-mono text-xs text-muted-foreground">
-            {path}
-          </span>
+          <PathText
+            path={path}
+            className="font-mono text-xs text-muted-foreground"
+          />
         </span>
         <span className="shrink-0 text-[11px] text-muted-foreground">
           {providerLabel} · {model}

--- a/src/features/repository/DeleteWorktreeDialog.tsx
+++ b/src/features/repository/DeleteWorktreeDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -142,9 +143,10 @@ export function DeleteWorktreeDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <p className="truncate rounded bg-muted px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
-          {worktree?.path}
-        </p>
+        <PathText
+          path={worktree?.path ?? ""}
+          className="rounded bg-muted px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
+        />
 
         {/* While a removal that recorded an archive intent runs, keep showing
             the checkbox even if the branch is archived from another surface

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -2,6 +2,7 @@ import { MinusIcon, PlusIcon } from "@phosphor-icons/react";
 import { memo } from "react";
 import { DiffStat } from "@/components/diff-stat";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { KIND_BADGE } from "@/lib/git/change-kind-badge";
 import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { ChangeKind, DiffStatEntry, FileEntry } from "@/lib/git/types";
@@ -89,9 +90,18 @@ export const FileRow = memo(function FileRow({
           is absolutely positioned so it never becomes a flex item here. The
           trailing space keeps the name from fusing with the path text. */}
       <span className="sr-only">{badge.label} </span>
-      <span className="min-w-0 flex-1 truncate" title={label}>
-        {label}
-      </span>
+      {entry.origPath ? (
+        // A rename is two paths and an arrow: the composite can't ride
+        // PathText's only-when-clipped measurement, so the row keeps a static
+        // title for the whole label.
+        <span className="flex min-w-0 flex-1 items-center gap-1" title={label}>
+          <PathText path={entry.origPath} />
+          <span className="shrink-0">→</span>
+          <PathText path={entry.path} />
+        </span>
+      ) : (
+        <PathText path={entry.path} className="flex-1" />
+      )}
       {stat ? (
         <DiffStat
           added={stat.added}

--- a/src/features/repository/PromoteWorktreeDialog.tsx
+++ b/src/features/repository/PromoteWorktreeDialog.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRef } from "react";
 import { toast } from "sonner";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -171,13 +172,13 @@ function PromoteBody({
 
       <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
         <span className="text-muted-foreground">Worktree</span>
-        <span className="truncate font-mono" title={worktree.path}>
-          {worktree.path}
-        </span>
+        <PathText path={worktree.path} className="font-mono" />
         <span className="text-muted-foreground">Main workspace</span>
-        <span className="truncate font-mono" title={mainPath ?? undefined}>
-          {mainPath ?? "—"}
-        </span>
+        {mainPath ? (
+          <PathText path={mainPath} className="font-mono" />
+        ) : (
+          <span className="font-mono">—</span>
+        )}
       </div>
 
       {checking ? (

--- a/src/features/repository/RepoHeader.tsx
+++ b/src/features/repository/RepoHeader.tsx
@@ -30,7 +30,7 @@ export function RepoHeader({ repoPath }: { repoPath: string }) {
       </Button>
       <RepoSwitcher />
       <RepositoryMenu repoPath={repoPath} />
-      <Separator orientation="vertical" className="h-5" />
+      <Separator orientation="vertical" className="my-1" />
       <BranchSwitcher repoPath={repoPath} />
       <BranchCiBadge repoPath={repoPath} />
       <BranchJiraBadge repoPath={repoPath} />

--- a/src/features/repository/RepoList.tsx
+++ b/src/features/repository/RepoList.tsx
@@ -9,6 +9,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { PathText } from "@/components/path-text";
 import { ProviderIcon } from "@/components/provider-icon";
 import {
   ContextMenu,
@@ -516,9 +517,10 @@ function RepoRow({
           >
             {repoDisplayName(repo)}
           </span>
-          <span className="block truncate text-[11px] text-muted-foreground">
-            {repo.path}
-          </span>
+          <PathText
+            path={repo.path}
+            className="text-[11px] text-muted-foreground"
+          />
         </span>
         {repo.isFork && (
           <span

--- a/src/features/repository/RepositoryFilesDialog.tsx
+++ b/src/features/repository/RepositoryFilesDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -936,8 +937,8 @@ export function RepositoryFilesDialog({
           {shownPending?.kind === "untrack" && (
             <ul className="max-h-40 overflow-auto border p-2 text-xs">
               {shownPending.paths.map((p) => (
-                <li key={p} className="truncate font-mono" title={p}>
-                  {ignoreLabel(p)}
+                <li key={p}>
+                  <PathText path={ignoreLabel(p)} className="font-mono" />
                 </li>
               ))}
             </ul>
@@ -945,10 +946,10 @@ export function RepositoryFilesDialog({
           {shownPending?.kind === "forceAdd" && (
             <ul className="max-h-40 overflow-auto border p-2 text-xs">
               {shownPending.paths.map((p) => (
-                <li key={p} className="truncate font-mono" title={p}>
-                  {p}
+                <li key={p} className="flex min-w-0 items-baseline font-mono">
+                  <PathText path={p} />
                   {p.endsWith("/") && (
-                    <span className="ml-1 font-sans text-muted-foreground">
+                    <span className="ml-1 shrink-0 font-sans text-muted-foreground">
                       — directory, adds all contents
                     </span>
                   )}
@@ -1176,15 +1177,11 @@ function FileList({
                       shortens instead of swallowing the marker. */}
                   {rowSuffix ? (
                     <span className="flex items-baseline gap-1">
-                      <span className="truncate font-mono" title={path}>
-                        {path}
-                      </span>
+                      <PathText path={path} className="font-mono" />
                       {rowSuffix(path)}
                     </span>
                   ) : (
-                    <span className="block truncate font-mono" title={path}>
-                      {path}
-                    </span>
+                    <PathText path={path} className="font-mono" />
                   )}
                   {rowInfo(path)}
                 </span>

--- a/src/features/repository/StashesDialog.tsx
+++ b/src/features/repository/StashesDialog.tsx
@@ -3,6 +3,7 @@ import { useDeferredValue, useEffectEvent, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { DiffStat } from "@/components/diff-stat";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import {
@@ -569,11 +570,8 @@ function StashFiles({
                     : "hover:bg-muted/60",
                 )}
                 onClick={() => setSelectedPath(file.path)}
-                title={file.path}
               >
-                <span className="min-w-0 flex-1 truncate font-mono">
-                  {file.path}
-                </span>
+                <PathText path={file.path} className="flex-1 font-mono" />
                 <DiffStat
                   added={file.added}
                   deleted={file.deleted}

--- a/src/features/repository/SubmodulesDialog.tsx
+++ b/src/features/repository/SubmodulesDialog.tsx
@@ -12,6 +12,7 @@ import type { ComponentProps } from "react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -506,9 +507,7 @@ function SubmoduleRow({
             clipped it on sight. Snug leading keeps the three lines one unit,
             and the line is dropped entirely when there is no URL. */}
         <span className="min-w-0 flex-1">
-          <span className="block truncate font-mono text-xs font-medium">
-            {path}
-          </span>
+          <PathText path={path} className="font-mono text-xs font-medium" />
           <span
             className="mt-0.5 block truncate text-[11px] leading-snug text-muted-foreground"
             onMouseEnter={clipTitle(detail)}

--- a/src/features/repository/WorktreesDialog.tsx
+++ b/src/features/repository/WorktreesDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Badge } from "@/components/ui/badge";
@@ -43,7 +44,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { copyText } from "@/lib/clipboard";
 import { normPath } from "@/lib/git/path";
 import {
@@ -386,12 +387,10 @@ function WorktreeRow({
               isRemoving={isRemoving}
             />
           </span>
-          <span
-            className="mt-0.5 block truncate text-[11px] text-muted-foreground"
-            onMouseEnter={clipTitle(path)}
-          >
-            {path}
-          </span>
+          <PathText
+            path={path}
+            className="mt-0.5 text-[11px] text-muted-foreground"
+          />
         </span>
         {lastActivityMs != null && validEpochMs(lastActivityMs) && (
           <span className="shrink-0 text-[11px] text-muted-foreground">
@@ -639,9 +638,16 @@ export function RenameWorktreeDialog({
             className="h-7 font-mono"
             aria-invalid={invalid || undefined}
           />
-          <span className="col-start-2 mt-1 block truncate font-mono text-[11px] text-muted-foreground">
-            {invalid ? "Use a folder name, not a path." : newPath}
-          </span>
+          {invalid ? (
+            <span className="col-start-2 mt-1 block truncate font-mono text-[11px] text-muted-foreground">
+              Use a folder name, not a path.
+            </span>
+          ) : (
+            <PathText
+              path={newPath}
+              className="col-start-2 mt-1 font-mono text-[11px] text-muted-foreground"
+            />
+          )}
         </form>
 
         {/* A disabled button can't carry a tooltip; the reason goes on screen. */}

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -555,8 +555,7 @@ function ResearchResult({ run }: { run: ResearchRun }) {
               </span>
             )}
             {reportPath && (
-              // gap-1, not a trailing space in the label: a flex line box
-              // trims a trailing collapsible space, fusing the two items.
+              // gap-1, not a trailing label space — flex line boxes trim those.
               <span className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
                 <span className="shrink-0">Saved to</span>
                 <PathText path={reportPath} className="font-mono" />

--- a/src/features/research/ResearchView.tsx
+++ b/src/features/research/ResearchView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { Markdown } from "@/components/markdown/markdown";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -554,11 +555,11 @@ function ResearchResult({ run }: { run: ResearchRun }) {
               </span>
             )}
             {reportPath && (
-              <span
-                className="min-w-0 truncate text-[11px] text-muted-foreground"
-                title={`Saved to ${reportPath}`}
-              >
-                Saved to <span className="font-mono">{reportPath}</span>
+              // gap-1, not a trailing space in the label: a flex line box
+              // trims a trailing collapsible space, fusing the two items.
+              <span className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
+                <span className="shrink-0">Saved to</span>
+                <PathText path={reportPath} className="font-mono" />
               </span>
             )}
             {report && (

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { LabeledGroup } from "@/components/form/labeled-group";
 import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,7 +24,6 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { clipTitle } from "@/lib/clip-title";
 import { isMac, isWindows } from "@/lib/hotkeys/binding";
 import { useGenerateChord } from "@/lib/hotkeys/useGenerateChord";
 import {
@@ -344,12 +344,13 @@ export function TaskDialog({
                           )}
                         </span>
                         {found ? (
-                          <span
-                            className="max-w-64 truncate font-mono text-[10px] text-muted-foreground"
-                            onMouseEnter={clipTitle(found)}
-                          >
-                            {found}
-                          </span>
+                          // max-w-64 self-bounds the row against ItemText's
+                          // `min-width: auto` floor, which no truncate inside a
+                          // Select popup engages without.
+                          <PathText
+                            path={found}
+                            className="max-w-64 font-mono text-[10px] text-muted-foreground"
+                          />
                         ) : isSelected && selectedResolving ? (
                           <span className="text-[11px] text-muted-foreground">
                             Checking your shell…

--- a/src/features/scripts/TaskDialog.tsx
+++ b/src/features/scripts/TaskDialog.tsx
@@ -318,8 +318,8 @@ export function TaskDialog({
               {/* Wider than the trigger: the popup defaults to the trigger's
                   width (w-(--anchor-width)) and hard-clips overflow, which cut
                   the detected interpreter paths mid-character. 320px gives the
-                  paths room; anything longer still ellipsizes inside the span
-                  (max-w-64) with the clipped-title tooltip. */}
+                  paths room; anything longer still middle-truncates inside the
+                  span (max-w-64) with its clipped-only tooltip. */}
               <SelectContent className="w-80">
                 {options.map((i) => {
                   // The selected interpreter reflects the login-shell confirm (what

--- a/src/features/scripts/TaskRunView.tsx
+++ b/src/features/scripts/TaskRunView.tsx
@@ -9,6 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { lazy, Suspense } from "react";
 import { LazyPanelFallback } from "@/components/lazy-panel-fallback";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
 import { clipTitle } from "@/lib/clip-title";
@@ -53,12 +54,10 @@ export function TaskRunView() {
       <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2 text-xs">
         <span className="shrink-0 truncate font-medium">{task.name}</span>
         {task.source.kind === "file" && (
-          <span
-            className="min-w-0 truncate font-mono text-[10px] text-muted-foreground"
-            onMouseEnter={clipTitle(task.source.path)}
-          >
-            {task.source.path}
-          </span>
+          <PathText
+            path={task.source.path}
+            className="font-mono text-[10px] text-muted-foreground"
+          />
         )}
         {args !== "" && (
           <span

--- a/src/features/security-findings/FindingDetailView.tsx
+++ b/src/features/security-findings/FindingDetailView.tsx
@@ -2,6 +2,7 @@ import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { ReactNode } from "react";
 import { Markdown } from "@/components/markdown/markdown";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -201,7 +202,7 @@ function AlertDetail({ alert }: { alert: DependabotAlertOut }) {
             </Row>
           ) : null}
           <Row label="Manifest">
-            <span className="font-mono">{alert.manifestPath}</span>
+            <PathText path={alert.manifestPath} className="font-mono" />
           </Row>
           <Row label="GHSA">
             <span className="font-mono">{alert.ghsaId}</span>

--- a/src/features/security-findings/FindingsPanel.tsx
+++ b/src/features/security-findings/FindingsPanel.tsx
@@ -15,6 +15,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { type ReactNode, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ListRowSkeletons } from "@/components/list-row-skeleton";
+import { PathText } from "@/components/path-text";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -383,22 +384,17 @@ function SectionHeader({ title }: { title: string }) {
   );
 }
 
-/** `path:line`, truncated from the *start* so the filename — the part that
- *  identifies the finding — survives. `dir="rtl"` moves the ellipsis to the
- *  leading edge; the `<bdi>` keeps the path itself reading left-to-right. */
+/** `path:line`, right-aligned in the row, middle-truncated so the filename —
+ *  the part that identifies the finding — survives. */
 function PathLabel({ path, line }: { path: string; line: number | null }) {
   // A tolerated alert can arrive with no path at all; a line number hung off the
   // placeholder would read as a location, so it's dropped with the path.
-  const text = path
-    ? line === null
-      ? path
-      : `${path}:${line}`
-    : "No file path";
-  return (
-    <span dir="rtl" className="ml-auto min-w-0 truncate font-mono" title={text}>
-      <bdi>{text}</bdi>
-    </span>
-  );
+  if (!path) {
+    return (
+      <span className="ml-auto min-w-0 truncate font-mono">No file path</span>
+    );
+  }
+  return <PathText path={path} line={line} className="ml-auto font-mono" />;
 }
 
 // `name` per call site: several sections load independently and can all be

--- a/src/features/sessions/AgentTranscript.tsx
+++ b/src/features/sessions/AgentTranscript.tsx
@@ -13,6 +13,7 @@ import {
 import type { UseQueryResult } from "@tanstack/react-query";
 import { type ComponentType, useState } from "react";
 import { Markdown } from "@/components/markdown/markdown";
+import { PathText } from "@/components/path-text";
 import { GitDiffView } from "@/features/diff/DiffSurfaceLazy";
 import { SPLIT_MIN_CONTAINER_PX } from "@/features/diff/split-threshold";
 import type { AgentToolKind, TranscriptSegment } from "@/lib/ai/agent";
@@ -80,17 +81,28 @@ function ToolStep({
   const Glyph = meta.icon;
   const shown = target && meta.file ? relativize(target, baseDir) : target;
   return (
-    <div className="flex items-center gap-1.5 bg-muted/40 px-2 py-1 text-[11px] leading-relaxed">
+    // A file row renders the path relative to the run's base dir, so the row
+    // itself carries the absolute one — PathText removes its own title when the
+    // text isn't clipped, which lets this tooltip through.
+    <div
+      className="flex items-center gap-1.5 bg-muted/40 px-2 py-1 text-[11px] leading-relaxed"
+      title={meta.file && target ? target : undefined}
+    >
       <Glyph className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="shrink-0 text-muted-foreground">{meta.verb}</span>
-      {shown && (
-        <span
-          className="min-w-0 truncate font-mono text-foreground/75"
-          title={target ?? undefined}
-        >
-          {shown}
-        </span>
-      )}
+      {shown &&
+        // `meta.file` is what makes the target a path; every other tool's
+        // target is a command or URL, which has no filename to protect.
+        (meta.file ? (
+          <PathText path={shown} className="font-mono text-foreground/75" />
+        ) : (
+          <span
+            className="min-w-0 truncate font-mono text-foreground/75"
+            title={target ?? undefined}
+          >
+            {shown}
+          </span>
+        ))}
     </div>
   );
 }
@@ -227,6 +239,10 @@ function EditDiffStep({
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
+        // The row renders the path relative to the run's base dir, so the
+        // button carries the absolute one — PathText removes its own title when
+        // the text isn't clipped, which lets this tooltip through.
+        title={target}
         className="flex items-center gap-1.5 px-2 py-1 text-left text-[11px] leading-relaxed hover:bg-muted/70 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
       >
         <CaretRightIcon
@@ -237,12 +253,10 @@ function EditDiffStep({
         />
         <Glyph className="size-3.5 shrink-0 text-muted-foreground" />
         <span className="shrink-0 text-muted-foreground">{meta.verb}</span>
-        <span
-          className="min-w-0 flex-1 truncate font-mono text-foreground/75"
-          title={target}
-        >
-          {relPath}
-        </span>
+        <PathText
+          path={relPath}
+          className="flex-1 font-mono text-foreground/75"
+        />
       </button>
       {open && <InlineDiff filePath={relPath} repoPath={baseDir} diff={diff} />}
     </div>

--- a/src/features/sessions/AgentTranscript.tsx
+++ b/src/features/sessions/AgentTranscript.tsx
@@ -82,8 +82,8 @@ function ToolStep({
   const shown = target && meta.file ? relativize(target, baseDir) : target;
   return (
     // A file row renders the path relative to the run's base dir, so the row
-    // itself carries the absolute one — PathText removes its own title when the
-    // text isn't clipped, which lets this tooltip through.
+    // carries the absolute one for hovers beside the path, and the title prop
+    // makes the path's own clipped tooltip show the same absolute form.
     <div
       className="flex items-center gap-1.5 bg-muted/40 px-2 py-1 text-[11px] leading-relaxed"
       title={meta.file && target ? target : undefined}
@@ -94,7 +94,11 @@ function ToolStep({
         // `meta.file` is what makes the target a path; every other tool's
         // target is a command or URL, which has no filename to protect.
         (meta.file ? (
-          <PathText path={shown} className="font-mono text-foreground/75" />
+          <PathText
+            path={shown}
+            title={target ?? undefined}
+            className="font-mono text-foreground/75"
+          />
         ) : (
           <span
             className="min-w-0 truncate font-mono text-foreground/75"
@@ -240,8 +244,8 @@ function EditDiffStep({
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         // The row renders the path relative to the run's base dir, so the
-        // button carries the absolute one — PathText removes its own title when
-        // the text isn't clipped, which lets this tooltip through.
+        // button carries the absolute one for hovers beside the path, and the
+        // title prop makes the path's clipped tooltip show the same absolute.
         title={target}
         className="flex items-center gap-1.5 px-2 py-1 text-left text-[11px] leading-relaxed hover:bg-muted/70 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
       >
@@ -255,6 +259,7 @@ function EditDiffStep({
         <span className="shrink-0 text-muted-foreground">{meta.verb}</span>
         <PathText
           path={relPath}
+          title={target}
           className="flex-1 font-mono text-foreground/75"
         />
       </button>

--- a/src/features/sessions/WorktreeChangesView.tsx
+++ b/src/features/sessions/WorktreeChangesView.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useState } from "react";
 import { DetailRail, DetailRailRow } from "@/components/detail-rail";
+import { PathText } from "@/components/path-text";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DiffPlaceholder } from "@/features/diff/DiffPlaceholder";
@@ -122,11 +123,8 @@ export function WorktreeChangesView({ repoPath }: { repoPath: string }) {
                       : "hover:bg-muted/60",
                   )}
                   onClick={() => setSelectedPath(file.path)}
-                  title={file.path}
                 >
-                  <span className="min-w-0 flex-1 truncate font-mono">
-                    {file.path}
-                  </span>
+                  <PathText path={file.path} className="flex-1 font-mono" />
                   <span className="shrink-0 text-muted-foreground">
                     {KIND_LABEL[entryKind(file)]}
                   </span>

--- a/src/features/settings/AboutSection.tsx
+++ b/src/features/settings/AboutSection.tsx
@@ -14,6 +14,7 @@ import {
 } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useState } from "react";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
@@ -126,21 +127,28 @@ function ToolRow({ tool }: { tool: ToolStatus }) {
           </span>
           {meta.auth && tool.found && <AuthState authed={tool.authed} />}
         </p>
-        <p className="truncate text-[11px] text-muted-foreground">
-          {tool.found ? (
-            <>
+        {tool.found ? (
+          // Flex row, not one truncating line: PathText is a flex box, so the
+          // version has to be a sibling item rather than inline text. Spacing
+          // rides `gap-1` because a flex line box trims a collapsible space,
+          // and both text items shrink so a long version banner truncates
+          // rather than pushing the path out of the row.
+          <p className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
+            <span className="min-w-0 truncate">
               {tool.version ?? "version unknown"}
-              {tool.path ? (
-                <>
-                  {" · "}
-                  <span className="font-mono">{tool.path}</span>
-                </>
-              ) : null}
-            </>
-          ) : (
-            meta.role
-          )}
-        </p>
+            </span>
+            {tool.path ? (
+              <>
+                <span className="shrink-0">·</span>
+                <PathText path={tool.path} className="font-mono" />
+              </>
+            ) : null}
+          </p>
+        ) : (
+          <p className="truncate text-[11px] text-muted-foreground">
+            {meta.role}
+          </p>
+        )}
         {floorWarning ? (
           <p className="text-[11px] text-warning">{floorWarning}</p>
         ) : null}

--- a/src/features/settings/EditorSection.tsx
+++ b/src/features/settings/EditorSection.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -123,9 +124,10 @@ export const EditorSection = withForm({
             <p className="text-xs text-muted-foreground">Detecting editors…</p>
           )}
           {!showCustom && matched && (
-            <p className="truncate font-mono text-xs text-muted-foreground">
-              {matched.path}
-            </p>
+            <PathText
+              path={matched.path}
+              className="font-mono text-xs text-muted-foreground"
+            />
           )}
         </div>
         {showCustom && (

--- a/src/features/settings/TerminalSection.tsx
+++ b/src/features/settings/TerminalSection.tsx
@@ -2,6 +2,7 @@ import { WarningCircleIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -157,9 +158,10 @@ export const TerminalSection = withForm({
             </p>
           )}
           {!showCustom && matched && (
-            <p className="truncate font-mono text-xs text-muted-foreground">
-              {matched.path}
-            </p>
+            <PathText
+              path={matched.path}
+              className="font-mono text-xs text-muted-foreground"
+            />
           )}
         </div>
         {showCustom && (

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { PathText } from "@/components/path-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -329,13 +330,16 @@ export function CloneRepoDialog({
               </Button>
             </div>
             {values.destination.trim() && finalName && (
-              <p className="truncate text-[11px] text-muted-foreground">
-                Clones into{" "}
-                <span className="font-mono">
-                  {values.destination.trim().replace(/[\\/]$/, "")}
-                  {values.destination.includes("/") ? "/" : "\\"}
-                  {finalName}
-                </span>
+              // gap-1, not a trailing space in the label: a flex line box
+              // trims a trailing collapsible space, fusing the two items.
+              <p className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
+                <span className="shrink-0">Clones into</span>
+                <PathText
+                  path={`${values.destination.trim().replace(/[\\/]$/, "")}${
+                    values.destination.includes("/") ? "/" : "\\"
+                  }${finalName}`}
+                  className="font-mono"
+                />
               </p>
             )}
           </div>

--- a/src/features/welcome/CloneRepoDialog.tsx
+++ b/src/features/welcome/CloneRepoDialog.tsx
@@ -330,8 +330,7 @@ export function CloneRepoDialog({
               </Button>
             </div>
             {values.destination.trim() && finalName && (
-              // gap-1, not a trailing space in the label: a flex line box
-              // trims a trailing collapsible space, fusing the two items.
+              // gap-1, not a trailing label space — flex line boxes trim those.
               <p className="flex min-w-0 gap-1 text-[11px] text-muted-foreground">
                 <span className="shrink-0">Clones into</span>
                 <PathText

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -1198,7 +1198,7 @@ async function deliver(
     if (notify) {
       const prNumber = event.target.number;
       pushNotification({
-        kind: "review-ready",
+        kind: "review-posted",
         tone: "success",
         title: `AI ${label} posted on #${prNumber}`,
         subtitle: `"${event.title}"`,
@@ -1251,7 +1251,7 @@ async function deliver(
   // Gated on the automations pref alone — see the commit arm.
   if (notify) {
     pushNotification({
-      kind: "review-ready",
+      kind: "review-posted",
       tone: "success",
       title: `AI ${label} added to "${pr.title}"`,
       repoPath: event.repoPath,

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -19,6 +19,7 @@ export type NotificationTone =
  *  kind minted by an older build. */
 export type NotificationKind =
   | "review-ready"
+  | "review-posted"
   | "review-failed"
   | "review-requested"
   | "checks-passed"
@@ -43,6 +44,7 @@ export type NotificationKind =
 export const AI_NOTIFICATION_KINDS: ReadonlySet<string> =
   new Set<NotificationKind>([
     "review-ready",
+    "review-posted",
     "review-failed",
     "agent-done",
     "research-done",


### PR DESCRIPTION
Paths were truncated inconsistently across the app — end-ellipsed in most rows, start-ellipsed in the findings list, and untruncated in a few places — so the filename, the part that identifies what you're looking at, was often the first thing to disappear. This adds a single `PathText` component that middle-truncates every file and directory display, and routes ~40 existing path renders through it.

### The shared component

- Adds `src/components/path-text.tsx`: `PathText` splits a path at its last separator and renders the directory head and the filename tail as two flex spans, so the filename survives at any width without measurement, and DOM order pins visual order against bidi reordering. Trailing separators go with the tail, so concatenating the two spans always reproduces the input exactly.
- Handles the degenerate cases: a lone filename with no head end-ellipses via `max-w-full truncate` instead of overflowing its row, and an optional `line` prop renders `:{line}` inside the protected tail.
- Owns its only-when-clipped tooltip: `onMouseEnter` measures the two inner spans and sets or removes `title` on the outer span, keeping `clipTitle`'s remove-don't-blank contract (the outer span never overflows itself once a child truncates, so a handler there would be dead).

### Call-site migration

- **Diff and file lists** — `DiffSurface.tsx`, `DiffViewer.tsx`, `ImageDiff.tsx`, `BranchDiffView.tsx`, `CommitDetailView.tsx`, `PrCommitDetail.tsx`, `RemotePrViewParts.tsx`, `StashesDialog.tsx`, `WorktreeChangesView.tsx`, `ConflictFileView.tsx`, `ConflictResolveView.tsx`.
- **Changes list and commit** — `FileRow.tsx` and `CommitDialog.tsx` render renames as `PathText → PathText` with a static `title` on the composite, since a two-path label can't ride the per-span clip measurement.
- **Repository surfaces** — `RepositoryFilesDialog.tsx`, `WorktreesDialog.tsx` (row paths and the rename preview, which now branches so the invalid-input message stays plain text), `DeleteWorktreeDialog.tsx`, `PromoteWorktreeDialog.tsx`, `SubmodulesDialog.tsx`, `RepoList.tsx`.
- **Findings** — `FindingsPanel.tsx`'s `PathLabel` drops the `dir="rtl"` / `<bdi>` start-truncation hack for `PathText` with its `line` prop, keeping a plain span for the no-path placeholder; `FindingDetailView.tsx` uses it for the manifest path.
- **Label composites** — `CloneRepoDialog.tsx`, `ExploreCloneDialog.tsx`, `ResearchView.tsx`, and `AboutSection.tsx` become flex rows spaced with `gap-1` rather than a trailing space in the label, because a flex line box trims the trailing space and fuses the items. `AboutSection`'s tool row splits found/not-found into separate paragraphs so the version and path shrink independently.
- **Everything else** — `CodeTodosPanel.tsx`, `CodeTodoDetailView.tsx`, `BlameDialog.tsx`, `BlameFilePickerDialog.tsx`, `FileHistoryDialog.tsx`, `PrMergeabilityBanner.tsx`, `ReviewThreads.tsx`, `TaskDialog.tsx` (keeps `max-w-64` to self-bound the row inside a Select popup), `TaskRunView.tsx`, `EditorSection.tsx`, `TerminalSection.tsx`.
- `AgentTranscript.tsx` hoists the absolute-path tooltip from the text span up to the row/button, since the rendered path is relativized to the run's base dir and `PathText` removes its own title when unclipped; only `meta.file` targets get `PathText`, as other tools' targets are commands or URLs.
- `RepoHeader.tsx` switches the header separator from a fixed `h-5` to `my-1`.

### Notification kind for posted reviews

- Adds a `review-posted` kind in `src/lib/stores/notifications.ts` and includes it in `AI_NOTIFICATION_KINDS`.
- `src/lib/automations/runner.ts` emits `review-posted` for the two paths that publish the review as a PR comment, instead of reusing `review-ready`.
- `ActivityDock.tsx` gives it the Sparkle glyph and routes it to the Conversation section, where the posted comment lives, while `review-ready` still lands on the Review panel.

### Conventions and docs

- `scripts/check-banned-patterns.mjs` allowlists `src/components/path-text.tsx` in the `inline-clip-title` check, with the rationale for why `clipTitle` can't serve the two-span shape.
- `.claude/rules/frontend.md` and `.claude/skills/gd-conventions/SKILL.md` record the rule: paths middle-truncate through `PathText`, never a hand-rolled `truncate`, and label composites space with `gap-*`.
- Adds `changelog.d/changed-path-middle-truncation.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File and directory paths now use consistent middle truncation across lists, dialogs, diffs, history, worktrees, and settings.
  * Hovering over clipped paths reveals the complete path, including line numbers where applicable.
  * Added support for “review posted” activity notifications, linking directly to the conversation timeline.

* **Style**
  * Improved spacing and alignment for path labels and repository interface elements.

* **Documentation**
  * Added guidance for consistent path display, truncation, and accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->