### PR TITLE
fix(agent): heap-allocate the capture read buffers

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -3358,14 +3358,14 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    /// Guards the read buffers staying off the future: every `run_capture_parts`
+    /// Guards the read buffers staying off the capture futures: every `run_capture_parts`
     /// caller is reachable from a `#[tauri::command]`, whose future is built on the
     /// WebView2 UI-thread stack in release builds, so inline arrays here would ride
     /// that stack. Building the future is enough to measure it; it is never polled.
     /// The composite `run_capture_parts` future is what a command actually holds, so
     /// it carries its own bound.
     #[test]
-    fn capture_capped_future_stays_small() {
+    fn capture_futures_stay_small() {
         let (mut o, mut e): (&[u8], &[u8]) = (b"", b"");
         let fut = capture_capped(&mut o, &mut e, 16);
         let size = std::mem::size_of_val(&fut);

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -778,8 +778,11 @@ where
 {
     let mut out = Vec::new();
     let mut err = Vec::new();
-    let mut obuf = [0u8; 8192];
-    let mut ebuf = [0u8; 8192];
+    // Heap, not inline arrays: these live across the select awaits, so arrays would
+    // ride every caller's future onto the stack a `#[tauri::command]` future is
+    // constructed on (the WebView2 UI thread in release builds).
+    let mut obuf = vec![0u8; 8192];
+    let mut ebuf = vec![0u8; 8192];
     let (mut odone, mut edone) = (false, false);
     let mut overflowed = false;
     loop {
@@ -3353,6 +3356,21 @@ mod tests {
         assert_eq!(err.len(), 16);
         assert!(!overflowed);
         assert!(out.is_empty());
+    }
+
+    /// Guards the read buffers staying off the future: every `run_capture_parts`
+    /// caller is reachable from a `#[tauri::command]`, whose future is built on the
+    /// WebView2 UI-thread stack in release builds, so inline arrays here would ride
+    /// that stack. Building the future is enough to measure it; it is never polled.
+    #[test]
+    fn capture_capped_future_stays_small() {
+        let (mut o, mut e): (&[u8], &[u8]) = (b"", b"");
+        let fut = capture_capped(&mut o, &mut e, 16);
+        let size = std::mem::size_of_val(&fut);
+        assert!(
+            size < 1024,
+            "capture_capped() future is {size} bytes (debug layout); keep the read buffers heap-allocated so it stays under 1 KiB"
+        );
     }
 
     // Real opencode `run --format json` lines (captured 2026-06-23, v1.17.9).

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -779,8 +779,8 @@ where
     let mut out = Vec::new();
     let mut err = Vec::new();
     // Heap, not inline arrays: these live across the select awaits, so arrays would
-    // ride every caller's future onto the stack a `#[tauri::command]` future is
-    // constructed on (the WebView2 UI thread in release builds).
+    // bloat every caller's future by 16 KiB — and release builds construct
+    // `#[tauri::command]` futures on the WebView2 UI thread's stack.
     let mut obuf = vec![0u8; 8192];
     let mut ebuf = vec![0u8; 8192];
     let (mut odone, mut edone) = (false, false);
@@ -3362,6 +3362,8 @@ mod tests {
     /// caller is reachable from a `#[tauri::command]`, whose future is built on the
     /// WebView2 UI-thread stack in release builds, so inline arrays here would ride
     /// that stack. Building the future is enough to measure it; it is never polled.
+    /// The composite `run_capture_parts` future is what a command actually holds, so
+    /// it carries its own bound.
     #[test]
     fn capture_capped_future_stays_small() {
         let (mut o, mut e): (&[u8], &[u8]) = (b"", b"");
@@ -3370,6 +3372,13 @@ mod tests {
         assert!(
             size < 1024,
             "capture_capped() future is {size} bytes (debug layout); keep the read buffers heap-allocated so it stays under 1 KiB"
+        );
+
+        let fut = run_capture_parts(Path::new("x"), &[], Duration::from_secs(1));
+        let size = std::mem::size_of_val(&fut);
+        assert!(
+            size < 2 * 1024,
+            "run_capture_parts() future is {size} bytes (debug layout); keep the capture read buffers heap-allocated so it stays under 2 KiB"
         );
     }
 


### PR DESCRIPTION
`capture_capped` in `src-tauri/src/agent.rs` held its two 8 KiB stdout/stderr read buffers as inline stack arrays. Because they stay live across the `select` awaits, they land in the generated future's layout, and every caller of `run_capture_parts` is reachable from a `#[tauri::command]` whose future is constructed on the WebView2 UI thread stack in release builds. Moving both buffers to the heap keeps that ~16 KiB off the UI thread's stack.

- Replaces `[0u8; 8192]` with `vec![0u8; 8192]` for `obuf` and `ebuf` in `capture_capped` (`src-tauri/src/agent.rs`), with a comment recording why the allocation is deliberate so a later reader doesn't "optimize" it back to arrays.
- Adds a regression test `capture_capped_future_stays_small` in the same file's `tests` module: it constructs (never polls) a `capture_capped` future over empty readers and asserts `size_of_val` stays under 1 KiB, so re-inlining the buffers fails the suite.
- Capture semantics are untouched — the 8192-byte read size, the `overflowed` cap handling, and the select loop are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability during command output capture by reducing memory usage on the interface thread, helping prevent release-build issues in WebView2.

* **Tests**
  * Added safeguards that verify output-capture operations maintain a small memory footprint and remain within expected limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->