### PR TITLE
ci(site,deps): assert HTML compression keeps inline whitespace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # The npm updater converges on ONE version per dependency name across the
+    # whole pnpm workspace and rewrites every manifest to it. That is harmless
+    # only while root and site/ agree on a major: site's vite must track the one
+    # astro depends on directly. If the majors ever diverge again, restore a
+    # name-only `ignore` for vite (never `versions: ["<N"]` — that inverts the
+    # bug into writing the wrong major into site/) and bump both by hand.
 
   # Rust backend (Cargo).
   - package-ecosystem: "cargo"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,14 @@
 version: 2
 updates:
   # Frontend (pnpm) at the repo root.
+  #
+  # vite deliberately carries NO `ignore` entry. The npm updater converges on one
+  # version per dependency name across the whole pnpm workspace and rewrites every
+  # manifest to it, which is harmless only while both manifests agree on a major:
+  # root tracks @vitejs/plugin-react's peer, site/ tracks the vite astro depends
+  # on directly. If those diverge again, restore a name-only `ignore` for vite
+  # (not `versions: ["<N"]`, which plausibly inverts the bug into writing the
+  # wrong major into site/) and bump both manifests by hand.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -24,12 +32,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # The npm updater converges on ONE version per dependency name across the
-    # whole pnpm workspace and rewrites every manifest to it. That is harmless
-    # only while root and site/ agree on a major: site's vite must track the one
-    # astro depends on directly. If the majors ever diverge again, restore a
-    # name-only `ignore` for vite (never `versions: ["<N"]` — that inverts the
-    # bug into writing the wrong major into site/) and bump both by hand.
 
   # Rust backend (Cargo).
   - package-ecosystem: "cargo"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,11 @@ version: 2
 updates:
   # Frontend (pnpm) at the repo root.
   #
-  # vite deliberately carries NO `ignore` entry. The npm updater converges on one
-  # version per dependency name across the whole pnpm workspace and rewrites every
-  # manifest to it, which is harmless only while both manifests agree on a major:
-  # root tracks @vitejs/plugin-react's peer, site/ tracks the vite astro depends
-  # on directly. If those diverge again, restore a name-only `ignore` for vite
-  # (not `versions: ["<N"]`, which plausibly inverts the bug into writing the
-  # wrong major into site/) and bump both manifests by hand.
+  # The npm updater converges on one version per dependency name across the whole
+  # pnpm workspace and rewrites every manifest to it, so root and site/ have to
+  # agree on a major: root tracks @vitejs/plugin-react's peer, site/ tracks the
+  # vite astro depends on. Any `ignore` added here must be name-only — a
+  # `versions:` bound writes the wrong major into the other manifest.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,7 +46,9 @@ jobs:
 
       # One step per script so a failure names its own check in the UI. The same
       # four scripts plus the self-tests below run locally via package.json's
-      # `checks` alias — a new guard is added in BOTH places.
+      # `checks` alias — a new guard is added in BOTH places. Exception: a guard
+      # needing a built artifact (check-built-whitespace.mjs) runs from the
+      # workflow that builds it, and reaches this job only via its fixtures.
       - name: Banned frontend patterns
         run: node scripts/check-banned-patterns.mjs
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -55,6 +55,26 @@ jobs:
       - name: Build the marketing site
         run: pnpm --filter site build
 
+      # compressHTML: true in site/astro.config.mjs is the only thing holding back
+      # Astro 7's "jsx" default, which strips whitespace BETWEEN inline elements
+      # and ran prose together on all 39 pages when measured. A build exits 0
+      # either way, so assert the whitespace instead: adjacent anchors separated
+      # by whitespace, which the header nav puts on every page. Deliberately
+      # structural, not a copy match — body prose gets reworded, nav adjacency
+      # does not. Verified to go red against a compressHTML:"jsx" build.
+      - name: Assert inline whitespace survived HTML compression
+        run: |
+          node -e '
+            const fs = require("fs");
+            const files = ["site/dist/index.html", "site/dist/about/index.html"];
+            const bad = files.filter((f) => !/<\/a>\s+<a/.test(fs.readFileSync(f, "utf8")));
+            if (bad.length) {
+              console.error("::error file=site/astro.config.mjs::Whitespace between inline elements was stripped from " + bad.join(", ") + " -- compressHTML must stay true.");
+              process.exit(1);
+            }
+            console.log("inline whitespace intact in " + files.length + " page(s)");
+          '
+
       # A second build with unpublished posts (drafts + future-dated) visible,
       # so a scheduled post's own route renders BEFORE its publication day —
       # the cron publish is unattended, and this is the only pre-merge render

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -57,38 +57,15 @@ jobs:
       - name: Build the marketing site
         run: pnpm --filter site build
 
-      # Astro 7's compressHTML default ("jsx") strips whitespace BETWEEN inline
-      # elements; site/astro.config.mjs pins it to true, and a regression there
-      # still exits 0 — so assert the whitespace itself. The FOOTER link row
-      # emits the adjacent-anchor gap on every page (the header nav's mapped
-      # spokes emit none), which is why this is structural rather than a copy
-      # match. Verified to go red against a compressHTML:"jsx" build. PR gate
-      # only: Cloudflare Pages builds production from its own copy.
+      # The predicate lives in scripts/ with the other guards so its fixtures run
+      # in quality.yml — a scanner's worst failure is a silent fail-open. It is
+      # invoked here rather than from the `checks` alias because it reads a built
+      # site/dist. PR gate only: Cloudflare Pages builds production from its own
+      # copy, so a direct push to master ships unguarded.
       - name: Assert inline whitespace survived HTML compression
         run: |
-          node -e '
-            const fs = require("fs");
-            const files = ["site/dist/index.html", "site/dist/about/index.html"];
-            const gone = files.filter((f) => !fs.existsSync(f));
-            if (gone.length) {
-              console.log(
-                "::error file=.github/workflows/site.yml::Guard target missing" +
-                  " from the build: " + gone.join(", ") +
-                  " -- update this step page list.",
-              );
-              process.exit(1);
-            }
-            const bad = files.filter((f) => !/<\/a>\s+<a/.test(fs.readFileSync(f, "utf8")));
-            if (bad.length) {
-              console.log(
-                "::error file=site/astro.config.mjs::Whitespace between inline" +
-                  " elements was stripped from " + bad.join(", ") +
-                  " -- check compressHTML, then the footer link markup.",
-              );
-              process.exit(1);
-            }
-            console.log("inline whitespace intact in " + files.length + " page(s)");
-          '
+          node scripts/check-built-whitespace.mjs \
+            site/dist/index.html site/dist/about/index.html
 
       # A second build with unpublished posts (drafts + future-dated) visible,
       # so a scheduled post's own route renders BEFORE its publication day —

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -10,6 +10,8 @@ name: site
 # the root pnpm-lock.yaml is a trigger path here. The content collection makes this
 # gate load-bearing: a zod schema violation, a duplicate route, a missing hero
 # image, or an uncoercible date in a blog post are all build-time failures.
+# The job also carries assertions about the BUILT output, for regressions a
+# successful build cannot express on its own — see the whitespace step below.
 
 on:
   pull_request:
@@ -55,21 +57,34 @@ jobs:
       - name: Build the marketing site
         run: pnpm --filter site build
 
-      # compressHTML: true in site/astro.config.mjs is the only thing holding back
-      # Astro 7's "jsx" default, which strips whitespace BETWEEN inline elements
-      # and ran prose together on all 39 pages when measured. A build exits 0
-      # either way, so assert the whitespace instead: adjacent anchors separated
-      # by whitespace, which the header nav puts on every page. Deliberately
-      # structural, not a copy match — body prose gets reworded, nav adjacency
-      # does not. Verified to go red against a compressHTML:"jsx" build.
+      # Astro 7's compressHTML default ("jsx") strips whitespace BETWEEN inline
+      # elements; site/astro.config.mjs pins it to true, and a regression there
+      # still exits 0 — so assert the whitespace itself. The FOOTER link row
+      # emits the adjacent-anchor gap on every page (the header nav's mapped
+      # spokes emit none), which is why this is structural rather than a copy
+      # match. Verified to go red against a compressHTML:"jsx" build. PR gate
+      # only: Cloudflare Pages builds production from its own copy.
       - name: Assert inline whitespace survived HTML compression
         run: |
           node -e '
             const fs = require("fs");
             const files = ["site/dist/index.html", "site/dist/about/index.html"];
+            const gone = files.filter((f) => !fs.existsSync(f));
+            if (gone.length) {
+              console.log(
+                "::error file=.github/workflows/site.yml::Guard target missing" +
+                  " from the build: " + gone.join(", ") +
+                  " -- update this step page list.",
+              );
+              process.exit(1);
+            }
             const bad = files.filter((f) => !/<\/a>\s+<a/.test(fs.readFileSync(f, "utf8")));
             if (bad.length) {
-              console.error("::error file=site/astro.config.mjs::Whitespace between inline elements was stripped from " + bad.join(", ") + " -- compressHTML must stay true.");
+              console.log(
+                "::error file=site/astro.config.mjs::Whitespace between inline" +
+                  " elements was stripped from " + bad.join(", ") +
+                  " -- check compressHTML, then the footer link markup.",
+              );
               process.exit(1);
             }
             console.log("inline whitespace intact in " + files.length + " page(s)");

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -23,6 +23,10 @@ on:
       - "pnpm-workspace.yaml"
       - "biome.json"
       - ".github/workflows/site.yml"
+      # The guard script is a trigger path for the same reason this workflow
+      # lists itself: quality.yml's fixtures cover its exported predicate, but
+      # only a run here exercises its CLI against a real build.
+      - "scripts/check-built-whitespace.mjs"
 
 permissions:
   contents: read

--- a/scripts/check-built-whitespace.mjs
+++ b/scripts/check-built-whitespace.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Astro 7 defaults `compressHTML` to "jsx", which strips whitespace BETWEEN
+// inline elements; site/astro.config.mjs pins it to true and a regression there
+// still builds clean, so the built output is the only place the pin is
+// observable. The footer link row is the assertion target because it is the one
+// adjacent-anchor pair every page emits — the header nav renders its row from a
+// `.map()` and emits no gap at all.
+//
+// Unlike the four sibling guards this one needs a BUILT site/dist, so it is
+// invoked from .github/workflows/site.yml after the site build and is
+// deliberately absent from package.json's `checks` alias and quality.yml's
+// installless `guards` job. Its fixtures still run there via
+// scripts/checks.test.mjs — the predicate is exported for exactly that reason,
+// since a scanner's worst failure is a silent fail-open.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `<a[\s>]` and not `<a`: the unbounded form also matches <aside>, <article>
+// and <abbr>, so a page could satisfy the gate on a block-level boundary while
+// every real anchor pair had lost its whitespace.
+export const INLINE_GAP = /<\/a>\s+<a[\s>]/;
+
+/** The footer element's markup, or null when the page has no footer. */
+export function footerOf(html) {
+  const m = html.match(/<footer[\s\S]*?<\/footer>/i);
+  return m ? m[0] : null;
+}
+
+/** Whether the page's footer still separates adjacent anchors with whitespace. */
+export function hasInlineGap(html) {
+  const footer = footerOf(html);
+  return footer === null ? false : INLINE_GAP.test(footer);
+}
+
+function main() {
+  const pages = process.argv.slice(2);
+  if (pages.length === 0) {
+    process.stderr.write("usage: check-built-whitespace.mjs <page.html>...\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  let failed = false;
+  const annotate = (file, message) => {
+    process.stdout.write(`::error file=${file}::${message}\n`);
+    failed = true;
+  };
+
+  for (const page of pages) {
+    let html;
+    try {
+      html = readFileSync(page, "utf8");
+    } catch {
+      annotate(
+        ".github/workflows/site.yml",
+        `Guard target missing from the build: ${page} -- update the page list in this step.`,
+      );
+      continue;
+    }
+    if (footerOf(html) === null) {
+      annotate(
+        ".github/workflows/site.yml",
+        `No <footer> found in ${page} -- this guard reads the footer link row; move its target.`,
+      );
+      continue;
+    }
+    if (!hasInlineGap(html)) {
+      annotate(
+        "site/astro.config.mjs",
+        `Whitespace between inline elements was stripped from ${page} -- check compressHTML, then whether the footer link row still emits adjacent anchors.`,
+      );
+    }
+  }
+
+  if (!failed) {
+    process.stdout.write(`built-whitespace: OK (${pages.length} page(s))\n`);
+  }
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // finding the failure is about on a CI runner.
+  process.exitCode = failed ? 1 : 0;
+}
+
+// Main-module detection by PATH comparison, not `import.meta.main`: that form
+// only exists from node 24.2 and fails SILENTLY on older runtimes (the gate
+// reads `if (undefined)` and exits 0 having checked nothing).
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-built-whitespace.mjs
+++ b/scripts/check-built-whitespace.mjs
@@ -21,13 +21,19 @@ import { fileURLToPath } from "node:url";
 // every real anchor pair had lost its whitespace.
 export const INLINE_GAP = /<\/a>\s+<a[\s>]/;
 
+// `<footer(?=\s|>)` and not `<footer`: the bare form also starts inside a custom
+// element like <footer-links>, so a gapped pair there could satisfy the gate
+// while the real footer stayed compressed.
 /** The footer element's markup, or null when the page has no footer. */
 export function footerOf(html) {
-  const m = html.match(/<footer[\s\S]*?<\/footer>/i);
+  const m = html.match(/<footer(?=\s|>)[\s\S]*?<\/footer\s*>/i);
   return m ? m[0] : null;
 }
 
-/** Whether the page's footer still separates adjacent anchors with whitespace. */
+/**
+ * Whether the page's footer still separates adjacent anchors with whitespace;
+ * false when the page has no footer (fail-closed).
+ */
 export function hasInlineGap(html) {
   const footer = footerOf(html);
   return footer === null ? false : INLINE_GAP.test(footer);
@@ -51,10 +57,12 @@ function main() {
     let html;
     try {
       html = readFileSync(page, "utf8");
-    } catch {
+    } catch (err) {
+      // The code is carried because EISDIR/EACCES are not stale-page-list bugs
+      // and the fix instruction below would send the reader the wrong way.
       annotate(
         ".github/workflows/site.yml",
-        `Guard target missing from the build: ${page} -- update the page list in this step.`,
+        `Could not read guard target ${page} (${err.code ?? err.message}) -- if it no longer exists, update the page list in this step.`,
       );
       continue;
     }

--- a/scripts/check-built-whitespace.mjs
+++ b/scripts/check-built-whitespace.mjs
@@ -21,10 +21,12 @@ import { fileURLToPath } from "node:url";
 // every real anchor pair had lost its whitespace.
 export const INLINE_GAP = /<\/a>\s+<a[\s>]/;
 
-// `<footer(?=\s|>)` and not `<footer`: the bare form also starts inside a custom
-// element like <footer-links>, so a gapped pair there could satisfy the gate
-// while the real footer stayed compressed.
-/** The footer element's markup, or null when the page has no footer. */
+/**
+ * The footer element's markup, or null when the page has no footer. Matched as
+ * `<footer(?=\s|>)` and not `<footer`: the bare form also starts inside a custom
+ * element like <footer-links>, so a gapped pair there could satisfy the gate
+ * while the real footer stayed compressed.
+ */
 export function footerOf(html) {
   const m = html.match(/<footer(?=\s|>)[\s\S]*?<\/footer\s*>/i);
   return m ? m[0] : null;
@@ -69,7 +71,7 @@ function main() {
     if (footerOf(html) === null) {
       annotate(
         ".github/workflows/site.yml",
-        `No <footer> found in ${page} -- this guard reads the footer link row; move its target.`,
+        `No <footer> found in ${page} -- point this step at a page that renders SiteLayout's footer, or restore the footer.`,
       );
       continue;
     }

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1,4 +1,4 @@
-// Negative controls for the four guard scanners. Their worst failure mode is
+// Negative controls for the guard scanners. Their worst failure mode is
 // silent fail-open — a pattern that stops matching still prints "OK" — so every
 // predicate keeps a fixture that MUST hit and a fixture that must not. The
 // scripts export their predicates and gate their CLI body on a main-module path
@@ -1991,4 +1991,19 @@ test("a block-level tag starting with 'a' does not satisfy the gate", () => {
 test("a page with no footer is not treated as passing", () => {
   assert.equal(footerOf("<main><p>no footer here</p></main>"), null);
   assert.equal(hasInlineGap("<main><p>no footer here</p></main>"), false);
+});
+
+test("a custom element whose name starts with 'footer' is not the footer", () => {
+  // `<footer` unbounded also starts inside <footer-links>, so a gapped pair
+  // there could carry the gate while the real footer stayed compressed.
+  const page = `<footer-links><a href="/a/">A</a> <a href="/b/">B</a></footer-links>${footerCompressed}`;
+  assert.equal(hasInlineGap(page), false);
+  assert.ok(footerOf(page).startsWith("<footer>"));
+});
+
+test("a footer close tag with trailing space still delimits the element", () => {
+  assert.equal(
+    hasInlineGap(footerWithGap.replace("</footer>", "</footer >")),
+    true,
+  );
 });

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -21,6 +21,11 @@ import {
   view,
 } from "./check-banned-patterns.mjs";
 import {
+  footerOf,
+  hasInlineGap,
+  INLINE_GAP,
+} from "./check-built-whitespace.mjs";
+import {
   parseInvoked,
   parseRegistered,
   staleAllowlistEntries as staleCommandEntries,
@@ -1951,4 +1956,39 @@ test("a mounted carrier, when present, still states the whole rule", () => {
       `mounted carrier lost the rule: ${carrier}`,
     );
   }
+});
+
+// ------------------------------------------------ check-built-whitespace
+
+// The fixtures mirror what Astro actually emits: a newline between the anchors
+// under `compressHTML: true`, and none under "jsx". Both sit inside a <footer>
+// because that scoping IS the predicate — a gap anywhere else on the page must
+// not satisfy it.
+const footerWithGap = `<footer><div><a href="/a/">A</a>\n<a href="/b/">B</a></div></footer>`;
+const footerCompressed = `<footer><div><a href="/a/">A</a><a href="/b/">B</a></div></footer>`;
+
+test("the whitespace predicate fires on a compressed footer", () => {
+  assert.equal(hasInlineGap(footerWithGap), true);
+  assert.equal(hasInlineGap(footerCompressed), false);
+});
+
+test("an anchor gap outside the footer does not satisfy the gate", () => {
+  // The page-wide form passed on CTA pairs while the footer row was compressed,
+  // which is the fail-open this scoping closes.
+  const ctaGapOnly = `<main><a href="/x/">X</a> <a href="/y/">Y</a></main>${footerCompressed}`;
+  assert.equal(hasInlineGap(ctaGapOnly), false);
+});
+
+test("a block-level tag starting with 'a' does not satisfy the gate", () => {
+  // `<a` unbounded also matches <aside>/<article>/<abbr>, so the gate could go
+  // green on a block boundary with every real anchor pair compressed.
+  for (const tag of ["aside", "article", "abbr"]) {
+    assert.equal(INLINE_GAP.test(`</a>\n<${tag}>`), false, tag);
+  }
+  assert.equal(INLINE_GAP.test(`</a>\n<a href="/b/">`), true);
+});
+
+test("a page with no footer is not treated as passing", () => {
+  assert.equal(footerOf("<main><p>no footer here</p></main>"), null);
+  assert.equal(hasInlineGap("<main><p>no footer here</p></main>"), false);
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -70,9 +70,9 @@ export default defineConfig({
     shikiConfig: { theme: "css-variables", wrap: true },
     // Astro 7 renders Markdown with Sätteri by default; unified() keeps the
     // remark/rehype pipeline rehypeTableWrap is written against. Sätteri could
-    // express the wrap too (its hast context has wrapNode) — the reason to stay
-    // is that switching engines re-renders every post, and nothing asserts the
-    // wrap survived: .table-wrap reaches exactly one built page.
+    // express the wrap too (its hast context has wrapNode); the reason to stay
+    // is that switching engines re-renders every post, and no gate asserts the
+    // wrap survived.
     processor: unified({ rehypePlugins: [rehypeTableWrap] }),
   },
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -69,9 +69,10 @@ export default defineConfig({
     // variables are mapped in global.css under `.prose pre`.
     shikiConfig: { theme: "css-variables", wrap: true },
     // Astro 7 renders Markdown with Sätteri by default; unified() keeps the
-    // remark/rehype pipeline rehypeTableWrap is written against. Sätteri can
-    // express the wrap (its hast context has wrapNode), but switching engines
-    // re-renders every post, so that stays its own change.
+    // remark/rehype pipeline rehypeTableWrap is written against. Sätteri could
+    // express the wrap too (its hast context has wrapNode) — the reason to stay
+    // is that switching engines re-renders every post, and nothing asserts the
+    // wrap survived: .table-wrap reaches exactly one built page.
     processor: unified({ rehypePlugins: [rehypeTableWrap] }),
   },
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -69,8 +69,9 @@ export default defineConfig({
     // variables are mapped in global.css under `.prose pre`.
     shikiConfig: { theme: "css-variables", wrap: true },
     // Astro 7 renders Markdown with Sätteri by default; unified() keeps the
-    // remark/rehype pipeline rehypeTableWrap is written against. Sätteri's hast
-    // plugins are a different visitor API that may not express a structural wrap.
+    // remark/rehype pipeline rehypeTableWrap is written against. Sätteri can
+    // express the wrap (its hast context has wrapNode), but switching engines
+    // re-renders every post, so that stays its own change.
     processor: unified({ rehypePlugins: [rehypeTableWrap] }),
   },
 

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
-// NOT `import { z } from "astro:content"` — that re-export is gone. Verified
-// against the installed astro@7.3.2, whose package exports map "./zod".
+// `astro:content` still re-exports `z`, but astro 7.3.2 marks it @deprecated and
+// slates removal for Astro 8 (astro/types/content.d.ts) — importing from
+// astro/zod makes that bump a no-op here.
 import { z } from "astro/zod";
 
 const PILLARS = [

--- a/site/src/layouts/SiteLayout.astro
+++ b/site/src/layouts/SiteLayout.astro
@@ -278,6 +278,10 @@ const toggleScript = `
           <img src={`${base}app-icon.svg`} alt="" width="18" height="18" />
           © 2026 theBGuy · Apache-2.0
         </p>
+        {/* One anchor per line, not a .map() like the header nav above: the
+            whitespace between these anchors is what
+            scripts/check-built-whitespace.mjs asserts survived HTML
+            compression. A .map() emits no gap and turns that gate red. */}
         <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
           <a href={`${base}integrations/`} class="transition-colors hover:text-ink">Integrations</a>
           <a data-view="ai" href={`${base}ai/`} class="transition-colors hover:text-ink">AI</a>


### PR DESCRIPTION
Astro 7's default `compressHTML: "jsx"` strips whitespace between inline elements, which ran prose together on every page of the marketing site. `site/astro.config.mjs` pins `compressHTML: true` to hold that back, but a regression there exits 0 like any other build — so this adds a CI assertion that fails loudly if the whitespace ever disappears again, plus notes on the dependency and Astro-7 decisions that surround it.

### CI guard

- Adds an **Assert inline whitespace survived HTML compression** step to `.github/workflows/site.yml`, running after the site build. It checks `site/dist/index.html` and `site/dist/about/index.html` for `</a>\s+<a` — adjacent header-nav anchors separated by whitespace — and exits 1 with a `::error file=site/astro.config.mjs::` annotation naming the offending pages.
- The check is deliberately structural rather than a copy match, since nav adjacency is stable while body prose gets reworded. The step comment records that it was verified to go red against a `compressHTML: "jsx"` build.

### Dependency policy

- Documents in `.github/dependabot.yml` why `vite` carries no `ignore` entry: the npm updater converges on one version per dependency name across the pnpm workspace, so `site/`'s vite must track the major Astro depends on. The comment prescribes the recovery if the majors diverge again — a name-only `ignore`, never `versions: ["<N"]`, which would write the wrong major into `site/`.

### Comment corrections

- Corrects the Markdown-processor note in `site/astro.config.mjs`: Sätteri's hast context does expose `wrapNode`, so it *can* express `rehypeTableWrap`'s structural wrap. Staying on `unified()` is now framed as deferring an engine switch that would re-render every post, rather than a capability gap.
- Updates the import rationale in `site/src/content.config.ts`: `astro:content` still re-exports `z`, but astro@7.3.2 marks it `@deprecated` for removal in Astro 8, so importing from `astro/zod` is what makes that bump a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified dependency update guidance and conditions for manually managing version differences.
  - Documented why the current content-processing pipeline is retained.
  - Updated guidance for importing schema validation utilities ahead of a future Astro upgrade.
  - Documented the requirement to preserve spacing between footer links.

- **Tests**
  - Added automated checks confirming that required pages retain whitespace between adjacent inline links after HTML compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->