### PR TITLE
feat(automations,pulls): log automation decisions and run them on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,7 +994,9 @@ review via its subscription login. The full list is under
 - **Automation history**: every decision a repository's automations made,
   in one read-only log — what ran, what was skipped, and the reason for
   each, with the repo's effective configuration at the top. Open it from
-  the activity bell or the repo ⋮ menu.
+  the activity bell or the repo ⋮ menu. And **Run automations on this pull
+  request** (command palette) runs the configured reviews on demand,
+  confirming the modes and the posted comment before spending a model call.
 - **Integrations**: open in any editor or terminal (auto-detected, point at
   any executable, or set a full custom command with a `{path}` placeholder),
   and tunable OS notifications for PR activity, checks, and CI runs.

--- a/README.md
+++ b/README.md
@@ -991,6 +991,10 @@ review via its subscription login. The full list is under
   commits to a reviewed PR) that runs AI review or security audit
   automatically, with per-action branch conditions, Save/Discard drafts,
   global defaults, and per-repo overrides (paused while **Hide AI** is on).
+- **Automation history**: every decision a repository's automations made,
+  in one read-only log — what ran, what was skipped, and the reason for
+  each, with the repo's effective configuration at the top. Open it from
+  the activity bell or the repo ⋮ menu.
 - **Integrations**: open in any editor or terminal (auto-detected, point at
   any executable, or set a full custom command with a `{path}` placeholder),
   and tunable OS notifications for PR activity, checks, and CI runs.

--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ review via its subscription login. The full list is under
 - **Automation history**: every decision a repository's automations made,
   in one read-only log — what ran, what was skipped, and the reason for
   each, with the repo's effective configuration at the top. Open it from
-  the activity bell or the repo ⋮ menu. And **Run automations on this pull
+  the activity bell or the repo ⋮ menu. **Run automations on this pull
   request** (command palette) runs the configured reviews on demand,
   confirming the modes and the posted comment before spending a model call.
 - **Integrations**: open in any editor or terminal (auto-detected, point at

--- a/changelog.d/added-automation-history-run-now.md
+++ b/changelog.d/added-automation-history-run-now.md
@@ -1,0 +1,7 @@
+- **Automation history and on-demand runs.** A new **Automation history** view
+  (activity bell footer, or the repository menu) records what each automation
+  did and why: reviews posted, heads skipped as already covered, branch
+  conditions that didn't match, claims held by another instance, and runs the
+  app closed on. And **Run automations on this pull request** (command palette) runs the
+  configured reviews on demand for the open PR, confirming the modes and the
+  posted comment before it spends a model call.

--- a/changelog.d/added-automation-history-run-now.md
+++ b/changelog.d/added-automation-history-run-now.md
@@ -2,6 +2,6 @@
   (activity bell footer, or the repository menu) records what each automation
   did and why: reviews posted, heads skipped as already covered, branch
   conditions that didn't match, claims held by another instance, and runs the
-  app closed on. And **Run automations on this pull request** (command
-  palette) runs the configured reviews on demand for the open PR, confirming
-  the modes and the posted comment before it spends a model call.
+  app closed on. **Run automations on this pull request** (command palette)
+  runs the configured reviews on demand for the open PR, confirming the modes
+  and the posted comment before it spends a model call.

--- a/changelog.d/added-automation-history-run-now.md
+++ b/changelog.d/added-automation-history-run-now.md
@@ -2,6 +2,6 @@
   (activity bell footer, or the repository menu) records what each automation
   did and why: reviews posted, heads skipped as already covered, branch
   conditions that didn't match, claims held by another instance, and runs the
-  app closed on. And **Run automations on this pull request** (command palette) runs the
-  configured reviews on demand for the open PR, confirming the modes and the
-  posted comment before it spends a model call.
+  app closed on. And **Run automations on this pull request** (command
+  palette) runs the configured reviews on demand for the open PR, confirming
+  the modes and the posted comment before it spends a model call.

--- a/changelog.d/fixed-branch-rules-merge-method-heal.md
+++ b/changelog.d/fixed-branch-rules-merge-method-heal.md
@@ -1,0 +1,4 @@
+- Hand-edited branch rules heal on load: unknown entries in a protection's
+  allowed merge methods are dropped from the working view (both the personal
+  store and a committed `.gitdesktop/branch-rules.json`), so the merge-method
+  checkboxes always show exactly what is enforced.

--- a/changelog.d/fixed-hand-edited-enum-heal.md
+++ b/changelog.d/fixed-hand-edited-enum-heal.md
@@ -1,0 +1,5 @@
+- Hand-edited `branch-rules.json` and `automations.json` values now heal on
+  load: unknown entries in a protection's allowed merge methods are dropped
+  (both the personal store and a committed `.gitdesktop/branch-rules.json`),
+  and every enumerated field falls back to a valid choice instead of quietly
+  restricting merges.

--- a/changelog.d/fixed-hand-edited-enum-heal.md
+++ b/changelog.d/fixed-hand-edited-enum-heal.md
@@ -1,5 +1,0 @@
-- Hand-edited `branch-rules.json` and `automations.json` values now heal on
-  load: unknown entries in a protection's allowed merge methods are dropped
-  (both the personal store and a committed `.gitdesktop/branch-rules.json`),
-  and every enumerated field falls back to a valid choice instead of quietly
-  restricting merges.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -685,6 +685,12 @@ export const capabilities: Capability[] = [
   {
     group: "AI · generate & review",
     ai: true,
+    label:
+      "Automation history — a per-repo log of what ran, what was skipped & why, plus run an automation on demand",
+  },
+  {
+    group: "AI · generate & review",
+    ai: true,
     label: "Resolve merge conflicts with AI — review the proposal, then accept",
   },
   {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ReconnectDialog } from "@/features/accounts/ReconnectDialog";
 import { ActivityStrip } from "@/features/activity/ActivityDock";
 import { useMacAppMenu } from "@/features/app-menu/useMacAppMenu";
+import { AutomationHistoryDialogHost } from "@/features/automations/AutomationHistoryDialog";
 import { AutomationResultDialog } from "@/features/automations/AutomationResultDialog";
 import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
@@ -259,6 +260,7 @@ function App() {
         <ActivityStrip />
       </div>
       <AutomationResultDialog />
+      <AutomationHistoryDialogHost />
       <CloneRepoDialog open={cloneOpen} onOpenChange={setCloneOpen} />
       <CreateRepoDialog open={createOpen} onOpenChange={setCreateOpen} />
       <ConfirmDialogHost />

--- a/src/features/activity/ActivityDock.tsx
+++ b/src/features/activity/ActivityDock.tsx
@@ -1,5 +1,6 @@
 import {
   BellIcon,
+  CaretRightIcon,
   CaretUpIcon,
   ChatCircleIcon,
   CheckCircleIcon,
@@ -26,6 +27,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { useAutomationHistoryDialog } from "@/features/automations/AutomationHistoryDialog";
 import { openAutomationResult } from "@/lib/automations/results";
 import { displayLogin } from "@/lib/git/bot-login";
 import type { RemoteLens } from "@/lib/git/types";
@@ -202,6 +204,7 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
   const openPr = useUiStore((s) => s.openPr);
   const openRun = useUiStore((s) => s.openRun);
   const openAgentTab = useUiStore((s) => s.openAgentTab);
+  const openHistory = useAutomationHistoryDialog((s) => s.open);
   const aiEnabled = useAiEnabled();
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -384,6 +387,26 @@ function ActivityPanel({ onClose }: { onClose: () => void }) {
             />
           ))}
         </div>
+      )}
+
+      {/* The dock's one way into the automation decision log. Needs a current
+          repo: the strip variant renders on welcome/settings/help, where a
+          repo-scoped dialog would have nothing to open. */}
+      {aiEnabled && repoPath && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-between border-t px-3 text-muted-foreground"
+          onClick={() => {
+            // Close FIRST: Base UI returns focus to the popover's trigger as it
+            // unwinds, which would steal it from a dialog opened before that.
+            onClose();
+            openHistory(repoPath);
+          }}
+        >
+          Automation history
+          <CaretRightIcon />
+        </Button>
       )}
     </>
   );

--- a/src/features/automations/AutomationHistoryDialog.tsx
+++ b/src/features/automations/AutomationHistoryDialog.tsx
@@ -9,7 +9,7 @@ import {
   PlayIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type KeyboardEvent,
   type ReactNode,
@@ -35,7 +35,6 @@ import {
   automationHistoryKey,
   listAutomationHistory,
   recordAutomationPauseMarker,
-  SESSION_START_MS,
   STEADY_OUTCOME_CODES,
 } from "@/lib/automations/history";
 import { useAutomations } from "@/lib/automations/queries";
@@ -49,8 +48,11 @@ import {
 } from "@/lib/automations/types";
 import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
 import { useRepoIdentity } from "@/lib/git/queries";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { applyRepoLens } from "@/lib/repo-lens/queries";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
+import { useReviewTasks } from "@/lib/stores/reviews";
 import { useUiStore } from "@/lib/stores/ui";
 import { COLD_START_AUTOMATIONS_OFF } from "@/lib/test-mode";
 import { validEpochMs } from "@/lib/time";
@@ -119,23 +121,34 @@ const UNKNOWN_REASON: ReasonLine = { text: "Unknown", tone: "muted" };
 
 /**
  * Reason copy + tone per outcome code, total over the union so a code added
- * later can't render as silence. `delivered` and `started` read the entry — one
- * varies with where the output went, the other with whether the run belongs to
- * this session or to one the app closed on.
+ * later can't render as silence. `delivered` reads the entry (where the output
+ * went); `started` reads `live` — whether THIS instance holds a running run for
+ * the row's target.
  */
 const OUTCOME_REASON: Record<
   AutomationOutcomeCode,
-  (entry: AutomationHistoryEntry, outcome: Outcome) => ReasonLine
+  (entry: AutomationHistoryEntry, outcome: Outcome, live: boolean) => ReasonLine
 > = {
   delivered: (entry) => ({
     text: DELIVERED_TEXT[entry.targetKind] ?? "Delivered",
     tone: "success",
   }),
-  started: (entry) =>
-    (stampMs(entry.ts) ?? 0) >= SESSION_START_MS
+  // Liveness, never the clock: instances share this store, so a row's age says
+  // nothing about whether its run is still going. "Running" is claimed only
+  // where this instance can show the row it points at; everything else — a
+  // crash mid-run, or a run another instance owns and will still post — is the
+  // same honest statement about the RECORD, which never settled.
+  started: (entry, _outcome, live) =>
+    live
       ? { text: "Running — watch it in Activity", tone: "info" }
       : {
-          text: "Interrupted — the app closed while this was running",
+          // Commit runs register a degenerate live target (no commit kind, empty
+          // ref), so their rows can never match liveness — the honest set for
+          // them includes "still running here".
+          text:
+            entry.targetKind === "commit"
+              ? "Didn't settle — it may still be running, or the app closed mid-run"
+              : "Didn't settle — the app closed mid-run, or another instance owns it",
           tone: "warning",
         },
   "branch-skip": () => ({
@@ -165,7 +178,7 @@ const OUTCOME_REASON: Record<
   // The recorder attaches a detail when it could NOT measure the PR's age, so
   // the 14-day claim is only made where an age was actually read.
   "too-old": (_entry, outcome) => ({
-    text: outcome.detail || "Skipped — opened more than 14 days ago",
+    text: asText(outcome.detail) || "Skipped — opened more than 14 days ago",
     tone: "muted",
   }),
   "empty-diff": () => ({
@@ -182,7 +195,9 @@ const OUTCOME_REASON: Record<
     tone: "warning",
   }),
   failed: (_entry, outcome) => ({
-    text: outcome.detail ? `Failed — ${outcome.detail}` : "Failed",
+    text: asText(outcome.detail)
+      ? `Failed — ${asText(outcome.detail)}`
+      : "Failed",
     tone: "destructive",
   }),
   "timed-out": () => ({
@@ -234,6 +249,35 @@ function actionLabel(action: ActionId | null): string {
   // A row can record a decision that belongs to no single action (a marker, a
   // whole-event skip), and the stored id may be one this build doesn't know.
   return (action && ACTION_LABELS[action]) || "Automations";
+}
+
+/**
+ * Row glyph. Target kind decides first: a pause marker is stored with the
+ * user-initiated trigger, and a Play glyph would claim a run that never was.
+ * The trigger lookup is OWN-property only — a hand-edited `"__proto__"` would
+ * otherwise resolve up the prototype chain to a truthy non-component that `??`
+ * can't catch and JSX throws on. (`action` and `targetKind` are
+ * membership-validated at the store's guard, so their Record lookups stay plain.)
+ */
+function glyphFor(entry: AutomationHistoryEntry): typeof LightningIcon {
+  if (entry.targetKind === "none") return LightningIcon;
+  if (!Object.hasOwn(TRIGGER_GLYPH, entry.trigger)) return LightningIcon;
+  return TRIGGER_GLYPH[entry.trigger] ?? LightningIcon;
+}
+
+/**
+ * One outcome's reason line. Own-property only, for the same reason
+ * {@link glyphFor} is: a hand-edited code resolves up the prototype chain
+ * otherwise — `"__proto__"` to a non-function the optional call throws on,
+ * `"toString"` to a real function that returns a string and renders as blanks.
+ */
+function reasonFor(
+  entry: AutomationHistoryEntry,
+  outcome: Outcome,
+  live: boolean,
+): ReasonLine {
+  if (!Object.hasOwn(OUTCOME_REASON, outcome.code)) return UNKNOWN_REASON;
+  return OUTCOME_REASON[outcome.code]?.(entry, outcome, live) ?? UNKNOWN_REASON;
 }
 
 /** Marker rows carry no target, so their title comes from what was recorded. */
@@ -379,6 +423,8 @@ function AutomationHistoryBody({
   onClose: () => void;
 }) {
   const aiEnabled = useAiEnabled();
+  const queryClient = useQueryClient();
+  const reviewTasks = useReviewTasks();
   const openPr = useUiStore((s) => s.openPr);
   const openSettings = useUiStore((s) => s.openSettings);
   const automations = useAutomations();
@@ -414,6 +460,58 @@ function AutomationHistoryBody({
   const newest = rows[0];
   const newestStamp = newest && stampMs(newest.ts) !== null ? newest.ts : null;
 
+  // Live automation runs in this instance — same discriminator as reviews.ts'
+  // imperative `hasLiveAutomationRun` (phase + the automation-only `rerun`); a
+  // shared reactive hook is a homed backlog follow-up. Filtered BEFORE the
+  // signature so the query key churns only on runs that could match.
+  const liveTasks = reviewTasks.filter(
+    (t) =>
+      (t.phase === "running" || t.phase === "queued") && t.rerun !== undefined,
+  );
+  const liveSignature = liveTasks
+    .map(
+      (t) => `${t.target.repoPath}#${t.target.kind}#${t.target.ref}#${t.mode}`,
+    )
+    .join("|");
+  // Matched by worktree-stable IDENTITY, never raw path: linked worktrees of one
+  // repo share this history, so a run started in a worktree is live for the main
+  // checkout's dialog too. A query because identities resolve over IPC and render
+  // can't await one per task; the signature in the key is what keeps it reactive,
+  // so a run starting or settling re-resolves the set.
+  const liveKeys = useQuery({
+    queryKey: [
+      "automation-live-targets",
+      repoPath,
+      identity ?? repoPath,
+      liveSignature,
+    ],
+    queryFn: async () => {
+      // Both sides go through the same memoized resolver, so the comparison can
+      // never straddle a raw path and an identity.
+      const mine = await repoIdentity(repoPath);
+      const resolved = await Promise.all(
+        liveTasks.map(async (t) => ({
+          key: `${t.target.kind}#${t.target.ref}#${t.mode}`,
+          identity: await repoIdentity(t.target.repoPath),
+        })),
+      );
+      return resolved.filter((r) => r.identity === mine).map((r) => r.key);
+    },
+    enabled: open,
+  }).data;
+  // Set built here, not returned from the query: structural sharing only
+  // recurses plain objects and arrays.
+  const liveTargets = new Set(liveKeys ?? []);
+  // Per OUTCOME, not per row: the outcome's action IS the run's mode, so an
+  // interrupted row can't light up because a NEW run for the same pull request
+  // is live. A null action (records are untrusted) matches nothing. Accepted
+  // residual: the live task carries no headSha, so two same-mode runs on one PR
+  // stay indistinguishable — head-granular matching needs the spine to register
+  // the head, and that follow-up is backlog-homed.
+  const isLive = (entry: AutomationHistoryEntry, action: ActionId | null) =>
+    action !== null &&
+    liveTargets.has(`${entry.targetKind}#${asText(entry.ref)}#${action}`);
+
   const onListKeyDown = listKeyboardNav({
     items: rows,
     activeIndex: focusedId ? rows.findIndex((r) => r.id === focusedId) : -1,
@@ -423,13 +521,33 @@ function AutomationHistoryBody({
 
   const openTarget = (entry: AutomationHistoryEntry) => {
     onClose();
+    const kind = entry.targetKind === "remote" ? "remote" : "local";
+    // Land under the lens the record was written for. Every automation path is
+    // origin-pinned, so a remote row always names an origin pull request, and a
+    // fork sitting on the upstream lens would otherwise open upstream's
+    // same-numbered one. Session-only (`persist: false`): a click is navigation,
+    // not a choice of lens. REMOTE only — a local PR is lens-independent, so
+    // applying one there would be a side effect its navigation never implied.
+    // No selection clears: the same call selects this PR.
+    const applyLens =
+      kind === "remote"
+        ? () =>
+            applyRepoLens(queryClient, repoPath, "origin", {
+              clearSelections: false,
+              persist: false,
+            })
+        : undefined;
     openPr({
-      kind: entry.targetKind === "remote" ? "remote" : "local",
+      kind,
       repoPath,
       repoName: repoPath.split(/[/\\]/).pop() ?? repoPath,
       ref: asText(entry.ref),
       section: null,
       reviewId: null,
+      // Run inside openPr's view-transition callback, so the lens and the
+      // selection reach the same commit; applied here it would land a render
+      // early and fetch the new lens against the OLD number.
+      beforeSelect: applyLens,
     });
   };
 
@@ -483,6 +601,7 @@ function AutomationHistoryBody({
         <HistoryList
           rows={rows}
           anyEnabled={anyEnabled}
+          isLive={isLive}
           onListKeyDown={onListKeyDown}
           onOpenTarget={openTarget}
           onSetUp={() => {
@@ -498,12 +617,16 @@ function AutomationHistoryBody({
 function HistoryList({
   rows,
   anyEnabled,
+  isLive,
   onListKeyDown,
   onOpenTarget,
   onSetUp,
 }: {
   rows: AutomationHistoryEntry[];
   anyEnabled: boolean;
+  /** Whether THIS instance holds a running/queued automation run for the row's
+   *  target in that outcome's mode. */
+  isLive: (entry: AutomationHistoryEntry, action: ActionId | null) => boolean;
   onListKeyDown: (e: KeyboardEvent) => void;
   onOpenTarget: (entry: AutomationHistoryEntry) => void;
   onSetUp: () => void;
@@ -547,7 +670,12 @@ function HistoryList({
       onKeyDown={onListKeyDown}
     >
       {rows.map((entry) => (
-        <HistoryRow key={entry.id} entry={entry} onOpenTarget={onOpenTarget} />
+        <HistoryRow
+          key={entry.id}
+          entry={entry}
+          isLive={isLive}
+          onOpenTarget={onOpenTarget}
+        />
       ))}
     </div>
   );
@@ -558,18 +686,15 @@ const ROW_CLASS =
 
 function HistoryRow({
   entry,
+  isLive,
   onOpenTarget,
 }: {
   entry: AutomationHistoryEntry;
+  isLive: (entry: AutomationHistoryEntry, action: ActionId | null) => boolean;
   onOpenTarget: (entry: AutomationHistoryEntry) => void;
 }) {
   const outcomes = Array.isArray(entry.outcomes) ? entry.outcomes : [];
-  // Target kind first, then trigger: a pause marker is stored with the
-  // user-initiated trigger, and a Play glyph would claim a run that never was.
-  const Glyph =
-    entry.targetKind === "none"
-      ? LightningIcon
-      : (TRIGGER_GLYPH[entry.trigger] ?? LightningIcon);
+  const Glyph = glyphFor(entry);
   const title =
     TITLE_FOR[entry.targetKind]?.(entry, outcomes) ?? markerTitle(outcomes);
   const count = asCount(entry.count);
@@ -596,8 +721,11 @@ function HistoryRow({
           {title}
         </span>
         {outcomes.map((outcome, i) => {
-          const reason =
-            OUTCOME_REASON[outcome.code]?.(entry, outcome) ?? UNKNOWN_REASON;
+          const reason = reasonFor(
+            entry,
+            outcome,
+            isLive(entry, outcome.action),
+          );
           return (
             <span
               // Index key: one entry's outcomes are a fixed list that never reorders.

--- a/src/features/automations/AutomationHistoryDialog.tsx
+++ b/src/features/automations/AutomationHistoryDialog.tsx
@@ -1,0 +1,651 @@
+import {
+  ArrowCounterClockwiseIcon,
+  ArrowsClockwiseIcon,
+  GitCommitIcon,
+  GitPullRequestIcon,
+  InfoIcon,
+  LightningIcon,
+  MagnifyingGlassIcon,
+  PlayIcon,
+  WarningIcon,
+} from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { create } from "zustand";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
+import { RelativeTime } from "@/components/relative-time";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  type AutomationHistoryEntry,
+  type AutomationOutcomeCode,
+  type AutomationTrigger,
+  automationHistoryKey,
+  listAutomationHistory,
+  recordAutomationPauseMarker,
+  SESSION_START_MS,
+  STEADY_OUTCOME_CODES,
+} from "@/lib/automations/history";
+import { useAutomations } from "@/lib/automations/queries";
+import {
+  ACTION_LABELS,
+  type ActionId,
+  effectiveActions,
+  LIFECYCLE_LABELS,
+  type LifecycleEvent,
+  repoEntry,
+} from "@/lib/automations/types";
+import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
+import { useRepoIdentity } from "@/lib/git/queries";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
+import { useUiStore } from "@/lib/stores/ui";
+import { COLD_START_AUTOMATIONS_OFF } from "@/lib/test-mode";
+import { validEpochMs } from "@/lib/time";
+import { useRetained } from "@/lib/use-retained";
+import { cn } from "@/lib/utils";
+
+interface AutomationHistoryDialogState {
+  /** Repo path whose history is open, or null when closed. */
+  openFor: string | null;
+  open: (repoPath: string) => void;
+  close: () => void;
+}
+
+/** Open-state for the one mounted {@link AutomationHistoryDialogHost} (the
+ *  AutomationResultDialog precedent), so any surface — the repo menu, the
+ *  activity dock's footer — opens it without threading props or a second mount. */
+export const useAutomationHistoryDialog =
+  create<AutomationHistoryDialogState>()((set) => ({
+    openFor: null,
+    open: (repoPath) => set({ openFor: repoPath }),
+    close: () => set({ openFor: null }),
+  }));
+
+type TargetKind = AutomationHistoryEntry["targetKind"];
+type Outcome = AutomationHistoryEntry["outcomes"][number];
+type Tone = "success" | "destructive" | "warning" | "info" | "muted";
+
+/** Tone → semantic token. Always applied to the WORDS of a reason line, never to
+ *  the row's glyph, so no state is carried by color alone (WCAG AA). */
+const TONE_CLASS: Record<Tone, string> = {
+  success: "text-success",
+  destructive: "text-destructive",
+  warning: "text-warning",
+  info: "text-info",
+  muted: "text-muted-foreground",
+};
+
+/** Glyph per trigger — the shape says what fired. Read with a plain string from
+ *  the log, so an entry written by a newer build must miss into the fallback
+ *  rather than fail. */
+const TRIGGER_GLYPH: Partial<Record<AutomationTrigger, typeof LightningIcon>> =
+  {
+    commit: GitCommitIcon,
+    "pr-open": GitPullRequestIcon,
+    "pr-sync": ArrowsClockwiseIcon,
+    "catch-up": MagnifyingGlassIcon,
+    "run-now": PlayIcon,
+    "re-run": ArrowCounterClockwiseIcon,
+  };
+
+/** Where a delivered result landed, which is a property of the target, not of
+ *  the outcome code. */
+const DELIVERED_TEXT: Record<TargetKind, string> = {
+  remote: "Posted as a comment",
+  local: "Posted as a comment",
+  commit: "Review saved",
+  none: "Delivered",
+};
+
+interface ReasonLine {
+  text: string;
+  tone: Tone;
+}
+
+const UNKNOWN_REASON: ReasonLine = { text: "Unknown", tone: "muted" };
+
+/**
+ * Reason copy + tone per outcome code, total over the union so a code added
+ * later can't render as silence. `delivered` and `started` read the entry — one
+ * varies with where the output went, the other with whether the run belongs to
+ * this session or to one the app closed on.
+ */
+const OUTCOME_REASON: Record<
+  AutomationOutcomeCode,
+  (entry: AutomationHistoryEntry, outcome: Outcome) => ReasonLine
+> = {
+  delivered: (entry) => ({
+    text: DELIVERED_TEXT[entry.targetKind] ?? "Delivered",
+    tone: "success",
+  }),
+  started: (entry) =>
+    (stampMs(entry.ts) ?? 0) >= SESSION_START_MS
+      ? { text: "Running — watch it in Activity", tone: "info" }
+      : {
+          text: "Interrupted — the app closed while this was running",
+          tone: "warning",
+        },
+  "branch-skip": () => ({
+    text: "Skipped — branch conditions didn't match",
+    tone: "muted",
+  }),
+  "needs-first-review": () => ({
+    text: "Skipped — waiting for a first review in this mode",
+    tone: "muted",
+  }),
+  "head-covered": () => ({
+    text: "Skipped — this head was already reviewed",
+    tone: "muted",
+  }),
+  "head-dismissed": () => ({
+    text: "Skipped — this head was dismissed",
+    tone: "muted",
+  }),
+  "already-reviewed": () => ({
+    text: "Skipped — already reviewed",
+    tone: "muted",
+  }),
+  "draft-skipped": () => ({
+    text: "Skipped — draft (draft reviews are off)",
+    tone: "muted",
+  }),
+  // The recorder attaches a detail when it could NOT measure the PR's age, so
+  // the 14-day claim is only made where an age was actually read.
+  "too-old": (_entry, outcome) => ({
+    text: outcome.detail || "Skipped — opened more than 14 days ago",
+    tone: "muted",
+  }),
+  "empty-diff": () => ({
+    text: "Skipped — no changes to review",
+    tone: "muted",
+  }),
+  cancelled: () => ({ text: "Cancelled", tone: "muted" }),
+  "claim-held": () => ({
+    text: "Skipped — this head is already claimed by a review run",
+    tone: "warning",
+  }),
+  "eligibility-error": () => ({
+    text: "Couldn't read review history — treated as already reviewed",
+    tone: "warning",
+  }),
+  failed: (_entry, outcome) => ({
+    text: outcome.detail ? `Failed — ${outcome.detail}` : "Failed",
+    tone: "destructive",
+  }),
+  "timed-out": () => ({
+    text: "Timed out — partial output kept",
+    tone: "destructive",
+  }),
+  paused: () => ({
+    text: "AI features hidden — automations paused",
+    tone: "muted",
+  }),
+  resumed: () => ({
+    text: "AI features shown — automations resumed",
+    tone: "muted",
+  }),
+};
+
+/** Codes whose catch-up run latched the (PR, head) pair for the session, so the
+ *  poller won't come back to it on its own. */
+const LATCHING_CODES = new Set<string>([
+  "eligibility-error",
+  "failed",
+  "claim-held",
+]);
+
+const LIFECYCLES: LifecycleEvent[] = ["commit", "pr-open", "pr-sync"];
+
+/** Every field below is read back from a JSON file a user can hand-edit, so a
+ *  non-string reaches JSX as an object React refuses to render. */
+function asText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** A stamp's epoch-ms, or null when it isn't a date `RelativeTime` can render —
+ *  a hand-edited value must drop its cell, not take down the dialog. */
+function stampMs(ts: string): number | null {
+  const ms = new Date(asText(ts)).getTime();
+  return validEpochMs(ms) ? ms : null;
+}
+
+/** Coalesced-entry count, floored at 1 — a hand-edited or absent value must read
+ *  as a single event, never as a negative or fractional one. */
+function asCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 1
+    ? Math.floor(value)
+    : 1;
+}
+
+function actionLabel(action: ActionId | null): string {
+  // A row can record a decision that belongs to no single action (a marker, a
+  // whole-event skip), and the stored id may be one this build doesn't know.
+  return (action && ACTION_LABELS[action]) || "Automations";
+}
+
+/** Marker rows carry no target, so their title comes from what was recorded. */
+function markerTitle(outcomes: Outcome[]): string {
+  if (outcomes.some((o) => o.code === "resumed")) return "Automations resumed";
+  if (outcomes.some((o) => o.code === "paused")) return "Automations paused";
+  return "Automations";
+}
+
+const TITLE_FOR: Record<
+  TargetKind,
+  (entry: AutomationHistoryEntry, outcomes: Outcome[]) => string
+> = {
+  remote: (entry) => {
+    const title = asText(entry.title);
+    const ref = asText(entry.ref);
+    return title ? `#${ref} · ${title}` : `#${ref}`;
+  },
+  local: (entry) => asText(entry.title),
+  commit: (entry) => {
+    const title = asText(entry.title);
+    const ref = asText(entry.ref);
+    return title ? `${ref} · ${title}` : ref;
+  },
+  none: (_entry, outcomes) => markerTitle(outcomes),
+};
+
+/** A coalesced row must read as a summary, not as one event: commit rows count
+ *  the commits inside the skip, PR rows count the times the same decision
+ *  recurred for one pull request. Only steady outcomes coalesce, so only they
+ *  carry the count into their words. */
+function joinCount(
+  text: string,
+  count: number,
+  kind: TargetKind,
+  code: AutomationOutcomeCode,
+): string {
+  if (count <= 1 || !STEADY_OUTCOME_CODES.includes(code)) return text;
+  if (kind !== "commit") return `${text} (seen ${count}×)`;
+  const skip = "Skipped — ";
+  return text.startsWith(skip)
+    ? `Skipped ${count} commits — ${text.slice(skip.length)}`
+    : `${text} (${count} commits)`;
+}
+
+type BannerTone = "info" | "warning";
+
+const BANNER_CLASS: Record<BannerTone, string> = {
+  info: "bg-info/10 text-info",
+  warning: "bg-warning/10 text-warning",
+};
+
+const BANNER_GLYPH: Record<BannerTone, typeof InfoIcon> = {
+  info: InfoIcon,
+  warning: WarningIcon,
+};
+
+/** A present-tense state, in the layout flow above the records — it pushes the
+ *  list down rather than covering any of it. */
+function Banner({ tone, children }: { tone: BannerTone; children: ReactNode }) {
+  const Glyph = BANNER_GLYPH[tone];
+  return (
+    <p
+      className={cn(
+        "flex items-start gap-1.5 border-b px-3 py-1.5 text-[11px]",
+        BANNER_CLASS[tone],
+      )}
+    >
+      <Glyph className="mt-px size-3.5 shrink-0" weight="fill" />
+      <span className="min-w-0">{children}</span>
+    </p>
+  );
+}
+
+/**
+ * What this repository's automations ran, skipped, and why — the durable
+ * decision log, read-only. Mounted once at the app root and opened by store
+ * flag, so the repo menu and the activity dock share one instance.
+ *
+ * Historical rows carry no actions: a record is evidence, and re-running from
+ * one would spend money and post publicly from a surface that reads as a log.
+ */
+export function AutomationHistoryDialogHost() {
+  const openFor = useAutomationHistoryDialog((s) => s.openFor);
+  const close = useAutomationHistoryDialog((s) => s.close);
+  // Retained so the body keeps its repo through the close fade instead of
+  // blanking the dialog as it animates out.
+  const shownRepo = useRetained(openFor);
+
+  // Mark the pause and the resume in the log itself, so a repository whose
+  // automations went quiet says why in line. It watches the SAVED setting, not
+  // a Settings draft, and lives on this always-mounted host rather than in the
+  // General panel — that panel only renders while it is the active one, so a
+  // flip saved from another panel would record nothing. The first observation
+  // seeds the ref: a mount is not a flip.
+  const savedHideAi = useSettings().data?.hideAi;
+  const recordedHideAi = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (savedHideAi === undefined) return;
+    const previous = recordedHideAi.current;
+    recordedHideAi.current = savedHideAi;
+    if (previous === undefined || previous === savedHideAi) return;
+    // Fire-and-forget: a marker that can't be written must never surface as a
+    // failure of the settings save that triggered it.
+    void recordAutomationPauseMarker(savedHideAi).catch(() => undefined);
+  }, [savedHideAi]);
+
+  return (
+    <Dialog
+      open={openFor !== null}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      {/* Capped flex column: the header stays pinned while the banners, the
+          config summary, and the records scroll as one body. */}
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Automation history</DialogTitle>
+          <DialogDescription>
+            What this repository's automations ran, what they skipped, and why.
+          </DialogDescription>
+        </DialogHeader>
+        {shownRepo !== null && (
+          <AutomationHistoryBody
+            repoPath={shownRepo}
+            open={openFor !== null}
+            onClose={close}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AutomationHistoryBody({
+  repoPath,
+  open,
+  onClose,
+}: {
+  repoPath: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const aiEnabled = useAiEnabled();
+  const openPr = useUiStore((s) => s.openPr);
+  const openSettings = useUiStore((s) => s.openSettings);
+  const automations = useAutomations();
+  // Worktree-stable identity, so a worktree checkout reads the same overrides as
+  // its main checkout; the raw path stands in while it resolves.
+  const identity = useRepoIdentity(repoPath).data;
+  const history = useQuery({
+    queryKey: automationHistoryKey(repoPath),
+    queryFn: () => listAutomationHistory(repoPath),
+    enabled: open,
+  });
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  // An entry with no id can't be keyed, focused, or arrow-navigated, so it is
+  // dropped rather than rendered into a list the keyboard can't address.
+  const rows = (history.data ?? []).filter(
+    (entry) => typeof entry?.id === "string" && entry.id !== "",
+  );
+
+  const config = automations.data;
+  const lifecycleRows = LIFECYCLES.map((lifecycle) => ({
+    lifecycle,
+    actions: config
+      ? effectiveActions(
+          config,
+          repoEntry(config, identity ?? repoPath, repoPath),
+          lifecycle,
+        )
+      : [],
+  }));
+  const anyEnabled = lifecycleRows.some((l) => l.actions.length > 0);
+
+  const newest = rows[0];
+  const newestStamp = newest && stampMs(newest.ts) !== null ? newest.ts : null;
+
+  const onListKeyDown = listKeyboardNav({
+    items: rows,
+    activeIndex: focusedId ? rows.findIndex((r) => r.id === focusedId) : -1,
+    onActivate: (entry) => setFocusedId(entry.id),
+    rowKey: (entry) => entry.id,
+  });
+
+  const openTarget = (entry: AutomationHistoryEntry) => {
+    onClose();
+    openPr({
+      kind: entry.targetKind === "remote" ? "remote" : "local",
+      repoPath,
+      repoName: repoPath.split(/[/\\]/).pop() ?? repoPath,
+      ref: asText(entry.ref),
+      section: null,
+      reviewId: null,
+    });
+  };
+
+  return (
+    // Full-bleed to the dialog's edges so the banners read as strips and the
+    // rows as a list, not as inset cards.
+    <div className="-mx-4 -mb-4 min-h-0 flex-1 overflow-x-hidden overflow-y-auto border-t">
+      {COLD_START_AUTOMATIONS_OFF && (
+        <Banner tone="info">
+          Automations are off in cold-start test mode.
+        </Banner>
+      )}
+      {!aiEnabled && (
+        <Banner tone="info">
+          Automations are paused while AI features are hidden.
+        </Banner>
+      )}
+      {/* The effective config IS the answer to "why did nothing run for that
+          event" — stated once here rather than repeated on every absent row. */}
+      <div className="border-b px-3 py-2">
+        {lifecycleRows.map(({ lifecycle, actions }) => (
+          <p
+            key={lifecycle}
+            className="truncate text-[11px] text-muted-foreground"
+            onMouseEnter={clipTitleFromText}
+          >
+            <span className="font-medium">{LIFECYCLE_LABELS[lifecycle]}:</span>{" "}
+            {actions.length === 0
+              ? "off"
+              : actions.map((a) => ACTION_LABELS[a.action]).join(" + ")}
+          </p>
+        ))}
+      </div>
+      {rows.length > 0 && !anyEnabled && (
+        <Banner tone="warning">
+          No automation is enabled for this repository
+          {newestStamp ? (
+            <>
+              {" — the most recent decision here was recorded "}
+              <RelativeTime date={newestStamp} />
+              {"."}
+            </>
+          ) : (
+            "."
+          )}
+        </Banner>
+      )}
+      {history.isPending ? (
+        <ListRowSkeletons rows={4} lines={2} name="automation history" />
+      ) : (
+        <HistoryList
+          rows={rows}
+          anyEnabled={anyEnabled}
+          onListKeyDown={onListKeyDown}
+          onOpenTarget={openTarget}
+          onSetUp={() => {
+            onClose();
+            openSettings("automations");
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function HistoryList({
+  rows,
+  anyEnabled,
+  onListKeyDown,
+  onOpenTarget,
+  onSetUp,
+}: {
+  rows: AutomationHistoryEntry[];
+  anyEnabled: boolean;
+  onListKeyDown: (e: KeyboardEvent) => void;
+  onOpenTarget: (entry: AutomationHistoryEntry) => void;
+  onSetUp: () => void;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="px-3 pt-4 pb-6 text-center">
+        <p className="text-xs font-medium">
+          {anyEnabled
+            ? "No decisions recorded yet."
+            : "No automations are set up for this repository."}
+        </p>
+        {anyEnabled ? (
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Decisions appear here as commits land and pull requests are checked.
+          </p>
+        ) : (
+          <Button
+            variant="outline"
+            size="xs"
+            className="mt-2"
+            onClick={onSetUp}
+          >
+            Set up automations
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    // Roving tabindex: the list takes one tab stop and the arrows walk the rows,
+    // so Tab never has to step through fifty records to leave the dialog.
+    <div
+      // The container is the tab stop, so it carries the name a reader hears on
+      // arrival; `group` is the generic role that can hold one.
+      role="group"
+      tabIndex={0}
+      aria-label="Recorded automation decisions"
+      className="outline-none"
+      onKeyDown={onListKeyDown}
+    >
+      {rows.map((entry) => (
+        <HistoryRow key={entry.id} entry={entry} onOpenTarget={onOpenTarget} />
+      ))}
+    </div>
+  );
+}
+
+const ROW_CLASS =
+  "flex w-full items-start gap-2 border-b px-3 py-2 text-left outline-none focus-visible:bg-muted";
+
+function HistoryRow({
+  entry,
+  onOpenTarget,
+}: {
+  entry: AutomationHistoryEntry;
+  onOpenTarget: (entry: AutomationHistoryEntry) => void;
+}) {
+  const outcomes = Array.isArray(entry.outcomes) ? entry.outcomes : [];
+  // Target kind first, then trigger: a pause marker is stored with the
+  // user-initiated trigger, and a Play glyph would claim a run that never was.
+  const Glyph =
+    entry.targetKind === "none"
+      ? LightningIcon
+      : (TRIGGER_GLYPH[entry.trigger] ?? LightningIcon);
+  const title =
+    TITLE_FOR[entry.targetKind]?.(entry, outcomes) ?? markerTitle(outcomes);
+  const count = asCount(entry.count);
+  const stamp = stampMs(entry.ts) !== null ? entry.ts : null;
+  // Only a pull request has somewhere to go; a commit or marker row would give
+  // Enter nothing to do, and a button that no-ops is worse than plain text.
+  const navigable =
+    (entry.targetKind === "remote" || entry.targetKind === "local") &&
+    asText(entry.ref) !== "";
+  // The catch-up poller latches per (PR, head), so an anomalous outcome there
+  // is the end of the line until a push or a relaunch.
+  const latched =
+    entry.trigger === "catch-up" &&
+    outcomes.some((o) => LATCHING_CODES.has(o.code));
+
+  const body = (
+    <>
+      <Glyph className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span
+          className="block truncate text-xs font-medium"
+          onMouseEnter={clipTitle(title)}
+        >
+          {title}
+        </span>
+        {outcomes.map((outcome, i) => {
+          const reason =
+            OUTCOME_REASON[outcome.code]?.(entry, outcome) ?? UNKNOWN_REASON;
+          return (
+            <span
+              // Index key: one entry's outcomes are a fixed list that never reorders.
+              key={i}
+              className="mt-0.5 block truncate text-[11px]"
+              onMouseEnter={clipTitleFromText}
+            >
+              <span className="text-muted-foreground">
+                {actionLabel(outcome.action)} ·{" "}
+              </span>
+              <span className={TONE_CLASS[reason.tone]}>
+                {joinCount(reason.text, count, entry.targetKind, outcome.code)}
+              </span>
+            </span>
+          );
+        })}
+        {latched && (
+          <span className="mt-0.5 block text-[11px] text-muted-foreground">
+            Won't retry for this head until you push or relaunch.
+          </span>
+        )}
+      </span>
+      {/* A stamp only had to be a `string` to survive JSON, so an unparseable
+          one drops its cell rather than rendering "in NaN years". */}
+      {stamp && (
+        <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+          <RelativeTime date={stamp} />
+        </span>
+      )}
+    </>
+  );
+
+  if (navigable) {
+    return (
+      <button
+        type="button"
+        data-row={entry.id}
+        tabIndex={-1}
+        onClick={() => onOpenTarget(entry)}
+        className={cn(ROW_CLASS, "hover:bg-muted/60")}
+      >
+        {body}
+      </button>
+    );
+  }
+  return (
+    <div data-row={entry.id} tabIndex={-1} className={ROW_CLASS}>
+      {body}
+    </div>
+  );
+}

--- a/src/features/automations/AutomationHistoryDialog.tsx
+++ b/src/features/automations/AutomationHistoryDialog.tsx
@@ -705,10 +705,13 @@ function HistoryRow({
   const count = asCount(entry.count);
   const stamp = stampMs(entry.ts) !== null ? entry.ts : null;
   // Only a pull request has somewhere to go; a commit or marker row would give
-  // Enter nothing to do, and a button that no-ops is worse than plain text.
+  // Enter nothing to do, and a button that no-ops is worse than plain text. A
+  // REMOTE ref must be numeric to be addressable — a hand-edited junk ref would
+  // navigate to a NaN PR number — while local ids are opaque strings.
   const navigable =
-    (entry.targetKind === "remote" || entry.targetKind === "local") &&
-    asText(entry.ref) !== "";
+    entry.targetKind === "local"
+      ? asText(entry.ref) !== ""
+      : entry.targetKind === "remote" && /^\d+$/.test(asText(entry.ref));
   // The catch-up poller latches per (PR, head), so an anomalous outcome there
   // is the end of the line until a push or a relaunch.
   const latched =

--- a/src/features/automations/AutomationHistoryDialog.tsx
+++ b/src/features/automations/AutomationHistoryDialog.tsx
@@ -42,8 +42,8 @@ import {
   ACTION_LABELS,
   type ActionId,
   effectiveActions,
+  LIFECYCLE_EVENTS,
   LIFECYCLE_LABELS,
-  type LifecycleEvent,
   repoEntry,
 } from "@/lib/automations/types";
 import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
@@ -190,8 +190,12 @@ const OUTCOME_REASON: Record<
     text: "Skipped — this head is already claimed by a review run",
     tone: "warning",
   }),
-  "eligibility-error": () => ({
-    text: "Couldn't read review history — treated as already reviewed",
+  // The Run-now toast sends users HERE for the error, so the recorded detail
+  // must render (the row truncates with a full-text hover tooltip).
+  "eligibility-error": (_entry, outcome) => ({
+    text: asText(outcome.detail)
+      ? `Couldn't read review history — ${asText(outcome.detail)}`
+      : "Couldn't read review history — treated as already reviewed",
     tone: "warning",
   }),
   failed: (_entry, outcome) => ({
@@ -222,7 +226,7 @@ const LATCHING_CODES = new Set<string>([
   "claim-held",
 ]);
 
-const LIFECYCLES: LifecycleEvent[] = ["commit", "pr-open", "pr-sync"];
+const LIFECYCLES = LIFECYCLE_EVENTS;
 
 /** Every field below is read back from a JSON file a user can hand-edit, so a
  *  non-string reaches JSX as an object React refuses to render. */
@@ -299,8 +303,11 @@ const TITLE_FOR: Record<
   local: (entry) => asText(entry.title),
   commit: (entry) => {
     const title = asText(entry.title);
+    // ref is the BRANCH, which a commit made on a detached HEAD records as ""
+    // — the separator must not render against an empty side.
     const ref = asText(entry.ref);
-    return title ? `${ref} · ${title}` : ref;
+    if (!title) return ref;
+    return ref ? `${ref} · ${title}` : title;
   },
   none: (_entry, outcomes) => markerTitle(outcomes),
 };

--- a/src/features/automations/AutomationHistoryDialog.tsx
+++ b/src/features/automations/AutomationHistoryDialog.tsx
@@ -226,8 +226,6 @@ const LATCHING_CODES = new Set<string>([
   "claim-held",
 ]);
 
-const LIFECYCLES = LIFECYCLE_EVENTS;
-
 /** Every field below is read back from a JSON file a user can hand-edit, so a
  *  non-string reaches JSX as an object React refuses to render. */
 function asText(value: unknown): string {
@@ -452,7 +450,7 @@ function AutomationHistoryBody({
   );
 
   const config = automations.data;
-  const lifecycleRows = LIFECYCLES.map((lifecycle) => ({
+  const lifecycleRows = LIFECYCLE_EVENTS.map((lifecycle) => ({
     lifecycle,
     actions: config
       ? effectiveActions(

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2586,7 +2586,31 @@ cancelling an auto re-review dismisses that commit so it won't run again on rest
 new commit still triggers. On pull request opened also catches up your own PRs opened outside the
 app (via the CLI, the web, or a bot) that never got their initial review — a non-draft PR of yours
 opened in the last two weeks and not yet reviewed gets one automatically on the next poll. Existing rules from the older flat list are migrated automatically on
-first load; any duplicates are merged and disclosed once with a toast.`,
+first load; any duplicates are merged and disclosed once with a toast.
+
+## Automation history
+
+**Automation history…** (the repo ⋮ menu, or the *Automation history* row at the bottom of
+the activity bell) is this repository's decision log. It opens on the repository's effective
+configuration, one line per moment, then lists every recorded decision, newest first.
+
+- **Skips are recorded too.** Each line names the action it belongs to and how it ended:
+  posted as a comment, review saved, skipped because branch conditions didn't match, already
+  reviewed, a draft while draft reviews are off, claimed by another review run, failed (with
+  the error), timed out, or cancelled. When a moment is switched off entirely, nothing is
+  recorded for it, and the configuration lines at the top say so.
+- **Repeats read as summaries.** A decision that recurred coalesces into one row with its
+  count — "Skipped 23 commits — branch conditions didn't match" for a run of commits, or
+  "(seen 4×)" for a pull request checked again.
+- **Pull request rows open their pull request** on click or Enter; commit rows and markers
+  are text. The arrow keys walk the whole list.
+- **Pausing is logged.** Turning **Hide AI** on records *Automations paused*, and turning it
+  off records *Automations resumed*, so a quiet stretch in the log carries its own reason.
+
+The command palette can also run your enabled automations against the pull request you
+currently have open, without waiting for the next trigger. It needs a pull request in view
+to have a target, and it confirms before starting, since the result posts as a comment on
+that pull request.`,
   },
   {
     id: "hooks",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2608,10 +2608,10 @@ configuration, one line per moment, then lists every recorded decision, newest f
   records *Automations paused*, and turning it off records *Automations resumed*, so a
   quiet stretch in the log carries its own reason.
 
-The command palette can also run your enabled automations against the pull request you
-currently have open, without waiting for the next trigger. It needs a pull request in view
-to have a target, and it confirms before starting, since the result posts as a comment on
-that pull request.`,
+The command palette ({{kbd:command-palette}}) can also run your enabled automations
+against the pull request you currently have open, without waiting for the next trigger.
+It needs a pull request in view to have a target, and it confirms before starting, since
+the result posts as a comment on that pull request.`,
   },
   {
     id: "hooks",

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2604,8 +2604,9 @@ configuration, one line per moment, then lists every recorded decision, newest f
   "(seen 4×)" for a pull request checked again.
 - **Pull request rows open their pull request** on click or Enter; commit rows and markers
   are text. The arrow keys walk the whole list.
-- **Pausing is logged.** Turning **Hide AI** on records *Automations paused*, and turning it
-  off records *Automations resumed*, so a quiet stretch in the log carries its own reason.
+- **Pausing is logged.** Once you have an automation enabled, turning **Hide AI** on
+  records *Automations paused*, and turning it off records *Automations resumed*, so a
+  quiet stretch in the log carries its own reason.
 
 The command palette can also run your enabled automations against the pull request you
 currently have open, without waiting for the next trigger. It needs a pull request in view

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowSquareOutIcon,
   ChartBarIcon,
+  ClockCounterClockwiseIcon,
   CodeIcon,
   CopyIcon,
   CubeIcon,
@@ -42,6 +43,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Radio, RadioGroup } from "@/components/ui/radio-group";
 import { Spinner } from "@/components/ui/spinner";
+import { useAutomationHistoryDialog } from "@/features/automations/AutomationHistoryDialog";
 import { RepoAutomationsDialog } from "@/features/automations/RepoAutomationsDialog";
 import { BranchRulesDialog } from "@/features/branch-rules/BranchRulesDialog";
 import { HooksDialog } from "@/features/hooks/HooksDialog";
@@ -52,6 +54,12 @@ import type {
   RepoSettingsDialog as RepoSettingsDialogComponent,
   SectionId,
 } from "@/features/repo-settings/RepoSettingsDialog";
+import { useAutomations } from "@/lib/automations/queries";
+import { runAutomationNow } from "@/lib/automations/runner";
+import {
+  repoEntry as automationRepoEntry,
+  effectiveActions,
+} from "@/lib/automations/types";
 import { copyText } from "@/lib/clipboard";
 import {
   forgeRepoUrl,
@@ -68,6 +76,7 @@ import {
   useForgeStatus,
   useForkRepo,
   useRepoAdmin,
+  useRepoIdentity,
   useRepoStarStatus,
   useRepoStatus,
   useSetRepoStar,
@@ -126,10 +135,34 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const aiEnabled = useAiEnabled();
   const repoName = useUiStore((s) => s.repoName);
   const setRepoTab = useUiStore((s) => s.setRepoTab);
+  const repoTab = useUiStore((s) => s.repoTab);
+  const selectedPr = useUiStore((s) => s.selectedPr);
   const fork = useForkRepo(repoPath);
   // The Fork item's verdict, sampled when the dropdown opens (see `canForkHere`).
   const [forkWhileOpen, setForkWhileOpen] = useState(false);
   const [automationsOpen, setAutomationsOpen] = useState(false);
+  // The history dialog is mounted once at the app root and opened by store flag,
+  // so it survives this menu closing under it.
+  const openAutomationHistory = useAutomationHistoryDialog((s) => s.open);
+  const automationsConfig = useAutomations().data;
+  const repoIdentity = useRepoIdentity(repoPath).data;
+  // Whether this repo's EFFECTIVE config enables any PR-lifecycle action — the
+  // same union Run-now executes, so the palette entry exists exactly when the
+  // action could start something.
+  const prAutomationConfigured =
+    automationsConfig !== undefined &&
+    (["pr-open", "pr-sync"] as const).some(
+      (lifecycle) =>
+        effectiveActions(
+          automationsConfig,
+          automationRepoEntry(
+            automationsConfig,
+            repoIdentity ?? repoPath,
+            repoPath,
+          ),
+          lifecycle,
+        ).length > 0,
+    );
   const [jiraOpen, setJiraOpen] = useState(false);
   const [repoSettingsOpen, setRepoSettingsOpen] = useState(false);
   // React's `lazy` suspends on its first element render even when the shared
@@ -425,6 +458,33 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   useHotkeyAction("manage-files", () => openFiles("tracked"));
   useHotkeyAction("ai-excluded-files", () => openFiles("ai"), aiEnabled);
   useHotkeyAction("automations", () => setAutomationsOpen(true), aiEnabled);
+  useHotkeyAction(
+    "automation-history",
+    () => openAutomationHistory(repoPath),
+    aiEnabled,
+  );
+  // Run-now targets the PR open in the pulls tab, and only when this repo's
+  // effective config enables a PR-lifecycle action — a palette entry whose only
+  // possible outcome is a "nothing configured" toast would be worse than none.
+  useHotkeyAction(
+    "run-pr-automations",
+    () => {
+      // Fire-time re-read: the palette closes before dispatching, so the
+      // selection gating this render may have moved by the time this runs.
+      const pr = useUiStore.getState().selectedPr;
+      if (!pr) return;
+      runAutomationNow(
+        repoPath,
+        pr.kind === "remote"
+          ? { kind: "remote", number: Number(pr.id) }
+          : { kind: "local", id: pr.id },
+      );
+    },
+    aiEnabled &&
+      repoTab === "pulls" &&
+      selectedPr !== null &&
+      prAutomationConfigured,
+  );
   useHotkeyAction("link-jira-project", () => setJiraOpen(true));
   useHotkeyAction("repository-settings", openRepoSettings, canOpenRepoSettings);
   useHotkeyAction("branch-rules", () => setBranchRulesOpen(true));
@@ -562,6 +622,12 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
           <DropdownMenuItem onClick={() => setAutomationsOpen(true)}>
             <LightningIcon />
             Automations…
+          </DropdownMenuItem>
+        )}
+        {aiEnabled && (
+          <DropdownMenuItem onClick={() => openAutomationHistory(repoPath)}>
+            <ClockCounterClockwiseIcon />
+            Automation history…
           </DropdownMenuItem>
         )}
         <DropdownMenuItem onClick={() => setJiraOpen(true)}>

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -480,6 +480,13 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
       // selection gating this render may have moved by the time this runs.
       const pr = useUiStore.getState().selectedPr;
       if (!pr) return;
+      // A remote selection's id can arrive from untrusted stores (a history
+      // row's hand-editable ref) — refuse junk here rather than sending NaN
+      // over IPC and surfacing an opaque invoke error.
+      if (pr.kind === "remote" && !/^\d+$/.test(pr.id)) {
+        toast.error("This pull request has no usable number.");
+        return;
+      }
       runAutomationNow(
         repoPath,
         pr.kind === "remote"

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -84,6 +84,7 @@ import {
 import { providerLabel } from "@/lib/git/types";
 import { useHotkeyAction } from "@/lib/hotkeys/hotkeys";
 import { useJiraLink } from "@/lib/jira/queries";
+import { useRepoLens } from "@/lib/repo-lens/queries";
 import type { RecentRepo } from "@/lib/settings/api";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
@@ -146,6 +147,12 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
   const openAutomationHistory = useAutomationHistoryDialog((s) => s.open);
   const automationsConfig = useAutomations().data;
   const repoIdentity = useRepoIdentity(repoPath).data;
+  // Automations are origin-pinned end to end, so Run-now must not exist for a
+  // REMOTE selection under the upstream lens — a fork's two lenses share PR
+  // numbers, and an origin-resolved run against an upstream selection would
+  // review the wrong pull request. Local PRs never touch the forge, so they
+  // stay runnable under either lens.
+  const repoLens = useRepoLens(repoPath);
   // Whether this repo's EFFECTIVE config enables any PR-lifecycle action — the
   // same union Run-now executes, so the palette entry exists exactly when the
   // action could start something.
@@ -483,6 +490,7 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
     aiEnabled &&
       repoTab === "pulls" &&
       selectedPr !== null &&
+      (selectedPr.kind === "local" || repoLens === "origin") &&
       prAutomationConfigured,
   );
   useHotkeyAction("link-jira-project", () => setJiraOpen(true));

--- a/src/features/repository/RepositoryMenu.tsx
+++ b/src/features/repository/RepositoryMenu.tsx
@@ -480,13 +480,6 @@ export function RepositoryMenu({ repoPath }: { repoPath: string }) {
       // selection gating this render may have moved by the time this runs.
       const pr = useUiStore.getState().selectedPr;
       if (!pr) return;
-      // A remote selection's id can arrive from untrusted stores (a history
-      // row's hand-editable ref) — refuse junk here rather than sending NaN
-      // over IPC and surfacing an opaque invoke error.
-      if (pr.kind === "remote" && !/^\d+$/.test(pr.id)) {
-        toast.error("This pull request has no usable number.");
-        return;
-      }
       runAutomationNow(
         repoPath,
         pr.kind === "remote"

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -126,7 +126,8 @@ export interface BranchNamePromptInput {
   globalInstructions: string;
 }
 
-export type ReviewMode = "general" | "security";
+export const REVIEW_MODES = ["general", "security"] as const;
+export type ReviewMode = (typeof REVIEW_MODES)[number];
 
 /** How the "changes since last review" delta relates to the prior review.
  *  `head-unchanged` is JS-only (the Rust command never returns it); the Rust

--- a/src/lib/automations/history.ts
+++ b/src/lib/automations/history.ts
@@ -71,12 +71,6 @@ export interface AutomationOutcome {
   detail?: string;
 }
 
-/**
- * One recorded automation decision — the evidence a user whose review didn't fire
- * can read. `ref` is the PR number (as a string) or local PR id; for commit-target
- * rows it is the BRANCH name (the branch is the steady axis of a commit scoping
- * decision, and the specific commit rides `headSha`); "" for the global markers.
- */
 /** What a row describes. The value list and the type derive from one another, so the
  *  guard's membership check below can't drift from the union it validates. */
 export const AUTOMATION_TARGET_KINDS = [
@@ -88,6 +82,12 @@ export const AUTOMATION_TARGET_KINDS = [
 
 export type AutomationTargetKind = (typeof AUTOMATION_TARGET_KINDS)[number];
 
+/**
+ * One recorded automation decision — the evidence a user whose review didn't fire
+ * can read. `ref` is the PR number (as a string) or local PR id; for commit-target
+ * rows it is the BRANCH name (the branch is the steady axis of a commit scoping
+ * decision, and the specific commit rides `headSha`); "" for the global markers.
+ */
 export interface AutomationHistoryEntry {
   schemaVersion: 1;
   id: string;

--- a/src/lib/automations/history.ts
+++ b/src/lib/automations/history.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/git/repo-identity";
 import { queryClient } from "@/lib/query-client";
 import { storeName } from "@/lib/test-mode";
-import type { ActionId } from "./types";
+import { type ActionId, ALL_ACTION_IDS } from "./types";
 
 /**
  * Every decision the automation pipeline can record. Deliberately absent:
@@ -76,13 +76,24 @@ export interface AutomationOutcome {
  * rows it is the BRANCH name (the branch is the steady axis of a commit scoping
  * decision, and the specific commit rides `headSha`); "" for the global markers.
  */
+/** What a row describes. The value list and the type derive from one another, so the
+ *  guard's membership check below can't drift from the union it validates. */
+export const AUTOMATION_TARGET_KINDS = [
+  "remote",
+  "local",
+  "commit",
+  "none",
+] as const;
+
+export type AutomationTargetKind = (typeof AUTOMATION_TARGET_KINDS)[number];
+
 export interface AutomationHistoryEntry {
   schemaVersion: 1;
   id: string;
   /** ISO-8601. */
   ts: string;
   trigger: AutomationTrigger;
-  targetKind: "remote" | "local" | "commit" | "none";
+  targetKind: AutomationTargetKind;
   ref: string;
   title: string;
   headSha: string;
@@ -90,10 +101,6 @@ export interface AutomationHistoryEntry {
   count?: number;
   outcomes: AutomationOutcome[];
 }
-
-/** Module-load stamp: a "started" outcome older than this belongs to a process
- *  that is gone, so the UI renders it as interrupted rather than in flight. */
-export const SESSION_START_MS = Date.now();
 
 /** Query key for one repo's history list. */
 export function automationHistoryKey(repoPath: string) {
@@ -149,39 +156,82 @@ async function reloadRaw(): Promise<void> {
   }
 }
 
+// Sets, not object lookups: `Set.has("__proto__")` is false, where a plain-object
+// lookup would answer with `Object.prototype` for the same key.
 const KNOWN_CODES = new Set<string>(AUTOMATION_OUTCOME_CODES);
+const KNOWN_TARGET_KINDS = new Set<string>(AUTOMATION_TARGET_KINDS);
+const KNOWN_ACTIONS = new Set<string>(ALL_ACTION_IDS);
 
-/** Shape-guard one record out of untrusted store JSON: a hand-edited (or newer)
- *  `automation-history.json` reaches the dialog verbatim, so a malformed record is
- *  dropped rather than blanking the list or throwing mid-render. `code` is checked
- *  against the known set because the UI looks its label up in a Record — an
- *  unrecognized code would render as a blank row. `schemaVersion` is write-only;
- *  `count` and `detail` are typeof-guarded at their render sites. */
-function isStoredEntry(x: unknown): x is AutomationHistoryEntry {
-  if (typeof x !== "object" || x === null) return false;
+/**
+ * Normalize one record out of untrusted store JSON, or drop it — a hand-edited (or
+ * newer) `automation-history.json` reaches the dialog verbatim, and every consumer
+ * reads what this returns, so this is the one place the file's contents are made
+ * safe. Returns a REBUILT entry: a value that survives here can be rendered, and a
+ * later rewrite of the file persists the normalized form rather than the junk.
+ *
+ * Membership-validated here, because each one is used as a Record KEY at a render
+ * site and a prototype-shaped string would otherwise resolve to `Object.prototype`
+ * (a truthy non-function, which throws when rendered or called):
+ *   - `targetKind` — junk drops the ENTRY; there is no honest way to render a row
+ *     whose target is unreadable.
+ *   - each outcome's `code` — junk drops the ENTRY; the code IS the decision.
+ *   - each outcome's `action` — junk COERCES to null, which already means "decided
+ *     before any action was considered" and renders as the neutral label. Dropping
+ *     the row would discard a decision we can still report truthfully.
+ * Left to consumers: `trigger` (any string; the dialog falls back to a default
+ * glyph, so dropping the row would lose evidence over a cosmetic lookup) and the
+ * optional `count` / `detail`, which are carried only when they hold the right
+ * primitive. `schemaVersion` is write-only, so it is stamped rather than read.
+ */
+function sanitizeStoredEntry(x: unknown): AutomationHistoryEntry | null {
+  if (typeof x !== "object" || x === null) return null;
   const r = x as Record<string, unknown>;
-  return (
-    typeof r.id === "string" &&
-    typeof r.ts === "string" &&
-    typeof r.trigger === "string" &&
-    typeof r.targetKind === "string" &&
-    typeof r.ref === "string" &&
-    typeof r.title === "string" &&
-    typeof r.headSha === "string" &&
-    Array.isArray(r.outcomes) &&
-    r.outcomes.every(
-      (o) =>
-        typeof o === "object" &&
-        o !== null &&
-        KNOWN_CODES.has((o as { code?: unknown }).code as string),
-    )
-  );
+  if (
+    typeof r.id !== "string" ||
+    typeof r.ts !== "string" ||
+    typeof r.trigger !== "string" ||
+    typeof r.ref !== "string" ||
+    typeof r.title !== "string" ||
+    typeof r.headSha !== "string" ||
+    typeof r.targetKind !== "string" ||
+    !KNOWN_TARGET_KINDS.has(r.targetKind) ||
+    !Array.isArray(r.outcomes)
+  ) {
+    return null;
+  }
+  const outcomes: AutomationOutcome[] = [];
+  for (const o of r.outcomes) {
+    if (typeof o !== "object" || o === null) return null;
+    const raw = o as Record<string, unknown>;
+    if (typeof raw.code !== "string" || !KNOWN_CODES.has(raw.code)) return null;
+    outcomes.push({
+      action:
+        typeof raw.action === "string" && KNOWN_ACTIONS.has(raw.action)
+          ? (raw.action as ActionId)
+          : null,
+      code: raw.code as AutomationOutcomeCode,
+      ...(typeof raw.detail === "string" ? { detail: raw.detail } : {}),
+    });
+  }
+  return {
+    schemaVersion: 1,
+    id: r.id,
+    ts: r.ts,
+    trigger: r.trigger as AutomationTrigger,
+    targetKind: r.targetKind as AutomationTargetKind,
+    ref: r.ref,
+    title: r.title,
+    headSha: r.headSha,
+    ...(typeof r.count === "number" ? { count: r.count } : {}),
+    outcomes,
+  };
 }
 
 async function readByKey(key: string): Promise<AutomationHistoryEntry[]> {
   const store = await getStore();
   const raw = await store.get<unknown>(key);
-  return Array.isArray(raw) ? raw.filter(isStoredEntry) : [];
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((item) => sanitizeStoredEntry(item) ?? []);
 }
 
 /** Reads a repo's records, merging in any still under a legacy checkout-path key
@@ -255,9 +305,14 @@ function prune(records: AutomationHistoryEntry[]): AutomationHistoryEntry[] {
   return ordered.filter((e) => keep.has(e));
 }
 
-function invalidateRepo(repoPath: string): void {
+/** Invalidate the whole history-query family, not one path's key: two checkouts
+ *  of one repo read the SAME identity-keyed records under DIFFERENT path-keyed
+ *  queries, so a path-scoped invalidation would leave a sibling checkout's open
+ *  dialog holding a stale "started" row after the run settled. Writes are rare
+ *  (steady ticks dedup to zero I/O), so the wider blast radius costs nothing. */
+function invalidateHistoryQueries(): void {
   void queryClient
-    .invalidateQueries({ queryKey: automationHistoryKey(repoPath) })
+    .invalidateQueries({ queryKey: ["automation-history"] })
     .catch(() => undefined);
 }
 
@@ -345,7 +400,7 @@ async function appendEntry(repoPath: string, entry: NewEntry): Promise<string> {
   const store = await getStore();
   const key = await keyFor(repoPath);
   const id = await appendUnder(store, key, await readByKey(key), entry);
-  invalidateRepo(repoPath);
+  invalidateHistoryQueries();
   return id;
 }
 
@@ -365,6 +420,12 @@ async function coalesceSteady(
     (e) =>
       e.targetKind === entry.targetKind &&
       e.ref === entry.ref &&
+      // User-initiated rows always APPEND (branch 1), so they are also never
+      // coalesce TARGETS: an automatic tick bumping a re-run's row would
+      // overwrite the retry's evidence and attribute later automatic skips
+      // to the user's click.
+      e.trigger !== "run-now" &&
+      e.trigger !== "re-run" &&
       allSteady(e.outcomes),
   );
   let id: string;
@@ -399,7 +460,7 @@ async function coalesceSteady(
     id = await appendUnder(store, key, all, entry);
   }
   steadySignatures.set(sigKey, sig);
-  invalidateRepo(repoPath);
+  invalidateHistoryQueries();
   return id;
 }
 
@@ -459,7 +520,7 @@ export async function updateAutomationActivity(
       };
       await store.set(key, prune([updated, ...all.filter((e) => e.id !== id)]));
       await store.save();
-      invalidateRepo(repoPath);
+      invalidateHistoryQueries();
     });
   } catch {
     // best-effort — a history failure must never surface to the run

--- a/src/lib/automations/history.ts
+++ b/src/lib/automations/history.ts
@@ -6,7 +6,8 @@ import {
 } from "@/lib/git/repo-identity";
 import { queryClient } from "@/lib/query-client";
 import { storeName } from "@/lib/test-mode";
-import { type ActionId, ALL_ACTION_IDS } from "./types";
+import { loadAutomations } from "./store";
+import { type ActionId, ALL_ACTION_IDS, anyAutomationEnabled } from "./types";
 
 /**
  * Every decision the automation pipeline can record. Deliberately absent:
@@ -535,11 +536,18 @@ export async function updateAutomationActivity(
  *
  * Markers carry `trigger: "run-now"` — the only user-initiated value in the union,
  * and a flip IS a user action; consumers branch on `targetKind: "none"` first.
+ *
+ * Gated on the user having ANY automation configured, the same no-automation-no-
+ * evidence rule the per-repo recorders follow — a marker is not repo-keyed, so one
+ * written by a never-configured user would make every repo's list non-empty and put
+ * the teaching empty state out of reach app-wide. Knock-on, accepted: a flip made
+ * before any automation existed leaves no marker behind.
  */
 export async function recordAutomationPauseMarker(
   paused: boolean,
 ): Promise<void> {
   try {
+    if (!anyAutomationEnabled(await loadAutomations())) return;
     await serialize(async () => {
       await reloadRaw();
       const store = await getStore();

--- a/src/lib/automations/history.ts
+++ b/src/lib/automations/history.ts
@@ -1,0 +1,510 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import {
+  identityKeyFor,
+  mergeById,
+  repoIdentity,
+} from "@/lib/git/repo-identity";
+import { queryClient } from "@/lib/query-client";
+import { storeName } from "@/lib/test-mode";
+import type { ActionId } from "./types";
+
+/**
+ * Every decision the automation pipeline can record. Deliberately absent:
+ * "no-rule", "not-author" and "catch-up-deferred" — those are derived from the
+ * config (the dialog's header) or self-resolve within minutes, so a durable row
+ * would be noise or a stale lie.
+ */
+export const AUTOMATION_OUTCOME_CODES = [
+  "started",
+  "delivered",
+  "failed",
+  "timed-out",
+  "cancelled",
+  "empty-diff",
+  "claim-held",
+  "eligibility-error",
+  "branch-skip",
+  "needs-first-review",
+  "head-covered",
+  "head-dismissed",
+  "already-reviewed",
+  "draft-skipped",
+  "too-old",
+  "paused",
+  "resumed",
+] as const;
+
+export type AutomationOutcomeCode = (typeof AUTOMATION_OUTCOME_CODES)[number];
+
+/**
+ * Outcomes that describe a repo's STEADY state rather than an event: they repeat
+ * identically on every poll tick for as long as nothing changes. Recording them
+ * verbatim would rewrite the store once a minute per repo, so they coalesce (see
+ * {@link recordAutomationActivity}) and are evicted first when the cap bites.
+ */
+export const STEADY_OUTCOME_CODES: readonly AutomationOutcomeCode[] = [
+  "branch-skip",
+  "needs-first-review",
+  "head-covered",
+  "head-dismissed",
+  "already-reviewed",
+  "draft-skipped",
+  "too-old",
+];
+
+/** What set this decision in motion — the lifecycle event, the catch-up poll, or
+ *  one of the two user-initiated re-fires. */
+export type AutomationTrigger =
+  | "commit"
+  | "pr-open"
+  | "pr-sync"
+  | "catch-up"
+  | "run-now"
+  | "re-run";
+
+/** One decision. `action` is null when the decision was made before any action was
+ *  considered (an eligibility error, a catch-up pre-filter, a global marker). */
+export interface AutomationOutcome {
+  action: ActionId | null;
+  code: AutomationOutcomeCode;
+  detail?: string;
+}
+
+/**
+ * One recorded automation decision — the evidence a user whose review didn't fire
+ * can read. `ref` is the PR number (as a string) or local PR id; for commit-target
+ * rows it is the BRANCH name (the branch is the steady axis of a commit scoping
+ * decision, and the specific commit rides `headSha`); "" for the global markers.
+ */
+export interface AutomationHistoryEntry {
+  schemaVersion: 1;
+  id: string;
+  /** ISO-8601. */
+  ts: string;
+  trigger: AutomationTrigger;
+  targetKind: "remote" | "local" | "commit" | "none";
+  ref: string;
+  title: string;
+  headSha: string;
+  /** How many times this steady row coalesced (absent = once). */
+  count?: number;
+  outcomes: AutomationOutcome[];
+}
+
+/** Module-load stamp: a "started" outcome older than this belongs to a process
+ *  that is gone, so the UI renders it as interrupted rather than in flight. */
+export const SESSION_START_MS = Date.now();
+
+/** Query key for one repo's history list. */
+export function automationHistoryKey(repoPath: string) {
+  return ["automation-history", repoPath] as const;
+}
+
+/** Records kept per repo, pruned on every write so the file stays bounded. */
+const MAX_PER_REPO = 50;
+
+/** The reserved store key holding the global paused/resumed markers. Hiding AI
+ *  features is an app-wide flip, so its markers are NOT repo-identity-keyed —
+ *  they merge into every repo's list instead. Never collides with a repo key,
+ *  which is always an absolute path. */
+const GLOBAL_MARKERS_KEY = "global-markers";
+
+/** Markers retained — only the recent pause/resume flips explain a quiet stretch. */
+const MAX_MARKERS = 10;
+
+// Personal app-data, keyed by the repo's worktree-stable identity. Routed through
+// storeName() so cold-start/test instances never pollute the real file.
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("automation-history.json"), {
+    autoSave: true,
+    defaults: {},
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write through one in-process queue: autoSave persists
+// on a ~100ms debounce, so two overlapping writes would both reload the same
+// pre-flush disk snapshot and the later would drop the earlier's record (two poll
+// ticks and a settling run all write this store). With the force-save below, each
+// reload sees fresh state. Cross-INSTANCE overlap still races last-writer-wins like
+// the sibling plugin stores.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+async function reloadRaw(): Promise<void> {
+  const store = await getStore();
+  // Tolerate a missing store file: `load()` tolerates one but `reload()` rejects with
+  // a raw io error (os error 2) until the first `save()` creates the file — without
+  // this guard the first-ever write throws before reaching `save()`.
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing file — the next save() creates it.
+  }
+}
+
+const KNOWN_CODES = new Set<string>(AUTOMATION_OUTCOME_CODES);
+
+/** Shape-guard one record out of untrusted store JSON: a hand-edited (or newer)
+ *  `automation-history.json` reaches the dialog verbatim, so a malformed record is
+ *  dropped rather than blanking the list or throwing mid-render. `code` is checked
+ *  against the known set because the UI looks its label up in a Record — an
+ *  unrecognized code would render as a blank row. `schemaVersion` is write-only;
+ *  `count` and `detail` are typeof-guarded at their render sites. */
+function isStoredEntry(x: unknown): x is AutomationHistoryEntry {
+  if (typeof x !== "object" || x === null) return false;
+  const r = x as Record<string, unknown>;
+  return (
+    typeof r.id === "string" &&
+    typeof r.ts === "string" &&
+    typeof r.trigger === "string" &&
+    typeof r.targetKind === "string" &&
+    typeof r.ref === "string" &&
+    typeof r.title === "string" &&
+    typeof r.headSha === "string" &&
+    Array.isArray(r.outcomes) &&
+    r.outcomes.every(
+      (o) =>
+        typeof o === "object" &&
+        o !== null &&
+        KNOWN_CODES.has((o as { code?: unknown }).code as string),
+    )
+  );
+}
+
+async function readByKey(key: string): Promise<AutomationHistoryEntry[]> {
+  const store = await getStore();
+  const raw = await store.get<unknown>(key);
+  return Array.isArray(raw) ? raw.filter(isStoredEntry) : [];
+}
+
+/** Reads a repo's records, merging in any still under a legacy checkout-path key
+ *  (folded onto the identity by the next write via `keyFor`). */
+async function readMerged(repo: string): Promise<AutomationHistoryEntry[]> {
+  const id = await repoIdentity(repo);
+  const primary = await readByKey(id);
+  const legacy = id === repo ? [] : await readByKey(repo);
+  return mergeById(primary, legacy);
+}
+
+/** The identity store key for `repo`, folding any legacy checkout-path-keyed records
+ *  onto it once. Called inside the serialized queue (after `reloadRaw`) so the fold
+ *  is ordered with the write. */
+async function keyFor(repo: string): Promise<string> {
+  const store = await getStore();
+  return identityKeyFor<AutomationHistoryEntry[]>(
+    store,
+    "automation-history",
+    repo,
+    mergeById,
+  );
+}
+
+/** Newest first by `ts`. A record whose stamp doesn't parse can't be ordered, so
+ *  those sort after the dated ones and keep their insertion order — a junk stamp
+ *  costs its own position, never someone else's. */
+function sortNewestFirst(
+  records: AutomationHistoryEntry[],
+): AutomationHistoryEntry[] {
+  return records
+    .map((record, index) => {
+      const ts = new Date(record.ts).getTime();
+      return { record, index, ts: Number.isNaN(ts) ? null : ts };
+    })
+    .sort((a, b) => {
+      if (a.ts === null || b.ts === null) {
+        if (a.ts !== b.ts) return a.ts === null ? 1 : -1;
+        return a.index - b.index;
+      }
+      return b.ts - a.ts;
+    })
+    .map((x) => x.record);
+}
+
+/** Whether every outcome describes steady state. An EMPTY list is not steady: the
+ *  coalescing path keys on the outcome set, so a row with nothing to match on must
+ *  take the plain-append arm. */
+function allSteady(outcomes: AutomationOutcome[]): boolean {
+  return (
+    outcomes.length > 0 &&
+    outcomes.every((o) => STEADY_OUTCOME_CODES.includes(o.code))
+  );
+}
+
+/**
+ * Newest {@link MAX_PER_REPO}, two-tier: steady rows are evicted first, and a row
+ * carrying any non-steady code is evicted only when those alone exceed the cap. The
+ * single `eligibility-error` row that proves a fail-closed trap must not lose its
+ * slot to a month of "already reviewed" noise.
+ */
+function prune(records: AutomationHistoryEntry[]): AutomationHistoryEntry[] {
+  const ordered = sortNewestFirst(records);
+  if (ordered.length <= MAX_PER_REPO) return ordered;
+  const notable = ordered.filter((e) => !allSteady(e.outcomes));
+  const keptNotable = notable.slice(0, MAX_PER_REPO);
+  const keptSteady = ordered
+    .filter((e) => allSteady(e.outcomes))
+    .slice(0, Math.max(0, MAX_PER_REPO - keptNotable.length));
+  const keep = new Set([...keptNotable, ...keptSteady]);
+  return ordered.filter((e) => keep.has(e));
+}
+
+function invalidateRepo(repoPath: string): void {
+  void queryClient
+    .invalidateQueries({ queryKey: automationHistoryKey(repoPath) })
+    .catch(() => undefined);
+}
+
+/**
+ * One repo's history, newest first, with the global pause/resume markers merged in.
+ * Reads through the write queue after a fresh reload — `getStore()` memoizes the
+ * first `load()`, so a row another instance wrote since then is absent from the
+ * cached snapshot. Never rejects: an unreadable store reads as empty.
+ */
+export async function listAutomationHistory(
+  repoPath: string,
+): Promise<AutomationHistoryEntry[]> {
+  const all = await serialize(async () => {
+    await reloadRaw();
+    const repoRows = await readMerged(repoPath);
+    const markers = await readByKey(GLOBAL_MARKERS_KEY);
+    return [...repoRows, ...markers];
+  }).catch((): AutomationHistoryEntry[] => []);
+  return sortNewestFirst(all);
+}
+
+/** The stored input of a record call — everything the caller decides. */
+type NewEntry = Omit<
+  AutomationHistoryEntry,
+  "schemaVersion" | "id" | "ts" | "count"
+>;
+
+/**
+ * Signature of the last steady row written per `(repo, targetKind, ref)`, so an
+ * unchanged poll tick costs ZERO store I/O — no parse, no rewrite, once a minute
+ * per repo. Accepted residual: a signature can outlive its row (pruned by a burst
+ * of notable rows), which suppresses the re-append until the head or the outcome
+ * set changes. Evidence of steady state is exactly the evidence that is cheap to
+ * re-derive, so that trade is deliberate.
+ */
+const steadySignatures = new Map<string, string>();
+
+function signatureKey(
+  repoPath: string,
+  targetKind: AutomationHistoryEntry["targetKind"],
+  ref: string,
+): string {
+  return `${repoPath}|${targetKind}|${ref}`;
+}
+
+/** The sorted (action, code) pair list — order-independent identity of an outcome
+ *  set, so two ticks that decide the same things in a different order coalesce. */
+function outcomeMultiset(outcomes: AutomationOutcome[]): string {
+  return outcomes
+    .map((o) => `${o.action ?? "-"}:${o.code}`)
+    .sort()
+    .join(",");
+}
+
+function steadySignature(
+  headSha: string,
+  outcomes: AutomationOutcome[],
+): string {
+  return `${headSha}|${outcomeMultiset(outcomes)}`;
+}
+
+/** Appends `entry` under an already-resolved key. Caller owns the reload + flush
+ *  ordering (it runs inside the serialized queue). */
+async function appendUnder(
+  store: Store,
+  key: string,
+  existing: AutomationHistoryEntry[],
+  entry: NewEntry,
+): Promise<string> {
+  const record: AutomationHistoryEntry = {
+    ...entry,
+    schemaVersion: 1,
+    id: crypto.randomUUID(),
+    ts: new Date().toISOString(),
+  };
+  await store.set(key, prune([record, ...existing]));
+  // Flush now instead of on autoSave's debounce, so the next serialized reload
+  // can't re-read a pre-write disk snapshot and drop this record.
+  await store.save();
+  return record.id;
+}
+
+async function appendEntry(repoPath: string, entry: NewEntry): Promise<string> {
+  await reloadRaw();
+  const store = await getStore();
+  const key = await keyFor(repoPath);
+  const id = await appendUnder(store, key, await readByKey(key), entry);
+  invalidateRepo(repoPath);
+  return id;
+}
+
+/** The all-steady arm: coalesce onto the newest matching steady row when one
+ *  exists, else append. Runs inside the serialized queue. */
+async function coalesceSteady(
+  repoPath: string,
+  entry: NewEntry,
+  sigKey: string,
+  sig: string,
+): Promise<string> {
+  await reloadRaw();
+  const store = await getStore();
+  const key = await keyFor(repoPath);
+  const all = await readByKey(key);
+  const prior = sortNewestFirst(all).find(
+    (e) =>
+      e.targetKind === entry.targetKind &&
+      e.ref === entry.ref &&
+      allSteady(e.outcomes),
+  );
+  let id: string;
+  if (
+    prior &&
+    outcomeMultiset(prior.outcomes) === outcomeMultiset(entry.outcomes)
+  ) {
+    // `===` rather than `sameSha` (which lives in sync.ts — importing it here would
+    // close a history→sync→runner→history cycle), so a provider flipping between a
+    // short and a full spelling of the SAME head costs one spurious count bump and a
+    // refreshed stamp on the existing row, never a wrong row.
+    if (prior.headSha === entry.headSha) {
+      // Identical row already on disk (a fresh session's first tick) — seed the map
+      // so every later tick short-circuits, and write nothing.
+      steadySignatures.set(sigKey, sig);
+      return prior.id;
+    }
+    // Same decision, new head (a push): bump the row rather than append a near-copy.
+    const upserted: AutomationHistoryEntry = {
+      ...prior,
+      ts: new Date().toISOString(),
+      headSha: entry.headSha,
+      count: (prior.count ?? 1) + 1,
+    };
+    await store.set(
+      key,
+      prune([upserted, ...all.filter((e) => e.id !== prior.id)]),
+    );
+    await store.save();
+    id = prior.id;
+  } else {
+    id = await appendUnder(store, key, all, entry);
+  }
+  steadySignatures.set(sigKey, sig);
+  invalidateRepo(repoPath);
+  return id;
+}
+
+/**
+ * Records one automation decision, returning the stored entry's id — or null when
+ * the write was suppressed (an unchanged steady tick) or failed. Never rejects:
+ * history is evidence, and evidence must never be able to break the run it records.
+ *
+ * A "run-now"/"re-run" trigger ALWAYS appends: a user action is a state change by
+ * definition, and the UI's promise that a click leaves evidence depends on it. An
+ * all-steady outcome set coalesces (see {@link steadySignatures}); anything else
+ * appends.
+ */
+export async function recordAutomationActivity(
+  repoPath: string,
+  entry: NewEntry,
+): Promise<string | null> {
+  try {
+    const userAction =
+      entry.trigger === "run-now" || entry.trigger === "re-run";
+    if (!userAction && allSteady(entry.outcomes)) {
+      const sigKey = signatureKey(repoPath, entry.targetKind, entry.ref);
+      const sig = steadySignature(entry.headSha, entry.outcomes);
+      if (steadySignatures.get(sigKey) === sig) return null;
+      return await serialize(() =>
+        coalesceSteady(repoPath, entry, sigKey, sig),
+      );
+    }
+    return await serialize(() => appendEntry(repoPath, entry));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Replaces an entry's outcomes and refreshes its stamp — how the runner settles a
+ * "started" row in place, so a run killed mid-stream leaves the started row behind
+ * instead of a lie. A no-op when the id is gone (pruned). Never rejects.
+ */
+export async function updateAutomationActivity(
+  repoPath: string,
+  id: string,
+  outcomes: AutomationOutcome[],
+): Promise<void> {
+  try {
+    await serialize(async () => {
+      await reloadRaw();
+      const store = await getStore();
+      const key = await keyFor(repoPath);
+      const all = await readByKey(key);
+      const found = all.find((e) => e.id === id);
+      if (!found) return;
+      const updated: AutomationHistoryEntry = {
+        ...found,
+        ts: new Date().toISOString(),
+        outcomes,
+      };
+      await store.set(key, prune([updated, ...all.filter((e) => e.id !== id)]));
+      await store.save();
+      invalidateRepo(repoPath);
+    });
+  } catch {
+    // best-effort — a history failure must never surface to the run
+  }
+}
+
+/**
+ * Records that automations were paused or resumed app-wide (the Hide-AI flip), so a
+ * quiet stretch in every repo's list has its explanation in line. Stored under the
+ * reserved global key rather than a repo's, since the flip is not per repo. Never
+ * rejects.
+ *
+ * Markers carry `trigger: "run-now"` — the only user-initiated value in the union,
+ * and a flip IS a user action; consumers branch on `targetKind: "none"` first.
+ */
+export async function recordAutomationPauseMarker(
+  paused: boolean,
+): Promise<void> {
+  try {
+    await serialize(async () => {
+      await reloadRaw();
+      const store = await getStore();
+      const all = await readByKey(GLOBAL_MARKERS_KEY);
+      const record: AutomationHistoryEntry = {
+        schemaVersion: 1,
+        id: crypto.randomUUID(),
+        ts: new Date().toISOString(),
+        trigger: "run-now",
+        targetKind: "none",
+        ref: "",
+        title: "",
+        headSha: "",
+        outcomes: [{ action: null, code: paused ? "paused" : "resumed" }],
+      };
+      await store.set(
+        GLOBAL_MARKERS_KEY,
+        sortNewestFirst([record, ...all]).slice(0, MAX_MARKERS),
+      );
+      await store.save();
+      // Markers merge into EVERY repo's list, so invalidate the whole family.
+      void queryClient
+        .invalidateQueries({ queryKey: ["automation-history"] })
+        .catch(() => undefined);
+    });
+  } catch {
+    // best-effort — a history failure must never surface to the caller
+  }
+}

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -24,6 +24,7 @@ import type { AiSettings, PromptProvider, ReviewMode } from "@/lib/ai/types";
 import {
   forgePrComment,
   forgePrDiff,
+  forgePrView,
   forgeStatus,
   gitBranchDiff,
   gitBranches,
@@ -45,11 +46,13 @@ import {
 } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { effectiveReviewAi, loadSettings } from "@/lib/settings/api";
+import { useConfirm } from "@/lib/stores/confirm";
 import {
   type NotificationTarget,
   pushNotification,
 } from "@/lib/stores/notifications";
 import {
+  hasLiveAutomationRun,
   type ReviewTarget,
   registerAutomationRun,
   resetReview,
@@ -61,10 +64,24 @@ import {
   getDismissedHeadMap,
   setDismissedHead,
 } from "./dismissals";
+import {
+  type AutomationOutcomeCode,
+  type AutomationTrigger,
+  recordAutomationActivity,
+  updateAutomationActivity,
+} from "./history";
 import { type AutomationRunResult, useAutomationResults } from "./results";
 import { loadAutomations, repoAutomationsFor } from "./store";
 import { sameSha } from "./sync";
-import { branchConditionsPass, effectiveActions } from "./types";
+import {
+  ACTION_LABELS,
+  type ActionId,
+  type AutomationsConfigV2,
+  branchConditionsPass,
+  effectiveActions,
+  type LifecycleEvent,
+  type RepoOverride,
+} from "./types";
 
 export type AutomationEvent =
   | {
@@ -233,49 +250,156 @@ function filesFromDiff(text: string): DiffStatEntry[] {
  * own progress toast; a failing rule never blocks the action that
  * triggered it or the remaining rules.
  */
-export function triggerAutomations(event: AutomationEvent): void {
-  void run(event).catch(() => undefined);
+export function triggerAutomations(
+  event: AutomationEvent,
+  trigger?: AutomationTrigger,
+): void {
+  void run(event, { trigger }).catch(() => undefined);
 }
+
+/** One action's decision in a {@link run} pass. Every code point below is reached
+ *  per action, so the action is always known here — unlike the action-less rows
+ *  `sync.ts` records before any action is considered. */
+type RunActionOutcome = {
+  action: ActionId;
+  code: AutomationOutcomeCode;
+  detail?: string;
+};
 
 /** What a {@link run} pass did, so a re-run can tell outcomes apart:
  *  - `matched`: rules that exist AND apply (past the `only` + branch gates). 0 = the rule
  *    no longer applies, or automations are paused (Hide AI, or cold start without opt-in).
  *  - `attempted`: runs actually started. `matched > 0 && attempted === 0` means a claim or
- *    an already-covered head blocked it — retryable. */
+ *    an already-covered head blocked it — retryable.
+ *  - `outcomes`: every decision the pass made, in the order it made them. */
 interface RunOutcome {
   matched: number;
   attempted: number;
+  outcomes: RunActionOutcome[];
+}
+
+/** Options for one {@link run} pass. An object rather than positionals: the three
+ *  optional knobs are independent, and two of them are booleans/strings a caller
+ *  could silently transpose. */
+interface RunOptions {
+  /** Scope the pass to a single mode (a stopped row's Re-run). */
+  only?: ReviewMode;
+  /** The stopped row a re-run replaces — removed the instant its replacement
+   *  registers, so the stopped row survives whenever nothing registers. */
+  replacesKey?: string;
+  /** Run-now: run every PR-lifecycle action regardless of the skip gates (the
+   *  claim still applies). See {@link runAutomationNow}. */
+  force?: boolean;
+  /** What set this pass in motion; defaults to the event's own lifecycle. */
+  trigger?: AutomationTrigger;
+}
+
+/** The PR-lifecycle actions a forced (Run-now) pass runs: the SET-union over both
+ *  PR lifecycles, deduped by action, so one click runs each mode exactly once
+ *  whichever lifecycle enabled it. Branch conditions ride along but are never
+ *  evaluated in force mode — the user named this PR explicitly. */
+function forcedActions(
+  config: AutomationsConfigV2,
+  repo: RepoOverride | undefined,
+): ReturnType<typeof effectiveActions> {
+  const seen = new Set<ActionId>();
+  const union: ReturnType<typeof effectiveActions> = [];
+  for (const lifecycle of ["pr-open", "pr-sync"] as const) {
+    for (const entry of effectiveActions(config, repo, lifecycle)) {
+      if (seen.has(entry.action)) continue;
+      seen.add(entry.action);
+      union.push(entry);
+    }
+  }
+  return union;
 }
 
 /**
  * Runs the automation rules matching `event`, unless AI features are hidden or this is
  * a cold-start instance without the automations opt-in — either pauses automations, so
- * it returns immediately with a zero outcome. `only` scopes a re-run to a single mode.
- * `replacesKey` is the stopped row a re-run replaces — removed the instant its
- * replacement registers, so the stopped row survives whenever nothing registers.
+ * it returns immediately with a zero outcome. See {@link RunOptions} for the knobs.
  * Returns a {@link RunOutcome} so a re-run can tell "rule gone" from "blocked" from
- * "started".
+ * "started", and so every decision it made lands in the history store.
  */
 async function run(
   event: AutomationEvent,
-  only?: ReviewMode,
-  replacesKey?: string,
+  opts: RunOptions = {},
 ): Promise<RunOutcome> {
+  const { only, replacesKey, force = false, trigger = event.kind } = opts;
   // Cold-start instances share the automation-claims dir with the real instance, so an
   // armed cold instance can win a claim meant for the real run and suppress it. First
-  // gate of all, so a gated tick reads no store at all and takes no claim.
-  if (COLD_START_AUTOMATIONS_OFF) return { matched: 0, attempted: 0 };
+  // gate of all, so a gated tick reads no store at all and takes no claim — including
+  // the history store, which is why neither this gate nor the next one records.
+  if (COLD_START_AUTOMATIONS_OFF)
+    return { matched: 0, attempted: 0, outcomes: [] };
   // Hiding AI features PAUSES automations: no NEW run starts while `hideAi` is set
   // (an in-flight run still completes and delivers — deliberate). Rules are kept and
-  // resume when AI is shown again.
+  // resume when AI is shown again. The paused/resumed markers cover this stretch.
   const settings = await loadSettings();
-  if (settings.hideAi) return { matched: 0, attempted: 0 };
+  if (settings.hideAi) return { matched: 0, attempted: 0, outcomes: [] };
   const config = await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
-  const actions = effectiveActions(config, repo, event.kind);
-  if (actions.length === 0) return { matched: 0, attempted: 0 };
+  // Whether this REPO has any automation at all, across every lifecycle — records
+  // happen only when it does, so a repo the user never configured accrues zero rows
+  // (its dialog's empty state teaches instead). Local literal rather than a shared
+  // constant: this list is the gate's own definition of "any lifecycle".
+  const lifecycles: LifecycleEvent[] = ["commit", "pr-open", "pr-sync"];
+  const recordingEnabled = lifecycles.some(
+    (lc) => effectiveActions(config, repo, lc).length > 0,
+  );
+  const actions = force
+    ? forcedActions(config, repo)
+    : effectiveActions(config, repo, event.kind);
+  // No enabled action for THIS lifecycle: records nothing by design — the dialog
+  // derives the config header from the live config, not from a row per tick.
+  if (actions.length === 0) return { matched: 0, attempted: 0, outcomes: [] };
   let matched = 0;
   let attempted = 0;
+  // The recorded entry's stable axes. A commit row keys on its BRANCH (the steady
+  // axis of a commit scoping decision); the specific commit rides `headSha`.
+  const recordTargetKind: "remote" | "local" | "commit" =
+    event.kind === "commit" ? "commit" : event.target.type;
+  const recordRef = event.kind === "commit" ? event.branch : targetRef(event);
+  const recordHeadSha =
+    event.kind === "commit" ? event.hash : (event.headSha ?? "");
+  // Skip decisions accumulated across the pass, and the terminal state of every
+  // action that actually ran. Both ride into the entry on each update, so one row
+  // tells the whole pass's story.
+  const skips: RunActionOutcome[] = [];
+  const settled: RunActionOutcome[] = [];
+  // The history entry this pass owns, minted at the first claim-win. Null until
+  // then — a pass that only skipped writes one coalescing row after the loop.
+  let entryId: string | null = null;
+  /** The outcome snapshot to store: everything decided so far, plus the action
+   *  currently in flight (if any). */
+  const snapshot = (running?: RunActionOutcome): RunActionOutcome[] =>
+    running ? [...skips, ...settled, running] : [...skips, ...settled];
+  /** Writes the pass's entry — minting it on the first call, updating in place
+   *  after. Swallows everything: history is evidence, and evidence must never be
+   *  able to affect the run it records. */
+  const recordProgress = async (running?: RunActionOutcome): Promise<void> => {
+    if (!recordingEnabled) return;
+    try {
+      if (entryId === null) {
+        entryId = await recordAutomationActivity(event.repoPath, {
+          trigger,
+          targetKind: recordTargetKind,
+          ref: recordRef,
+          title: event.title,
+          headSha: recordHeadSha,
+          outcomes: snapshot(running),
+        });
+      } else {
+        await updateAutomationActivity(
+          event.repoPath,
+          entryId,
+          snapshot(running),
+        );
+      }
+    } catch {
+      // best-effort — a history failure must never reach the run
+    }
+  };
   // Cleared once consumed so a second registering action can't double-remove
   // (harmless — resetReview no-ops on a missing key — but keeps intent explicit).
   let staleKey = replacesKey;
@@ -325,7 +449,10 @@ async function run(
   };
   for (const { action, conditions } of actions) {
     if (only && action !== only) continue;
+    // Force mode never evaluates conditions: the user named this PR explicitly, so
+    // a branch scope meant for unattended firing has nothing left to decide.
     if (
+      !force &&
       !branchConditionsPass(conditions, {
         kind: event.kind,
         branch,
@@ -333,6 +460,7 @@ async function run(
         base,
       })
     ) {
+      skips.push({ action, code: "branch-skip" });
       continue;
     }
     matched++;
@@ -340,21 +468,28 @@ async function run(
     // never for ANY head that mode covered — a poll can re-serve an older head after a
     // push, which isn't new work. Every retained record counts, so the flap window is
     // the history store's MAX_PER_GROUP per (kind, ref, mode).
-    if (event.kind === "pr-sync") {
+    // Split into three arms with the same `continue` (short-circuit order preserved,
+    // so the gating is unchanged): each skip is a different thing to tell the user.
+    if (!force && event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
       const { reviews, dismissed } = await gateState(event);
       const covered = reviews.filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
       const dismissedHead = dismissed[action];
+      if (covered.length === 0) {
+        skips.push({ action, code: "needs-first-review" });
+        continue;
+      }
       // sameSha (not `===`) so a short-vs-full sha for the SAME head (Bitbucket's
       // 12-char poll head vs a full-40 seed) counts as "already reviewed" and
       // doesn't re-fire a redundant review each poll tick.
-      if (
-        covered.length === 0 ||
-        covered.some((r) => sameSha(r.headSha, headSha)) ||
-        sameSha(dismissedHead ?? "", headSha)
-      ) {
+      if (covered.some((r) => sameSha(r.headSha, headSha))) {
+        skips.push({ action, code: "head-covered" });
+        continue;
+      }
+      if (sameSha(dismissedHead ?? "", headSha)) {
+        skips.push({ action, code: "head-dismissed" });
         continue;
       }
     }
@@ -362,14 +497,18 @@ async function run(
     // this PR (so real and catch-up-synthesized events are idempotent per mode), and skip
     // a head this mode already dismissed. Mirror of the pr-sync gate, inverted — pr-sync
     // requires a prior review, pr-open requires its absence.
-    if (event.kind === "pr-open") {
+    if (!force && event.kind === "pr-open") {
       const { reviews, dismissed } = await gateState(event);
       // The list is newest-first, so this mode's first entry IS its latest review — the
       // same record `getLatestReview` would return.
       const prior = reviews.find((r) => r.mode === action);
-      if (prior) continue;
+      if (prior) {
+        skips.push({ action, code: "already-reviewed" });
+        continue;
+      }
       const dismissedHead = dismissed[action];
       if (event.headSha && sameSha(dismissedHead ?? "", event.headSha)) {
+        skips.push({ action, code: "head-dismissed" });
         continue;
       }
     }
@@ -386,6 +525,35 @@ async function run(
     // release so both target the SAME claim file (releasing under the raw path would
     // miss it). Empty until a claim is actually taken.
     let claimKey = "";
+    // Run-now on a head a DELIVERED run already covers: a delivered run KEEPS its claim
+    // by design, so without this release the claim below loses to the record of its own
+    // last success and the user's explicit click becomes a silent no-op. Skipped while a
+    // run is live in this instance — that claim belongs to work still in flight.
+    // Accepted residual: the release is identity-keyed, not instance-keyed, so two
+    // windows clicking Run-now on the same delivered head inside one run window can
+    // both claim and both post.
+    if (force && event.kind !== "commit" && headSha) {
+      const { reviews } = await gateState(event);
+      const alreadyCovered = reviews.some(
+        (r) => r.mode === action && sameSha(r.headSha, headSha),
+      );
+      if (
+        alreadyCovered &&
+        !hasLiveAutomationRun(
+          event.repoPath,
+          event.target.type,
+          targetRef(event),
+        )
+      ) {
+        const repoKey = await repoIdentity(event.repoPath);
+        await invoke("release_automation_claim", {
+          repoKey,
+          target: claimTarget,
+          headSha,
+          action,
+        }).catch(() => undefined);
+      }
+    }
     if (headSha) {
       const repoKey = await repoIdentity(event.repoPath);
       let won = true;
@@ -399,7 +567,10 @@ async function run(
       } catch {
         // fail open — a claim-infrastructure error must not disable automations
       }
-      if (!won) continue; // another instance owns this run
+      if (!won) {
+        skips.push({ action, code: "claim-held" });
+        continue; // another instance owns this run
+      }
       claimKey = repoKey;
     }
     // Liveness heartbeat for the claim just won: refreshing the claim file's mtime makes
@@ -436,6 +607,10 @@ async function run(
     // Past every skip gate — counted so a Re-run that matches nothing can toast instead of
     // dying silently.
     attempted++;
+    // Record BEFORE the paid work: the longest operation must not be the one with zero
+    // trace. A process killed mid-stream leaves this "started" row behind, which the
+    // dialog reads as interrupted (against SESSION_START_MS) rather than in flight.
+    await recordProgress({ action, code: "started" });
     // Per-rule cancellation: HTTP providers stop via the AbortSignal, CLI providers by
     // killing the subprocess (`cancelAgentReview` once its id is known); both are driven
     // by the dock row's Cancel → `cancelReview`. `handle.isCancelled()` stays readable
@@ -517,11 +692,15 @@ async function run(
         // and deleted the control — do NOT settle/remove it here.
         releaseClaim();
         dismissOnCancel();
+        settled.push({ action, code: "cancelled" });
+        await recordProgress();
         toast.info(`AI ${label} cancelled.`, { duration: 4000 });
         continue;
       }
       if (result === null) {
         releaseClaim();
+        settled.push({ action, code: "empty-diff" });
+        await recordProgress();
         toast.info(`AI ${label} skipped — no changes to review.`);
         handle.settle(); // no-op run: remove the row as before
         continue;
@@ -575,6 +754,8 @@ async function run(
       }
       // Success: remove the dock row — a delivered review lands in Notifications.
       handle.settle();
+      settled.push({ action, code: "delivered" });
+      await recordProgress();
     } catch (e) {
       // Release the claim on every failure/cancel path so a transient error doesn't
       // permanently suppress this automation for this head across instances.
@@ -583,6 +764,8 @@ async function run(
         // Cancelled mid-stream: same as the post-generate cancel arm — the dock
         // already owns the "cancelled" row, so leave it (do not settle).
         dismissOnCancel();
+        settled.push({ action, code: "cancelled" });
+        await recordProgress();
         toast.info(`AI ${label} cancelled.`, { duration: 4000 });
         continue;
       }
@@ -712,6 +895,14 @@ async function run(
       }
       // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
       handle.fail(message);
+      // A deadline kill and an outright failure look the same from the dock but not
+      // from the history: one is a budget to raise, the other a thing to fix.
+      settled.push({
+        action,
+        code: progress.timedOut ? "timed-out" : "failed",
+        detail: message,
+      });
+      await recordProgress();
     } finally {
       // Every terminal path lands here — including both `continue`s and the delivered
       // success path, which keeps its claim but must stop heartbeating it.
@@ -722,7 +913,24 @@ async function run(
       gateSnapshot = null;
     }
   }
-  return { matched, attempted };
+  // Nothing ran, but something was decided: one coalescing row. The steady upsert
+  // in the store is what keeps a poll tick over an unchanged repo from paying a
+  // whole-file parse and rewrite per minute.
+  if (entryId === null && skips.length > 0 && recordingEnabled) {
+    await recordAutomationActivity(event.repoPath, {
+      trigger,
+      targetKind: recordTargetKind,
+      ref: recordRef,
+      title: event.title,
+      headSha: recordHeadSha,
+      outcomes: skips,
+    }).catch(() => undefined);
+  }
+  // An action ran, so the entry exists — but the in-loop writes stop at each
+  // action's terminal, and a LATER action's skip lands in `skips` after the last
+  // one. Re-snapshot once so the row carries every decision the pass made.
+  if (entryId !== null) await recordProgress();
+  return { matched, attempted, outcomes: [...skips, ...settled] };
 }
 
 /**
@@ -770,7 +978,11 @@ export function rerunAutomation(
       }
       // The stopped row is removed inside run() only when a replacement registers —
       // so every non-registering outcome below keeps it as a retry target.
-      const { matched, attempted } = await run(event, only, staleKey);
+      const { matched, attempted } = await run(event, {
+        only,
+        replacesKey: staleKey,
+        trigger: "re-run",
+      });
       if (matched === 0) {
         // The rule genuinely no longer applies (disabled / conditions changed).
         toast.info(`Automated ${label} for this ${noun} is turned off.`);
@@ -786,6 +998,170 @@ export function rerunAutomation(
       // A throw before/inside the loop (loadAutomations, store I/O) must not be swallowed —
       // surface it; the stopped row stays.
       toast.error(`Couldn't re-run the ${label}: ${errorMessage(e)}`);
+    }
+  })();
+}
+
+/**
+ * PR targets a Run-now is starting for, keyed `repoPath|kind|ref` and held from the
+ * click to the run's `finally`. The cross-instance claim doesn't exist yet during the
+ * multi-second window this spends resolving the PR and waiting on a confirm, so
+ * without this latch palette spam would start two runs on the same PR.
+ */
+const runNowStarting = new Set<string>();
+
+/** Shared copy: a repo whose PR lifecycles have no enabled action has nothing to
+ *  run now, whether we learn that before the run or from its zero match. */
+const NO_PR_AUTOMATION_COPY =
+  "No automation is enabled for pull requests in this repository — set one up in Settings → Automations.";
+
+const CLOSED_PR_COPY =
+  "This pull request is closed — automations run on open pull requests.";
+
+const UNRESOLVED_HEAD_COPY =
+  "Couldn't resolve the pull request's current head — try refreshing.";
+
+/**
+ * Runs this repo's PR automations against one pull request right now — the explicit
+ * user action behind the Run-now command. Runs exactly what the lifecycle would run,
+ * bypassing only the gates that exist to stop AUTOMATIC re-fires (branch conditions,
+ * first-review/covered-head/dismissed-head); the cross-instance claim still applies,
+ * so two machines can't both post. Fire-and-forget, like {@link triggerAutomations}.
+ */
+export function runAutomationNow(
+  repoPath: string,
+  target: { kind: "remote"; number: number } | { kind: "local"; id: string },
+): void {
+  const ref = target.kind === "remote" ? String(target.number) : target.id;
+  const latchKey = `${repoPath}|${target.kind}|${ref}`;
+  if (runNowStarting.has(latchKey)) {
+    toast.info("Already starting for this pull request.");
+    return;
+  }
+  runNowStarting.add(latchKey);
+  void (async () => {
+    try {
+      // Same order as run()'s own pause gates, and for the same reason: a gated cold
+      // instance must read no store at all.
+      if (COLD_START_AUTOMATIONS_OFF) {
+        toast.info("Automations are off in cold-start test mode.");
+        return;
+      }
+      if ((await loadSettings()).hideAi) {
+        toast.info("Automations are paused while AI features are hidden.");
+        return;
+      }
+      // Resolved here as well as inside run() so the confirm can NAME the modes it
+      // is about to spend on.
+      const config = await loadAutomations();
+      const repo = await repoAutomationsFor(config, repoPath);
+      const modes = forcedActions(config, repo).map((a) => a.action);
+      if (modes.length === 0) {
+        toast.info(NO_PR_AUTOMATION_COPY);
+        return;
+      }
+      if (hasLiveAutomationRun(repoPath, target.kind, ref)) {
+        toast.info(
+          "An AI review of this pull request is already running — watch it in Activity.",
+        );
+        return;
+      }
+
+      let base: string;
+      let head: string;
+      let title: string;
+      let body: string;
+      let commitSubjects: string[];
+      let headSha: string;
+      if (target.kind === "remote") {
+        // Origin-pinned like every other store/forge touch on this path.
+        const pr = await forgePrView(repoPath, target.number, "origin");
+        if (pr.state !== "OPEN") {
+          toast.info(CLOSED_PR_COPY);
+          return;
+        }
+        base = pr.baseRefName;
+        head = pr.headRefName;
+        title = pr.title;
+        body = pr.body;
+        commitSubjects = pr.commits.map((c) => c.headline);
+        // The neutral commit list is oldest-first on every provider — GitLab and
+        // Bitbucket reverse their newest-first payloads to match GitHub's — so the
+        // PR head is the LAST entry (same read as RemotePrView's merge/review paths).
+        headSha = pr.commits.at(-1)?.oid ?? "";
+      } else {
+        const prs = await listLocalPrs(repoPath);
+        const pr = prs.find((p) => p.id === target.id);
+        // Deleted since the menu opened — a head to resolve was never the problem,
+        // so "try refreshing" would send the user looking for the wrong thing.
+        if (!pr) {
+          toast.error("This pull request no longer exists.");
+          return;
+        }
+        if (pr.status !== "open") {
+          toast.info(CLOSED_PR_COPY);
+          return;
+        }
+        base = pr.base;
+        head = pr.head;
+        title = pr.title;
+        body = pr.body;
+        // Local PRs carry no commit list; the branch diff is the source of truth.
+        commitSubjects = [];
+        const tips = await gitBranchTips(repoPath, [pr.head]);
+        headSha = tips[pr.head] ?? "";
+      }
+      // The claim keys on the head: running without one forfeits cross-instance
+      // dedup, so refuse rather than risk a duplicate paid review.
+      if (!headSha) {
+        toast.error(UNRESOLVED_HEAD_COPY);
+        return;
+      }
+
+      const reference =
+        target.kind === "remote" ? `#${target.number} · ${title}` : title;
+      const modeList = modes.map((m) => ACTION_LABELS[m]).join(" and ");
+      const ok = await useConfirm.getState().ask({
+        title: "Run automations on this pull request?",
+        body: `${reference} — runs ${modeList}. The result is posted as a comment on the pull request.`,
+        confirmLabel: "Run",
+      });
+      if (!ok) return;
+
+      const { matched, attempted } = await run(
+        {
+          kind: "pr-sync",
+          repoPath,
+          base,
+          head,
+          headSha,
+          title,
+          body,
+          commitSubjects,
+          target:
+            target.kind === "remote"
+              ? { type: "remote", number: target.number }
+              : { type: "local", id: target.id },
+        },
+        { force: true, trigger: "run-now" },
+      );
+      if (matched === 0) {
+        // The config changed between the confirm and the run.
+        toast.info(NO_PR_AUTOMATION_COPY);
+      } else if (attempted === 0) {
+        // The claim is identity-keyed, so this may be another worktree of this repo
+        // or another machine — say what is true, not where it is.
+        toast.info(
+          "This pull request's head is already claimed by a review run — it will post when that one finishes.",
+        );
+      }
+      // attempted > 0: the dock's live row is the feedback — no toast.
+    } catch (e) {
+      toast.error(
+        `Couldn't run automations on this pull request: ${errorMessage(e)}`,
+      );
+    } finally {
+      runNowStarting.delete(latchKey);
     }
   })();
 }

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -1131,6 +1131,16 @@ export function runAutomationNow(
   repoPath: string,
   target: { kind: "remote"; number: number } | { kind: "local"; id: string },
 ): void {
+  // A remote number can arrive derived from an untrusted store ref (a history
+  // row's hand-editable value) — refuse junk HERE, where every other refusal
+  // toast on this path lives, so any future entry point is covered for free.
+  if (
+    target.kind === "remote" &&
+    (!Number.isInteger(target.number) || target.number <= 0)
+  ) {
+    toast.error("This pull request has no usable number.");
+    return;
+  }
   const ref = target.kind === "remote" ? String(target.number) : target.id;
   const latchKey = `${repoPath}|${target.kind}|${ref}`;
   if (runNowStarting.has(latchKey)) {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -24,6 +24,7 @@ import type { AiSettings, PromptProvider, ReviewMode } from "@/lib/ai/types";
 import {
   forgePrComment,
   forgePrDiff,
+  forgePrPoll,
   forgePrView,
   forgeStatus,
   gitBranchDiff,
@@ -1052,7 +1053,10 @@ export function rerunAutomation(
         only,
         replacesKey: staleKey,
         force,
-        trigger: force ? "run-now" : "re-run",
+        // The trigger names the SURFACE that initiated the pass, not its semantics —
+        // this is a Re-run click however the original pass was started; `force` is
+        // what carries the gate-skipping forward.
+        trigger: "re-run",
       });
       if (matched === 0) {
         // The rule genuinely no longer applies (disabled / conditions changed).
@@ -1096,6 +1100,14 @@ const CLOSED_PR_COPY =
 
 const UNRESOLVED_HEAD_COPY =
   "Couldn't resolve the pull request's current head — try refreshing.";
+
+/** Nothing started because another run owns this head — it still lands. */
+const HEAD_CLAIMED_COPY =
+  "This pull request's head is already claimed by a review run — it will post when that one finishes.";
+
+/** Nothing started because a gate store couldn't be read — nothing will land. */
+const GATE_READ_FAILED_COPY =
+  "Couldn't read this pull request's review history, so nothing ran — see Automation history for the error.";
 
 /** A Run-now target's state at one moment: everything the synthesized event needs.
  *  Every field is a point-in-time read, which is why it gets resolved twice. */
@@ -1165,16 +1177,27 @@ export function runAutomationNow(
             toast.info(CLOSED_PR_COPY);
             return null;
           }
+          // The head-OID poll is the authority here — it is provider-neutral and its
+          // `headSha` is the very value pr-sync detection keys on, so Run-now claims
+          // and persists the same head the lifecycle would. The commits list alone
+          // can't be trusted for this: `gh_pr_view` completes a >100-commit PR from
+          // the paginated REST endpoint and falls back to the TRUNCATED 100-entry
+          // GraphQL list when that read fails, and the last entry of a truncated list
+          // is not the head. Best-effort — a poll hiccup shouldn't refuse a run the
+          // commits list can serve, so it falls back to the oldest-first list's last
+          // entry (GitLab and Bitbucket reverse their newest-first payloads to match
+          // GitHub's; same read as RemotePrView's merge/review paths). The
+          // empty-headSha refusal below is the final backstop.
+          const polledHead = await forgePrPoll(repoPath)
+            .then((prs) => prs.find((p) => p.number === target.number)?.headSha)
+            .catch(() => undefined);
           resolved = {
             base: pr.baseRefName,
             head: pr.headRefName,
             title: pr.title,
             body: pr.body,
             commitSubjects: pr.commits.map((c) => c.headline),
-            // The neutral commit list is oldest-first on every provider — GitLab and
-            // Bitbucket reverse their newest-first payloads to match GitHub's — so the
-            // PR head is the LAST entry (same read as RemotePrView's merge/review paths).
-            headSha: pr.commits.at(-1)?.oid ?? "",
+            headSha: polledHead || (pr.commits.at(-1)?.oid ?? ""),
           };
         } else {
           // `listLocalPrs` reads the memoized store instance, so without this the
@@ -1242,7 +1265,7 @@ export function runAutomationNow(
       const current = await resolveTarget();
       if (!current) return;
 
-      const { matched, attempted } = await run(
+      const { matched, attempted, outcomes } = await run(
         {
           kind: "pr-sync",
           repoPath,
@@ -1265,11 +1288,18 @@ export function runAutomationNow(
         // Every confirmed mode was disabled between the confirm and the run.
         toast.info(NO_PR_AUTOMATION_COPY);
       } else if (attempted === 0) {
-        // The claim is identity-keyed, so this may be another worktree of this repo
-        // or another machine — say what is true, not where it is.
-        toast.info(
-          "This pull request's head is already claimed by a review run — it will post when that one finishes.",
-        );
+        // Nothing started, and WHY decides the copy: a held claim still posts when it
+        // finishes, a failed gate read never will — telling the user to wait for a run
+        // that cannot arrive is the silent no-op this feature exists to end. A claim
+        // wins when both are present: it is the arm that still has a run behind it.
+        const codes = new Set(outcomes.map((o) => o.code));
+        if (!codes.has("claim-held") && codes.has("eligibility-error")) {
+          toast.error(GATE_READ_FAILED_COPY);
+        } else {
+          // The claim is identity-keyed, so this may be another worktree of this repo
+          // or another machine — say what is true, not where it is.
+          toast.info(HEAD_CLAIMED_COPY);
+        }
       }
       // attempted > 0: the dock's live row is the feedback — no toast.
     } catch (e) {

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -1168,7 +1168,9 @@ export function runAutomationNow(
 
       /** This target's state right now, or null when it can't run — the refusal
        *  toast is already shown by the time null comes back. */
-      const resolveTarget = async (): Promise<ResolvedRunTarget | null> => {
+      const resolveTarget = async (
+        pollHead: boolean,
+      ): Promise<ResolvedRunTarget | null> => {
         let resolved: ResolvedRunTarget;
         if (target.kind === "remote") {
           // Origin-pinned like every other store/forge touch on this path.
@@ -1177,20 +1179,16 @@ export function runAutomationNow(
             toast.info(CLOSED_PR_COPY);
             return null;
           }
-          // The head-OID poll is the authority here — it is provider-neutral and its
-          // `headSha` is the very value pr-sync detection keys on, so Run-now claims
-          // and persists the same head the lifecycle would. The commits list alone
-          // can't be trusted for this: `gh_pr_view` completes a >100-commit PR from
-          // the paginated REST endpoint and falls back to the TRUNCATED 100-entry
-          // GraphQL list when that read fails, and the last entry of a truncated list
-          // is not the head. Best-effort — a poll hiccup shouldn't refuse a run the
-          // commits list can serve, so it falls back to the oldest-first list's last
-          // entry (GitLab and Bitbucket reverse their newest-first payloads to match
-          // GitHub's; same read as RemotePrView's merge/review paths). The
-          // empty-headSha refusal below is the final backstop.
-          const polledHead = await forgePrPoll(repoPath)
-            .then((prs) => prs.find((p) => p.number === target.number)?.headSha)
-            .catch(() => undefined);
+          // The poll's `headSha` is the value pr-sync detection keys on; `gh_pr_view`'s
+          // commit list truncates at 100, so its last entry may not be the head. The
+          // preview pass skips it — its head only has to prove resolvable.
+          const polledHead = pollHead
+            ? await forgePrPoll(repoPath)
+                .then(
+                  (prs) => prs.find((p) => p.number === target.number)?.headSha,
+                )
+                .catch(() => undefined)
+            : undefined;
           resolved = {
             base: pr.baseRefName,
             head: pr.headRefName,
@@ -1239,7 +1237,7 @@ export function runAutomationNow(
 
       // Read once to name the PR in the confirm — and to refuse a closed or
       // unresolvable PR before spending a prompt on it.
-      const preview = await resolveTarget();
+      const preview = await resolveTarget(false);
       if (!preview) return;
 
       const reference =
@@ -1262,7 +1260,7 @@ export function runAutomationNow(
       // past the open-state check entirely. Re-read; the SECOND read is what runs.
       // Both arms read through to their source, so the only remaining window is the
       // milliseconds between here and the claim inside run().
-      const current = await resolveTarget();
+      const current = await resolveTarget(true);
       if (!current) return;
 
       const { matched, attempted, outcomes } = await run(

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -36,7 +36,7 @@ import { sectionFilePath } from "@/lib/git/diff-split";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import type { DiffStatEntry } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
-import { listLocalPrs, updateLocalPr } from "@/lib/pulls/local";
+import { listLocalPrs, reloadLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import {
   listReviews,
   type PersistedReview,
@@ -71,7 +71,11 @@ import {
   updateAutomationActivity,
 } from "./history";
 import { type AutomationRunResult, useAutomationResults } from "./results";
-import { loadAutomations, repoAutomationsFor } from "./store";
+import {
+  loadAutomations,
+  loadAutomationsFresh,
+  repoAutomationsFor,
+} from "./store";
 import { sameSha } from "./sync";
 import {
   ACTION_LABELS,
@@ -290,6 +294,12 @@ interface RunOptions {
   /** Run-now: run every PR-lifecycle action regardless of the skip gates (the
    *  claim still applies). See {@link runAutomationNow}. */
   force?: boolean;
+  /** Force mode only: the modes the user was shown and agreed to spend on. The
+   *  confirm's whole job is naming the spend, so execution is pinned to what it
+   *  named, INTERSECTED with what is still enabled at run time — a mode enabled
+   *  while the confirm sat open never runs, and one disabled since simply doesn't
+   *  match (the `matched === 0` toast already covers that). Absent = no pin. */
+  modes?: ReviewMode[];
   /** What set this pass in motion; defaults to the event's own lifecycle. */
   trigger?: AutomationTrigger;
 }
@@ -297,16 +307,22 @@ interface RunOptions {
 /** The PR-lifecycle actions a forced (Run-now) pass runs: the SET-union over both
  *  PR lifecycles, deduped by action, so one click runs each mode exactly once
  *  whichever lifecycle enabled it. Branch conditions ride along but are never
- *  evaluated in force mode — the user named this PR explicitly. */
+ *  evaluated in force mode — the user named this PR explicitly. `confirmed` pins
+ *  the result to the modes a confirm named (see {@link RunOptions.modes}); without
+ *  it the whole currently-enabled union runs. */
 function forcedActions(
   config: AutomationsConfigV2,
   repo: RepoOverride | undefined,
+  confirmed?: ReviewMode[],
 ): ReturnType<typeof effectiveActions> {
+  const allowed = confirmed ? new Set<ActionId>(confirmed) : null;
   const seen = new Set<ActionId>();
   const union: ReturnType<typeof effectiveActions> = [];
   for (const lifecycle of ["pr-open", "pr-sync"] as const) {
     for (const entry of effectiveActions(config, repo, lifecycle)) {
       if (seen.has(entry.action)) continue;
+      // Intersection, not replacement: still-enabled AND named by the confirm.
+      if (allowed && !allowed.has(entry.action)) continue;
       seen.add(entry.action);
       union.push(entry);
     }
@@ -325,7 +341,13 @@ async function run(
   event: AutomationEvent,
   opts: RunOptions = {},
 ): Promise<RunOutcome> {
-  const { only, replacesKey, force = false, trigger = event.kind } = opts;
+  const {
+    only,
+    replacesKey,
+    force = false,
+    modes,
+    trigger = event.kind,
+  } = opts;
   // Cold-start instances share the automation-claims dir with the real instance, so an
   // armed cold instance can win a claim meant for the real run and suppress it. First
   // gate of all, so a gated tick reads no store at all and takes no claim — including
@@ -337,7 +359,12 @@ async function run(
   // resume when AI is shown again. The paused/resumed markers cover this stretch.
   const settings = await loadSettings();
   if (settings.hideAi) return { matched: 0, attempted: 0, outcomes: [] };
-  const config = await loadAutomations();
+  // Force passes read through to disk: they are rare, user-initiated, and about to
+  // spend money against a mode set a confirm named, so a mode another instance
+  // disabled meanwhile must not execute. Lifecycle passes keep the cached read —
+  // poll-tick frequency, and cross-instance staleness there is the accepted
+  // sibling-store class.
+  const config = force ? await loadAutomationsFresh() : await loadAutomations();
   const repo = await repoAutomationsFor(config, event.repoPath);
   // Whether this REPO has any automation at all, across every lifecycle — records
   // happen only when it does, so a repo the user never configured accrues zero rows
@@ -347,8 +374,9 @@ async function run(
   const recordingEnabled = lifecycles.some(
     (lc) => effectiveActions(config, repo, lc).length > 0,
   );
+  // `modes` is force-only: a lifecycle pass runs whatever its own lifecycle enables.
   const actions = force
-    ? forcedActions(config, repo)
+    ? forcedActions(config, repo, modes)
     : effectiveActions(config, repo, event.kind);
   // No enabled action for THIS lifecycle: records nothing by design — the dialog
   // derives the config header from the live config, not from a row per tick.
@@ -447,6 +475,29 @@ async function run(
     }
     return gateSnapshot;
   };
+  /**
+   * The gate snapshot, or null when its stores couldn't be read — a failure records an
+   * `eligibility-error` for this action and the caller skips it. Fail-closed like
+   * `prOpenEligible`, but with EVIDENCE: an unguarded rejection escapes run(),
+   * `triggerAutomations` swallows it, and `maybeFireSync` has already latched this head
+   * for the session — so an enabled re-review dies leaving nothing behind, the exact
+   * class this history exists to end.
+   */
+  const gateStateOrRecord = async (
+    prEvent: PrAutomationEvent,
+    forAction: ActionId,
+  ) => {
+    try {
+      return await gateState(prEvent);
+    } catch (e) {
+      skips.push({
+        action: forAction,
+        code: "eligibility-error",
+        detail: errorMessage(e),
+      });
+      return null;
+    }
+  };
   for (const { action, conditions } of actions) {
     if (only && action !== only) continue;
     // Force mode never evaluates conditions: the user named this PR explicitly, so
@@ -472,7 +523,9 @@ async function run(
     // so the gating is unchanged): each skip is a different thing to tell the user.
     if (!force && event.kind === "pr-sync") {
       const headSha = event.headSha ?? "";
-      const { reviews, dismissed } = await gateState(event);
+      const gate = await gateStateOrRecord(event, action);
+      if (!gate) continue;
+      const { reviews, dismissed } = gate;
       const covered = reviews.filter((r) => r.mode === action);
       // A CANCELLED re-review persists the dismissed head, so a cancelled head doesn't
       // re-fire after an app relaunch — only a genuinely newer head does.
@@ -498,7 +551,9 @@ async function run(
     // a head this mode already dismissed. Mirror of the pr-sync gate, inverted — pr-sync
     // requires a prior review, pr-open requires its absence.
     if (!force && event.kind === "pr-open") {
-      const { reviews, dismissed } = await gateState(event);
+      const gate = await gateStateOrRecord(event, action);
+      if (!gate) continue;
+      const { reviews, dismissed } = gate;
       // The list is newest-first, so this mode's first entry IS its latest review — the
       // same record `getLatestReview` would return.
       const prior = reviews.find((r) => r.mode === action);
@@ -533,17 +588,20 @@ async function run(
     // windows clicking Run-now on the same delivered head inside one run window can
     // both claim and both post.
     if (force && event.kind !== "commit" && headSha) {
-      const { reviews } = await gateState(event);
-      const alreadyCovered = reviews.some(
+      // A failed read leaves this action un-run with a recorded reason, rather than
+      // claiming a head whose coverage we couldn't check.
+      const gate = await gateStateOrRecord(event, action);
+      if (!gate) continue;
+      const alreadyCovered = gate.reviews.some(
         (r) => r.mode === action && sameSha(r.headSha, headSha),
       );
       if (
         alreadyCovered &&
-        !hasLiveAutomationRun(
+        !(await hasLiveAutomationRun(
           event.repoPath,
           event.target.type,
           targetRef(event),
-        )
+        ))
       ) {
         const repoKey = await repoIdentity(event.repoPath);
         await invoke("release_automation_claim", {
@@ -609,7 +667,7 @@ async function run(
     attempted++;
     // Record BEFORE the paid work: the longest operation must not be the one with zero
     // trace. A process killed mid-stream leaves this "started" row behind, which the
-    // dialog reads as interrupted (against SESSION_START_MS) rather than in flight.
+    // dialog renders as unsettled (its liveness check finds no matching live run).
     await recordProgress({ action, code: "started" });
     // Per-rule cancellation: HTTP providers stop via the AbortSignal, CLI providers by
     // killing the subprocess (`cancelAgentReview` once its id is known); both are driven
@@ -635,8 +693,9 @@ async function run(
       abort: controller,
       // Re-fires THIS event + mode (closes over this iteration's action) when the
       // run's stopped row's Re-run is clicked, passing its own row key so the
-      // fresh run removes THIS row when it registers.
-      rerun: () => rerunAutomation(event, action, selfKey),
+      // fresh row removes THIS row when it registers. `force` rides along so the
+      // retry of an explicitly-started run keeps the semantics the user chose.
+      rerun: () => rerunAutomation(event, action, selfKey, { force }),
     });
     selfKey = handle.key;
     // The replacement has registered — now remove the stopped row it replaces. Done here
@@ -880,7 +939,8 @@ async function run(
           // no-ops on a gone key).
           action: {
             label: "Re-run",
-            run: () => rerunAutomation(event, mode, selfKey),
+            // Same semantics as the dock row's Re-run — both re-fire the same pass.
+            run: () => rerunAutomation(event, mode, selfKey, { force }),
           },
           dedupeKey: `automation-failed:${event.repoPath}:${event.kind}:${
             event.kind === "commit" ? event.hash : targetRef(event)
@@ -944,12 +1004,20 @@ async function run(
  * than leave a dead button. While AI features are hidden — or in a cold-start instance
  * that never opted automations in — it stops before the clear: a paused re-run must not
  * consume the watermark.
+ *
+ * `opts.force` carries the ORIGINATING pass's mode through: retrying a stopped Run-now
+ * must skip the same gates the Run-now did, or the retry of a run the user started by
+ * hand gets rejected by a first-review/covered-head/branch rule it was never subject to
+ * (and on a pr-open-only repo, by the synthesized event's lifecycle having no rules at
+ * all). Absent = a lifecycle run's Re-run, unchanged.
  */
 export function rerunAutomation(
   event: AutomationEvent,
   only: ReviewMode,
   staleKey: string,
+  opts?: { force?: boolean },
 ): void {
+  const force = opts?.force ?? false;
   const label = modeLabel(only);
   const noun = event.kind === "commit" ? "commit" : "pull request";
   void (async () => {
@@ -967,7 +1035,9 @@ export function rerunAutomation(
       }
       // Best-effort ONLY here: a cleared-dismissal failure must not block the
       // re-run (it just means the pr-sync gate might skip; we then toast retryable).
-      if (event.kind !== "commit") {
+      // Skipped under force, which consults no watermark — clearing one would spend
+      // a record the next LIFECYCLE run still needs.
+      if (event.kind !== "commit" && !force) {
         await clearDismissedHead(
           event.repoPath,
           "origin",
@@ -981,7 +1051,8 @@ export function rerunAutomation(
       const { matched, attempted } = await run(event, {
         only,
         replacesKey: staleKey,
-        trigger: "re-run",
+        force,
+        trigger: force ? "run-now" : "re-run",
       });
       if (matched === 0) {
         // The rule genuinely no longer applies (disabled / conditions changed).
@@ -1007,6 +1078,11 @@ export function rerunAutomation(
  * click to the run's `finally`. The cross-instance claim doesn't exist yet during the
  * multi-second window this spends resolving the PR and waiting on a confirm, so
  * without this latch palette spam would start two runs on the same PR.
+ *
+ * Keyed on the RAW checkout path, unlike the identity-aware live-run check: resolving
+ * an identity here would mean awaiting before the latch is set, opening the TOCTOU
+ * window the latch exists to close. Residual: a double-invoke from two checkouts of
+ * one repo inside the pre-claim window rides the cross-instance claim dedup instead.
  */
 const runNowStarting = new Set<string>();
 
@@ -1020,6 +1096,17 @@ const CLOSED_PR_COPY =
 
 const UNRESOLVED_HEAD_COPY =
   "Couldn't resolve the pull request's current head — try refreshing.";
+
+/** A Run-now target's state at one moment: everything the synthesized event needs.
+ *  Every field is a point-in-time read, which is why it gets resolved twice. */
+interface ResolvedRunTarget {
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  commitSubjects: string[];
+  headSha: string;
+}
 
 /**
  * Runs this repo's PR automations against one pull request right now — the explicit
@@ -1060,66 +1147,82 @@ export function runAutomationNow(
         toast.info(NO_PR_AUTOMATION_COPY);
         return;
       }
-      if (hasLiveAutomationRun(repoPath, target.kind, ref)) {
+      if (await hasLiveAutomationRun(repoPath, target.kind, ref)) {
         toast.info(
           "An AI review of this pull request is already running — watch it in Activity.",
         );
         return;
       }
 
-      let base: string;
-      let head: string;
-      let title: string;
-      let body: string;
-      let commitSubjects: string[];
-      let headSha: string;
-      if (target.kind === "remote") {
-        // Origin-pinned like every other store/forge touch on this path.
-        const pr = await forgePrView(repoPath, target.number, "origin");
-        if (pr.state !== "OPEN") {
-          toast.info(CLOSED_PR_COPY);
-          return;
+      /** This target's state right now, or null when it can't run — the refusal
+       *  toast is already shown by the time null comes back. */
+      const resolveTarget = async (): Promise<ResolvedRunTarget | null> => {
+        let resolved: ResolvedRunTarget;
+        if (target.kind === "remote") {
+          // Origin-pinned like every other store/forge touch on this path.
+          const pr = await forgePrView(repoPath, target.number, "origin");
+          if (pr.state !== "OPEN") {
+            toast.info(CLOSED_PR_COPY);
+            return null;
+          }
+          resolved = {
+            base: pr.baseRefName,
+            head: pr.headRefName,
+            title: pr.title,
+            body: pr.body,
+            commitSubjects: pr.commits.map((c) => c.headline),
+            // The neutral commit list is oldest-first on every provider — GitLab and
+            // Bitbucket reverse their newest-first payloads to match GitHub's — so the
+            // PR head is the LAST entry (same read as RemotePrView's merge/review paths).
+            headSha: pr.commits.at(-1)?.oid ?? "",
+          };
+        } else {
+          // `listLocalPrs` reads the memoized store instance, so without this the
+          // re-read below would answer from this process's snapshot and miss a
+          // close/delete/retarget made by another instance or the MCP server. The
+          // remote arm gets this for free — it is a network read.
+          await reloadLocalPrs();
+          const prs = await listLocalPrs(repoPath);
+          const pr = prs.find((p) => p.id === target.id);
+          // Deleted since the menu opened — a head to resolve was never the problem,
+          // so "try refreshing" would send the user looking for the wrong thing.
+          if (!pr) {
+            toast.error("This pull request no longer exists.");
+            return null;
+          }
+          if (pr.status !== "open") {
+            toast.info(CLOSED_PR_COPY);
+            return null;
+          }
+          const tips = await gitBranchTips(repoPath, [pr.head]);
+          resolved = {
+            base: pr.base,
+            head: pr.head,
+            title: pr.title,
+            body: pr.body,
+            // Local PRs carry no commit list; the branch diff is the source of truth.
+            commitSubjects: [],
+            headSha: tips[pr.head] ?? "",
+          };
         }
-        base = pr.baseRefName;
-        head = pr.headRefName;
-        title = pr.title;
-        body = pr.body;
-        commitSubjects = pr.commits.map((c) => c.headline);
-        // The neutral commit list is oldest-first on every provider — GitLab and
-        // Bitbucket reverse their newest-first payloads to match GitHub's — so the
-        // PR head is the LAST entry (same read as RemotePrView's merge/review paths).
-        headSha = pr.commits.at(-1)?.oid ?? "";
-      } else {
-        const prs = await listLocalPrs(repoPath);
-        const pr = prs.find((p) => p.id === target.id);
-        // Deleted since the menu opened — a head to resolve was never the problem,
-        // so "try refreshing" would send the user looking for the wrong thing.
-        if (!pr) {
-          toast.error("This pull request no longer exists.");
-          return;
+        // The claim keys on the head: running without one forfeits cross-instance
+        // dedup, so refuse rather than risk a duplicate paid review.
+        if (!resolved.headSha) {
+          toast.error(UNRESOLVED_HEAD_COPY);
+          return null;
         }
-        if (pr.status !== "open") {
-          toast.info(CLOSED_PR_COPY);
-          return;
-        }
-        base = pr.base;
-        head = pr.head;
-        title = pr.title;
-        body = pr.body;
-        // Local PRs carry no commit list; the branch diff is the source of truth.
-        commitSubjects = [];
-        const tips = await gitBranchTips(repoPath, [pr.head]);
-        headSha = tips[pr.head] ?? "";
-      }
-      // The claim keys on the head: running without one forfeits cross-instance
-      // dedup, so refuse rather than risk a duplicate paid review.
-      if (!headSha) {
-        toast.error(UNRESOLVED_HEAD_COPY);
-        return;
-      }
+        return resolved;
+      };
+
+      // Read once to name the PR in the confirm — and to refuse a closed or
+      // unresolvable PR before spending a prompt on it.
+      const preview = await resolveTarget();
+      if (!preview) return;
 
       const reference =
-        target.kind === "remote" ? `#${target.number} · ${title}` : title;
+        target.kind === "remote"
+          ? `#${target.number} · ${preview.title}`
+          : preview.title;
       const modeList = modes.map((m) => ACTION_LABELS[m]).join(" and ");
       const ok = await useConfirm.getState().ask({
         title: "Run automations on this pull request?",
@@ -1128,25 +1231,38 @@ export function runAutomationNow(
       });
       if (!ok) return;
 
+      // The confirm has no deadline, so everything read above is stale by
+      // construction. A push while it sat open would have run() claim and persist
+      // the OLD head while `resolveDiff` fetches the provider's CURRENT diff — the
+      // review would cover content that no record then marks as covered, leaving the
+      // reviewed head eligible for a duplicate paid re-review. A close would slip
+      // past the open-state check entirely. Re-read; the SECOND read is what runs.
+      // Both arms read through to their source, so the only remaining window is the
+      // milliseconds between here and the claim inside run().
+      const current = await resolveTarget();
+      if (!current) return;
+
       const { matched, attempted } = await run(
         {
           kind: "pr-sync",
           repoPath,
-          base,
-          head,
-          headSha,
-          title,
-          body,
-          commitSubjects,
+          base: current.base,
+          head: current.head,
+          headSha: current.headSha,
+          title: current.title,
+          body: current.body,
+          commitSubjects: current.commitSubjects,
           target:
             target.kind === "remote"
               ? { type: "remote", number: target.number }
               : { type: "local", id: target.id },
         },
-        { force: true, trigger: "run-now" },
+        // `modes` is the exact set the confirm named, so a mode enabled in another
+        // window while the prompt sat open can't ride along on the user's yes.
+        { force: true, modes, trigger: "run-now" },
       );
       if (matched === 0) {
-        // The config changed between the confirm and the run.
+        // Every confirmed mode was disabled between the confirm and the run.
         toast.info(NO_PR_AUTOMATION_COPY);
       } else if (attempted === 0) {
         // The claim is identity-keyed, so this may be another worktree of this repo

--- a/src/lib/automations/store.ts
+++ b/src/lib/automations/store.ts
@@ -357,6 +357,25 @@ export async function loadAutomations(): Promise<AutomationsConfigV2> {
 }
 
 /**
+ * {@link loadAutomations}, re-reading disk first — for the callers that must not
+ * decide on this process's snapshot, since a mode another instance disabled stays
+ * invisible to the memoized store until something reloads it. Same idea as
+ * `listReviews`' `{ fresh: true }`: cheap enough for a user-initiated gate, too
+ * expensive for a poll tick.
+ *
+ * A separate export rather than an option on {@link loadAutomations}: that one is
+ * handed to react-query as a BARE `queryFn` reference (`automations/queries.ts`),
+ * which would pass its own context object into any leading parameter.
+ */
+export async function loadAutomationsFresh(): Promise<AutomationsConfigV2> {
+  const store = await getStore();
+  // Inside the serialized queue so the reload can't land between a concurrent
+  // mutation's set and its flush.
+  await serialize(() => reloadRaw(store));
+  return loadAutomations();
+}
+
+/**
  * Persists the GLOBAL lifecycle defaults from `config`. Only `config.lifecycles` is
  * written; per-repo overrides are re-derived from fresh disk state inside the
  * serialized queue rather than taken from the caller's (possibly stale) snapshot, so

--- a/src/lib/automations/store.ts
+++ b/src/lib/automations/store.ts
@@ -1,13 +1,15 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { toast } from "sonner";
-import type { ReviewMode } from "@/lib/ai/types";
+import { REVIEW_MODES, type ReviewMode } from "@/lib/ai/types";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { storeName } from "@/lib/test-mode";
 import {
   type ActionConfig,
   type ActionId,
   type AutomationsConfigV2,
+  BRANCH_MATCH_MODES,
   type BranchConditions,
+  LIFECYCLE_EVENTS,
   type LifecycleConfig,
   type LifecycleEvent,
   type RepoActionOverride,
@@ -15,8 +17,8 @@ import {
   repoEntry,
 } from "./types";
 
-const LIFECYCLES: LifecycleEvent[] = ["commit", "pr-open", "pr-sync"];
-const ACTIONS: ActionId[] = ["general", "security"];
+const LIFECYCLES = LIFECYCLE_EVENTS;
+const ACTIONS = REVIEW_MODES;
 
 // Personal app-data — automation rules are the user's, never the repo's.
 let storePromise: Promise<Store> | null = null;
@@ -94,10 +96,10 @@ interface V1Config {
 }
 
 function isReviewMode(v: unknown): v is ReviewMode {
-  return v === "general" || v === "security";
+  return ACTIONS.some((action) => action === v);
 }
 function isLifecycle(v: unknown): v is LifecycleEvent {
-  return v === "commit" || v === "pr-open" || v === "pr-sync";
+  return LIFECYCLES.some((lifecycle) => lifecycle === v);
 }
 
 /** A stored value is v1 when it has a `global` array and isn't already v2. */
@@ -121,10 +123,7 @@ function normalizeConditions(v: unknown): BranchConditions | undefined {
   };
   const strArray = (a: unknown): string[] =>
     Array.isArray(a) ? a.filter((x): x is string => typeof x === "string") : [];
-  const match =
-    obj.match === "head" || obj.match === "base" || obj.match === "either"
-      ? obj.match
-      : "head";
+  const match = BRANCH_MATCH_MODES.find((mode) => mode === obj.match) ?? "head";
   return {
     include: strArray(obj.include),
     exclude: strArray(obj.exclude),

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -1,7 +1,14 @@
 import { listReviews } from "@/lib/pulls/reviews-history";
+import { errorMessage } from "@/lib/tauri/invoke";
 import { getDismissedHeadMap } from "./dismissals";
+import {
+  type AutomationOutcomeCode,
+  type AutomationTrigger,
+  recordAutomationActivity,
+} from "./history";
 import { triggerAutomations } from "./runner";
-import { ALL_ACTION_IDS } from "./types";
+import { loadAutomations, repoAutomationsFor } from "./store";
+import { ALL_ACTION_IDS, effectiveActions } from "./types";
 
 /**
  * Per-`(kind, repo, ref)` EVERY head already fired for, `sameSha`-matched — an
@@ -129,43 +136,140 @@ export function maybeCatchUpMissedOpen(
   if (!viewerLogin) return;
 
   const now = Date.now();
+  // Decisions worth durable evidence, collected DURING the synchronous pre-filter
+  // and recorded afterwards — the author gate runs first, so a foreign PR (the
+  // poll's majority) can never reach the store and evict the user's own rows.
+  const skipped: {
+    candidate: CatchUpCandidate;
+    code: AutomationOutcomeCode;
+    detail?: string;
+  }[] = [];
   // Synchronous pre-filter: mine, has a head, opened recently, drafts only when
   // `reviewDrafts` is on, and not already attempted this session.
   const eligible = candidates
     .filter((c) => {
       if (!c.currentHeadSha) return false;
       if (c.author !== viewerLogin) return false;
-      if (c.isDraft && !reviewDrafts) return false;
+      if (c.isDraft && !reviewDrafts) {
+        skipped.push({ candidate: c, code: "draft-skipped" });
+        return false;
+      }
       const opened = Date.parse(c.createdAt);
-      if (Number.isNaN(opened)) return false;
-      if (now - opened > CATCH_UP_WINDOW_MS) return false;
+      if (Number.isNaN(opened)) {
+        // Shares the fail-closed code with a genuine window miss, but carries its
+        // own reason: the age this code usually implies was never measured here.
+        skipped.push({
+          candidate: c,
+          code: "too-old",
+          detail: "Skipped — couldn't read when this pull request was opened",
+        });
+        return false;
+      }
+      if (now - opened > CATCH_UP_WINDOW_MS) {
+        skipped.push({ candidate: c, code: "too-old" });
+        return false;
+      }
+      // Already attempted this session: self-resolving, so it records nothing.
       return !catchUpAttempted.has(`${repoPath}#${c.ref}@${c.currentHeadSha}`);
     })
     // Oldest first (lowest number) so the backlog drains in order, one per tick.
     .sort((a, b) => Number(a.ref) - Number(b.ref));
 
   const pick = eligible[0];
+  // Fire-and-forget (no await here), so the mark below still precedes every await
+  // in this function. Runs even when nothing was picked — a skipped PR's evidence
+  // doesn't depend on another PR being caught up. Candidates that are eligible but
+  // merely NOT PICKED record nothing: that deferral resolves within minutes by
+  // construction, so a durable row would be a stale lie.
+  void recordCatchUpSkips(repoPath, skipped).catch(() => undefined);
   if (!pick) return;
 
   // Mark BEFORE any await so a concurrent tick can't also claim this PR.
   catchUpAttempted.add(`${repoPath}#${pick.ref}@${pick.currentHeadSha}`);
 
-  void catchUpEligible(repoPath, pick).then((ok) => {
-    if (!ok) return;
-    triggerAutomations({
-      kind: "pr-open",
-      repoPath,
-      base: pick.base,
-      head: pick.head,
-      headSha: pick.currentHeadSha,
-      title: pick.title,
-      // The poll payload carries no body/commit subjects; the PR diff is the
-      // source of truth (pr-sync already fires them empty the same way).
-      body: "",
-      commitSubjects: [],
-      target: { type: "remote", number: Number(pick.ref) },
-    });
+  void catchUpEligible(repoPath, pick).then(({ eligible: ok, error }) => {
+    if (!ok) {
+      // An eligibility ERROR is recorded inside the core (it knows the reason); a
+      // genuine false means every mode already has its review.
+      if (error === undefined) {
+        void recordCatchUpDecision(
+          repoPath,
+          pick,
+          "already-reviewed",
+          "catch-up",
+        ).catch(() => undefined);
+      }
+      return;
+    }
+    triggerAutomations(
+      {
+        kind: "pr-open",
+        repoPath,
+        base: pick.base,
+        head: pick.head,
+        headSha: pick.currentHeadSha,
+        title: pick.title,
+        // The poll payload carries no body/commit subjects; the PR diff is the
+        // source of truth (pr-sync already fires them empty the same way).
+        body: "",
+        commitSubjects: [],
+        target: { type: "remote", number: Number(pick.ref) },
+      },
+      "catch-up",
+    );
   });
+}
+
+/** Whether this repo has any effective `pr-open` action — the gate on every row
+ *  this module records, so a repo with no pr-open automation accrues none at all
+ *  (its dialog's empty state teaches instead). */
+async function prOpenAutomationEnabled(repoPath: string): Promise<boolean> {
+  const config = await loadAutomations();
+  const repo = await repoAutomationsFor(config, repoPath);
+  return effectiveActions(config, repo, "pr-open").length > 0;
+}
+
+/** One action-less catch-up row for a remote PR. Best-effort by construction —
+ *  `recordAutomationActivity` resolves null rather than rejecting. */
+async function recordCatchUpDecision(
+  repoPath: string,
+  row: { ref: string; title: string; currentHeadSha: string },
+  code: AutomationOutcomeCode,
+  trigger: AutomationTrigger,
+): Promise<void> {
+  if (!(await prOpenAutomationEnabled(repoPath))) return;
+  await recordAutomationActivity(repoPath, {
+    trigger,
+    targetKind: "remote",
+    ref: row.ref,
+    title: row.title,
+    headSha: row.currentHeadSha,
+    outcomes: [{ action: null, code }],
+  });
+}
+
+/** The pre-filter's skipped candidates, gated ONCE per call. Sequential so the
+ *  store's own queue takes them in order; the steady upsert coalesces repeats. */
+async function recordCatchUpSkips(
+  repoPath: string,
+  skipped: {
+    candidate: CatchUpCandidate;
+    code: AutomationOutcomeCode;
+    detail?: string;
+  }[],
+): Promise<void> {
+  if (skipped.length === 0) return;
+  if (!(await prOpenAutomationEnabled(repoPath))) return;
+  for (const { candidate, code, detail } of skipped) {
+    await recordAutomationActivity(repoPath, {
+      trigger: "catch-up",
+      targetKind: "remote",
+      ref: candidate.ref,
+      title: candidate.title,
+      headSha: candidate.currentHeadSha,
+      outcomes: [{ action: null, code, ...(detail ? { detail } : {}) }],
+    });
+  }
 }
 
 /**
@@ -185,7 +289,29 @@ export async function prOpenEligible(
   repoPath: string,
   ref: string,
   currentHeadSha: string,
+  trigger: AutomationTrigger = "pr-open",
 ): Promise<boolean> {
+  const { eligible } = await prOpenEligibleDetailed(
+    repoPath,
+    ref,
+    currentHeadSha,
+    trigger,
+  );
+  return eligible;
+}
+
+/**
+ * The eligibility core {@link prOpenEligible} maps to a boolean, distinguishing a
+ * genuine "every mode already reviewed" from a store failure that failed CLOSED —
+ * the pair reads identically at the call sites, and only this layer can tell them
+ * apart, so this is where the fail-closed trap leaves its evidence.
+ */
+async function prOpenEligibleDetailed(
+  repoPath: string,
+  ref: string,
+  currentHeadSha: string,
+  trigger: AutomationTrigger,
+): Promise<{ eligible: boolean; error?: string }> {
   try {
     // One fresh read of each store for the whole PR instead of one per mode, and the two
     // concurrently — separate stores, independent queues. `fresh` reloads from disk and
@@ -205,21 +331,57 @@ export async function prOpenEligible(
       // A dismissed head matching the current head means this mode was deliberately
       // skipped for this head — it doesn't need a review either.
       if (dismissed && sameSha(dismissed, currentHeadSha)) continue;
-      return true;
+      return { eligible: true };
     }
-    return false;
-  } catch {
-    return false;
+    return { eligible: false };
+  } catch (e) {
+    const detail = errorMessage(e);
+    // Fire-and-forget with its own catch, so the recording attempt is structurally
+    // incapable of changing the verdict below. This placement is what gives the
+    // Mark-ready call site (RemotePrView) evidence too.
+    void recordEligibilityError(
+      repoPath,
+      ref,
+      currentHeadSha,
+      trigger,
+      detail,
+    ).catch(() => undefined);
+    return { eligible: false, error: detail };
   }
 }
 
+/** The eligibility-error row, gated on this repo actually having a pr-open
+ *  automation (an error nobody's automation would have acted on is not evidence). */
+async function recordEligibilityError(
+  repoPath: string,
+  ref: string,
+  currentHeadSha: string,
+  trigger: AutomationTrigger,
+  detail: string,
+): Promise<void> {
+  if (!(await prOpenAutomationEnabled(repoPath))) return;
+  await recordAutomationActivity(repoPath, {
+    trigger,
+    targetKind: "remote",
+    ref,
+    title: "",
+    headSha: currentHeadSha,
+    outcomes: [{ action: null, code: "eligibility-error", detail }],
+  });
+}
+
 /**
- * Catch-up wrapper over {@link prOpenEligible}. Runs after the synchronous
+ * Catch-up wrapper over {@link prOpenEligibleDetailed}. Runs after the synchronous
  * attempt-mark, so a failure here won't re-enter the same PR this session.
  */
 async function catchUpEligible(
   repoPath: string,
   pick: CatchUpCandidate,
-): Promise<boolean> {
-  return prOpenEligible(repoPath, pick.ref, pick.currentHeadSha);
+): Promise<{ eligible: boolean; error?: string }> {
+  return prOpenEligibleDetailed(
+    repoPath,
+    pick.ref,
+    pick.currentHeadSha,
+    "catch-up",
+  );
 }

--- a/src/lib/automations/sync.ts
+++ b/src/lib/automations/sync.ts
@@ -2,13 +2,22 @@ import { listReviews } from "@/lib/pulls/reviews-history";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { getDismissedHeadMap } from "./dismissals";
 import {
+  type AutomationOutcome,
   type AutomationOutcomeCode,
   type AutomationTrigger,
   recordAutomationActivity,
 } from "./history";
 import { triggerAutomations } from "./runner";
 import { loadAutomations, repoAutomationsFor } from "./store";
-import { ALL_ACTION_IDS, effectiveActions } from "./types";
+import { type ActionId, ALL_ACTION_IDS, effectiveActions } from "./types";
+
+/** Why one mode didn't need a first review — the two genuine-false axes, kept apart
+ *  because they are different facts: a cancel writes a dismissal with no review at
+ *  all, so "already reviewed" would be a lie about a PR that has zero reviews. */
+interface BlockedMode {
+  action: ActionId;
+  code: "already-reviewed" | "head-dismissed";
+}
 
 /**
  * Per-`(kind, repo, ref)` EVERY head already fired for, `sameSha`-matched — an
@@ -187,37 +196,38 @@ export function maybeCatchUpMissedOpen(
   // Mark BEFORE any await so a concurrent tick can't also claim this PR.
   catchUpAttempted.add(`${repoPath}#${pick.ref}@${pick.currentHeadSha}`);
 
-  void catchUpEligible(repoPath, pick).then(({ eligible: ok, error }) => {
-    if (!ok) {
-      // An eligibility ERROR is recorded inside the core (it knows the reason); a
-      // genuine false means every mode already has its review.
-      if (error === undefined) {
-        void recordCatchUpDecision(
-          repoPath,
-          pick,
-          "already-reviewed",
-          "catch-up",
-        ).catch(() => undefined);
+  void catchUpEligible(repoPath, pick).then(
+    ({ eligible: ok, error, blocked }) => {
+      if (!ok) {
+        // An eligibility ERROR is recorded inside the core (it knows the reason); a
+        // genuine false is recorded here, one outcome PER MODE — "already reviewed"
+        // and "this head was dismissed" are different facts, and a cancelled run
+        // writes a dismissal with no review at all.
+        if (error === undefined && blocked && blocked.length > 0) {
+          void recordCatchUpDecision(repoPath, pick, blocked, "catch-up").catch(
+            () => undefined,
+          );
+        }
+        return;
       }
-      return;
-    }
-    triggerAutomations(
-      {
-        kind: "pr-open",
-        repoPath,
-        base: pick.base,
-        head: pick.head,
-        headSha: pick.currentHeadSha,
-        title: pick.title,
-        // The poll payload carries no body/commit subjects; the PR diff is the
-        // source of truth (pr-sync already fires them empty the same way).
-        body: "",
-        commitSubjects: [],
-        target: { type: "remote", number: Number(pick.ref) },
-      },
-      "catch-up",
-    );
-  });
+      triggerAutomations(
+        {
+          kind: "pr-open",
+          repoPath,
+          base: pick.base,
+          head: pick.head,
+          headSha: pick.currentHeadSha,
+          title: pick.title,
+          // The poll payload carries no body/commit subjects; the PR diff is the
+          // source of truth (pr-sync already fires them empty the same way).
+          body: "",
+          commitSubjects: [],
+          target: { type: "remote", number: Number(pick.ref) },
+        },
+        "catch-up",
+      );
+    },
+  );
 }
 
 /** Whether this repo has any effective `pr-open` action — the gate on every row
@@ -234,7 +244,7 @@ async function prOpenAutomationEnabled(repoPath: string): Promise<boolean> {
 async function recordCatchUpDecision(
   repoPath: string,
   row: { ref: string; title: string; currentHeadSha: string },
-  code: AutomationOutcomeCode,
+  outcomes: AutomationOutcome[],
   trigger: AutomationTrigger,
 ): Promise<void> {
   if (!(await prOpenAutomationEnabled(repoPath))) return;
@@ -244,7 +254,7 @@ async function recordCatchUpDecision(
     ref: row.ref,
     title: row.title,
     headSha: row.currentHeadSha,
-    outcomes: [{ action: null, code }],
+    outcomes,
   });
 }
 
@@ -311,7 +321,13 @@ async function prOpenEligibleDetailed(
   ref: string,
   currentHeadSha: string,
   trigger: AutomationTrigger,
-): Promise<{ eligible: boolean; error?: string }> {
+): Promise<{
+  eligible: boolean;
+  error?: string;
+  /** Present on a GENUINE false: the axis that blocked each mode. Absent when the
+   *  verdict came from the fail-closed catch, where nothing is known. */
+  blocked?: BlockedMode[];
+}> {
   try {
     // One fresh read of each store for the whole PR instead of one per mode, and the two
     // concurrently — separate stores, independent queues. `fresh` reloads from disk and
@@ -323,17 +339,27 @@ async function prOpenEligibleDetailed(
       listReviews(repoPath, "origin", "remote", ref, { fresh: true }),
       getDismissedHeadMap(repoPath, "origin", "remote", ref, { fresh: true }),
     ]);
+    // The loop already knows which arm each mode hits, so keep it rather than
+    // re-deriving a reason at the log site from a bare boolean.
+    const blocked: BlockedMode[] = [];
     for (const mode of ALL_ACTION_IDS) {
       // Newest-first, so this mode's first entry is the latest review for it.
       const prior = reviews.find((r) => r.mode === mode);
-      if (prior) continue; // this mode already reviewed — no need on its account
+      if (prior) {
+        // this mode already reviewed — no need on its account
+        blocked.push({ action: mode, code: "already-reviewed" });
+        continue;
+      }
       const dismissed = dismissedByMode[mode];
       // A dismissed head matching the current head means this mode was deliberately
       // skipped for this head — it doesn't need a review either.
-      if (dismissed && sameSha(dismissed, currentHeadSha)) continue;
+      if (dismissed && sameSha(dismissed, currentHeadSha)) {
+        blocked.push({ action: mode, code: "head-dismissed" });
+        continue;
+      }
       return { eligible: true };
     }
-    return { eligible: false };
+    return { eligible: false, blocked };
   } catch (e) {
     const detail = errorMessage(e);
     // Fire-and-forget with its own catch, so the recording attempt is structurally
@@ -377,7 +403,7 @@ async function recordEligibilityError(
 async function catchUpEligible(
   repoPath: string,
   pick: CatchUpCandidate,
-): Promise<{ eligible: boolean; error?: string }> {
+): Promise<{ eligible: boolean; error?: string; blocked?: BlockedMode[] }> {
   return prOpenEligibleDetailed(
     repoPath,
     pick.ref,

--- a/src/lib/automations/types.ts
+++ b/src/lib/automations/types.ts
@@ -1,11 +1,14 @@
-import type { ReviewMode } from "@/lib/ai/types";
+import { REVIEW_MODES, type ReviewMode } from "@/lib/ai/types";
 import { matchesGlob } from "@/lib/branch-rules/match";
 
 /** The moments an automation can fire on. */
-export type LifecycleEvent = "commit" | "pr-open" | "pr-sync";
+export const LIFECYCLE_EVENTS = ["commit", "pr-open", "pr-sync"] as const;
+export type LifecycleEvent = (typeof LIFECYCLE_EVENTS)[number];
 
 /** What an automation runs — the same modes as the manual Review tab. */
-export type ActionId = ReviewMode; // "general" | "security"
+export type ActionId = ReviewMode;
+
+export const BRANCH_MATCH_MODES = ["head", "base", "either"] as const;
 
 /**
  * Which branches an action applies to. `include`/`exclude` are fnmatch-style
@@ -19,7 +22,7 @@ export interface BranchConditions {
   /** Globs; a matching exclude beats any include. */
   exclude: string[];
   /** PR events only; ignored for commit. */
-  match: "head" | "base" | "either";
+  match: (typeof BRANCH_MATCH_MODES)[number];
 }
 
 /** One action cell: whether it fires, and the branches it's scoped to. */
@@ -79,7 +82,7 @@ export const ACTION_LABELS: Record<ActionId, string> = {
 };
 
 /** The action ids in a stable display order. */
-export const ALL_ACTION_IDS: ActionId[] = ["general", "security"];
+export const ALL_ACTION_IDS: ActionId[] = [...REVIEW_MODES];
 
 /**
  * A repo's per-repo overrides, looked up by its worktree-stable identity with a

--- a/src/lib/branch-rules/store.ts
+++ b/src/lib/branch-rules/store.ts
@@ -30,9 +30,11 @@ function healMergeMethods(value: unknown): MergeMethod[] {
 
 /**
  * Coerces a loosely-typed (possibly older or hand-edited) config into a full
- * BranchRulesConfig, filling in per-field defaults so partial data never
- * suddenly restricts — or fails to restrict. Shared by the personal store and
- * the repo-committed `.gitdesktop/branch-rules.json` file.
+ * BranchRulesConfig, filling in per-field defaults so partial data never fails
+ * to restrict. The one field that can GAIN a restriction from malformed input
+ * is `allowedMergeMethods`, which fails closed — see {@link healMergeMethods}.
+ * Shared by the personal store and the repo-committed
+ * `.gitdesktop/branch-rules.json` file.
  */
 export function normalizeBranchRules(saved: unknown): BranchRulesConfig {
   const obj = (saved ?? {}) as {

--- a/src/lib/branch-rules/store.ts
+++ b/src/lib/branch-rules/store.ts
@@ -7,8 +7,26 @@ import {
   type BranchProtection,
   type BranchRulesConfig,
   EMPTY_BRANCH_RULES,
+  type MergeMethod,
   type NamingPolicy,
 } from "./types";
+
+/**
+ * Heals a hand-edited `allowedMergeMethods`: absent = unrestricted (the documented
+ * default), an array keeps only real methods, and ANY other shape allows NONE. Junk
+ * fails CLOSED because a protection must never heal toward permissiveness — a bare
+ * string like `"squash"` restricted by accident before this normalizer ran (the
+ * matcher's `includes` was reading it as a substring test), so widening it to all
+ * three would unblock merges the file asked to block.
+ */
+function healMergeMethods(value: unknown): MergeMethod[] {
+  if (value == null) return [...ALL_MERGE_METHODS];
+  if (!Array.isArray(value)) return [];
+  const known: readonly string[] = ALL_MERGE_METHODS;
+  return value.filter(
+    (m): m is MergeMethod => typeof m === "string" && known.includes(m),
+  );
+}
 
 /**
  * Coerces a loosely-typed (possibly older or hand-edited) config into a full
@@ -30,11 +48,7 @@ export function normalizeBranchRules(saved: unknown): BranchRulesConfig {
       blockDeletion: p.blockDeletion ?? false,
       blockForcePush: p.blockForcePush ?? false,
       requirePr: p.requirePr ?? false,
-      allowedMergeMethods: Array.isArray(p.allowedMergeMethods)
-        ? p.allowedMergeMethods.filter((method) =>
-            ALL_MERGE_METHODS.includes(method),
-          )
-        : [...ALL_MERGE_METHODS],
+      allowedMergeMethods: healMergeMethods(p.allowedMergeMethods),
     })),
     // Typed loosely because the shared file is hand-editable: anything but an
     // array of strings yields no promotion branches rather than throwing away

--- a/src/lib/branch-rules/store.ts
+++ b/src/lib/branch-rules/store.ts
@@ -30,7 +30,11 @@ export function normalizeBranchRules(saved: unknown): BranchRulesConfig {
       blockDeletion: p.blockDeletion ?? false,
       blockForcePush: p.blockForcePush ?? false,
       requirePr: p.requirePr ?? false,
-      allowedMergeMethods: p.allowedMergeMethods ?? [...ALL_MERGE_METHODS],
+      allowedMergeMethods: Array.isArray(p.allowedMergeMethods)
+        ? p.allowedMergeMethods.filter((method) =>
+            ALL_MERGE_METHODS.includes(method),
+          )
+        : [...ALL_MERGE_METHODS],
     })),
     // Typed loosely because the shared file is hand-editable: anything but an
     // array of strings yields no promotion branches rather than throwing away

--- a/src/lib/branch-rules/types.ts
+++ b/src/lib/branch-rules/types.ts
@@ -7,7 +7,8 @@
  */
 
 /** Allowed ways to integrate a head branch into a protected base. */
-export type MergeMethod = "merge" | "squash" | "rebase";
+export const ALL_MERGE_METHODS = ["merge", "squash", "rebase"] as const;
+export type MergeMethod = (typeof ALL_MERGE_METHODS)[number];
 
 /** A protection that applies to every branch whose name matches `pattern`. */
 export interface BranchProtection {
@@ -26,8 +27,6 @@ export interface BranchProtection {
    *  history. New protections default to all three. */
   allowedMergeMethods: MergeMethod[];
 }
-
-export const ALL_MERGE_METHODS: MergeMethod[] = ["merge", "squash", "rebase"];
 
 export const MERGE_METHOD_LABEL: Record<MergeMethod, string> = {
   merge: "Merge commit",

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -369,6 +369,12 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "automation-history",
+    label: "Automation history",
+    category: "Repository",
+    defaultBinding: null,
+  },
+  {
     id: "link-jira-project",
     label: "Link Jira project…",
     category: "Repository",
@@ -804,6 +810,12 @@ export const ACTIONS = [
   {
     id: "discard-pending-review",
     label: "Discard pending review",
+    category: "Pull requests",
+    defaultBinding: null,
+  },
+  {
+    id: "run-pr-automations",
+    label: "Run automations on this pull request",
     category: "Pull requests",
     defaultBinding: null,
   },

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -79,6 +79,9 @@ const IDENTITY_STORES: IdentityStore[] = [
   { file: "local-issues.json", merge: "id-merge" },
   { file: "pr-reviews.json", merge: "id-merge" },
   { file: "automation-results.json", merge: "id-merge" },
+  // The reserved "global-markers" key is not a repo key, and the walk below only
+  // touches keys matching the old checkout path — so it is naturally untouched.
+  { file: "automation-history.json", merge: "id-merge" },
   { file: "pr-review-drafts.json", merge: "inner-key" },
   { file: "review-notes.json", merge: "inner-key" },
   { file: "automation-dismissals.json", merge: "inner-key" },

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -1031,6 +1031,28 @@ export function registerAutomationRun(opts: {
   };
 }
 
+/**
+ * Whether an automation run for this PR is live IN THIS INSTANCE — running or
+ * queued, and carrying the `rerun` closure that marks a row as automation-owned
+ * (the same discriminator the dock's Stopped group uses; a manual panel run also
+ * reaches running/queued but never carries one). Read-only, synchronous: the
+ * Run-now path checks it before offering to start another.
+ */
+export function hasLiveAutomationRun(
+  repoPath: string,
+  kind: "remote" | "local",
+  ref: string,
+): boolean {
+  return Object.values(useReviewStore.getState().entries).some(
+    (e) =>
+      (e.phase === "running" || e.phase === "queued") &&
+      e.rerun !== undefined &&
+      e.target.repoPath === repoPath &&
+      e.target.kind === kind &&
+      e.target.ref === ref,
+  );
+}
+
 /** The runs the activity dock shows, newest first (dismissing removes them). */
 export function useReviewTasks(): ReviewTask[] {
   const entries = useReviewStore((s) => s.entries);

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -32,6 +32,7 @@ import type {
 } from "@/lib/ai/types";
 import { track } from "@/lib/analytics";
 import { readRepoInstructions } from "@/lib/git/api";
+import { repoIdentity } from "@/lib/git/repo-identity";
 import type { DiffStatEntry, RemoteLens } from "@/lib/git/types";
 import { notifyIfUnfocused } from "@/lib/notify";
 import {
@@ -1035,22 +1036,36 @@ export function registerAutomationRun(opts: {
  * Whether an automation run for this PR is live IN THIS INSTANCE — running or
  * queued, and carrying the `rerun` closure that marks a row as automation-owned
  * (the same discriminator the dock's Stopped group uses; a manual panel run also
- * reaches running/queued but never carries one). Read-only, synchronous: the
- * Run-now path checks it before offering to start another.
+ * reaches running/queued but never carries one). Read-only.
+ *
+ * Matched on the repo's worktree-stable IDENTITY, not the checkout path a row was
+ * registered under: a linked worktree and its main checkout are different paths but
+ * the same repo, and a path compare would report "nothing live" for a run started
+ * from the other one — which is exactly when a second start is most dangerous (the
+ * caller may release that live run's identity-keyed claim). Async for the identity
+ * resolution; the cheap discriminators filter first, so a store with no candidate
+ * row resolves nothing at all.
  */
-export function hasLiveAutomationRun(
+export async function hasLiveAutomationRun(
   repoPath: string,
   kind: "remote" | "local",
   ref: string,
-): boolean {
-  return Object.values(useReviewStore.getState().entries).some(
+): Promise<boolean> {
+  const candidates = Object.values(useReviewStore.getState().entries).filter(
     (e) =>
       (e.phase === "running" || e.phase === "queued") &&
       e.rerun !== undefined &&
-      e.target.repoPath === repoPath &&
       e.target.kind === kind &&
       e.target.ref === ref,
   );
+  if (candidates.length === 0) return false;
+  // `repoIdentity` memoizes per path and falls back to the raw path when git can't
+  // resolve one, so this is a map lookup after the first call and never rejects.
+  const [identity, rowIdentities] = await Promise.all([
+    repoIdentity(repoPath),
+    Promise.all(candidates.map((e) => repoIdentity(e.target.repoPath))),
+  ]);
+  return rowIdentities.includes(identity);
 }
 
 /** The runs the activity dock shows, newest first (dismissing removes them). */


### PR DESCRIPTION
When an automated review doesn't show up, there's currently nothing to inspect: the pipeline's skips, claim losses, and eligibility misses leave no trace. This adds a per-repo automation decision log with a read-only viewer, and a command-palette action that runs the configured reviews against the pull request you have open instead of waiting for the next trigger.

### Decision log storage

- Adds `src/lib/automations/history.ts`: a `automation-history.json` plugin store keyed by worktree-stable repo identity, with the `AUTOMATION_OUTCOME_CODES` union (`delivered`, `branch-skip`, `head-covered`, `claim-held`, `too-old`, `paused`/`resumed`, …), `AutomationTrigger`, and the `AutomationHistoryEntry` record at `schemaVersion: 1`.
- Bounds the file on every write: `MAX_PER_REPO` (50) records per repo, and `STEADY_OUTCOME_CODES` (the outcomes that repeat identically on each poll tick) coalesce into a counted row and are evicted first.
- Serializes read-modify-write through a single `opChain` queue, since the store's `autoSave` debounce would let two overlapping writes reload the same pre-flush snapshot and drop the earlier record. `reloadRaw()` tolerates the store file not existing yet.
- Shape-guards every record read back out of the store, including checking `code` against the known set, so a hand-edited or newer-build file drops bad records rather than blanking the list or throwing mid-render.
- Reserves `GLOBAL_MARKERS_KEY` for the app-wide paused/resumed markers (capped at `MAX_MARKERS`), which merge into every repo's list rather than being identity-keyed.
- Registers `automation-history.json` as an `id-merge` identity store in `src/lib/repo-data-migration.ts` so it follows a relocated repo.

### History dialog and entry points

- Adds `src/features/automations/AutomationHistoryDialog.tsx`: the read-only log, opening on the repo's effective configuration and listing decisions newest first. `OUTCOME_REASON` is total over the outcome union so a code added later can't render as silence, `TRIGGER_GLYPH` falls back for unknown triggers, and `DELIVERED_TEXT` varies the copy by target kind.
- `TONE_CLASS` is applied to the words of a reason line and never to the row glyph, keeping state off color alone; arrow-key navigation rides `listKeyboardNav`.
- Open state lives in a `useAutomationHistoryDialog` zustand store with a single `AutomationHistoryDialogHost` mounted in `src/App.tsx` (the `AutomationResultDialog` precedent), so any surface opens it without a second mount.
- `src/features/activity/ActivityDock.tsx` gains an "Automation history" footer row, gated on `aiEnabled && repoPath`, which closes the popover before opening the dialog so Base UI's focus return doesn't steal from it.
- `src/features/repository/RepositoryMenu.tsx` gains an "Automation history…" item and the `automation-history` hotkey action; both `automation-history` and `run-pr-automations` are registered in `src/lib/hotkeys/registry.ts`.
- `started` outcomes older than `SESSION_START_MS` render as interrupted rather than in flight.

### Recording decisions in the pipeline

- `src/lib/automations/runner.ts`: `run()` now takes a `RunOptions` object (`only`, `replacesKey`, `force`, `trigger`) rather than positionals, and `RunOutcome` carries an `outcomes: RunActionOutcome[]` list of every per-action decision the pass made, which is written through `recordAutomationActivity` / `updateAutomationActivity`. The `COLD_START_AUTOMATIONS_OFF` gate still runs first, so a gated tick touches no store at all, history included.
- `src/lib/automations/sync.ts`: the catch-up pre-filter collects skip reasons while it filters and records them afterwards, so the author gate runs before anything can reach the store. Unparsable `createdAt` shares the `too-old` code but carries its own detail string instead of implying an age that was never measured. `catchUpEligible` now returns `{ eligible, error }` so a genuine "already reviewed" is distinguishable from an eligibility error, and `prOpenAutomationEnabled` gates every row so a repo with no `pr-open` action accrues none.
- Candidates that are eligible but merely not picked this tick record nothing, since that deferral resolves on its own.
- `triggerAutomations` accepts an optional `trigger` so catch-up passes are tagged as such.

### Run automations on demand

- Adds `runAutomationNow` in `src/lib/automations/runner.ts`, with `forcedActions()` taking the deduped set-union of `pr-open` and `pr-sync` actions so one invocation runs each mode exactly once; branch conditions are skipped in force mode because the user named the PR, while the claim still applies. It confirms via `useConfirm` before spending a model call.
- `src/lib/stores/reviews.ts` adds `hasLiveAutomationRun()`, a synchronous read that discriminates automation-owned runs by the presence of the `rerun` closure, so Run-now can check before starting another.
- `RepositoryMenu.tsx` enables the `run-pr-automations` action only when AI is on, the pulls tab is active, a PR is selected, and this repo's effective config enables a PR-lifecycle action; it re-reads `useUiStore.getState().selectedPr` at fire time because the palette closes before dispatching.

### Enum normalization

- Derives unions from const tuples so validators and UI lists stay in step: `REVIEW_MODES` in `src/lib/ai/types.ts`, `LIFECYCLE_EVENTS` and `BRANCH_MATCH_MODES` in `src/lib/automations/types.ts`, `ALL_MERGE_METHODS` in `src/lib/branch-rules/types.ts`.
- `src/lib/automations/store.ts` rebuilds `isReviewMode`, `isLifecycle`, and the `normalizeConditions` match fallback off those tuples.
- `src/lib/branch-rules/store.ts` filters unknown entries out of `allowedMergeMethods` during `normalizeBranchRules`, so a hand-edited value no longer restricts merges.

### Docs

- `README.md` gains an Automation history bullet; `site/src/data/capabilities.ts` gains the matching AI capability line.
- `src/features/help/content.ts` gains an "Automation history" guide section covering recorded skips, coalesced repeats, row activation, and pause logging, plus the on-demand run.
- Changelog fragments `changelog.d/added-automation-history-run-now.md` and `changelog.d/fixed-hand-edited-enum-heal.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Automation history, showing review decisions, skipped actions, outcomes, and effective configuration.
  - Open history from the activity panel or repository menu, with links to related pull requests and automation settings.
  - Added on-demand automation runs for the selected pull request through the command palette, with confirmation before execution.

- **Bug Fixes**
  - Branch-rule merge-method settings now discard unknown values and accurately reflect enforced options.

- **Documentation**
  - Updated the in-app guide and README with Automation history and run-now instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->