### PR TITLE
fix(about,health): spawn tool probes off the command future

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -384,7 +384,9 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   arity: sub-futures holding capture buffers or nested async chains get
   spawned (`tauri::async_runtime::spawn`) or `Box::pin`ned before a `join!`.
   A 7-way inline join of process-spawning probes measured ~721 KB of handler
-  frame and shipped a stack-overflow crash (v0.12.1 About page).
+  frame and shipped a stack-overflow crash (v0.12.1 About page). (guard:
+  `system_health_future_stays_small`, src-tauri/src/health.rs — per-command
+  by choice; a new command joining capture-buffer futures adds its own.)
 - **Untrusted JSON** (CLI output, forge APIs): TS derivers `typeof`/shape-guard
   each field with `try/catch` per item; Rust uses tolerant serde (`Option<T>`,
   null-tolerant defaults) over strict shapes. Grammar-validate command/URL

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -374,6 +374,16 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   querying it.
 - **Sync Tauri commands run on the main thread** — take the value under the
   lock, drop the guard, then block; prefer `try_wait`-style non-blocking.
+- **Command futures stay small:** the invoke handler CONSTRUCTS a
+  `#[tauri::command]`'s future on the WebView2 UI-thread stack before the
+  runtime polls it on a worker — a large command future overflows that stack
+  in release builds (debug lays futures out smaller and `Box::pin`s them at
+  the IPC boundary, so dev never sees it; on Windows dev IPC uses the same
+  custom protocol). The trigger is per-future stack footprint, not join
+  arity: sub-futures holding capture buffers or nested async chains get
+  spawned (`tauri::async_runtime::spawn`) or `Box::pin`ned before a `join!`.
+  A 7-way inline join of process-spawning probes measured ~721 KB of handler
+  frame and shipped a stack-overflow crash (v0.12.1 About page).
 - **Untrusted JSON** (CLI output, forge APIs): TS derivers `typeof`/shape-guard
   each field with `try/catch` per item; Rust uses tolerant serde (`Option<T>`,
   null-tolerant defaults) over strict shapes. Grammar-validate command/URL

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -377,9 +377,10 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
 - **Command futures stay small:** the invoke handler CONSTRUCTS a
   `#[tauri::command]`'s future on the WebView2 UI-thread stack before the
   runtime polls it on a worker — a large command future overflows that stack
-  in release builds (debug lays futures out smaller and `Box::pin`s them at
-  the IPC boundary, so dev never sees it; on Windows dev IPC uses the same
-  custom protocol). The trigger is per-future stack footprint, not join
+  in release builds (dev never reproduced it: the debug-profile future
+  measured 123,000 B against a ~721 KB release handler frame, and debug
+  `Box::pin`s command futures at the IPC boundary; on Windows dev IPC uses
+  the same custom protocol). The trigger is per-future stack footprint, not join
   arity: sub-futures holding capture buffers or nested async chains get
   spawned (`tauri::async_runtime::spawn`) or `Box::pin`ned before a `join!`.
   A 7-way inline join of process-spawning probes measured ~721 KB of handler

--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -383,10 +383,10 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   the same custom protocol). The trigger is per-future stack footprint, not join
   arity: sub-futures holding capture buffers or nested async chains get
   spawned (`tauri::async_runtime::spawn`) or `Box::pin`ned before a `join!`.
-  A 7-way inline join of process-spawning probes measured ~721 KB of handler
-  frame and shipped a stack-overflow crash (v0.12.1 About page). (guard:
-  `system_health_future_stays_small`, src-tauri/src/health.rs — per-command
-  by choice; a new command joining capture-buffer futures adds its own.)
+  A 7-way inline join of process-spawning probes shipped a stack-overflow
+  crash (v0.12.1 About page). (guard: `system_health_future_stays_small`,
+  src-tauri/src/health.rs — per-command by choice; a new command joining
+  capture-buffer futures adds its own.)
 - **Untrusted JSON** (CLI output, forge APIs): TS derivers `typeof`/shape-guard
   each field with `try/catch` per item; Rust uses tolerant serde (`Option<T>`,
   null-tolerant defaults) over strict shapes. Grammar-validate command/URL

--- a/changelog.d/fixed-about-system-health-crash.md
+++ b/changelog.d/fixed-about-system-health-crash.md
@@ -1,0 +1,2 @@
+- Settings → About opens reliably, reporting your system details and the
+  status of every command-line tool GitDesktop uses.

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -49,17 +49,23 @@ fn system_info() -> SystemInfo {
     }
 }
 
+/// The "we know nothing about this tool" status: it isn't installed, or its
+/// probe didn't complete.
+fn undetected(id: &str) -> ToolStatus {
+    ToolStatus {
+        id: id.to_string(),
+        found: false,
+        path: None,
+        version: None,
+        authed: AuthStatus::Unknown,
+    }
+}
+
 /// Detect one CLI: resolve it, read `--version`, and (when it has a login) its
 /// auth state. `auth_args` is `None` for tools without a login concept (git).
 async fn detect(id: &str, names: &[&str], auth_args: Option<&[&str]>) -> ToolStatus {
     let Some(binary) = resolve_named(names, None).await else {
-        return ToolStatus {
-            id: id.to_string(),
-            found: false,
-            path: None,
-            version: None,
-            authed: AuthStatus::Unknown,
-        };
+        return undetected(id);
     };
 
     let version = run_capture(&binary, &["--version"], DETECT_TIMEOUT)
@@ -89,23 +95,77 @@ async fn detect(id: &str, names: &[&str], auth_args: Option<&[&str]>) -> ToolSta
     }
 }
 
+/// One tool detection: id, candidate binary names, and the auth-status args for
+/// tools that have a login (`None` for tools without one).
+type Probe = (
+    &'static str,
+    &'static [&'static str],
+    Option<&'static [&'static str]>,
+);
+
+/// Every CLI the About screen reports on, in the order it displays them. Copilot
+/// has no non-interactive auth-status command (it authenticates via the OS
+/// credential store / a token env var), so its login state stays Unknown.
+static PROBES: [Probe; 7] = [
+    ("git", &["git"], None),
+    ("gh", &["gh"], Some(&["auth", "status"])),
+    ("glab", &["glab"], Some(&["auth", "status"])),
+    ("claude", &["claude"], Some(&["auth", "status"])),
+    ("codex", &["codex"], Some(&["login", "status"])),
+    ("copilot", &["copilot"], None),
+    ("opencode", &["opencode"], None),
+];
+
 /// OS/app info + the status of every external CLI, for Settings → About. The
 /// per-tool detections (each spawns subprocesses) run concurrently.
 #[tauri::command]
 pub async fn system_health() -> AppResult<SystemHealth> {
-    // Copilot has no non-interactive auth-status command (it authenticates via the
-    // OS credential store / a token env var), so its login state stays Unknown.
-    let (git, gh, glab, claude, codex, copilot, opencode) = tokio::join!(
-        detect("git", &["git"], None),
-        detect("gh", &["gh"], Some(&["auth", "status"])),
-        detect("glab", &["glab"], Some(&["auth", "status"])),
-        detect("claude", &["claude"], Some(&["auth", "status"])),
-        detect("codex", &["codex"], Some(&["login", "status"])),
-        detect("copilot", &["copilot"], None),
-        detect("opencode", &["opencode"], None),
-    );
+    // Each detection runs as its own task to keep this command's future tiny:
+    // the invoke handler CONSTRUCTS a command future on the WebView2 UI-thread
+    // stack before tauri's runtime polls it on a worker, and the seven detect
+    // futures inlined here overflowed that stack in release builds (~721 KB
+    // handler frame, v0.12.1 crash dump; the same future was 123,000 B in
+    // debug and fit — why dev never crashed).
+    let handles: Vec<_> = PROBES
+        .iter()
+        .map(|&(id, names, auth_args)| {
+            let handle = tauri::async_runtime::spawn(detect(id, names, auth_args));
+            (id, handle)
+        })
+        // collect() is the concurrency: it drives every spawn before the first
+        // await below — awaiting inside one loop would serialize seven probes of
+        // up to two 20 s captures each.
+        .collect();
+
+    let mut tools = Vec::with_capacity(handles.len());
+    for (id, handle) in handles {
+        // A panicked or cancelled probe degrades to that one tool being unknown;
+        // an advisory panel must not go blank over it.
+        tools.push(handle.await.unwrap_or_else(|_| undetected(id)));
+    }
+
     Ok(SystemHealth {
         system: system_info(),
-        tools: vec![git, gh, glab, claude, codex, copilot, opencode],
+        tools,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the fix in `system_health`: the command future is constructed on
+    /// the WebView2 UI-thread stack (see the comment there), so it must stay
+    /// small. Pre-fix, the inline 7-way join measured 123,000 bytes in this
+    /// (debug) profile and ~721 KB in the release handler frame. Building the
+    /// future is enough to measure it; it is never polled here.
+    #[test]
+    fn system_health_future_stays_small() {
+        let fut = system_health();
+        let size = std::mem::size_of_val(&fut);
+        assert!(
+            size < 16 * 1024,
+            "system_health() future is {size} bytes (debug layout); keep per-tool detections spawned so it stays under 16 KiB"
+        );
+    }
 }

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -133,8 +133,8 @@ pub async fn system_health() -> AppResult<SystemHealth> {
             (id, handle)
         })
         // collect() is the concurrency: it drives every spawn before the first
-        // await below — awaiting inside one loop would serialize seven probes of
-        // up to two 20 s captures each.
+        // await below — awaiting inside one loop would serialize seven probes,
+        // each up to three 20 s subprocess legs (resolve + two captures).
         .collect();
 
     let mut tools = Vec::with_capacity(handles.len());

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -132,9 +132,9 @@ pub async fn system_health() -> AppResult<SystemHealth> {
             let handle = tauri::async_runtime::spawn(detect(id, names, auth_args));
             (id, handle)
         })
-        // collect() is the concurrency: it drives every spawn before the first
-        // await below — awaiting inside one loop would serialize seven probes,
-        // each up to three 20 s subprocess legs (resolve + two captures).
+        // collect() drives every spawn before the first await below; awaiting
+        // inside one loop would serialize seven probes, each up to three 20 s
+        // subprocess legs (resolve + two captures).
         .collect();
 
     let mut tools = Vec::with_capacity(handles.len());


### PR DESCRIPTION
Settings → About crashed on release builds: `system_health` built a single future that inlined a 7-way `tokio::join!` of process-spawning CLI probes, and Tauri's invoke handler constructs a command future on the WebView2 UI-thread stack before the runtime polls it on a worker — ~721 KB of handler frame overflowed that stack. Debug builds lay futures out smaller and `Box::pin` them at the IPC boundary, so dev never reproduced it. Each detection now runs as its own spawned task, keeping the command future tiny while preserving concurrency.

### Fix

- Rewrites `system_health` in `src-tauri/src/health.rs` to spawn each probe with `tauri::async_runtime::spawn` and collect the handles before the first `await` — the `collect()` is what keeps the seven probes concurrent instead of serializing up to two 20 s captures each.
- Replaces the seven positional `detect(...)` call sites with a `PROBES` static (a `[Probe; 7]` of id, candidate binary names, and optional auth-status args), carrying over the note that Copilot has no non-interactive auth-status command so its login state stays `Unknown`.
- Extracts the "nothing known about this tool" `ToolStatus` into a shared `undetected(id)` helper, reused both by `detect`'s resolve-failure path and by the new join loop so a panicked or cancelled probe degrades to one unknown tool rather than failing the whole panel.

### Regression guard

- Adds `system_health_future_stays_small` in `src-tauri/src/health.rs`, which builds (never polls) the command future and asserts `size_of_val` stays under 16 KiB, with the pre-fix measurements — 123,000 bytes in the debug profile, ~721 KB in the release handler frame — recorded in the test's doc comment.

### Documentation

- Adds a **Command futures stay small** convention to `.claude/skills/gd-conventions/SKILL.md`, describing the UI-thread construction mechanism, why dev builds hide it, and the rule that sub-futures holding capture buffers or nested async chains get spawned or `Box::pin`ned before a `join!`.
- Adds `changelog.d/fixed-about-system-health-crash.md` stating that Settings → About opens reliably and reports system details plus the status of every command-line tool GitDesktop uses.

Relates to #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when opening **Settings → About**.
  * System details and GitDesktop command-line tool statuses now display reliably.
  * Improved handling when a command-line tool is unavailable or its status check fails.

* **Documentation**
  * Added guidance for maintaining reliable system health checks and preventing related stability issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->