### PR TITLE
feat(diff,staging): select both sides in one unified drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ A unified or split diff with syntax highlighting, collapsible surrounding
 context, and image diffing. Filter the changes list by path or category, and
 read a file's `+added -deleted` line counts without opening it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
-and discarding (drag across the line numbers; hold Ctrl, or Cmd on macOS, to
-add to a selection, so one selection can mix added and removed lines across
-hunks), including committing or discarding only part of a brand-new
-(untracked) file. Stage or unstage a drag-made selection with
+and discarding (drag across the line numbers — in the unified view a drag
+picks up added and removed lines together and can span hunks; hold Ctrl,
+or Cmd on macOS, to add to a selection), including committing or
+discarding only part of a brand-new (untracked) file. Stage or unstage a drag-made selection with
 `Ctrl`/`⌘`+`Shift`+`Enter`, without reaching for the button. Stage, unstage,
 or discard single files or a multi-selection from the context menu (staging
 and unstaging a selection sit in the command palette too); discarding a

--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers — in the unified view a drag
 picks up added and removed lines together and can span hunks; hold Ctrl,
 or Cmd on macOS, to add to a selection), including committing or
-discarding only part of a brand-new (untracked) file. Stage or unstage a drag-made selection with
-`Ctrl`/`⌘`+`Shift`+`Enter`, without reaching for the button. Stage, unstage,
-or discard single files or a multi-selection from the context menu (staging
-and unstaging a selection sit in the command palette too); discarding a
-whole untracked file goes to the recycle bin. Commit with title + body,
-co-authors suggested from history, amend, undo, reset, and revert.
+discarding only part of a brand-new (untracked) file. Stage or unstage a
+drag-made selection with `Ctrl`/`⌘`+`Shift`+`Enter`, without reaching for
+the button. Stage, unstage, or discard single files or a multi-selection
+from the context menu (staging and unstaging a selection sit in the command
+palette too); discarding a whole untracked file goes to the recycle bin.
+Commit with title + body, co-authors suggested from history, amend, undo,
+reset, and revert.
 
 Markdown and MDX files add a Raw / Preview toggle to the diff, so you can
 read a doc change as rendered prose (headings, tables, and code blocks) on

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ A unified or split diff with syntax highlighting, collapsible surrounding
 context, and image diffing. Filter the changes list by path or category, and
 read a file's `+added -deleted` line counts without opening it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
-and discarding (drag across the line numbers — in the unified view a drag
-picks up added and removed lines together and can span hunks; hold Ctrl,
-or Cmd on macOS, to add to a selection), including committing or
+and discarding (drag across the line numbers, spanning hunks freely — in
+the unified view a drag picks up added and removed lines together; hold
+Ctrl, or Cmd on macOS, to add to a selection), including committing or
 discarding only part of a brand-new (untracked) file. Stage or unstage a
 drag-made selection with `Ctrl`/`⌘`+`Shift`+`Enter`, without reaching for
 the button. Stage, unstage, or discard single files or a multi-selection

--- a/changelog.d/changed-unified-drag-both-sides.md
+++ b/changelog.d/changed-unified-drag-both-sides.md
@@ -1,0 +1,3 @@
+- In the unified diff view, dragging across the line numbers now selects every
+  changed line the drag crosses — added and removed lines land in one
+  selection, ready to stage, unstage, or discard together.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -43,7 +43,7 @@ export const capabilities: Capability[] = [
   {
     group: "Diffs & staging",
     label:
-      "Line, hunk & file staging — drag the line numbers or use a keybind; one drag picks up added and removed lines together",
+      "Line, hunk & file staging — drag the line numbers or use a keybind; in the unified view one drag picks up added and removed lines together",
   },
   {
     group: "Diffs & staging",

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -43,7 +43,7 @@ export const capabilities: Capability[] = [
   {
     group: "Diffs & staging",
     label:
-      "Line, hunk & file staging — drag the line numbers or use a keybind, mixing added and removed lines in one selection",
+      "Line, hunk & file staging — drag the line numbers or use a keybind; one drag picks up added and removed lines together",
   },
   {
     group: "Diffs & staging",

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -705,7 +705,8 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
 /** Highlight the library-reported drag range for live feedback (includes
  *  context), over `base` — the lines an additive drag is merging into, which
  *  would otherwise vanish on the next mousemove (this repaints from scratch).
- *  Split view only; unified paints from its own row anchors. */
+ *  Split view's painter; unified falls through here only on a cleared (null)
+ *  range or a start row it can't resolve — otherwise `paintRowSpan`. */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -766,8 +767,8 @@ function paintRowSpan(
 ) {
   paintLines(container, base);
   for (const row of rowsBetween(container, startRow, endRow)) {
-    const { old, new: added } = rowLineNumbers(row);
-    if (old !== undefined || added !== undefined)
+    const { old: oldNum, new: newNum } = rowLineNumbers(row);
+    if (oldNum !== undefined || newNum !== undefined)
       row.classList.add(SELECT_CLASS);
   }
 }
@@ -777,10 +778,10 @@ function paintRowSpan(
 function linesForRows(rows: HTMLTableRowElement[]): SelectedLine[] {
   const out: SelectedLine[] = [];
   for (const row of rows) {
-    const { old, new: added } = rowLineNumbers(row);
-    if (old !== undefined && added !== undefined) continue;
-    if (old !== undefined) out.push({ side: "old", line: old });
-    else if (added !== undefined) out.push({ side: "new", line: added });
+    const { old: oldNum, new: newNum } = rowLineNumbers(row);
+    if (oldNum !== undefined && newNum !== undefined) continue;
+    if (oldNum !== undefined) out.push({ side: "old", line: oldNum });
+    else if (newNum !== undefined) out.push({ side: "new", line: newNum });
   }
   return out;
 }
@@ -1017,8 +1018,11 @@ function StagingDiffView({
       if (!unified || !drag || !(e.target instanceof Element)) return;
       const row = e.target.closest(".diff-line-num")?.closest("tr");
       if (!row) return;
-      const { old, new: added } = rowLineNumbers(row);
-      if (old === undefined && added === undefined) return; // separator row
+      // mouseover fires per descendant entered (the gutter cell and its number
+      // spans fire separately), so same-row is the common case — skip its repaint.
+      if (row === drag.endRow) return;
+      const { old: oldNum, new: newNum } = rowLineNumbers(row);
+      if (oldNum === undefined && newNum === undefined) return; // separator row
       drag.endRow = row;
       paintRowSpan(container, drag.startRow, row, paintBase());
     };

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -705,8 +705,9 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
 /** Highlight the library-reported drag range for live feedback (includes
  *  context), over `base` — the lines an additive drag is merging into, which
  *  would otherwise vanish on the next mousemove (this repaints from scratch).
- *  Split view's painter; unified falls through here only on a cleared (null)
- *  range or a start row it can't resolve — otherwise `paintRowSpan`. */
+ *  Split view's painter; unified falls through here only when no anchors
+ *  exist — a cleared (null) range, an unresolvable start row, or a stranded
+ *  drag's advance that must not re-mint them — otherwise `paintRowSpan`. */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -1016,6 +1017,13 @@ function StagingDiffView({
       additiveRef.current ? (selectedRef.current ?? []) : [];
     const onMouseOver = (e: MouseEvent) => {
       if (!unified || !drag || !(e.target instanceof Element)) return;
+      // A mouseup lost to a focus steal leaves `drag` set with no button held —
+      // without this, plain hovering would wipe the committed tint and trail a
+      // phantom span until the next press re-anchors.
+      if ((e.buttons & 1) === 0) {
+        drag = null;
+        return;
+      }
       const row = e.target.closest(".diff-line-num")?.closest("tr");
       if (!row) return;
       // mouseover fires per descendant entered (the gutter cell and its number
@@ -1031,9 +1039,12 @@ function StagingDiffView({
       isUnifiedMode: unified,
       onSelectionChange: (range) => {
         if (unified) {
-          // A null range is the manager clearing itself (teardown).
+          // A null range is the manager clearing itself (teardown). Anchors
+          // mint only on a fresh press (start === end at mousedown): a stranded
+          // drag's library range stays live after a lost mouseup, and its
+          // start !== end advances must not re-create what the hover guard cleared.
           if (!range) drag = null;
-          else if (!drag) {
+          else if (!drag && range.startLineNumber === range.endLineNumber) {
             const row = rowForLine(
               container,
               range.side,

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -1004,16 +1004,20 @@ function StagingDiffView({
       startRow: HTMLTableRowElement;
       endRow: HTMLTableRowElement;
     } | null = null;
-    // The latch that licenses anchor minting: our capture-phase mousedown runs
-    // ahead of the manager's, so a mint request without a live press can only
-    // be a stranded drag's range still emitting after a lost mouseup.
+    // The latch that licenses anchor minting: a primary press on the number
+    // gutter — the only press the manager starts a selection from — captured
+    // ahead of its mousedown. A mint request without one can only be a
+    // stranded drag's range still emitting after a lost mouseup.
     let pressed = false;
     const onMouseDownCapture = (e: MouseEvent) => {
       additiveRef.current = isAdditiveDrag(e);
       // A mouseup lost to a focus steal would strand the last drag's anchors;
       // capture precedes the manager's mousedown, so every press re-anchors.
       drag = null;
-      pressed = true;
+      pressed =
+        e.button === 0 &&
+        e.target instanceof Element &&
+        !!e.target.closest(".diff-line-num");
     };
     container.addEventListener("mousedown", onMouseDownCapture, true);
     // An additive drag paints over the committed selection; a plain one replaces

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -706,8 +706,8 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
  *  context), over `base` — the lines an additive drag is merging into, which
  *  would otherwise vanish on the next mousemove (this repaints from scratch).
  *  Split view's painter; unified falls through here only when no anchors
- *  exist — a cleared (null) range, an unresolvable start row, or a stranded
- *  drag's advance that must not re-mint them — otherwise `paintRowSpan`. */
+ *  exist — a cleared (null) range, an unresolvable start row, or a press
+ *  already released — otherwise `paintRowSpan`. */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -1004,11 +1004,16 @@ function StagingDiffView({
       startRow: HTMLTableRowElement;
       endRow: HTMLTableRowElement;
     } | null = null;
+    // The latch that licenses anchor minting: our capture-phase mousedown runs
+    // ahead of the manager's, so a mint request without a live press can only
+    // be a stranded drag's range still emitting after a lost mouseup.
+    let pressed = false;
     const onMouseDownCapture = (e: MouseEvent) => {
       additiveRef.current = isAdditiveDrag(e);
       // A mouseup lost to a focus steal would strand the last drag's anchors;
       // capture precedes the manager's mousedown, so every press re-anchors.
       drag = null;
+      pressed = true;
     };
     container.addEventListener("mousedown", onMouseDownCapture, true);
     // An additive drag paints over the committed selection; a plain one replaces
@@ -1016,14 +1021,20 @@ function StagingDiffView({
     const paintBase = () =>
       additiveRef.current ? (selectedRef.current ?? []) : [];
     const onMouseOver = (e: MouseEvent) => {
-      if (!unified || !drag || !(e.target instanceof Element)) return;
-      // A mouseup lost to a focus steal leaves `drag` set with no button held —
-      // without this, plain hovering would wipe the committed tint and trail a
-      // phantom span until the next press re-anchors.
+      if (!unified || !(e.target instanceof Element)) return;
+      // No button held: drop the latch, and if a stranded drag left its span
+      // painted, restore the committed paint — this stops OUR two-sided span
+      // from following the cursor or re-anchoring; the library's own stranded
+      // range still repaints single-sided via paintRange (pre-existing).
       if ((e.buttons & 1) === 0) {
-        drag = null;
+        if (drag) {
+          drag = null;
+          paintLines(container, selectedRef.current ?? []);
+        }
+        pressed = false;
         return;
       }
+      if (!drag) return;
       const row = e.target.closest(".diff-line-num")?.closest("tr");
       if (!row) return;
       // mouseover fires per descendant entered (the gutter cell and its number
@@ -1040,11 +1051,11 @@ function StagingDiffView({
       onSelectionChange: (range) => {
         if (unified) {
           // A null range is the manager clearing itself (teardown). Anchors
-          // mint only on a fresh press (start === end at mousedown): a stranded
-          // drag's library range stays live after a lost mouseup, and its
-          // start !== end advances must not re-create what the hover guard cleared.
+          // mint only under a live press: a stranded drag's library range keeps
+          // emitting after a lost mouseup and must not re-create what the hover
+          // guard cleared.
           if (!range) drag = null;
-          else if (!drag && range.startLineNumber === range.endLineNumber) {
+          else if (!drag && pressed) {
             const row = rowForLine(
               container,
               range.side,
@@ -1068,6 +1079,7 @@ function StagingDiffView({
           ? rowsBetween(container, drag.startRow, drag.endRow)
           : [];
         drag = null;
+        pressed = false;
         const lines = rows.length
           ? linesForRows(rows)
           : (result?.lines ?? [])

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -1008,9 +1008,9 @@ function StagingDiffView({
     // The latch that licenses anchor minting. Gutter ancestry is what lets
     // the manager start a selection at all; the primary-button clause then
     // scopes the two-sided span deliberately — a non-primary gutter drag
-    // keeps the library's single-sided range. A mint request without a live
-    // primary gutter press can only be a stranded drag's range still
-    // emitting after a lost mouseup.
+    // keeps the library's single-sided range. Absent the latch a mint is
+    // declined: either that non-primary drag, or a stranded drag's range
+    // still emitting after a lost mouseup.
     let pressed = false;
     const onMouseDownCapture = (e: MouseEvent) => {
       additiveRef.current = isAdditiveDrag(e);

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -706,8 +706,9 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
  *  context), over `base` — the lines an additive drag is merging into, which
  *  would otherwise vanish on the next mousemove (this repaints from scratch).
  *  Split view's painter; unified falls through here only when no anchors
- *  exist — a cleared (null) range, an unresolvable start row, or a press
- *  already released — otherwise `paintRowSpan`. */
+ *  exist — a cleared (null) range, an unresolvable start row, or no live
+ *  primary gutter press (one already released, or a non-primary-button
+ *  drag) — otherwise `paintRowSpan`. */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -1004,10 +1005,12 @@ function StagingDiffView({
       startRow: HTMLTableRowElement;
       endRow: HTMLTableRowElement;
     } | null = null;
-    // The latch that licenses anchor minting: a primary press on the number
-    // gutter — the only press the manager starts a selection from — captured
-    // ahead of its mousedown. A mint request without one can only be a
-    // stranded drag's range still emitting after a lost mouseup.
+    // The latch that licenses anchor minting. Gutter ancestry is what lets
+    // the manager start a selection at all; the primary-button clause then
+    // scopes the two-sided span deliberately — a non-primary gutter drag
+    // keeps the library's single-sided range. A mint request without a live
+    // primary gutter press can only be a stranded drag's range still
+    // emitting after a lost mouseup.
     let pressed = false;
     const onMouseDownCapture = (e: MouseEvent) => {
       additiveRef.current = isAdditiveDrag(e);

--- a/src/features/diff/DiffViewer.tsx
+++ b/src/features/diff/DiffViewer.tsx
@@ -576,8 +576,7 @@ function WorkingTreeDiff({
                 <span className="flex-1 leading-snug">
                   Drag across the line numbers to{" "}
                   {file.staged ? "unstage" : "stage"} just those lines. Hold{" "}
-                  {ADDITIVE_MODIFIER} while dragging to add to the selection, so
-                  one selection can mix added and removed lines.
+                  {ADDITIVE_MODIFIER} while dragging to add to the selection.
                   {selectionBinding !== null && (
                     <>
                       {" "}
@@ -703,9 +702,10 @@ function paintLines(container: HTMLElement, lines: SelectedLine[]) {
   }
 }
 
-/** Highlight an in-progress drag range for live feedback (includes context),
- *  over `base` — the lines an additive drag is merging into, which would
- *  otherwise vanish on the next mousemove (this repaints from scratch). */
+/** Highlight the library-reported drag range for live feedback (includes
+ *  context), over `base` — the lines an additive drag is merging into, which
+ *  would otherwise vanish on the next mousemove (this repaints from scratch).
+ *  Split view only; unified paints from its own row anchors. */
 function paintRange(
   container: HTMLElement,
   range: {
@@ -724,9 +724,70 @@ function paintRange(
   }
 }
 
+/** The old/new numbers a unified row carries: both = context, one = added or
+ *  removed, neither = a `@@` separator or expand control. An empty attribute
+ *  counts as absent, matching the library's own validity test. */
+function rowLineNumbers(row: Element): { old?: number; new?: number } {
+  const read = (attr: string) => {
+    const raw = row
+      .querySelector(`.diff-line-num span[${attr}]`)
+      ?.getAttribute(attr);
+    const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return Number.isNaN(n) ? undefined : n;
+  };
+  return { old: read("data-line-old-num"), new: read("data-line-new-num") };
+}
+
+/** The rows a unified drag crossed, inclusive and in document order (either
+ *  drag direction). Empty when an anchor has left the DOM — the signal callers
+ *  use to fall back to the library's own range. */
+function rowsBetween(
+  container: HTMLElement,
+  startRow: HTMLTableRowElement,
+  endRow: HTMLTableRowElement,
+): HTMLTableRowElement[] {
+  const rows = Array.from(
+    container.querySelectorAll<HTMLTableRowElement>("tr"),
+  );
+  const a = rows.indexOf(startRow);
+  const b = rows.indexOf(endRow);
+  if (a < 0 || b < 0) return [];
+  return rows.slice(Math.min(a, b), Math.max(a, b) + 1);
+}
+
+/** Highlight a unified drag's crossed rows over `base` (same additive base as
+ *  `paintRange`). Context rows in the span tint for live feedback; numberless
+ *  rows never do. */
+function paintRowSpan(
+  container: HTMLElement,
+  startRow: HTMLTableRowElement,
+  endRow: HTMLTableRowElement,
+  base: SelectedLine[],
+) {
+  paintLines(container, base);
+  for (const row of rowsBetween(container, startRow, endRow)) {
+    const { old, new: added } = rowLineNumbers(row);
+    if (old !== undefined || added !== undefined)
+      row.classList.add(SELECT_CLASS);
+  }
+}
+
+/** The changed lines of a crossed-row span — a row with both numbers is
+ *  context and one with neither is a separator, so both drop out. */
+function linesForRows(rows: HTMLTableRowElement[]): SelectedLine[] {
+  const out: SelectedLine[] = [];
+  for (const row of rows) {
+    const { old, new: added } = rowLineNumbers(row);
+    if (old !== undefined && added !== undefined) continue;
+    if (old !== undefined) out.push({ side: "old", line: old });
+    else if (added !== undefined) out.push({ side: "new", line: added });
+  }
+  return out;
+}
+
 /** Union of two line selections, deduped by side+line — an additive drag adds
- *  to the committed selection instead of replacing it, and the two can overlap
- *  or (unlike one library-reported drag) span both sides. */
+ *  to the committed selection instead of replacing it, and the two can
+ *  overlap. */
 function mergeSelection(
   base: SelectedLine[] | null,
   added: SelectedLine[],
@@ -805,8 +866,10 @@ function HunkActionButtons({
  * collapsible expand, drag the line-number gutter to select lines to stage
  * across the whole file, and per-hunk Stage/Unstage/Discard buttons OVERLAID on
  * each hunk header (the library exposes no hunk-header slot). The library's
- * selection manager handles the drag; we paint the `gd-line-selected` highlight
- * ourselves (its own class doesn't apply in this standalone setup).
+ * selection manager drives the drag, but unified mode derives the crossed rows
+ * from our own anchors (its range is single-sided); we paint the
+ * `gd-line-selected` highlight ourselves — its own class doesn't apply in this
+ * standalone setup.
  */
 function StagingDiffView({
   repoPath,
@@ -930,31 +993,83 @@ function StagingDiffView({
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !diffFile) return;
+    const unified = viewMode !== "split";
+    // A unified drag's two anchor rows. The library's range is pinned to the
+    // side the drag started on and its end sticks at the last row bearing a
+    // number there, so the end anchor is tracked below instead. Effect-scoped:
+    // the drag dies with the manager it belongs to.
+    let drag: {
+      startRow: HTMLTableRowElement;
+      endRow: HTMLTableRowElement;
+    } | null = null;
     const onMouseDownCapture = (e: MouseEvent) => {
       additiveRef.current = isAdditiveDrag(e);
+      // A mouseup lost to a focus steal would strand the last drag's anchors;
+      // capture precedes the manager's mousedown, so every press re-anchors.
+      drag = null;
     };
     container.addEventListener("mousedown", onMouseDownCapture, true);
     // An additive drag paints over the committed selection; a plain one replaces
     // it, so its base is empty (the pre-additive behavior).
     const paintBase = () =>
       additiveRef.current ? (selectedRef.current ?? []) : [];
+    const onMouseOver = (e: MouseEvent) => {
+      if (!unified || !drag || !(e.target instanceof Element)) return;
+      const row = e.target.closest(".diff-line-num")?.closest("tr");
+      if (!row) return;
+      const { old, new: added } = rowLineNumbers(row);
+      if (old === undefined && added === undefined) return; // separator row
+      drag.endRow = row;
+      paintRowSpan(container, drag.startRow, row, paintBase());
+    };
+    container.addEventListener("mouseover", onMouseOver);
     const manager = createDiffMultiSelectManager(container, diffFile, {
-      isUnifiedMode: viewMode !== "split",
-      onSelectionChange: (range) => paintRange(container, range, paintBase()),
+      isUnifiedMode: unified,
+      onSelectionChange: (range) => {
+        if (unified) {
+          // A null range is the manager clearing itself (teardown).
+          if (!range) drag = null;
+          else if (!drag) {
+            const row = rowForLine(
+              container,
+              range.side,
+              range.startLineNumber,
+            );
+            if (row) drag = { startRow: row, endRow: row };
+          }
+          if (drag) {
+            paintRowSpan(container, drag.startRow, drag.endRow, paintBase());
+            return;
+          }
+        }
+        paintRange(container, range, paintBase());
+      },
       onSelectionComplete: (result) => {
-        // One drag is single-sided by library contract; the union across drags
-        // is what lets a selection carry added AND deleted lines.
-        const lines = (result?.lines ?? [])
-          .filter((l) => l.isAdd || l.isDelete)
-          .map(
-            (l): SelectedLine => ({
-              side: l.isAdd ? "new" : "old",
-              line: l.lineNumber,
-            }),
-          );
+        // Unified derives the crossed rows from our own anchors — the library's
+        // range is single-sided by model, so it drops the opposite side's lines.
+        // Split takes the library-reported lines; so does unified when an anchor
+        // is gone, which degrades to that same single-sided behavior.
+        const rows = drag
+          ? rowsBetween(container, drag.startRow, drag.endRow)
+          : [];
+        drag = null;
+        const lines = rows.length
+          ? linesForRows(rows)
+          : (result?.lines ?? [])
+              .filter((l) => l.isAdd || l.isDelete)
+              .map(
+                (l): SelectedLine => ({
+                  side: l.isAdd ? "new" : "old",
+                  line: l.lineNumber,
+                }),
+              );
         const next = additiveRef.current
           ? mergeSelection(selectedRef.current, lines)
           : lines;
+        // Paint the outcome now — a null commit over an already-null selection
+        // re-renders nothing and would strand the drag tint. If the text moved
+        // mid-drag this tints briefly; the manager effect's re-run clears it.
+        paintLines(container, next);
         // Stamp against the text these rows were BUILT from — the live
         // diff.data.text can already be newer while the deferred render lags.
         onSelectRef.current(next.length ? next : null, deferredText);
@@ -963,6 +1078,7 @@ function StagingDiffView({
     paintLines(container, selectedRef.current ?? []); // re-assert after (re)mount
     return () => {
       container.removeEventListener("mousedown", onMouseDownCapture, true);
+      container.removeEventListener("mouseover", onMouseOver);
       manager.destroy();
     };
   }, [diffFile, viewMode, deferredText]);

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -458,9 +458,10 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
 - **Hunk-level staging** — in a file's diff, each hunk has its own Stage / Unstage /
   Discard buttons.
 - **Line-level staging** — drag across the line-number gutter to select specific lines,
-  then stage or discard just those. Hold {{key:mod}} while dragging and the new run joins
-  the selection instead of replacing it, so one selection can mix added and removed lines
-  across as many hunks as you like; a plain drag starts a fresh one.
+  spanning as many hunks as you like, then stage or discard just those. In the unified
+  view a drag picks up every changed line it crosses, added and removed alike; in the
+  split view each drag selects one side. Hold {{key:mod}} while dragging and the new
+  run joins the selection instead of replacing it; a plain drag starts a fresh one.
   {{kbd:stage-selected-lines}} stages the selection (or unstages it, on a staged file's
   diff) without reaching for the button, and the command palette offers **Clear line
   selection**.


### PR DESCRIPTION
In the unified diff view, dragging across the line-number gutter now selects every changed line the drag crosses — added and removed together, across hunks — instead of being pinned to the side the drag started on. The underlying selection manager reports a single-sided range by model, so mixing added and deleted lines previously took several additive (Ctrl/⌘) drags; one drag is now enough.

### Diff selection (`src/features/diff/DiffViewer.tsx`)

- `StagingDiffView` now tracks its own pair of anchor rows for unified drags, since the library's reported range sticks at the last row bearing a number on the starting side. A `mouseover` listener on the container advances the end anchor as the pointer crosses numbered rows, and the `mousedown` capture handler resets the anchors so a mouseup lost to a focus steal can't strand them.
- Adds row-level helpers: `rowLineNumbers` reads a row's `data-line-old-num` / `data-line-new-num` (both = context, one = added/removed, neither = separator or expand control), `rowsBetween` returns the inclusive crossed rows in document order for either drag direction, and `linesForRows` distills those into `SelectedLine[]`, dropping context and separator rows.
- `paintRowSpan` paints live drag feedback from the crossed-row span for unified mode, layered over the same additive base as the existing `paintRange`, which is now documented as split-view only.
- `onSelectionComplete` derives lines from the anchors when they're still in the DOM and falls back to the library's `result.lines` otherwise, degrading to the previous single-sided behavior rather than losing the selection. It also repaints the committed selection via `paintLines`, so a null commit over an already-null selection can't leave the drag tint behind.
- `mergeSelection`'s contract comment drops the "unlike one library-reported drag" caveat now that a unified drag can itself span both sides, and the in-diff hint in `WorkingTreeDiff` no longer sells the additive modifier as the only way to mix added and removed lines.

### Documentation

- `src/features/help/content.ts`: the Changes tab's *Line-level staging* bullet now distinguishes the two views — unified picks up every changed line crossed, split selects one side per drag — with the additive-modifier note kept as its own sentence.
- `README.md`: reworks the working-tree diff paragraph to describe the unified drag picking up added and removed lines together.
- `site/src/data/capabilities.ts`: updates the "Line, hunk & file staging" label to match.
- `changelog.d/changed-unified-drag-both-sides.md`: new fragment covering the behavior change.

Relates to #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unified diff dragging now selects every changed line crossed, including added and removed lines.
  - Selected lines can be staged, unstaged, or discarded together.
  - Improved drag handling restores the correct selection state when dragging is interrupted.

- **Documentation**
  - Clarified unified- and split-view line-selection behavior in help content, capability descriptions, changelog entries, and commit guidance.
  - Updated guidance to distinguish selection behavior between unified and split diff views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->