### PR TITLE
feat(changes,branches): add directory tree view to the Changes panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ delete), and deep links to the settings GitHub keeps browser-only.
 
 A unified or split diff with syntax highlighting, collapsible surrounding
 context, and image diffing. Filter the changes list by path or category, and
-read a file's `+added -deleted` line counts without opening it. The
+read a file's `+added -deleted` line counts without opening it. Show that
+list flat or as a compacted directory tree: collapsible folders, single-child
+folder chains merged into one row, and arrow keys that walk and fold it. The
 working-tree diff is one whole-file view with hunk- and line-level staging
 and discarding (drag across the line numbers, spanning hunks freely — in
 the unified view a drag picks up added and removed lines together; hold

--- a/changelog.d/added-changes-tree-view.md
+++ b/changelog.d/added-changes-tree-view.md
@@ -1,5 +1,6 @@
 - **Directory tree in the Changes panel.** See your files as a compacted
   directory tree: folders collapse, single-child chains merge into one row, and
   the flat list stays one toggle away, in the panel's filter row or the command
-  palette. Multi-select, keyboard navigation, and the Staged / Changes split
-  work the same in both views.
+  palette. Multi-select, keyboard navigation, and the Staged / Changes split are
+  available in both views, and collapsing a folder drops its hidden files from a
+  multi-selection.

--- a/changelog.d/added-changes-tree-view.md
+++ b/changelog.d/added-changes-tree-view.md
@@ -1,0 +1,5 @@
+- **Directory tree in the Changes panel.** See your files as a compacted
+  directory tree: folders collapse, single-child chains merge into one row, and
+  the flat list stays one toggle away, in the panel's filter row or the command
+  palette. Multi-select, keyboard navigation, and the Staged / Changes split
+  work the same in both views.

--- a/changelog.d/changed-branch-menu-busy-reasons.md
+++ b/changelog.d/changed-branch-menu-busy-reasons.md
@@ -1,0 +1,3 @@
+- Branch context-menu actions that wait on a running branch operation say
+  **(operation in progress)** on their label, so the reason sits with the
+  action.

--- a/changelog.d/fixed-branch-picker-main-workspace.md
+++ b/changelog.d/fixed-branch-picker-main-workspace.md
@@ -1,0 +1,3 @@
+- The **Compare** tab's branch picker and the base-branch picker name the
+  **main workspace** when that's where a branch is checked out, matching the
+  branch dropdown's own wording.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -65,6 +65,11 @@ export const capabilities: Capability[] = [
   },
   {
     group: "Diffs & staging",
+    label:
+      "Flat list ⇄ compacted directory tree in the Changes panel — collapsible folders, keyboard-first",
+  },
+  {
+    group: "Diffs & staging",
     label: "Per-file added/deleted line counts on the changes list",
   },
   {

--- a/src/features/compare/CompareBranchCombobox.tsx
+++ b/src/features/compare/CompareBranchCombobox.tsx
@@ -15,6 +15,7 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { rowCheckoutCopy } from "@/features/repository/checkout-copy";
 import { clipTitle } from "@/lib/clip-title";
 import { normPath } from "@/lib/git/path";
 import { useBranchDivergence, useUserWorktrees } from "@/lib/git/queries";
@@ -68,16 +69,18 @@ export function CompareBranchCombobox({
     [divergence.data],
   );
 
-  // Branches checked out in *another* worktree → that worktree's path. Git
-  // forbids the same branch in two worktrees; the active repo's own checkout is
-  // excluded (that's just the current branch). Fetched only while open.
+  // Branches checked out in *another* checkout → that checkout. Git forbids the
+  // same branch in two worktrees; the active repo's own checkout is excluded
+  // (that's just the current branch). The main workspace stays IN — git counts
+  // it as a worktree, and `isMain` is what lets the row name it properly.
+  // Fetched only while open.
   const userWorktrees = useUserWorktrees(repoPath, open);
   const activeNorm = normPath(repoPath);
   const worktreeByBranch = useMemo(() => {
-    const map = new Map<string, string>();
+    const map = new Map<string, { path: string; isMain: boolean }>();
     for (const w of userWorktrees.data ?? []) {
       if (w.branch && normPath(w.path) !== activeNorm)
-        map.set(w.branch, w.path);
+        map.set(w.branch, { path: w.path, isMain: w.isMain });
     }
     return map;
   }, [userWorktrees.data, activeNorm]);
@@ -139,7 +142,7 @@ export function CompareBranchCombobox({
               defaultName={defaultName}
               currentName={currentName}
               div={divByName.get(name)}
-              worktreePath={worktreeByBranch.get(name)}
+              worktree={worktreeByBranch.get(name)}
             />
           )}
         </ComboboxList>
@@ -160,15 +163,20 @@ function BranchRow({
   defaultName,
   currentName,
   div,
-  worktreePath,
+  worktree,
 }: {
   name: string;
   branch: Branch | undefined;
   defaultName: string | null;
   currentName: string;
   div: BranchDivergence | undefined;
-  worktreePath: string | undefined;
+  /** The other checkout holding this branch, when any. */
+  worktree: { path: string; isMain: boolean } | undefined;
 }) {
+  // Names the holding checkout the way every branch row does. The record's
+  // `title` arm is deliberately not used: its "this row opens it" clause is true
+  // in the branch dropdown, while this row selects a compare base.
+  const copy = rowCheckoutCopy(worktree?.isMain);
   return (
     <ComboboxItem value={name}>
       <span className="min-w-0 flex-1 truncate" onMouseEnter={clipTitle(name)}>
@@ -179,13 +187,13 @@ function BranchRow({
           </span>
         )}
       </span>
-      {worktreePath && (
+      {worktree && (
         <span
           className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
-          title={`Checked out in another worktree (${worktreePath})`}
+          title={copy.blockedTitle(worktree.path)}
         >
           <TreeStructureIcon className="size-3" weight="bold" />
-          worktree
+          {copy.noun}
         </span>
       )}
       {/* ↑/↓ describe THIS row's branch vs `currentName` (the app-wide row-badge

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -470,6 +470,17 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   palette ({{kbd:command-palette}}) for Stage / Unstage selected files.
 - Filter the list by path, or by category (new / modified / deleted, included /
   excluded) with the funnel button.
+- The **Directory tree view** button in the filter row swaps the flat list for a
+  compacted directory tree: single-child folder chains merge into one row, and shared
+  prefixes roll up. Click a folder to collapse or expand it (Enter or Space does the
+  same); from the keyboard ↑ and ↓ walk folders and files alike, ← folds the folder
+  you're on or jumps to its parent, and → unfolds a folder or steps inside it.
+  Collapsing a folder drops its hidden files from a multi-selection, and the diff you
+  have open stays open. Selection, staging, and filtering behave the same in both
+  views; file rows keep their {{secondaryclick}} menu, while a folder row opens the
+  whole-list menu. Your choice is remembered for every repository. *Toggle directory tree view* in the command palette
+  ({{kbd:command-palette}}) flips it too (palette-only by default — bind a key in
+  **Settings → Keyboard**).
 - **Discard all changes…** clears the whole working tree after a confirm. It sits on the
   changes list's own {{secondaryclick}} menu (over the header or the empty space below
   the files), in the branch ⋮ menu beside **Stash all changes…**, and in the command

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -478,9 +478,9 @@ The **Changes** tab ({{kbd:tab-changes}}) lists your modified files, split into
   Collapsing a folder drops its hidden files from a multi-selection, and the diff you
   have open stays open. Selection, staging, and filtering behave the same in both
   views; file rows keep their {{secondaryclick}} menu, while a folder row opens the
-  whole-list menu. Your choice is remembered for every repository. *Toggle directory tree view* in the command palette
-  ({{kbd:command-palette}}) flips it too (palette-only by default — bind a key in
-  **Settings → Keyboard**).
+  whole-list menu. Your choice is remembered for every repository. *Toggle
+  directory tree view* in the command palette ({{kbd:command-palette}}) flips it
+  too (palette-only by default — bind a key in **Settings → Keyboard**).
 - **Discard all changes…** clears the whole working tree after a confirm. It sits on the
   changes list's own {{secondaryclick}} menu (over the header or the empty space below
   the files), in the branch ⋮ menu beside **Stash all changes…**, and in the command

--- a/src/features/repository/BaseBranchCombobox.tsx
+++ b/src/features/repository/BaseBranchCombobox.tsx
@@ -22,6 +22,7 @@ import {
   useUserWorktrees,
 } from "@/lib/git/queries";
 import type { Branch } from "@/lib/git/types";
+import { rowCheckoutCopy } from "./checkout-copy";
 
 /** Whether a local branch may be offered as a base: drop the agent-session
  *  namespace (a hard repo invariant — every branch surface filters
@@ -47,8 +48,9 @@ function isOfferableRemoteName(name: string): boolean {
 interface RowMeta {
   /** ISO-8601 committer date of the branch tip (recency chip). */
   lastCommitDate: string;
-  /** Set when this branch is checked out in ANOTHER worktree. */
-  worktreePath?: string;
+  /** Set when this branch is checked out in ANOTHER checkout — the main
+   *  workspace included, which is what `isMain` lets the row name properly. */
+  worktree?: { path: string; isMain: boolean };
 }
 
 /**
@@ -92,15 +94,16 @@ export function BaseBranchCombobox({
   const remoteBranches = useRemoteBranches(repoPath, open);
   const userWorktrees = useUserWorktrees(repoPath, open);
 
-  // Branches checked out in *another* worktree → that worktree's path. Git
-  // forbids the same branch in two worktrees; the active repo's own checkout is
-  // excluded (that's just the current branch).
+  // Branches checked out in *another* checkout → that checkout. Git forbids the
+  // same branch in two worktrees; the active repo's own checkout is excluded
+  // (that's just the current branch). The main workspace stays IN — git counts
+  // it as a worktree, and `isMain` is what lets the row name it properly.
   const activeNorm = normPath(repoPath);
   const worktreeByBranch = useMemo(() => {
-    const map = new Map<string, string>();
+    const map = new Map<string, { path: string; isMain: boolean }>();
     for (const w of userWorktrees.data ?? []) {
       if (w.branch && normPath(w.path) !== activeNorm)
-        map.set(w.branch, w.path);
+        map.set(w.branch, { path: w.path, isMain: w.isMain });
     }
     return map;
   }, [userWorktrees.data, activeNorm]);
@@ -156,7 +159,7 @@ export function BaseBranchCombobox({
     for (const b of localBranches) {
       map.set(b.name, {
         lastCommitDate: b.lastCommitDate,
-        worktreePath: worktreeByBranch.get(b.name),
+        worktree: worktreeByBranch.get(b.name),
       });
     }
     for (const r of remoteBranchList) {
@@ -285,6 +288,10 @@ function BaseBranchRow({
   currentName: string | null;
   defaultName: string | null;
 }) {
+  // Names the holding checkout the way every branch row does. The record's
+  // `title` arm is deliberately not used: its "this row opens it" clause is true
+  // in the branch dropdown, while this row picks a base branch.
+  const copy = rowCheckoutCopy(meta?.worktree?.isMain);
   return (
     <ComboboxItem value={name}>
       <span className="min-w-0 flex-1 truncate" onMouseEnter={clipTitle(name)}>
@@ -300,13 +307,13 @@ function BaseBranchRow({
           </span>
         )}
       </span>
-      {meta?.worktreePath && (
+      {meta?.worktree && (
         <span
           className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground"
-          title={`Checked out in another worktree (${meta.worktreePath})`}
+          title={copy.blockedTitle(meta.worktree.path)}
         >
           <TreeStructureIcon className="size-3" weight="bold" />
-          worktree
+          {copy.noun}
         </span>
       )}
       {meta?.lastCommitDate && (

--- a/src/features/repository/BranchSwitcher.tsx
+++ b/src/features/repository/BranchSwitcher.tsx
@@ -121,6 +121,7 @@ import {
   worktreeCheckStateFrom,
 } from "./CleanupBranchesDialog";
 import { CreateBranchDialog } from "./CreateBranchDialog";
+import { baseName, rowCheckoutCopy } from "./checkout-copy";
 import { DeleteWorktreeDialog } from "./DeleteWorktreeDialog";
 import { ForkPrPublishGuard } from "./ForkPrPublishGuard";
 import { OperationHistoryDialog } from "./OperationHistoryDialog";
@@ -140,42 +141,6 @@ import {
   refuseWhileLeaving,
   worktreeItemLabel,
 } from "./WorktreesDialog";
-
-/** Last path segment (folder name), tolerating either separator. */
-const baseName = (p: string) => p.split(/[/\\]/).filter(Boolean).pop() ?? p;
-
-/** How a branch row NAMES the checkout holding its branch — chip, tooltip, open
- *  item, after-the-fact toast, and the phrases that say a row is held because of
- *  it. Git counts the main workspace as a worktree and this row can point at it
- *  when you're standing in a linked one, but users don't call it one; routing
- *  the naming through one record keeps a later phrase from drifting back.
- *  "Rename worktree…" and "Delete worktree…" are deliberately NOT routed here:
- *  they name the git operation, and their held-reason carries the naming instead.
- *  `noun` is bare, for badges and parenthetical reasons. */
-const ROW_CHECKOUT_COPY = {
-  linked: {
-    noun: "worktree",
-    open: "Open worktree",
-    title: (path: string) =>
-      `Checked out in worktree ${baseName(path)} (${path}) — this row opens it`,
-    opened: (path: string) => `Opened worktree ${baseName(path)}`,
-    blocked: "checked out in another worktree",
-    held: "in a worktree",
-  },
-  main: {
-    noun: "main workspace",
-    open: "Open main workspace",
-    title: (path: string) =>
-      `Checked out in the main workspace (${path}) — this row opens it`,
-    opened: (_path: string) => "Opened the main workspace",
-    blocked: "checked out in the main workspace",
-    held: "in the main workspace",
-  },
-} as const;
-
-/** Which {@link ROW_CHECKOUT_COPY} arm a listed worktree speaks in. */
-const rowCheckoutCopy = (isMain: boolean | undefined) =>
-  ROW_CHECKOUT_COPY[isMain ? "main" : "linked"];
 
 /** Sentence-initial form of the platform's secondary-click word — for
  *  status-icon hints where the phrase leads a sentence. */
@@ -1830,6 +1795,10 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
     // this row's holding checkout come from the record instead of saying
     // "worktree" flat.
     const rowCopy = rowCheckoutCopy(rowWorktree?.isMain);
+    // A natively-disabled menu item swallows its tooltip, so the items `busy`
+    // alone holds carry the reason in the label. A structural reason always
+    // wins — this arm shows only where nothing else explains the dimming.
+    const busySuffix = busy ? " (operation in progress)" : "";
     const rowWorktreeRemoving = Boolean(
       rowWorktree && removingPaths.has(rowWorktree.path),
     );
@@ -2158,7 +2127,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   onClick={() => void doUpdateFromDefault(branch.name)}
                 >
                   Update from {defaultName}
-                  {rowPromotion ? " (promotion branch)" : ""}
+                  {rowPromotion ? " (promotion branch)" : busySuffix}
                 </ContextMenuItem>
               )}
               {/* Pull the branch's own upstream in without switching — the star
@@ -2188,7 +2157,9 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                         onClick={() => void doResetToUpstream(branch, resetTip)}
                       >
                         Reset to {base}…
-                        {inWorktree && ` (checked out in ${holder})`}
+                        {inWorktree
+                          ? ` (checked out in ${holder})`
+                          : busySuffix}
                       </ContextMenuItem>
                     );
                   }
@@ -2208,6 +2179,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                       }
                     >
                       Update from {base}
+                      {busySuffix}
                     </ContextMenuItem>
                   );
                 })()}
@@ -2224,7 +2196,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                 >
                   {branch.upstreamBehind > 0
                     ? `Push to ${branch.upstream} (diverged)`
-                    : `Push to ${branch.upstream}`}
+                    : `Push to ${branch.upstream}${busySuffix}`}
                 </ContextMenuItem>
               )}
               {/* Publish an unpushed / upstream-deleted branch: one remote → a
@@ -2237,8 +2209,8 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                   onClick={() => doPushBranch(branch, publishRemotes[0])}
                 >
                   {publishRemotes[0] === "origin"
-                    ? "Publish branch"
-                    : `Publish to ${publishRemotes[0]}`}
+                    ? `Publish branch${busySuffix}`
+                    : `Publish to ${publishRemotes[0]}${busySuffix}`}
                 </ContextMenuItem>
               ) : (
                 publishRemotes.map((r) => (
@@ -2248,6 +2220,7 @@ export function BranchSwitcher({ repoPath }: { repoPath: string }) {
                     onClick={() => doPushBranch(branch, r)}
                   >
                     Publish to {r}
+                    {busySuffix}
                   </ContextMenuItem>
                 ))
               )}

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -5,10 +5,11 @@ import {
   FunnelIcon,
   InfoIcon,
   StackIcon,
-  TreeStructureIcon,
+  TreeViewIcon,
 } from "@phosphor-icons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  type FocusEvent,
   type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
@@ -61,6 +62,7 @@ import { formatBinding } from "@/lib/hotkeys/binding";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { flattenPathTree } from "@/lib/path-tree";
+import { CHANGES_VIEW_MODES } from "@/lib/settings/api";
 import {
   useAiEnabled,
   useReviewConfigured,
@@ -284,6 +286,9 @@ export function ChangesPanel({
   const pendingFocusKey = useRef<string | null>(null);
   // The view mode a flip-armed claim waits for; null = claimable right away.
   const pendingFocusMode = useRef<"list" | "tree" | null>(null);
+  // The row focus sat in when that claim was armed; null = focus was not on a
+  // row (a background arm, with the caret in the filter or outside the list).
+  const pendingFocusSource = useRef<string | null>(null);
 
   const entries = status.data?.entries ?? [];
   const conflictedPaths = entries
@@ -508,6 +513,18 @@ export function ChangesPanel({
   function deferFocusRow(key: string, untilMode?: "list" | "tree") {
     pendingFocusKey.current = key;
     pendingFocusMode.current = untilMode ?? null;
+    // Where the gesture started, so the claim can tell focus that never moved
+    // from focus that belongs to somebody else. Null for the arms that fire
+    // while the caret is outside the list — they stay orphan-only.
+    const from = focusedNavRow();
+    pendingFocusSource.current = from ? rowKeyOf(from.row) : null;
+  }
+
+  /** A claim and its source row retire together — nothing reads one without the
+   *  other. */
+  function clearPendingFocus() {
+    pendingFocusKey.current = null;
+    pendingFocusSource.current = null;
   }
 
   /** Claims focus for a deferred row once the list has scrolled to it. Returns
@@ -528,18 +545,29 @@ export function ChangesPanel({
     pendingFocusMode.current = null;
     // A newer cursor move owns focus now, so this claim is stale.
     if (key !== cursorKey) {
-      pendingFocusKey.current = null;
+      clearPendingFocus();
       return true;
     }
-    if (!focusIsOrphaned()) {
-      pendingFocusKey.current = null;
+    // The orphan guard is what keeps a claim from stealing a live control's
+    // caret. Focus still sitting in the row the jump was armed from is the one
+    // sanctioned exception: it hasn't moved since the gesture, so the claim
+    // finishes that gesture instead of interrupting somebody. Without it a jump
+    // past the mounted window strands focus on the row the user left, and every
+    // later key reads that row instead of the one the cursor names.
+    const from = focusedNavRow();
+    const atSource =
+      pendingFocusSource.current !== null &&
+      from !== null &&
+      rowKeyOf(from.row) === pendingFocusSource.current;
+    if (!focusIsOrphaned() && !atSource) {
+      clearPendingFocus();
       return true;
     }
     const el = listRef.current?.querySelector<HTMLElement>(
       `[data-row="${CSS.escape(key)}"]`,
     );
     if (!el) return false;
-    pendingFocusKey.current = null;
+    clearPendingFocus();
     el.focus();
     return true;
   }
@@ -576,6 +604,10 @@ export function ChangesPanel({
     }
   }
 
+  // List mode has no tree to walk, so Left/Right stay the browser's — one gate
+  // for both the hook and the focused-row wrapper below.
+  const arrowLeft = treeMode ? onArrowLeft : undefined;
+  const arrowRight = treeMode ? onArrowRight : undefined;
   // Arrow keys walk the rows across both sections; Shift extends from the
   // anchor, a plain arrow collapses to the single active row.
   const navKeyDown = listKeyboardNav({
@@ -583,10 +615,46 @@ export function ChangesPanel({
     activeIndex: navIndex,
     rowKey: rowKeyOf,
     onActivate: activateRow,
-    // List mode has no tree to walk, so Left/Right stay the browser's.
-    onArrowLeft: treeMode ? onArrowLeft : undefined,
-    onArrowRight: treeMode ? onArrowRight : undefined,
+    onArrowLeft: arrowLeft,
+    onArrowRight: arrowRight,
   });
+
+  /** The navigable row DOM focus sits in, resolved from the DOM at use rather
+   *  than stored: a focused-row cursor of our own would re-mint the whole
+   *  stale-key family the folder-cursor reconciliation exists for. Null unless
+   *  focus is inside the list and inside a row (its own controls included). */
+  function focusedNavRow(): { row: FlatRow; index: number } | null {
+    const list = listRef.current;
+    const focused = document.activeElement;
+    if (!list || !(focused instanceof HTMLElement) || !list.contains(focused))
+      return null;
+    const key = focused.closest("[data-row]")?.getAttribute("data-row");
+    if (!key) return null;
+    const index = navRows.findIndex((r) => rowKeyOf(r) === key);
+    return index === -1 ? null : { row: navRows[index], index };
+  }
+
+  /** Left/Right fold and walk the tree, so they act on the row FOCUS is on: the
+   *  hook resolves from the cursor, which a bare Tab leaves behind (and with no
+   *  file selected it returns before the horizontal callbacks at all), so those
+   *  keys would fold the old selection's parent, or nothing. Up/Down keep
+   *  anchoring at the cursor — master's Tab behaviour, unchanged. A focused tree
+   *  region swallows both keys whether or not they moved anything, exactly as
+   *  the hook path does, so the list never scrolls sideways under them. */
+  function handleListKeyDown(e: KeyboardEvent) {
+    let horizontal: typeof arrowLeft;
+    if (e.key === "ArrowLeft") horizontal = arrowLeft;
+    else if (e.key === "ArrowRight") horizontal = arrowRight;
+    if (horizontal) {
+      const hit = focusedNavRow();
+      if (hit) {
+        e.preventDefault();
+        horizontal(hit.row, hit.index);
+        return;
+      }
+    }
+    navKeyDown(e);
+  }
   // The list element lives in the virtualized child, and every focus restore
   // queries through it — so it comes from the mount itself, never from an event
   // a mouse-only session would never fire. Stable identity: a fresh callback
@@ -634,7 +702,7 @@ export function ChangesPanel({
   // compaction, the toggles, any path added later; the toggle-site
   // reconciliations remain the synchronous fast path, which usually prevents the
   // orphan window entirely.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: runs when the cursor key stops resolving
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the cursor key stopped resolving
   useEffect(() => {
     if (activeFolderKey === null || navIndex !== -1) return;
     const parsed = FOLDER_ROW_KEY_RE.exec(activeFolderKey);
@@ -716,6 +784,22 @@ export function ChangesPanel({
     }
     setSelectedKeys(new Set([key]));
     setAnchorKey(key);
+  }
+
+  /** Keeps the folder cursor off a row focus has left — the arrow and view-flip
+   *  arms act on it. A folder row parks it (pure cursor state); a file row only
+   *  CLEARS it, because a file cursor IS the shown-diff selection and selecting
+   *  on focus would make Tab clobber the open diff. Delegated over the list, so
+   *  no row kind can miss it and a row's own controls count too (React's
+   *  `onFocus` is `focusin`, which bubbles); focus outside a row — the filter, a
+   *  palette dispatch — must leave the cursor where the flip arms read it. */
+  function handleRowFocus(e: FocusEvent) {
+    if (!(e.target instanceof HTMLElement)) return;
+    const key = e.target.closest("[data-row]")?.getAttribute("data-row");
+    if (!key || key === cursorKey) return;
+    const row = navRows.find((r) => rowKeyOf(r) === key);
+    if (!row) return;
+    setActiveFolderKey(row.type === "folder" ? key : null);
   }
 
   // Toggle one file's staged state — the row's +/- button and the single menu.
@@ -1294,10 +1378,8 @@ export function ChangesPanel({
           data-row={rowKeyOf(row)}
           role="option"
           aria-selected={false}
-          aria-expanded={!row.collapsed}
-          // ARIA 1.2 doesn't give `option` an expanded state, so the label
-          // carries what the caret shows; `aria-expanded` stays for the readers
-          // that do honour it.
+          // ARIA 1.2 gives `option` no expanded state, so the label carries
+          // what the caret shows.
           aria-label={`${row.label} — ${row.count} ${
             row.count === 1 ? "file" : "files"
           }, ${row.collapsed ? "collapsed" : "expanded"}`}
@@ -1442,7 +1524,7 @@ export function ChangesPanel({
               }
               onClick={toggleViewMode}
             >
-              <TreeStructureIcon />
+              <TreeViewIcon />
             </Button>
           </div>
 
@@ -1497,7 +1579,8 @@ export function ChangesPanel({
                 setFilterText("");
                 setActiveKinds(new Set());
               }}
-              onListKeyDown={navKeyDown}
+              onListKeyDown={handleListKeyDown}
+              onListFocus={handleRowFocus}
               onListEl={handleListEl}
               onContextMenuCapture={handleContextMenu}
               onCursorScrolled={claimPendingFocus}
@@ -1635,6 +1718,7 @@ function VirtualizedChangeList({
   nothingMatches,
   onClearFilter,
   onListKeyDown,
+  onListFocus,
   onListEl,
   onContextMenuCapture,
   onCursorScrolled,
@@ -1647,7 +1731,7 @@ function VirtualizedChangeList({
   text: string;
   activeKinds: Set<FilterKind>;
   /** A `getItemKey` identity input, not read directly. */
-  viewMode: string;
+  viewMode: (typeof CHANGES_VIEW_MODES)[number];
   /** A `getItemKey` identity input, not read directly. */
   collapsedFolders: Set<string>;
   /** The cursor row — a file or (tree mode) a folder — kept scrolled into view. */
@@ -1655,6 +1739,9 @@ function VirtualizedChangeList({
   nothingMatches: boolean;
   onClearFilter: () => void;
   onListKeyDown: (e: KeyboardEvent) => void;
+  /** Every focus inside the list, delegated: the panel keeps its folder cursor
+   *  in step with the row focus landed in. */
+  onListFocus: (e: FocusEvent) => void;
   /** Hands the mounted scroll container up to the panel, which queries rows
    *  through it. Must be referentially stable — it rides the element's ref. */
   onListEl: (el: HTMLDivElement | null) => void;
@@ -1763,6 +1850,7 @@ function VirtualizedChangeList({
           ref={setListEl}
           className="min-h-0 flex-1 overflow-y-auto"
           onKeyDown={onListKeyDown}
+          onFocus={onListFocus}
           onContextMenuCapture={onContextMenuCapture}
           role="listbox"
           aria-label="Changed files"

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -1399,7 +1399,11 @@ export function ChangesPanel({
           ) : (
             <CaretDownIcon className="size-3 shrink-0" />
           )}
-          <PathText path={row.label} className="min-w-0 flex-1" />
+          <PathText
+            path={row.label}
+            title={row.path}
+            className="min-w-0 flex-1"
+          />
           <span className="shrink-0 tabular-nums">({row.count})</span>
         </div>
       );

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -157,6 +157,14 @@ type FlatRow =
 
 type FolderRow = Extract<FlatRow, { type: "folder" }>;
 
+/** Focus nobody owns: the document body, nothing at all, or a node a render has
+ *  detached. Every focus restore here gates on it — a live control's caret (the
+ *  filter input, the toggle button) is never ours to take. */
+function focusIsOrphaned(): boolean {
+  const focused = document.activeElement;
+  return !focused || focused === document.body || !focused.isConnected;
+}
+
 /** Drops the selection keys hidden under `collapsedKeys` (each `"<section>:<dir>"`,
  *  sharing the selection keys' `"<section>:<path>"` spelling). One rule for both
  *  ways a row can go hidden — collapsing a folder, and entering tree mode with
@@ -254,6 +262,7 @@ export function ChangesPanel({
   const [menuTarget, setMenuTarget] = useState<MenuTarget>(null);
   const filterRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLElement | null>(null);
+  const viewToggleRef = useRef<HTMLButtonElement>(null);
   // A cursor row a horizontal jump could not focus because the virtualizer had
   // not mounted it yet; claimed once the scroll brings it in.
   const pendingFocusKey = useRef<string | null>(null);
@@ -484,10 +493,7 @@ export function ChangesPanel({
       pendingFocusKey.current = null;
       return true;
     }
-    const focused = document.activeElement;
-    // Only an orphaned focus is ours to claim — never take a caret out of the
-    // filter input or any other live control.
-    if (focused && focused !== document.body && focused.isConnected) {
+    if (!focusIsOrphaned()) {
       pendingFocusKey.current = null;
       return true;
     }
@@ -737,6 +743,20 @@ export function ChangesPanel({
     // hide rows selected while they were flat — prune them as a collapse does.
     if (!treeMode)
       setSelectedKeys((prev) => pruneHiddenKeys(prev, collapsedFolders));
+    // Leaving tree mode unmounts the folder rows, so a cursor parked on one
+    // takes its focus with it — the palette route dispatches with focus still on
+    // the doomed row, and it lands on <body>. Hand focus to the file row the
+    // list keeps, or to the control that owns the swap.
+    if (treeMode && activeFolderKey !== null) {
+      const focused = document.activeElement;
+      const onDoomedRow =
+        focused instanceof HTMLElement &&
+        focused.getAttribute("data-row") === activeFolderKey;
+      if (onDoomedRow || focusIsOrphaned()) {
+        if (activeKey !== null) focusRow(activeKey);
+        else viewToggleRef.current?.focus();
+      }
+    }
     void saveSettings
       .mutateAsync({
         ...settings.data,
@@ -1300,6 +1320,7 @@ export function ChangesPanel({
               autoComplete="off"
             />
             <Button
+              ref={viewToggleRef}
               variant={treeMode ? "secondary" : "outline"}
               size="icon-sm"
               aria-pressed={treeMode}

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -165,6 +165,19 @@ function focusIsOrphaned(): boolean {
   return !focused || focused === document.body || !focused.isConnected;
 }
 
+/** Whether a restore may move focus away on behalf of the row `key` names: focus
+ *  sits on that row (still mounted, about to go) or on nobody. A view flip
+ *  dispatched from the palette leaves the doomed row focused, so orphan-only
+ *  would never fire — and a caret in a live control must still be left alone. */
+function focusLeavingRow(key: string): boolean {
+  const focused = document.activeElement;
+  return (
+    (focused instanceof HTMLElement &&
+      focused.getAttribute("data-row") === key) ||
+    focusIsOrphaned()
+  );
+}
+
 /** Drops the selection keys hidden under `collapsedKeys` (each `"<section>:<dir>"`,
  *  sharing the selection keys' `"<section>:<path>"` spelling). One rule for both
  *  ways a row can go hidden — collapsing a folder, and entering tree mode with
@@ -194,6 +207,9 @@ function rowKeyOf(row: FlatRow): string {
   if (row.type === "folder") return `folder:${row.section}:${row.path}`;
   return keyOf(row.entry.path, row.staged);
 }
+
+/** Splits a folder row key back into its section and directory path. */
+const FOLDER_ROW_KEY_RE = /^folder:(staged|unstaged):(.+)$/;
 
 /** The indent level a row sits at; headers and list-mode files are at the root. */
 function rowDepth(row: FlatRow): number {
@@ -266,6 +282,8 @@ export function ChangesPanel({
   // A cursor row a horizontal jump could not focus because the virtualizer had
   // not mounted it yet; claimed once the scroll brings it in.
   const pendingFocusKey = useRef<string | null>(null);
+  // The view mode a flip-armed claim waits for; null = claimable right away.
+  const pendingFocusMode = useRef<"list" | "tree" | null>(null);
 
   const entries = status.data?.entries ?? [];
   const conflictedPaths = entries
@@ -475,19 +493,39 @@ export function ChangesPanel({
       `[data-row="${CSS.escape(key)}"]`,
     );
     if (!el) {
-      pendingFocusKey.current = key;
+      deferFocusRow(key);
       return;
     }
     el.focus();
     el.scrollIntoView({ block: "nearest" });
   }
 
+  /** Arms the claim without trying the DOM — the one place that writes the
+   *  pending key. For a row mounted NOW that the coming re-render may carry out
+   *  of the virtualized window: `focusRow` would find it, re-focus the node that
+   *  already has focus, and arm nothing for the window exit. `untilMode` holds
+   *  the claim until that view mode is on screen (see {@link claimPendingFocus}). */
+  function deferFocusRow(key: string, untilMode?: "list" | "tree") {
+    pendingFocusKey.current = key;
+    pendingFocusMode.current = untilMode ?? null;
+  }
+
   /** Claims focus for a deferred row once the list has scrolled to it. Returns
-   *  false only while the row is still unmounted, so the caller can retry on a
-   *  later frame. */
+   *  false only while the claim cannot be settled yet, so the caller can retry on
+   *  a later frame. */
   function claimPendingFocus(): boolean {
     const key = pendingFocusKey.current;
     if (key === null) return true;
+    // A flip-armed claim survives until the flip RENDERS. The cursor moves at
+    // dispatch but the mode only changes once the settings write lands, so this
+    // runs first against the old layout, where "the row is mounted" and "focus
+    // is live" are pre-flip facts that must not settle — let alone clear — it.
+    if (
+      pendingFocusMode.current !== null &&
+      viewMode !== pendingFocusMode.current
+    )
+      return false;
+    pendingFocusMode.current = null;
     // A newer cursor move owns focus now, so this claim is stale.
     if (key !== cursorKey) {
       pendingFocusKey.current = null;
@@ -549,12 +587,13 @@ export function ChangesPanel({
     onArrowLeft: treeMode ? onArrowLeft : undefined,
     onArrowRight: treeMode ? onArrowRight : undefined,
   });
-  const onListKeyDown = (e: KeyboardEvent) => {
-    // The list element only exists in the virtualized child; take it from the
-    // event so the horizontal keys can focus the row they move to.
-    listRef.current = e.currentTarget as HTMLElement;
-    navKeyDown(e);
-  };
+  // The list element lives in the virtualized child, and every focus restore
+  // queries through it — so it comes from the mount itself, never from an event
+  // a mouse-only session would never fire. Stable identity: a fresh callback
+  // each render would detach and re-attach the node.
+  const handleListEl = useCallback((el: HTMLDivElement | null) => {
+    listRef.current = el;
+  }, []);
 
   // Drop the selection when the selected file leaves its section
   // (e.g. it was staged, committed, or reverted externally).
@@ -589,6 +628,33 @@ export function ChangesPanel({
     setCollapsedFolders(new Set());
     setActiveFolderKey(null);
   }, [repoPath]);
+  // The backstop for a folder cursor whose row was re-keyed: whenever
+  // `activeFolderKey` stops resolving, it is re-keyed to the surviving row or
+  // cleared. Every re-key source lands here — external status churn changing
+  // compaction, the toggles, any path added later; the toggle-site
+  // reconciliations remain the synchronous fast path, which usually prevents the
+  // orphan window entirely.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: runs when the cursor key stops resolving
+  useEffect(() => {
+    if (activeFolderKey === null || navIndex !== -1) return;
+    const parsed = FOLDER_ROW_KEY_RE.exec(activeFolderKey);
+    if (!parsed) return;
+    const section = parsed[1] as "staged" | "unstaged";
+    const dir = parsed[2];
+    // A re-key only ever extends the chain downward (a shortened chain keeps its
+    // key), so the survivor is the first row at or under the stale directory.
+    const nextKey = findFolderRowKey(
+      section,
+      collapsedIn(section),
+      (p) => p === dir || p.startsWith(`${dir}/`),
+    );
+    // Null = the folder's files are gone entirely; the cursor just clears.
+    setActiveFolderKey(nextKey);
+    // Post-commit the old row is already unmounted, so orphaned focus is the
+    // whole signal — a caret parked in the filter input during a background
+    // refresh must stay where it is.
+    if (nextKey !== null && focusIsOrphaned()) focusRow(nextKey);
+  }, [activeFolderKey, navIndex]);
   const mutating = stage.isPending || unstage.isPending;
   const onError = (e: unknown) => toastError(e);
 
@@ -664,31 +730,40 @@ export function ChangesPanel({
     void stage.mutateAsync([literalPathspec(entry.path)]).catch(onError);
   }
 
+  /** The key of the first folder row whose path satisfies `match` in `section`'s
+   *  tree under `collapsed`. The tree is pure, so a not-yet-rendered arrangement
+   *  can be asked directly; rows come in render order, so "first" is the
+   *  outermost match. Null = no such row. */
+  function findFolderRowKey(
+    section: "staged" | "unstaged",
+    collapsed: Set<string>,
+    match: (path: string) => boolean,
+  ): string | null {
+    const sectionEntries =
+      section === "staged" ? stagedEntries : unstagedEntries;
+    const row = flattenPathTree(sectionEntries, (e) => e.path, collapsed).find(
+      (r) => r.kind === "folder" && match(r.path),
+    );
+    return row && row.kind === "folder"
+      ? `folder:${section}:${row.path}`
+      : null;
+  }
+
   /** The row key `dirPath` carries once `nextCollapsed` applies. Expanding a
    *  node re-enables compaction THROUGH it, which re-keys its row to the deeper
-   *  compacted path; the tree is pure, so the post-toggle rows can be asked
-   *  directly. Null = no folder row names this directory any more. */
+   *  compacted path. Null = no folder row names this directory any more. */
   function folderKeyAfterToggle(
     section: "staged" | "unstaged",
     dirPath: string,
     nextCollapsed: Set<string>,
   ): string | null {
-    const sectionEntries =
-      section === "staged" ? stagedEntries : unstagedEntries;
     // The node's own row precedes every descendant, so the first row at or under
     // dirPath is the (possibly re-keyed) chain this directory now lives in.
-    const row = flattenPathTree(
-      sectionEntries,
-      (e) => e.path,
+    return findFolderRowKey(
+      section,
       nextCollapsed,
-    ).find(
-      (r) =>
-        r.kind === "folder" &&
-        (r.path === dirPath || r.path.startsWith(`${dirPath}/`)),
+      (path) => path === dirPath || path.startsWith(`${dirPath}/`),
     );
-    return row && row.kind === "folder"
-      ? `folder:${section}:${row.path}`
-      : null;
   }
 
   // Collapse or expand one directory. Collapsing drops the hidden descendants
@@ -737,31 +812,66 @@ export function ChangesPanel({
 
   function toggleViewMode() {
     if (!settings.data) return;
+    const nextMode = treeMode ? "list" : "tree";
     // The flat list has no folder rows for a parked cursor to name.
     setActiveFolderKey(null);
-    // Collapse state outlives list mode by design, so entering tree mode can
-    // hide rows selected while they were flat — prune them as a collapse does.
-    if (!treeMode)
-      setSelectedKeys((prev) => pruneHiddenKeys(prev, collapsedFolders));
-    // Leaving tree mode unmounts the folder rows, so a cursor parked on one
-    // takes its focus with it — the palette route dispatches with focus still on
-    // the doomed row, and it lands on <body>. Hand focus to the file row the
-    // list keeps, or to the control that owns the swap.
-    if (treeMode && activeFolderKey !== null) {
-      const focused = document.activeElement;
-      const onDoomedRow =
-        focused instanceof HTMLElement &&
-        focused.getAttribute("data-row") === activeFolderKey;
-      if (onDoomedRow || focusIsOrphaned()) {
-        if (activeKey !== null) focusRow(activeKey);
+    // A flip can unmount the focused row OR merely reorder it out of the
+    // virtualized window, and the palette route dispatches with focus still on
+    // it — either way focus lands on <body> and the arrow keys go dead. The arms
+    // route by cursor: a parked FOLDER cursor exists only leaving tree mode; a
+    // file cursor a collapse will swallow exists only entering it; every other
+    // surviving file cursor takes the deferred claim last.
+    let swallowedByCollapse = false;
+    if (treeMode) {
+      // Leaving tree mode: the folder rows go, so a cursor parked on one takes
+      // the file row the list keeps, or the control that owns the swap. The
+      // claim is DEFERRED: the file row is mounted in the old layout, but the
+      // flip's reorder can carry it out of the window — focusing it now would
+      // arm nothing for that exit.
+      if (activeFolderKey !== null && focusLeavingRow(activeFolderKey)) {
+        if (activeKey !== null) deferFocusRow(activeKey, nextMode);
         else viewToggleRef.current?.focus();
       }
+    } else {
+      // Collapse state outlives list mode by design, so entering tree mode can
+      // hide rows selected while they were flat — prune them as a collapse does.
+      setSelectedKeys((prev) => pruneHiddenKeys(prev, collapsedFolders));
+      // The same collapse can swallow the focused file row: park the cursor on
+      // the folder that now stands for it. That folder row cannot exist before
+      // the flip, so the claim is armed for it outright.
+      if (selectedFile && activeKey !== null) {
+        const section = selectedFile.staged ? "staged" : "unstaged";
+        const collapsed = collapsedIn(section);
+        swallowedByCollapse = [...collapsed].some((dir) =>
+          selectedFile.path.startsWith(`${dir}/`),
+        );
+        if (swallowedByCollapse && focusLeavingRow(activeKey)) {
+          const swallowing = findFolderRowKey(
+            section,
+            collapsed,
+            (path) =>
+              collapsed.has(path) && selectedFile.path.startsWith(`${path}/`),
+          );
+          if (swallowing !== null) {
+            setActiveFolderKey(swallowing);
+            deferFocusRow(swallowing, nextMode);
+          } else viewToggleRef.current?.focus();
+        }
+      }
     }
+    // Both directions re-sort the rows (tree mode puts folders first), so a file
+    // cursor whose row survives visible can still leave the window. Its row is
+    // mounted right now, so the claim is armed directly for the post-flip
+    // window; if the row never moves, focus survives and the claim no-ops.
+    if (
+      !swallowedByCollapse &&
+      activeFolderKey === null &&
+      activeKey !== null &&
+      focusLeavingRow(activeKey)
+    )
+      deferFocusRow(activeKey, nextMode);
     void saveSettings
-      .mutateAsync({
-        ...settings.data,
-        changesViewMode: treeMode ? "list" : "tree",
-      })
+      .mutateAsync({ ...settings.data, changesViewMode: nextMode })
       .catch(() => undefined);
   }
 
@@ -1387,7 +1497,8 @@ export function ChangesPanel({
                 setFilterText("");
                 setActiveKinds(new Set());
               }}
-              onListKeyDown={onListKeyDown}
+              onListKeyDown={navKeyDown}
+              onListEl={handleListEl}
               onContextMenuCapture={handleContextMenu}
               onCursorScrolled={claimPendingFocus}
               renderRow={renderRow}
@@ -1524,6 +1635,7 @@ function VirtualizedChangeList({
   nothingMatches,
   onClearFilter,
   onListKeyDown,
+  onListEl,
   onContextMenuCapture,
   onCursorScrolled,
   renderRow,
@@ -1543,6 +1655,9 @@ function VirtualizedChangeList({
   nothingMatches: boolean;
   onClearFilter: () => void;
   onListKeyDown: (e: KeyboardEvent) => void;
+  /** Hands the mounted scroll container up to the panel, which queries rows
+   *  through it. Must be referentially stable — it rides the element's ref. */
+  onListEl: (el: HTMLDivElement | null) => void;
   onContextMenuCapture: (e: MouseEvent) => void;
   /** Called a frame after the cursor row is scrolled to, so the panel can focus
    *  a row it could not reach while unmounted. False = still unmounted, retry. */
@@ -1552,6 +1667,16 @@ function VirtualizedChangeList({
   // State-backed (not a plain ref) so the virtualizer observes the scroll
   // element the instant it mounts — a plain ref would leave the first paint blank.
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  // Both sinks for that one element: the state write the virtualizer's mount
+  // contract needs, and the panel's handle for its focus restores. Stable, or
+  // React would detach and re-attach the node on every render.
+  const setListEl = useCallback(
+    (el: HTMLDivElement | null) => {
+      setScrollEl(el);
+      onListEl(el);
+    },
+    [onListEl],
+  );
   // The virtualizer keys its measurement projection on `getItemKey`'s IDENTITY,
   // so this is re-minted per row sequence rather than per render: a fresh closure
   // every render rebuilds all rows (1.7ms vs 0.019ms at 20k rows, measured on
@@ -1597,7 +1722,10 @@ function VirtualizedChangeList({
   // mounts on the virtualizer's own re-render, a frame or more after the scroll,
   // so the deferred focus claim gets a few frames before it gives up. Keyed on
   // the row IDENTITY too: an expand can re-key the cursor row at the SAME flat
-  // index, and the pending-focus claim must still run.
+  // index, and the pending-focus claim must still run — and on the view MODE,
+  // which is what a flip-armed claim waits for: the cursor's row can sit at the
+  // same index in both layouts (a root-level file above the section that held
+  // the folders), and that claim would then never be re-offered.
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on active change
   useEffect(() => {
     if (activeFlatIndex < 0) return;
@@ -1611,7 +1739,7 @@ function VirtualizedChangeList({
     };
     frame = requestAnimationFrame(claim);
     return () => cancelAnimationFrame(frame);
-  }, [activeFlatIndex, activeRowKey]);
+  }, [activeFlatIndex, activeRowKey, viewMode]);
   // Jump back to the top whenever the filter changes the visible set. Gated on
   // the filter actually changing: <Activity> replays effects on every tab show,
   // and an unguarded reset would drop the scroll position it preserves.
@@ -1632,7 +1760,7 @@ function VirtualizedChangeList({
         // `onContextMenuCapture` (capture phase, so it runs before the menu
         // opens) records which row/header was hit.
         <div
-          ref={setScrollEl}
+          ref={setListEl}
           className="min-h-0 flex-1 overflow-y-auto"
           onKeyDown={onListKeyDown}
           onContextMenuCapture={onContextMenuCapture}

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -604,19 +604,17 @@ export function ChangesPanel({
     }
   }
 
-  // List mode has no tree to walk, so Left/Right stay the browser's — one gate
-  // for both the hook and the focused-row wrapper below.
+  // List mode has no tree to walk, so Left/Right stay the browser's — the gate
+  // the focused-row wrapper below reads.
   const arrowLeft = treeMode ? onArrowLeft : undefined;
   const arrowRight = treeMode ? onArrowRight : undefined;
-  // Arrow keys walk the rows across both sections; Shift extends from the
-  // anchor, a plain arrow collapses to the single active row.
+  // Up/Down walk the rows across both sections; Shift extends from the anchor,
+  // a plain arrow collapses to the single active row.
   const navKeyDown = listKeyboardNav({
     items: navRows,
     activeIndex: navIndex,
     rowKey: rowKeyOf,
     onActivate: activateRow,
-    onArrowLeft: arrowLeft,
-    onArrowRight: arrowRight,
   });
 
   /** The navigable row DOM focus sits in, resolved from the DOM at use rather
@@ -634,13 +632,13 @@ export function ChangesPanel({
     return index === -1 ? null : { row: navRows[index], index };
   }
 
-  /** Left/Right fold and walk the tree, so they act on the row FOCUS is on: the
-   *  hook resolves from the cursor, which a bare Tab leaves behind (and with no
-   *  file selected it returns before the horizontal callbacks at all), so those
-   *  keys would fold the old selection's parent, or nothing. Up/Down keep
-   *  anchoring at the cursor — master's Tab behaviour, unchanged. A focused tree
-   *  region swallows both keys whether or not they moved anything, exactly as
-   *  the hook path does, so the list never scrolls sideways under them. */
+  /** Left/Right fold and walk the tree, so they act on the row FOCUS is on and
+   *  live here rather than in the shared hook, which resolves from the cursor: a
+   *  bare Tab leaves that behind, and those keys would fold the old selection's
+   *  parent, or nothing at all with no file selected. Up/Down stay the hook's and
+   *  keep anchoring at the cursor — master's Tab behaviour, unchanged. A focused
+   *  tree region swallows both keys whether or not they moved anything, so the
+   *  list never scrolls sideways under them. */
   function handleListKeyDown(e: KeyboardEvent) {
     let horizontal: typeof arrowLeft;
     if (e.key === "ArrowLeft") horizontal = arrowLeft;
@@ -1379,8 +1377,9 @@ export function ChangesPanel({
           role="option"
           aria-selected={false}
           // ARIA 1.2 gives `option` no expanded state, so the label carries
-          // what the caret shows.
-          aria-label={`${row.label} — ${row.count} ${
+          // what the caret shows — and the full directory path, because two
+          // compacted rows can share a display label.
+          aria-label={`${row.path} — ${row.count} ${
             row.count === 1 ? "file" : "files"
           }, ${row.collapsed ? "collapsed" : "expanded"}`}
           tabIndex={0}

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -437,6 +437,8 @@ export function ChangesPanel({
     select(row.entry, row.staged);
     if (shift && anchorKey) {
       const a = navRows.findIndex((r) => rowKeyOf(r) === anchorKey);
+      // An anchor that has gone hidden (collapsed away, committed away) leaves
+      // no range to extend; fall through and re-anchor on the landed row.
       if (a !== -1) {
         const [lo, hi] = a <= to ? [a, to] : [to, a];
         // Folder rows contribute no keys: a range spans the files it covers.
@@ -448,11 +450,11 @@ export function ChangesPanel({
               .map(rowKeyOf),
           ),
         );
+        return;
       }
-    } else {
-      setSelectedKeys(new Set([key]));
-      setAnchorKey(key);
     }
+    setSelectedKeys(new Set([key]));
+    setAnchorKey(key);
   }
 
   /** Focus + reveal a row the horizontal keys moved the cursor to (the vertical

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -1,9 +1,11 @@
 import { Popover } from "@base-ui/react/popover";
 import {
+  CaretDownIcon,
   CaretRightIcon,
   FunnelIcon,
   InfoIcon,
   StackIcon,
+  TreeStructureIcon,
 } from "@phosphor-icons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -19,6 +21,7 @@ import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { usePanelPortalContainer } from "@/components/panel-portal";
+import { PathText } from "@/components/path-text";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -57,6 +60,7 @@ import type { ChangeKind, FileEntry } from "@/lib/git/types";
 import { formatBinding } from "@/lib/hotkeys/binding";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { flattenPathTree } from "@/lib/path-tree";
 import {
   useAiEnabled,
   useReviewConfigured,
@@ -133,12 +137,42 @@ type ChangeActionScope =
   | { kind: "all" }
   | null;
 
-/** A flattened row in the virtualized changes list: a section header or a file.
- *  One flat list (not two nested sections) keeps virtualization, cross-section
- *  arrow-key navigation, and range selection in a single index space. */
+/** A flattened row in the virtualized changes list: a section header, a file, or
+ *  (tree mode) a compacted directory. One flat list (not two nested sections)
+ *  keeps virtualization, cross-section arrow-key navigation, and range selection
+ *  in a single index space. */
 type FlatRow =
   | { type: "header"; section: "staged" | "unstaged"; count: number }
-  | { type: "file"; entry: FileEntry; staged: boolean };
+  | {
+      type: "folder";
+      section: "staged" | "unstaged";
+      path: string;
+      label: string;
+      depth: number;
+      count: number;
+      collapsed: boolean;
+    }
+  /** `depth` is the tree-mode indent level; list mode leaves it unset. */
+  | { type: "file"; entry: FileEntry; staged: boolean; depth?: number };
+
+type FolderRow = Extract<FlatRow, { type: "folder" }>;
+
+/** Drops the selection keys hidden under `collapsedKeys` (each `"<section>:<dir>"`,
+ *  sharing the selection keys' `"<section>:<path>"` spelling). One rule for both
+ *  ways a row can go hidden — collapsing a folder, and entering tree mode with
+ *  folders already collapsed — so a collapsed folder can never hold a
+ *  selectable-but-invisible row. Returns `keys` itself when nothing was hidden. */
+function pruneHiddenKeys(
+  keys: Set<string>,
+  collapsedKeys: Iterable<string>,
+): Set<string> {
+  const prefixes = [...collapsedKeys].map((k) => `${k}/`);
+  if (prefixes.length === 0) return keys;
+  const next = new Set(
+    [...keys].filter((k) => !prefixes.some((p) => k.startsWith(p))),
+  );
+  return next.size === keys.size ? keys : next;
+}
 
 /** A row's identity, shared by React's key and the virtualizer's `getItemKey`
  *  so the two can't drift. A measured height only follows its row while
@@ -148,9 +182,16 @@ function keyOf(path: string, staged: boolean): string {
   return `${staged ? "staged" : "unstaged"}:${path}`;
 }
 function rowKeyOf(row: FlatRow): string {
-  return row.type === "header"
-    ? `header:${row.section}`
-    : keyOf(row.entry.path, row.staged);
+  if (row.type === "header") return `header:${row.section}`;
+  if (row.type === "folder") return `folder:${row.section}:${row.path}`;
+  return keyOf(row.entry.path, row.staged);
+}
+
+/** The indent level a row sits at; headers and list-mode files are at the root. */
+function rowDepth(row: FlatRow): number {
+  if (row.type === "header") return 0;
+  if (row.type === "folder") return row.depth;
+  return row.depth ?? 0;
 }
 
 export function ChangesPanel({
@@ -195,6 +236,15 @@ export function ChangesPanel({
   // whose diff is shown; `anchorKey` is the pivot for shift-range selection.
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [anchorKey, setAnchorKey] = useState<string | null>(null);
+  // Tree mode's collapsed directories, keyed `"<section>:<dirPath>"`. Session-local
+  // by design: the changes list is ephemeral, so a collapse outlives neither a
+  // repo switch nor a restart.
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(
+    new Set(),
+  );
+  // The nav cursor when it rests on a folder row (which has no diff to show, so
+  // `selectedFile` stays where it was). Null = the cursor follows `selectedFile`.
+  const [activeFolderKey, setActiveFolderKey] = useState<string | null>(null);
   const [filterText, setFilterText] = useState("");
   const [activeKinds, setActiveKinds] = useState<Set<FilterKind>>(new Set());
   const [stashesOpen, setStashesOpen] = useState(false);
@@ -203,6 +253,10 @@ export function ChangesPanel({
   // The one shared context menu acts on whatever was right-clicked.
   const [menuTarget, setMenuTarget] = useState<MenuTarget>(null);
   const filterRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLElement | null>(null);
+  // A cursor row a horizontal jump could not focus because the virtualizer had
+  // not mounted it yet; claimed once the scroll brings it in.
+  const pendingFocusKey = useRef<string | null>(null);
 
   const entries = status.data?.entries ?? [];
   const conflictedPaths = entries
@@ -282,12 +336,8 @@ export function ChangesPanel({
     stagedEntries.length === 0 &&
     unstagedEntries.length === 0;
 
-  // The rows in render order, so ArrowUp/Down can walk the selection
-  // across both sections.
-  const visibleRows = [
-    ...stagedEntries.map((entry) => ({ entry, staged: true })),
-    ...unstagedEntries.map((entry) => ({ entry, staged: false })),
-  ];
+  const viewMode = settings.data?.changesViewMode ?? "list";
+  const treeMode = viewMode === "tree";
   const activeKey = selectedFile
     ? keyOf(selectedFile.path, selectedFile.staged)
     : null;
@@ -305,54 +355,198 @@ export function ChangesPanel({
     (e) => e.unstaged !== "untracked" && e.staged !== "added",
   );
 
+  /** A section's collapsed directories, its `"<section>:"` prefix stripped. */
+  function collapsedIn(section: "staged" | "unstaged"): Set<string> {
+    const prefix = `${section}:`;
+    return new Set(
+      [...collapsedFolders]
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => k.slice(prefix.length)),
+    );
+  }
+
   // One flattened list (section headers + their files) drives a single
   // virtualizer, so a working tree with thousands of changed files only renders
-  // a window of rows instead of mounting every row (which used to crash).
+  // a window of rows instead of mounting every row (which used to crash). Tree
+  // mode swaps each section's flat run for a compacted directory tree; the
+  // filter has already been applied, so folder counts describe what's listed.
   const flatRows: FlatRow[] = [];
-  if (stagedEntries.length > 0) {
-    flatRows.push({
-      type: "header",
-      section: "staged",
-      count: stagedEntries.length,
-    });
-    for (const entry of stagedEntries)
-      flatRows.push({ type: "file", entry, staged: true });
+  function pushSection(
+    section: "staged" | "unstaged",
+    sectionEntries: FileEntry[],
+  ) {
+    if (sectionEntries.length === 0) return;
+    const staged = section === "staged";
+    flatRows.push({ type: "header", section, count: sectionEntries.length });
+    if (!treeMode) {
+      for (const entry of sectionEntries)
+        flatRows.push({ type: "file", entry, staged });
+      return;
+    }
+    const collapsed = collapsedIn(section);
+    // A rename is placed by its NEW path; the old one is only the label's left
+    // half, and the row's identity is the new path everywhere else too.
+    for (const row of flattenPathTree(
+      sectionEntries,
+      (e) => e.path,
+      collapsed,
+    )) {
+      if (row.kind === "folder") {
+        flatRows.push({
+          type: "folder",
+          section,
+          path: row.path,
+          label: row.label,
+          depth: row.depth,
+          count: row.fileCount,
+          collapsed: collapsed.has(row.path),
+        });
+      } else {
+        flatRows.push({
+          type: "file",
+          entry: row.item,
+          staged,
+          depth: row.depth,
+        });
+      }
+    }
   }
-  if (unstagedEntries.length > 0) {
-    flatRows.push({
-      type: "header",
-      section: "unstaged",
-      count: unstagedEntries.length,
-    });
-    for (const entry of unstagedEntries)
-      flatRows.push({ type: "file", entry, staged: false });
+  pushSection("staged", stagedEntries);
+  pushSection("unstaged", unstagedEntries);
+
+  // The navigable rows in render order (headers excepted), so ArrowUp/Down walk
+  // the cursor across both sections — and, in tree mode, across folder rows.
+  const navRows = flatRows.filter((r) => r.type !== "header");
+  // The cursor may rest on a folder, which owns no diff; file rows keep pointing
+  // at `selectedFile`, so selection behaviour is unchanged.
+  const cursorKey = activeFolderKey ?? activeKey;
+  const navIndex = cursorKey
+    ? navRows.findIndex((r) => rowKeyOf(r) === cursorKey)
+    : -1;
+
+  /** Moves the cursor to `row` (at `to` in `navRows`); `shift` extends the
+   *  selection from the anchor. Folder rows take the cursor alone. */
+  function activateRow(row: FlatRow, to: number, shift: boolean) {
+    if (row.type === "folder") {
+      setActiveFolderKey(rowKeyOf(row));
+      return;
+    }
+    if (row.type === "header") return;
+    setActiveFolderKey(null);
+    const key = rowKeyOf(row);
+    select(row.entry, row.staged);
+    if (shift && anchorKey) {
+      const a = navRows.findIndex((r) => rowKeyOf(r) === anchorKey);
+      if (a !== -1) {
+        const [lo, hi] = a <= to ? [a, to] : [to, a];
+        // Folder rows contribute no keys: a range spans the files it covers.
+        setSelectedKeys(
+          new Set(
+            navRows
+              .slice(lo, hi + 1)
+              .filter((r) => r.type === "file")
+              .map(rowKeyOf),
+          ),
+        );
+      }
+    } else {
+      setSelectedKeys(new Set([key]));
+      setAnchorKey(key);
+    }
   }
+
+  /** Focus + reveal a row the horizontal keys moved the cursor to (the vertical
+   *  keys get this from `listKeyboardNav` itself). A jump past the virtualizer's
+   *  overscan window finds no node, so it defers instead: unfocused, the row the
+   *  user came from unmounts and every arrow key goes dead. */
+  function focusRow(key: string) {
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-row="${CSS.escape(key)}"]`,
+    );
+    if (!el) {
+      pendingFocusKey.current = key;
+      return;
+    }
+    el.focus();
+    el.scrollIntoView({ block: "nearest" });
+  }
+
+  /** Claims focus for a deferred row once the list has scrolled to it. Returns
+   *  false only while the row is still unmounted, so the caller can retry on a
+   *  later frame. */
+  function claimPendingFocus(): boolean {
+    const key = pendingFocusKey.current;
+    if (key === null) return true;
+    // A newer cursor move owns focus now, so this claim is stale.
+    if (key !== cursorKey) {
+      pendingFocusKey.current = null;
+      return true;
+    }
+    const focused = document.activeElement;
+    // Only an orphaned focus is ours to claim — never take a caret out of the
+    // filter input or any other live control.
+    if (focused && focused !== document.body && focused.isConnected) {
+      pendingFocusKey.current = null;
+      return true;
+    }
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-row="${CSS.escape(key)}"]`,
+    );
+    if (!el) return false;
+    pendingFocusKey.current = null;
+    el.focus();
+    return true;
+  }
+
+  function moveCursor(row: FlatRow, to: number) {
+    activateRow(row, to, false);
+    focusRow(rowKeyOf(row));
+  }
+
+  // Right expands a collapsed folder, else steps into it; Left collapses an
+  // expanded one, else steps out to the parent folder.
+  function onArrowRight(row: FlatRow, index: number) {
+    if (row.type !== "folder") return;
+    if (row.collapsed) {
+      toggleFolder(row.section, row.path);
+      return;
+    }
+    const child = navRows[index + 1];
+    if (child && rowDepth(child) > row.depth) moveCursor(child, index + 1);
+  }
+
+  function onArrowLeft(row: FlatRow, index: number) {
+    if (row.type === "folder" && !row.collapsed) {
+      toggleFolder(row.section, row.path);
+      return;
+    }
+    const depth = rowDepth(row);
+    for (let i = index - 1; i >= 0; i--) {
+      const candidate = navRows[i];
+      if (candidate.type === "folder" && candidate.depth < depth) {
+        moveCursor(candidate, i);
+        return;
+      }
+    }
+  }
+
   // Arrow keys walk the rows across both sections; Shift extends from the
   // anchor, a plain arrow collapses to the single active row.
-  const rowKey = (r: { entry: FileEntry; staged: boolean }) =>
-    keyOf(r.entry.path, r.staged);
-  const onListKeyDown = listKeyboardNav({
-    items: visibleRows,
-    activeIndex: activeKey
-      ? visibleRows.findIndex((r) => rowKey(r) === activeKey)
-      : -1,
-    rowKey,
-    onActivate: (row, to, shift) => {
-      const key = rowKey(row);
-      select(row.entry, row.staged);
-      if (shift && anchorKey) {
-        const keys = visibleRows.map(rowKey);
-        const a = keys.indexOf(anchorKey);
-        if (a !== -1) {
-          const [lo, hi] = a <= to ? [a, to] : [to, a];
-          setSelectedKeys(new Set(keys.slice(lo, hi + 1)));
-        }
-      } else {
-        setSelectedKeys(new Set([key]));
-        setAnchorKey(key);
-      }
-    },
+  const navKeyDown = listKeyboardNav({
+    items: navRows,
+    activeIndex: navIndex,
+    rowKey: rowKeyOf,
+    onActivate: activateRow,
+    // List mode has no tree to walk, so Left/Right stay the browser's.
+    onArrowLeft: treeMode ? onArrowLeft : undefined,
+    onArrowRight: treeMode ? onArrowRight : undefined,
   });
+  const onListKeyDown = (e: KeyboardEvent) => {
+    // The list element only exists in the virtualized child; take it from the
+    // event so the horizontal keys can focus the row they move to.
+    listRef.current = e.currentTarget as HTMLElement;
+    navKeyDown(e);
+  };
 
   // Drop the selection when the selected file leaves its section
   // (e.g. it was staged, committed, or reverted externally).
@@ -377,6 +571,16 @@ export function ChangesPanel({
       return next.size === prev.size ? prev : next;
     });
   }, [status.data]);
+  // Collapse state and the folder cursor name directories of the repo they were
+  // made in. Guarded on the path actually changing: <Activity> replays effects
+  // on every tab show, and an unguarded reset would drop the user's collapses.
+  const prevRepo = useRef(repoPath);
+  useEffect(() => {
+    if (prevRepo.current === repoPath) return;
+    prevRepo.current = repoPath;
+    setCollapsedFolders(new Set());
+    setActiveFolderKey(null);
+  }, [repoPath]);
   const mutating = stage.isPending || unstage.isPending;
   const onError = (e: unknown) => toastError(e);
 
@@ -407,13 +611,22 @@ export function ChangesPanel({
   ) {
     const key = keyOf(entry.path, staged);
     select(entry, staged);
+    setActiveFolderKey(null);
     if (mods.shift && anchorKey) {
-      const keys = visibleRows.map((r) => keyOf(r.entry.path, r.staged));
+      const keys = navRows.map(rowKeyOf);
       const a = keys.indexOf(anchorKey);
       const b = keys.indexOf(key);
       if (a !== -1 && b !== -1) {
         const [lo, hi] = a <= b ? [a, b] : [b, a];
-        setSelectedKeys(new Set(keys.slice(lo, hi + 1)));
+        // Folder rows contribute no keys: a range spans the files it covers.
+        setSelectedKeys(
+          new Set(
+            navRows
+              .slice(lo, hi + 1)
+              .filter((r) => r.type === "file")
+              .map(rowKeyOf),
+          ),
+        );
         return;
       }
     }
@@ -441,6 +654,45 @@ export function ChangesPanel({
     // site must not reach a `git add` that dies reading the device.
     if (!canStage(entry)) return;
     void stage.mutateAsync([literalPathspec(entry.path)]).catch(onError);
+  }
+
+  // Collapse or expand one directory. Collapsing drops the hidden descendants
+  // from the multi-selection: a collapsed folder must never hold a
+  // selectable-but-invisible row. The shown diff deliberately survives being
+  // hidden, exactly as it does behind the text filter.
+  function toggleFolder(section: "staged" | "unstaged", dirPath: string) {
+    const key = `${section}:${dirPath}`;
+    const collapsing = !collapsedFolders.has(key);
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (collapsing) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+    if (!collapsing) return;
+    setSelectedKeys((prev) => pruneHiddenKeys(prev, [key]));
+  }
+
+  // Clicking a folder both toggles it and parks the cursor there.
+  function handleFolderActivate(row: FolderRow) {
+    toggleFolder(row.section, row.path);
+    setActiveFolderKey(rowKeyOf(row));
+  }
+
+  function toggleViewMode() {
+    if (!settings.data) return;
+    // The flat list has no folder rows for a parked cursor to name.
+    setActiveFolderKey(null);
+    // Collapse state outlives list mode by design, so entering tree mode can
+    // hide rows selected while they were flat — prune them as a collapse does.
+    if (!treeMode)
+      setSelectedKeys((prev) => pruneHiddenKeys(prev, collapsedFolders));
+    void saveSettings
+      .mutateAsync({
+        ...settings.data,
+        changesViewMode: treeMode ? "list" : "tree",
+      })
+      .catch(() => undefined);
   }
 
   // Single-file ignore / untrack (the per-row menu); the bulk equivalents are
@@ -490,7 +742,8 @@ export function ChangesPanel({
   function handleContextMenu(e: MouseEvent) {
     const rowEl = (e.target as HTMLElement).closest("[data-row]");
     const key = rowEl?.getAttribute("data-row");
-    if (key) {
+    // A directory row carries no file actions, so it takes the whole-tree menu.
+    if (key && !key.startsWith("folder:")) {
       const staged = key.startsWith("staged:");
       const path = key.slice(key.indexOf(":") + 1);
       const entry = entries.find((en) => en.path === path);
@@ -710,6 +963,11 @@ export function ChangesPanel({
     () => filterRef.current?.focus(),
     entries.length > 0,
   );
+  useHotkeyAction(
+    "toggle-changes-tree",
+    toggleViewMode,
+    entries.length > 0 && settings.data !== undefined,
+  );
   // Resolve the selected conflicted file with AI, or start an all-conflicts run
   // when the selection isn't a conflict. Palette-only (no default binding).
   useHotkeyAction(
@@ -811,41 +1069,80 @@ export function ChangesPanel({
   // One row's inner content, closing over the panel's selection/mutation state.
   // Passed to the virtualized list so all that state stays here and only the
   // virtualizer instance lives in the keyed leaf.
-  const renderRow = (row: FlatRow): ReactNode =>
-    row.type === "header" ? (
-      <div
-        data-section-header
-        className={cn(
-          "flex items-center justify-between pr-1 pl-2",
-          // Gap only between the staged and unstaged sections, never at the
-          // very top of the list.
-          row.section === "unstaged" && stagedEntries.length > 0 && "pt-2",
-        )}
-      >
-        <h3 className="py-1 text-xs font-medium text-muted-foreground">
-          {row.section === "staged"
-            ? `Staged (${row.count})`
-            : `Changes (${row.count})`}
-        </h3>
-        <DisabledReasonButton
-          variant="ghost"
-          size="xs"
-          className="text-muted-foreground"
-          disabled={
-            mutating ||
-            (row.section === "unstaged" && stageableUnstaged.length === 0)
-          }
-          reason={
-            row.section === "unstaged" && stageableUnstaged.length === 0
-              ? "Git can't stage Windows-reserved device names, and every file here has one"
-              : null
-          }
-          onClick={row.section === "staged" ? unstageAll : stageAll}
+  const renderRow = (row: FlatRow): ReactNode => {
+    if (row.type === "header")
+      return (
+        <div
+          data-section-header
+          className={cn(
+            "flex items-center justify-between pr-1 pl-2",
+            // Gap only between the staged and unstaged sections, never at the
+            // very top of the list.
+            row.section === "unstaged" && stagedEntries.length > 0 && "pt-2",
+          )}
         >
-          {row.section === "staged" ? "Unstage all" : "Stage all"}
-        </DisabledReasonButton>
-      </div>
-    ) : (
+          <h3 className="py-1 text-xs font-medium text-muted-foreground">
+            {row.section === "staged"
+              ? `Staged (${row.count})`
+              : `Changes (${row.count})`}
+          </h3>
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            className="text-muted-foreground"
+            disabled={
+              mutating ||
+              (row.section === "unstaged" && stageableUnstaged.length === 0)
+            }
+            reason={
+              row.section === "unstaged" && stageableUnstaged.length === 0
+                ? "Git can't stage Windows-reserved device names, and every file here has one"
+                : null
+            }
+            onClick={row.section === "staged" ? unstageAll : stageAll}
+          >
+            {row.section === "staged" ? "Unstage all" : "Stage all"}
+          </DisabledReasonButton>
+        </div>
+      );
+    if (row.type === "folder")
+      return (
+        // The caret, the indent, and the count carry the structure — never the
+        // colour alone. No collapse animation: the rows are virtualized, so the
+        // caret swap is the state feedback.
+        <div
+          data-row={rowKeyOf(row)}
+          role="option"
+          aria-selected={false}
+          aria-expanded={!row.collapsed}
+          // ARIA 1.2 doesn't give `option` an expanded state, so the label
+          // carries what the caret shows; `aria-expanded` stays for the readers
+          // that do honour it.
+          aria-label={`${row.label} — ${row.count} ${
+            row.count === 1 ? "file" : "files"
+          }, ${row.collapsed ? "collapsed" : "expanded"}`}
+          tabIndex={0}
+          className="flex cursor-pointer items-center gap-1 py-1 pr-2 text-xs text-muted-foreground hover:bg-muted/60"
+          style={{ paddingLeft: 8 + row.depth * 12 }}
+          onClick={() => handleFolderActivate(row)}
+          onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return;
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleFolderActivate(row);
+            }
+          }}
+        >
+          {row.collapsed ? (
+            <CaretRightIcon className="size-3 shrink-0" />
+          ) : (
+            <CaretDownIcon className="size-3 shrink-0" />
+          )}
+          <PathText path={row.label} className="min-w-0 flex-1" />
+          <span className="shrink-0 tabular-nums">({row.count})</span>
+        </div>
+      );
+    return (
       <FileRow
         entry={row.entry}
         kind={
@@ -859,10 +1156,13 @@ export function ChangesPanel({
           selectedFile?.path === row.entry.path &&
           selectedFile.staged === row.staged
         }
+        treeDisplay={treeMode}
+        indentPx={treeMode ? (row.depth ?? 0) * 12 : undefined}
         onSelect={handleSelect}
         onToggle={handleToggle}
       />
     );
+  };
 
   return (
     // Calm fade as data replaces the loading skeleton (runs once on mount; a
@@ -949,6 +1249,20 @@ export function ChangesPanel({
               className="h-7 flex-1"
               autoComplete="off"
             />
+            <Button
+              variant={treeMode ? "secondary" : "outline"}
+              size="icon-sm"
+              aria-pressed={treeMode}
+              aria-label="Directory tree view"
+              title={
+                treeMode
+                  ? "Show changes as a flat list"
+                  : "Group changes by directory"
+              }
+              onClick={toggleViewMode}
+            >
+              <TreeStructureIcon />
+            </Button>
           </div>
 
           {/* Gate on settings.data being loaded so "Don't show again" (which
@@ -994,7 +1308,9 @@ export function ChangesPanel({
               entries={status.data?.entries}
               text={text}
               activeKinds={activeKinds}
-              activeKey={activeKey}
+              viewMode={viewMode}
+              collapsedFolders={collapsedFolders}
+              activeRowKey={cursorKey}
               nothingMatches={nothingMatches}
               onClearFilter={() => {
                 setFilterText("");
@@ -1002,6 +1318,7 @@ export function ChangesPanel({
               }}
               onListKeyDown={onListKeyDown}
               onContextMenuCapture={handleContextMenu}
+              onCursorScrolled={claimPendingFocus}
               renderRow={renderRow}
             />
             <ContextMenuContent className="min-w-64">
@@ -1130,11 +1447,14 @@ function VirtualizedChangeList({
   entries,
   text,
   activeKinds,
-  activeKey,
+  viewMode,
+  collapsedFolders,
+  activeRowKey,
   nothingMatches,
   onClearFilter,
   onListKeyDown,
   onContextMenuCapture,
+  onCursorScrolled,
   renderRow,
 }: {
   flatRows: FlatRow[];
@@ -1143,11 +1463,19 @@ function VirtualizedChangeList({
   entries: FileEntry[] | undefined;
   text: string;
   activeKinds: Set<FilterKind>;
-  activeKey: string | null;
+  /** A `getItemKey` identity input, not read directly. */
+  viewMode: string;
+  /** A `getItemKey` identity input, not read directly. */
+  collapsedFolders: Set<string>;
+  /** The cursor row — a file or (tree mode) a folder — kept scrolled into view. */
+  activeRowKey: string | null;
   nothingMatches: boolean;
   onClearFilter: () => void;
   onListKeyDown: (e: KeyboardEvent) => void;
   onContextMenuCapture: (e: MouseEvent) => void;
+  /** Called a frame after the cursor row is scrolled to, so the panel can focus
+   *  a row it could not reach while unmounted. False = still unmounted, retry. */
+  onCursorScrolled: () => boolean;
   renderRow: (row: FlatRow) => ReactNode;
 }) {
   // State-backed (not a plain ref) so the virtualizer observes the scroll
@@ -1158,7 +1486,8 @@ function VirtualizedChangeList({
   // every render rebuilds all rows (1.7ms vs 0.019ms at 20k rows, measured on
   // virtual-core 3.17.8), while never re-minting leaves a pure permutation —
   // stage one file, count unchanged — painting each header into the previous
-  // occupant's slot. These deps are the sequence's only inputs.
+  // occupant's slot. These deps are the sequence's only inputs: the entries, the
+  // filter, and (tree mode) the layout and which directories are collapsed.
   const flatRowsRef = useRef(flatRows);
   flatRowsRef.current = flatRows;
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps re-mint the identity; the ref supplies the rows
@@ -1167,7 +1496,7 @@ function VirtualizedChangeList({
       const row = flatRowsRef.current[index];
       return row ? rowKeyOf(row) : index;
     },
-    [entries, text, activeKinds],
+    [entries, text, activeKinds, viewMode, collapsedFolders],
   );
   const rowVirtualizer = useVirtualizer({
     count: flatRows.length,
@@ -1175,6 +1504,7 @@ function VirtualizedChangeList({
     estimateSize: (i) => {
       const r = flatRows[i];
       if (r.type === "file") return 28;
+      if (r.type === "folder") return 24;
       // The "Changes" header carries a top gap only when it follows the staged
       // section; bake that into the estimate so the first paint never overlaps.
       return r.section === "unstaged" && hasStaged ? 40 : 32;
@@ -1185,19 +1515,29 @@ function VirtualizedChangeList({
     getItemKey,
     overscan: 16,
   });
-  // Flat index of the active file row, so we can keep it scrolled into view
-  // under virtualization (its own DOM node may not be mounted).
-  const activeFlatIndex = activeKey
-    ? flatRows.findIndex(
-        (r) => r.type === "file" && keyOf(r.entry.path, r.staged) === activeKey,
-      )
+  // Flat index of the cursor row, so we can keep it scrolled into view under
+  // virtualization (its own DOM node may not be mounted). Folder rows count: in
+  // tree mode the cursor can rest on one.
+  const activeFlatIndex = activeRowKey
+    ? flatRows.findIndex((r) => rowKeyOf(r) === activeRowKey)
     : -1;
   // Keep the active row scrolled into view as the selection moves — under
-  // virtualization its DOM node may not be mounted, so scroll by index.
+  // virtualization its DOM node may not be mounted, so scroll by index. The row
+  // mounts on the virtualizer's own re-render, a frame or more after the scroll,
+  // so the deferred focus claim gets a few frames before it gives up.
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on active change
   useEffect(() => {
-    if (activeFlatIndex >= 0)
-      rowVirtualizer.scrollToIndex(activeFlatIndex, { align: "auto" });
+    if (activeFlatIndex < 0) return;
+    rowVirtualizer.scrollToIndex(activeFlatIndex, { align: "auto" });
+    let frame = 0;
+    let tries = 3;
+    const claim = () => {
+      tries -= 1;
+      if (onCursorScrolled() || tries === 0) return;
+      frame = requestAnimationFrame(claim);
+    };
+    frame = requestAnimationFrame(claim);
+    return () => cancelAnimationFrame(frame);
   }, [activeFlatIndex]);
   // Jump back to the top whenever the filter changes the visible set. Gated on
   // the filter actually changing: <Activity> replays effects on every tab show,

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -510,7 +510,7 @@ export function ChangesPanel({
   function onArrowRight(row: FlatRow, index: number) {
     if (row.type !== "folder") return;
     if (row.collapsed) {
-      toggleFolder(row.section, row.path);
+      toggleFolder(row.section, row.path, true);
       return;
     }
     const child = navRows[index + 1];
@@ -519,7 +519,7 @@ export function ChangesPanel({
 
   function onArrowLeft(row: FlatRow, index: number) {
     if (row.type === "folder" && !row.collapsed) {
-      toggleFolder(row.section, row.path);
+      toggleFolder(row.section, row.path, true);
       return;
     }
     const depth = rowDepth(row);
@@ -658,27 +658,75 @@ export function ChangesPanel({
     void stage.mutateAsync([literalPathspec(entry.path)]).catch(onError);
   }
 
+  /** The row key `dirPath` carries once `nextCollapsed` applies. Expanding a
+   *  node re-enables compaction THROUGH it, which re-keys its row to the deeper
+   *  compacted path; the tree is pure, so the post-toggle rows can be asked
+   *  directly. Null = no folder row names this directory any more. */
+  function folderKeyAfterToggle(
+    section: "staged" | "unstaged",
+    dirPath: string,
+    nextCollapsed: Set<string>,
+  ): string | null {
+    const sectionEntries =
+      section === "staged" ? stagedEntries : unstagedEntries;
+    // The node's own row precedes every descendant, so the first row at or under
+    // dirPath is the (possibly re-keyed) chain this directory now lives in.
+    const row = flattenPathTree(
+      sectionEntries,
+      (e) => e.path,
+      nextCollapsed,
+    ).find(
+      (r) =>
+        r.kind === "folder" &&
+        (r.path === dirPath || r.path.startsWith(`${dirPath}/`)),
+    );
+    return row && row.kind === "folder"
+      ? `folder:${section}:${row.path}`
+      : null;
+  }
+
   // Collapse or expand one directory. Collapsing drops the hidden descendants
   // from the multi-selection: a collapsed folder must never hold a
   // selectable-but-invisible row. The shown diff deliberately survives being
   // hidden, exactly as it does behind the text filter.
-  function toggleFolder(section: "staged" | "unstaged", dirPath: string) {
+  function toggleFolder(
+    section: "staged" | "unstaged",
+    dirPath: string,
+    /** The cursor belongs on this row after the toggle (click / arrow routes),
+     *  even when it sat elsewhere before. */
+    cursorFollows = false,
+  ) {
     const key = `${section}:${dirPath}`;
+    const rowKey = `folder:${key}`;
     const collapsing = !collapsedFolders.has(key);
+    const cursorHere = cursorFollows || activeFolderKey === rowKey;
     setCollapsedFolders((prev) => {
       const next = new Set(prev);
       if (collapsing) next.add(key);
       else next.delete(key);
       return next;
     });
-    if (!collapsing) return;
-    setSelectedKeys((prev) => pruneHiddenKeys(prev, [key]));
+    if (collapsing) {
+      // A collapsing row keeps its key — compaction never runs through a
+      // collapsed node — so the cursor and its focus stay put.
+      if (cursorHere) setActiveFolderKey(rowKey);
+      setSelectedKeys((prev) => pruneHiddenKeys(prev, [key]));
+      return;
+    }
+    if (!cursorHere) return;
+    // Re-key the cursor with the row, or the expanded row unmounts under the
+    // focus and every arrow key goes dead. `focusRow` misses the not-yet-mounted
+    // row and defers to the pending-focus claim.
+    const nextCollapsed = collapsedIn(section);
+    nextCollapsed.delete(dirPath);
+    const nextKey = folderKeyAfterToggle(section, dirPath, nextCollapsed);
+    setActiveFolderKey(nextKey);
+    if (nextKey !== null) focusRow(nextKey);
   }
 
   // Clicking a folder both toggles it and parks the cursor there.
   function handleFolderActivate(row: FolderRow) {
-    toggleFolder(row.section, row.path);
-    setActiveFolderKey(rowKeyOf(row));
+    toggleFolder(row.section, row.path, true);
   }
 
   function toggleViewMode() {

--- a/src/features/repository/ChangesPanel.tsx
+++ b/src/features/repository/ChangesPanel.tsx
@@ -1574,7 +1574,9 @@ function VirtualizedChangeList({
   // Keep the active row scrolled into view as the selection moves — under
   // virtualization its DOM node may not be mounted, so scroll by index. The row
   // mounts on the virtualizer's own re-render, a frame or more after the scroll,
-  // so the deferred focus claim gets a few frames before it gives up.
+  // so the deferred focus claim gets a few frames before it gives up. Keyed on
+  // the row IDENTITY too: an expand can re-key the cursor row at the SAME flat
+  // index, and the pending-focus claim must still run.
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on active change
   useEffect(() => {
     if (activeFlatIndex < 0) return;
@@ -1588,7 +1590,7 @@ function VirtualizedChangeList({
     };
     frame = requestAnimationFrame(claim);
     return () => cancelAnimationFrame(frame);
-  }, [activeFlatIndex]);
+  }, [activeFlatIndex, activeRowKey]);
   // Jump back to the top whenever the filter changes the visible set. Gated on
   // the filter actually changing: <Activity> replays effects on every tab show,
   // and an unguarded reset would drop the scroll position it preserves.

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -6,6 +6,7 @@ import { PathText } from "@/components/path-text";
 import { KIND_BADGE } from "@/lib/git/change-kind-badge";
 import { reservedDeviceName } from "@/lib/git/reserved-device-name";
 import type { ChangeKind, DiffStatEntry, FileEntry } from "@/lib/git/types";
+import { pathBasename } from "@/lib/path-tree";
 import { cn } from "@/lib/utils";
 
 /**
@@ -23,6 +24,8 @@ export const FileRow = memo(function FileRow({
   active,
   disabled,
   stat,
+  treeDisplay,
+  indentPx,
   onSelect,
   onToggle,
 }: {
@@ -37,6 +40,10 @@ export const FileRow = memo(function FileRow({
   /** This row's OWN side of the diff (staged rows: index vs HEAD; unstaged:
    *  working tree vs index). Absent = no counts to show. */
   stat?: DiffStatEntry;
+  /** Tree mode: render only the basename(s); the row carries a static full-path title. */
+  treeDisplay?: boolean;
+  /** Tree mode: depth indent in px, applied as style paddingLeft on top of the row's base. */
+  indentPx?: number;
   onSelect: (
     entry: FileEntry,
     staged: boolean,
@@ -51,10 +58,32 @@ export const FileRow = memo(function FileRow({
   // Staging is the only direction that reads the working-tree file, so only it
   // hits the device; unstaging works on such a path as on any other.
   const reservedName = staged ? null : reservedDeviceName(entry.path);
+  // The name cell. A rename is two paths and an arrow, and tree mode shows
+  // basenames (the folder row above carries the directory): neither can ride
+  // PathText's only-when-clipped measurement, so both keep a static full title.
+  let nameCell = <PathText path={entry.path} className="flex-1" />;
+  if (entry.origPath) {
+    nameCell = (
+      <span className="flex min-w-0 flex-1 items-center gap-1" title={label}>
+        <PathText
+          path={treeDisplay ? pathBasename(entry.origPath) : entry.origPath}
+        />
+        <span className="shrink-0">→</span>
+        <PathText path={treeDisplay ? pathBasename(entry.path) : entry.path} />
+      </span>
+    );
+  } else if (treeDisplay) {
+    nameCell = (
+      <span className="flex min-w-0 flex-1" title={label}>
+        <PathText path={pathBasename(entry.path)} className="min-w-0 flex-1" />
+      </span>
+    );
+  }
 
   return (
     <div
       data-row={`${staged ? "staged" : "unstaged"}:${entry.path}`}
+      style={indentPx === undefined ? undefined : { paddingLeft: 8 + indentPx }}
       className={cn(
         "group flex w-full cursor-pointer items-center gap-2 px-2 py-1 text-left text-xs",
         selected ? "bg-accent text-accent-foreground" : "hover:bg-muted/60",
@@ -90,18 +119,7 @@ export const FileRow = memo(function FileRow({
           is absolutely positioned so it never becomes a flex item here. The
           trailing space keeps the name from fusing with the path text. */}
       <span className="sr-only">{badge.label} </span>
-      {entry.origPath ? (
-        // A rename is two paths and an arrow: the composite can't ride
-        // PathText's only-when-clipped measurement, so the row keeps a static
-        // title for the whole label.
-        <span className="flex min-w-0 flex-1 items-center gap-1" title={label}>
-          <PathText path={entry.origPath} />
-          <span className="shrink-0">→</span>
-          <PathText path={entry.path} />
-        </span>
-      ) : (
-        <PathText path={entry.path} className="flex-1" />
-      )}
+      {nameCell}
       {stat ? (
         <DiffStat
           added={stat.added}

--- a/src/features/repository/FileRow.tsx
+++ b/src/features/repository/FileRow.tsx
@@ -59,23 +59,36 @@ export const FileRow = memo(function FileRow({
   // hits the device; unstaging works on such a path as on any other.
   const reservedName = staged ? null : reservedDeviceName(entry.path);
   // The name cell. A rename is two paths and an arrow, and tree mode shows
-  // basenames (the folder row above carries the directory): neither can ride
-  // PathText's only-when-clipped measurement, so both keep a static full title.
+  // basenames (the folder row above carries the directory): the wrapper's title
+  // only wins while nothing is clipped, so each PathText also carries the full
+  // path it stands for as its own only-when-clipped tooltip.
   let nameCell = <PathText path={entry.path} className="flex-1" />;
   if (entry.origPath) {
     nameCell = (
-      <span className="flex min-w-0 flex-1 items-center gap-1" title={label}>
+      <span
+        aria-hidden={treeDisplay || undefined}
+        className="flex min-w-0 flex-1 items-center gap-1"
+        title={label}
+      >
         <PathText
           path={treeDisplay ? pathBasename(entry.origPath) : entry.origPath}
+          title={label}
         />
         <span className="shrink-0">→</span>
-        <PathText path={treeDisplay ? pathBasename(entry.path) : entry.path} />
+        <PathText
+          path={treeDisplay ? pathBasename(entry.path) : entry.path}
+          title={label}
+        />
       </span>
     );
   } else if (treeDisplay) {
     nameCell = (
-      <span className="flex min-w-0 flex-1" title={label}>
-        <PathText path={pathBasename(entry.path)} className="min-w-0 flex-1" />
+      <span aria-hidden className="flex min-w-0 flex-1" title={label}>
+        <PathText
+          path={pathBasename(entry.path)}
+          title={entry.path}
+          className="min-w-0 flex-1"
+        />
       </span>
     );
   }
@@ -117,8 +130,13 @@ export const FileRow = memo(function FileRow({
       {/* The status letter carries no meaning for assistive tech; the name span
           sits ahead of the path so the kind is announced first, and `sr-only`
           is absolutely positioned so it never becomes a flex item here. The
-          trailing space keeps the name from fusing with the path text. */}
-      <span className="sr-only">{badge.label} </span>
+          trailing space keeps the name from fusing with the path text. Tree
+          mode's visible cell shows basenames, so the full path(s) ride here
+          instead and that cell is `aria-hidden` — otherwise the basename is
+          announced twice and same-named files in different folders alike. */}
+      <span className="sr-only">
+        {treeDisplay ? `${badge.label} ${label} ` : `${badge.label} `}
+      </span>
       {nameCell}
       {stat ? (
         <DiffStat

--- a/src/features/repository/checkout-copy.ts
+++ b/src/features/repository/checkout-copy.ts
@@ -1,0 +1,45 @@
+// Shared by every branch-row surface (the switcher, the compare picker, the
+// base picker), so it lives apart from all three: hosting it in one of them
+// would make the other two import a component module to read copy.
+
+/** Last path segment (folder name), tolerating either separator. */
+export const baseName = (p: string) =>
+  p.split(/[/\\]/).filter(Boolean).pop() ?? p;
+
+/** How a branch row NAMES the checkout holding its branch — chip, tooltip, open
+ *  item, after-the-fact toast, and the phrases that say a row is held because of
+ *  it. Git counts the main workspace as a worktree and this row can point at it
+ *  when you're standing in a linked one, but users don't call it one; routing
+ *  the naming through one record keeps a later phrase from drifting back.
+ *  "Rename worktree…" and "Delete worktree…" are deliberately NOT routed here:
+ *  they name the git operation, and their held-reason carries the naming instead.
+ *  `noun` is bare, for badges and parenthetical reasons; `blockedTitle` is the
+ *  sentence-capitalized chip-tooltip form of `blocked`, for rows that name the
+ *  holding checkout without offering to open it. */
+export const ROW_CHECKOUT_COPY = {
+  linked: {
+    noun: "worktree",
+    open: "Open worktree",
+    title: (path: string) =>
+      `Checked out in worktree ${baseName(path)} (${path}) — this row opens it`,
+    opened: (path: string) => `Opened worktree ${baseName(path)}`,
+    blocked: "checked out in another worktree",
+    blockedTitle: (path: string) => `Checked out in another worktree (${path})`,
+    held: "in a worktree",
+  },
+  main: {
+    noun: "main workspace",
+    open: "Open main workspace",
+    title: (path: string) =>
+      `Checked out in the main workspace (${path}) — this row opens it`,
+    opened: (_path: string) => "Opened the main workspace",
+    blocked: "checked out in the main workspace",
+    blockedTitle: (path: string) =>
+      `Checked out in the main workspace (${path})`,
+    held: "in the main workspace",
+  },
+} as const;
+
+/** Which {@link ROW_CHECKOUT_COPY} arm a listed worktree speaks in. */
+export const rowCheckoutCopy = (isMain: boolean | undefined) =>
+  ROW_CHECKOUT_COPY[isMain ? "main" : "linked"];

--- a/src/features/repository/checkout-copy.ts
+++ b/src/features/repository/checkout-copy.ts
@@ -2,9 +2,10 @@
 // base picker), so it lives apart from all three: hosting it in one of them
 // would make the other two import a component module to read copy.
 
-/** Last path segment (folder name), tolerating either separator. */
-export const baseName = (p: string) =>
-  p.split(/[/\\]/).filter(Boolean).pop() ?? p;
+/** Last path segment (folder name). Git reports worktree paths forward-slashed
+ *  on every platform (`UserWorktree.path`), and a backslash is a legal
+ *  character in a POSIX directory name, so splitting on one truncates it. */
+export const baseName = (p: string) => p.split("/").filter(Boolean).pop() ?? p;
 
 /** How a branch row NAMES the checkout holding its branch — chip, tooltip, open
  *  item, after-the-fact toast, and the phrases that say a row is held because of

--- a/src/features/settings/settings-form.ts
+++ b/src/features/settings/settings-form.ts
@@ -10,6 +10,7 @@ export type SettingsDraft = Omit<
   AppSettings,
   | "recentRepos"
   | "diffViewMode"
+  | "changesViewMode"
   | "defaultBranch"
   | "theme"
   | "diffFileListCollapsed"
@@ -18,11 +19,13 @@ export type SettingsDraft = Omit<
 
 export function toDraft(settings: AppSettings): SettingsDraft {
   // defaultBranch is dropped: it now lives in global git config, edited by its
-  // own form in GitSection, not the bulk Save bar. theme, diffViewMode, and the
-  // two collapse prefs are apply-on-change, owned by their own controls.
+  // own form in GitSection, not the bulk Save bar. theme, diffViewMode,
+  // changesViewMode, and the two collapse prefs are apply-on-change, owned by
+  // their own controls.
   const {
     recentRepos,
     diffViewMode,
+    changesViewMode,
     defaultBranch,
     theme,
     diffFileListCollapsed,

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -671,6 +671,12 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "toggle-changes-tree",
+    label: "Toggle directory tree view",
+    category: "Changes",
+    defaultBinding: null,
+  },
+  {
     id: "change-diff-language",
     label: "Change diff language…",
     category: "Changes",

--- a/src/lib/list-keyboard-nav.ts
+++ b/src/lib/list-keyboard-nav.ts
@@ -16,19 +16,14 @@ export interface ListKeyboardNavOptions<T> {
    * several callers deliberately drive nav from a filter input.
    */
   ignoreTextEntry?: boolean;
-  /** Handle ArrowLeft/ArrowRight for the ACTIVE item (tree consumers: collapse/
-   *  expand, jump to parent). Only consulted when provided AND an item is active;
-   *  absent = Left/Right pass through untouched (existing consumers unchanged). */
-  onArrowLeft?: (item: T, index: number) => void;
-  onArrowRight?: (item: T, index: number) => void;
 }
 
 /**
  * Builds the `onKeyDown` handler for ArrowUp/ArrowDown navigation of a vertical
- * list, plus ArrowLeft/ArrowRight for callers that opt in. Callers own their
- * selection logic via `onActivate` (single- or multi-select) and optionally a
- * `rowKey` so the active row is focused and scrolled into view. Not a hook — it
- * calls no hooks, so it's safe to build after early returns.
+ * list. Callers own their selection logic via `onActivate` (single- or
+ * multi-select) and optionally a `rowKey` so the active row is focused and
+ * scrolled into view. Not a hook — it calls no hooks, so it's safe to build
+ * after early returns.
  */
 export function listKeyboardNav<T>({
   items,
@@ -37,15 +32,9 @@ export function listKeyboardNav<T>({
   rowKey,
   rowAttr = "data-row",
   ignoreTextEntry = false,
-  onArrowLeft,
-  onArrowRight,
 }: ListKeyboardNavOptions<T>) {
   return (e: KeyboardEvent) => {
-    let horizontal: ((item: T, index: number) => void) | undefined;
-    if (e.key === "ArrowLeft") horizontal = onArrowLeft;
-    else if (e.key === "ArrowRight") horizontal = onArrowRight;
-    const vertical = e.key === "ArrowDown" || e.key === "ArrowUp";
-    if (!vertical && !horizontal) return;
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
     if (items.length === 0) return;
     // Ancestor walk for the form controls (a keydown can bubble from a wrapper
     // inside an editor); isContentEditable covers every editable state — true,
@@ -57,14 +46,6 @@ export function listKeyboardNav<T>({
         e.target.isContentEditable)
     )
       return;
-    if (horizontal) {
-      // Nothing active = nothing to collapse or step out of; the key stays the
-      // browser's (caret/scroll) rather than being swallowed.
-      if (activeIndex === -1) return;
-      e.preventDefault();
-      horizontal(items[activeIndex], activeIndex);
-      return;
-    }
     // Move the selection, not the scrollbar.
     e.preventDefault();
     const to =

--- a/src/lib/list-keyboard-nav.ts
+++ b/src/lib/list-keyboard-nav.ts
@@ -16,14 +16,19 @@ export interface ListKeyboardNavOptions<T> {
    * several callers deliberately drive nav from a filter input.
    */
   ignoreTextEntry?: boolean;
+  /** Handle ArrowLeft/ArrowRight for the ACTIVE item (tree consumers: collapse/
+   *  expand, jump to parent). Only consulted when provided AND an item is active;
+   *  absent = Left/Right pass through untouched (existing consumers unchanged). */
+  onArrowLeft?: (item: T, index: number) => void;
+  onArrowRight?: (item: T, index: number) => void;
 }
 
 /**
  * Builds the `onKeyDown` handler for ArrowUp/ArrowDown navigation of a vertical
- * list. Callers own their selection logic via `onActivate` (single- or
- * multi-select) and optionally a `rowKey` so the active row is focused and
- * scrolled into view. Not a hook — it calls no hooks, so it's safe to build
- * after early returns.
+ * list, plus ArrowLeft/ArrowRight for callers that opt in. Callers own their
+ * selection logic via `onActivate` (single- or multi-select) and optionally a
+ * `rowKey` so the active row is focused and scrolled into view. Not a hook — it
+ * calls no hooks, so it's safe to build after early returns.
  */
 export function listKeyboardNav<T>({
   items,
@@ -32,9 +37,15 @@ export function listKeyboardNav<T>({
   rowKey,
   rowAttr = "data-row",
   ignoreTextEntry = false,
+  onArrowLeft,
+  onArrowRight,
 }: ListKeyboardNavOptions<T>) {
   return (e: KeyboardEvent) => {
-    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    let horizontal: ((item: T, index: number) => void) | undefined;
+    if (e.key === "ArrowLeft") horizontal = onArrowLeft;
+    else if (e.key === "ArrowRight") horizontal = onArrowRight;
+    const vertical = e.key === "ArrowDown" || e.key === "ArrowUp";
+    if (!vertical && !horizontal) return;
     if (items.length === 0) return;
     // Ancestor walk for the form controls (a keydown can bubble from a wrapper
     // inside an editor); isContentEditable covers every editable state — true,
@@ -46,6 +57,14 @@ export function listKeyboardNav<T>({
         e.target.isContentEditable)
     )
       return;
+    if (horizontal) {
+      // Nothing active = nothing to collapse or step out of; the key stays the
+      // browser's (caret/scroll) rather than being swallowed.
+      if (activeIndex === -1) return;
+      e.preventDefault();
+      horizontal(items[activeIndex], activeIndex);
+      return;
+    }
     // Move the selection, not the scrollbar.
     e.preventDefault();
     const to =

--- a/src/lib/path-tree.ts
+++ b/src/lib/path-tree.ts
@@ -27,8 +27,8 @@ export type PathTreeRow<T> = PathTreeFolderRow | PathTreeLeafRow<T>;
  * DISCARDS the prefix — splitting on "\" too would drop half of `foo\bar.ts` and
  * collide it with a real `bar.ts`. Truncating displays like `PathText` may treat
  * both as separators because they keep both sides. `checkout-copy.ts`'s
- * `baseName` is the other domain — OS worktree paths, where "\" IS a separator —
- * so the two must not be unified.
+ * `baseName` splits the same way for its own domain (git-reported worktree
+ * paths) — a shared spelling, not a shared contract, so keep them separate.
  */
 export function pathBasename(path: string): string {
   const cut = path.lastIndexOf("/");

--- a/src/lib/path-tree.ts
+++ b/src/lib/path-tree.ts
@@ -21,11 +21,17 @@ export interface PathTreeLeafRow<T> {
 
 export type PathTreeRow<T> = PathTreeFolderRow | PathTreeLeafRow<T>;
 
-/** Last path segment ("src/lib/x.ts" → "x.ts"). Both separators, so a name this
- *  abbreviates starts where `PathText` also splits it — git emits "/", but the
- *  two displays must not disagree on a path holding a literal "\". */
+/**
+ * Last path segment ("src/lib/x.ts" → "x.ts"). Splits on "/" ALONE: these are
+ * git repo paths, where "\" is a legal POSIX filename character, and this helper
+ * DISCARDS the prefix — splitting on "\" too would drop half of `foo\bar.ts` and
+ * collide it with a real `bar.ts`. Truncating displays like `PathText` may treat
+ * both as separators because they keep both sides. `checkout-copy.ts`'s
+ * `baseName` is the other domain — OS worktree paths, where "\" IS a separator —
+ * so the two must not be unified.
+ */
 export function pathBasename(path: string): string {
-  const cut = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const cut = path.lastIndexOf("/");
   return cut === -1 ? path : path.slice(cut + 1);
 }
 

--- a/src/lib/path-tree.ts
+++ b/src/lib/path-tree.ts
@@ -1,0 +1,117 @@
+/** A directory row of a compacted path tree. */
+export interface PathTreeFolderRow {
+  kind: "folder";
+  /** Full directory path of the node's DEEPEST segment (e.g.
+   *  "src/features/repository") — the collapse identity. Stable when compaction
+   *  changes as siblings appear and disappear. */
+  path: string;
+  /** Compacted label relative to the parent (e.g. "features/repository"). */
+  label: string;
+  depth: number;
+  /** Total descendant leaves, including those hidden under nested collapse. */
+  fileCount: number;
+}
+
+/** A file row of a compacted path tree, carrying the caller's own item. */
+export interface PathTreeLeafRow<T> {
+  kind: "leaf";
+  item: T;
+  depth: number;
+}
+
+export type PathTreeRow<T> = PathTreeFolderRow | PathTreeLeafRow<T>;
+
+/** Last path segment ("src/lib/x.ts" → "x.ts"). Both separators, so a name this
+ *  abbreviates starts where `PathText` also splits it — git emits "/", but the
+ *  two displays must not disagree on a path holding a literal "\". */
+export function pathBasename(path: string): string {
+  const cut = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return cut === -1 ? path : path.slice(cut + 1);
+}
+
+/** Numeric-aware, case-insensitive name order — "file2" before "file10". */
+function compareNames(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}
+
+interface DirNode<T> {
+  /** Full path of this directory ("" at the root). */
+  path: string;
+  dirs: Map<string, DirNode<T>>;
+  leaves: T[];
+  /** Descendant leaves, counted as the tree is built. */
+  count: number;
+}
+
+/**
+ * Builds a compacted directory tree over `items`' slash-separated paths and
+ * flattens it to render-order rows, omitting descendants of folders whose
+ * `path` is in `collapsed` (a collapsed folder row itself still appears, with
+ * its full `fileCount`). Folders sort before leaves, both by name.
+ *
+ * Compaction is the VS Code SCM shape: a directory holding one subdirectory and
+ * no files of its own merges into it, so one ROW can span several path segments
+ * and `depth` counts rows, not segments.
+ */
+export function flattenPathTree<T>(
+  items: T[],
+  getPath: (item: T) => string,
+  collapsed: ReadonlySet<string>,
+): PathTreeRow<T>[] {
+  const root: DirNode<T> = {
+    path: "",
+    dirs: new Map(),
+    leaves: [],
+    count: 0,
+  };
+  for (const item of items) {
+    const segments = getPath(item).split("/");
+    let node = root;
+    node.count++;
+    for (const name of segments.slice(0, -1)) {
+      let child = node.dirs.get(name);
+      if (!child) {
+        child = {
+          path: node.path ? `${node.path}/${name}` : name,
+          dirs: new Map(),
+          leaves: [],
+          count: 0,
+        };
+        node.dirs.set(name, child);
+      }
+      child.count++;
+      node = child;
+    }
+    node.leaves.push(item);
+  }
+
+  const rows: PathTreeRow<T>[] = [];
+  const emit = (node: DirNode<T>, depth: number) => {
+    const dirs = [...node.dirs.entries()].toSorted((a, b) =>
+      compareNames(a[0], b[0]),
+    );
+    for (const [name, child] of dirs) {
+      let folder = child;
+      let label = name;
+      while (folder.leaves.length === 0 && folder.dirs.size === 1) {
+        const [onlyName, only] = [...folder.dirs.entries()][0];
+        label = `${label}/${onlyName}`;
+        folder = only;
+      }
+      rows.push({
+        kind: "folder",
+        path: folder.path,
+        label,
+        depth,
+        fileCount: folder.count,
+      });
+      if (!collapsed.has(folder.path)) emit(folder, depth + 1);
+    }
+    const leaves = node.leaves.toSorted((a, b) =>
+      compareNames(pathBasename(getPath(a)), pathBasename(getPath(b))),
+    );
+    for (const item of leaves) rows.push({ kind: "leaf", item, depth });
+  };
+  emit(root, 0);
+  return rows;
+}

--- a/src/lib/path-tree.ts
+++ b/src/lib/path-tree.ts
@@ -93,7 +93,13 @@ export function flattenPathTree<T>(
     for (const [name, child] of dirs) {
       let folder = child;
       let label = name;
-      while (folder.leaves.length === 0 && folder.dirs.size === 1) {
+      // A collapsed node ends its chain: compacting THROUGH it would re-key the
+      // row to a deeper path, and the row would render expanded again.
+      while (
+        folder.leaves.length === 0 &&
+        folder.dirs.size === 1 &&
+        !collapsed.has(folder.path)
+      ) {
         const [onlyName, only] = [...folder.dirs.entries()][0];
         label = `${label}/${onlyName}`;
         folder = only;

--- a/src/lib/path-tree.ts
+++ b/src/lib/path-tree.ts
@@ -35,9 +35,15 @@ export function pathBasename(path: string): string {
   return cut === -1 ? path : path.slice(cut + 1);
 }
 
+/** Hoisted: a per-comparison collator is the expensive half of a sort this size. */
+const NAME_COLLATOR = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
+
 /** Numeric-aware, case-insensitive name order — "file2" before "file10". */
 function compareNames(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+  return NAME_COLLATOR.compare(a, b);
 }
 
 interface DirNode<T> {

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -216,6 +216,9 @@ export const NODE_VERSIONS = ["24", "22", "20"] as const;
 /** The diff layouts offered in the diff surface's view toggle. */
 export const DIFF_VIEW_MODES = ["unified", "split"] as const;
 
+/** The layouts offered in the Changes panel's view toggle. */
+export const CHANGES_VIEW_MODES = ["list", "tree"] as const;
+
 export interface AppSettings {
   ai: AiSettings;
   /** Provider/model for AI PR review (independent of the commit model). */
@@ -346,6 +349,9 @@ export interface AppSettings {
    *  outside the bulk settings form (apply-on-change), like diffViewMode. */
   theme: ThemeSetting;
   diffViewMode: (typeof DIFF_VIEW_MODES)[number];
+  /** Changes panel layout: flat list or compacted directory tree. Applied outside
+   *  the bulk settings form (apply-on-change), like diffViewMode. */
+  changesViewMode: (typeof CHANGES_VIEW_MODES)[number];
   /** Which conversation-list sections the user collapsed, keyed `"<feature>:<kind>"`
    *  (`pulls:local`, `issues:remote`, …); a missing key = expanded. Global and
    *  feature-scoped, so the remote key collapses that section across every repo. */
@@ -428,6 +434,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   recentRepos: [],
   theme: "system",
   diffViewMode: "unified",
+  changesViewMode: "list",
   collapsedConversationSections: [],
   commentComposerCollapsed: false,
   diffFileListCollapsed: false,
@@ -590,6 +597,11 @@ function healEnumerated(settings: AppSettings): AppSettings {
       settings.diffViewMode,
       DIFF_VIEW_MODES,
       DEFAULT_SETTINGS.diffViewMode,
+    ),
+    changesViewMode: pick(
+      settings.changesViewMode,
+      CHANGES_VIEW_MODES,
+      DEFAULT_SETTINGS.changesViewMode,
     ),
     // A corrupt container is passed through, never substituted: every writer in the
     // serialized RMW chain re-reads through loadSettings, so a stand-in [] would

--- a/src/lib/stores/worktree-removal.ts
+++ b/src/lib/stores/worktree-removal.ts
@@ -159,6 +159,13 @@ export function isWorktreePromoting(path: string): boolean {
   return promotingWorktrees.has(normPath(path));
 }
 
+/** True while a promote has claimed this MAIN workspace as its destination.
+ *  Fire-time check only, like {@link isWorktreePromoting} — {@link promotingMains}
+ *  is deliberately not store state, so never use this to decide what renders. */
+export function isMainPromoting(path: string): boolean {
+  return promotingMains.has(normPath(path));
+}
+
 /** The refusal every surface shows for a worktree a promote has claimed — one
  *  spelling, so the store's refusals and the callers' can't drift apart. */
 export const WORKTREE_PROMOTING_MESSAGE = "This worktree is being promoted.";


### PR DESCRIPTION
Adds a compacted directory tree as a second layout for the Changes panel, so a working tree with changes scattered across deep paths can be read by folder instead of as one long flat run. The flat list stays the default and is one toggle away; multi-select, staging, filtering, and the Staged / Changes split are available in both views (collapsing a folder drops its hidden files from a multi-selection). The branch-row work in this PR is the second half: the copy that names the checkout holding a branch is now shared across all three branch surfaces, so the compare and base pickers stop calling the main workspace a worktree.

### Tree building

- Adds `src/lib/path-tree.ts` with `flattenPathTree`, which builds a directory tree over slash-separated paths and flattens it to render-order rows. Compaction follows the VS Code SCM shape: a directory with one subdirectory and no files of its own merges into it, so a row can span several segments and `depth` counts rows rather than path segments. Folders sort before leaves, both numeric-aware and case-insensitive.
- Exports `pathBasename` from the same module, splitting on `/` only — backslash is a legal character in a POSIX filename, never a separator in a repo-relative path.

### Changes panel

- Extends `FlatRow` in `src/features/repository/ChangesPanel.tsx` with a `folder` variant and gives files an optional `depth`, keeping headers, folders, and files in one index space for the single virtualizer. `rowKeyOf` gains a `folder:<section>:<path>` spelling and a new `rowDepth` helper reports a row's indent level.
- Holds collapsed directories in `collapsedFolders` (keyed `"<section>:<dirPath>"`, session-local) and the folder cursor in `activeFolderKey`; `pushSection` swaps each section's flat run for tree rows when tree mode is on.
- Adds `pruneHiddenKeys`, applied both when collapsing a folder (`toggleFolder`) and when entering tree mode with folders already collapsed (`toggleViewMode`), so a collapsed folder can never hold a selected-but-invisible row. Range selection in `activateRow` and `handleSelect` filters folder rows out of the emitted keys.
- Wires horizontal navigation through `onArrowLeft` / `onArrowRight`: Right expands a collapsed folder or steps into it, Left collapses an expanded one or jumps to the parent. `focusRow` / `claimPendingFocus` handle a jump past the virtualizer's overscan window by deferring the focus until `VirtualizedChangeList` reports the scroll landed (`onCursorScrolled`, retried for a few frames).
- Adds the **Directory tree view** toggle button to the filter row (`aria-pressed`, title switching between "Show changes as a flat list" and "Group changes by directory") and renders folder rows with a caret, indent, file count, and an `aria-label` spelling out the collapsed/expanded state that `role="option"` can't carry.
- Routes `folder:`-prefixed rows in `handleContextMenu` to the whole-list menu, since a directory row carries no file actions, and resets collapse state plus the folder cursor on an actual `repoPath` change (guarded against `<Activity>` effect replays).
- `VirtualizedChangeList` takes `viewMode` and `collapsedFolders` as `getItemKey` identity inputs, estimates folder rows at 24px, and scrolls by the cursor row key rather than the active file key.

### File rows and shared navigation

- `src/features/repository/FileRow.tsx` gains `treeDisplay` and `indentPx`: tree mode renders basenames with a static full-path title, including both halves of a rename, and applies the depth indent as `paddingLeft` on top of the row's base.
- `src/lib/list-keyboard-nav.ts` grows opt-in `onArrowLeft` / `onArrowRight` handlers, consulted only when provided and an item is active; existing consumers keep Left/Right as the browser's.

### Settings and command palette

- Adds `changesViewMode` (`CHANGES_VIEW_MODES = ["list", "tree"]`, default `"list"`) to `AppSettings` in `src/lib/settings/api.ts`, including a `healEnumerated` arm, and excludes it from `SettingsDraft` in `src/features/settings/settings-form.ts` as an apply-on-change preference like `diffViewMode`.
- Registers the palette-only `toggle-changes-tree` action ("Toggle directory tree view", no default binding) in `src/lib/hotkeys/registry.ts` and binds it in the panel via `useHotkeyAction`.

### Branch-row checkout copy

- Moves `ROW_CHECKOUT_COPY`, `baseName`, and `rowCheckoutCopy` out of `BranchSwitcher.tsx` into the new `src/features/repository/checkout-copy.ts`, so the compare and base pickers can read the copy without importing a component module. Adds a `blockedTitle` arm for rows that name the holding checkout without offering to open it.
- `CompareBranchCombobox.tsx` and `BaseBranchCombobox.tsx` now map a branch to `{ path, isMain }` instead of a bare path, so a branch checked out in the main workspace is named as such in the chip and tooltip.
- `BranchSwitcher.tsx` appends a `(operation in progress)` suffix to the labels of context-menu items held only by `busy` (update from default/base, reset to upstream, push, publish), since a natively-disabled item swallows its tooltip; a structural reason still wins.

### Store

- Adds `isMainPromoting` to `src/lib/stores/worktree-removal.ts`, a fire-time check mirroring `isWorktreePromoting` for the main workspace.

### Documentation

- Extends the diff/staging bullet in `README.md` with the flat-vs-tree description.
- Adds the capability line to `site/src/data/capabilities.ts` under "Diffs & staging".
- Adds a Changes-tab bullet to `src/features/help/content.ts` covering the toggle, click and keyboard collapse, selection pruning, the persisted preference (global, like the diff view), and the palette action (shortcuts as `{{kbd:…}}` tokens).
- Adds three fragments: `changelog.d/added-changes-tree-view.md`, `changelog.d/changed-branch-menu-busy-reasons.md`, and `changelog.d/fixed-branch-picker-main-workspace.md`.

Relates to #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact directory tree view for the Changes panel, with collapsible folders, merged single-child paths, keyboard navigation, and preserved staging and selection behavior.
  * Switch between tree and flat list views from the panel, command palette, or shortcut; the preference is remembered per repository.
* **Bug Fixes**
  * Branch menus now explain when actions are unavailable because another operation is in progress.
  * Compare and branch selectors now clearly identify branches checked out in the main workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->