### PR TITLE
ci(guards,deps): gate Tauri npm/crate version parity

### DIFF
--- a/.claude/skills/gd-conventions/SKILL.md
+++ b/.claude/skills/gd-conventions/SKILL.md
@@ -428,6 +428,13 @@ build-order lottery (tailwind-merge 3.6.0; in-repo: `data-open:animate-none!`).
   `src/features/pulls/usePrCapabilities.ts`.
 - A server-constrained field in a shared PATCH rejects the whole request when
   ineligible — model as `Option` + eligibility check; hide/omit when ineligible.
+- **A Tauri package's two halves move together:** the crate
+  (`src-tauri/Cargo.toml` → `Cargo.lock`) and its npm half (`package.json` →
+  `pnpm-lock.yaml`) must agree on major.minor or `tauri build` refuses the
+  pair. An npm bump already reddens appimage-check (its paths filter lists
+  `package.json`); the blind spots are a crate-only bump and a lockfile-only
+  drift inside a caret range, both gated by check-tauri-plugin-parity.mjs on
+  every PR. A Dependabot group can't span ecosystems, so the two PRs combine.
 
 ## Code comments
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # Hold off on freshly-published releases (supply-chain safety),
-    # mirroring pnpm's minimumReleaseAge in pnpm-workspace.yaml.
+    # Hold off on freshly-published releases (supply-chain safety). pnpm's
+    # minimumReleaseAge in pnpm-workspace.yaml is the same idea for direct
+    # installs, on its own shorter delay — the two are not kept in step.
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -26,9 +27,11 @@ updates:
       prefix-development: "chore(deps-dev)"
     groups:
       # Tauri's npm and crate halves must reach master in ONE commit: a group
-      # cannot span ecosystems, and the parity guard is a required check, so
-      # each half alone reddens its own merge ref — combine this PR and its
-      # cargo twin onto one branch. Declared FIRST: first matching group wins.
+      # cannot span ecosystems, so combine this PR with its cargo twin — on a
+      # MINOR bump the parity guard (a required check) reddens each half alone,
+      # while a patch-only split passes by design. A package with no
+      # counterpart (@tauri-apps/cli here, tauri-build there) opens and merges
+      # solo. Declared FIRST: first matching group wins.
       tauri:
         patterns:
           - "@tauri-apps/*"
@@ -61,8 +64,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      # The crate half of the npm `tauri` group above — a separate PR only
-      # because groups cannot span ecosystems; it merges combined with that one.
+      # The crate half of the npm `tauri` group above — separate only because
+      # groups cannot span ecosystems; combine the two unless this PR carries
+      # only crates with no npm counterpart (tauri-build).
       tauri:
         patterns:
           - "tauri"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,16 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     groups:
+      # Tauri's npm and crate halves must reach master in ONE commit: a group
+      # cannot span ecosystems, and the parity guard is a required check, so
+      # each half alone reddens its own merge ref — combine this PR and its
+      # cargo twin onto one branch. Declared FIRST: first matching group wins.
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
+        update-types:
+          - "minor"
+          - "patch"
       # One PR for routine minor/patch bumps; majors stay separate.
       minor-and-patch:
         update-types:
@@ -45,6 +55,16 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # The crate half of the npm `tauri` group above — a separate PR only
+      # because groups cannot span ecosystems; it merges combined with that one.
+      tauri:
+        patterns:
+          - "tauri"
+          - "tauri-build"
+          - "tauri-plugin-*"
+        update-types:
+          - "minor"
+          - "patch"
       minor-and-patch:
         update-types:
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,10 @@ updates:
       # Tauri's npm and crate halves must reach master in ONE commit: a group
       # cannot span ecosystems, so combine this PR with its cargo twin. Majors
       # are grouped too, unlike the ordinary deps below, because that bump
-      # moves both halves. A minor or major split reddens the parity gate, a
-      # patch-only one passes by design, and a package with no counterpart
-      # (@tauri-apps/cli, tauri-build) opens solo. First matching group wins.
+      # moves both halves; a minor or major split reddens the parity gate, a
+      # patch-only one passes by design. A package with no counterpart
+      # (@tauri-apps/cli on this side, tauri-build on the cargo side) opens
+      # solo. First matching group wins.
       tauri:
         patterns:
           - "@tauri-apps/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     open-pull-requests-limit: 10
     # Hold off on freshly-published releases (supply-chain safety). pnpm's
     # minimumReleaseAge in pnpm-workspace.yaml is the same idea for direct
-    # installs, on its own shorter delay — the two are not kept in step.
+    # installs, on its own never-longer delay, not kept in step with these.
     cooldown:
       default-days: 7
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,15 +27,16 @@ updates:
       prefix-development: "chore(deps-dev)"
     groups:
       # Tauri's npm and crate halves must reach master in ONE commit: a group
-      # cannot span ecosystems, so combine this PR with its cargo twin — on a
-      # MINOR bump the parity guard (a required check) reddens each half alone,
-      # while a patch-only split passes by design. A package with no
-      # counterpart (@tauri-apps/cli here, tauri-build there) opens and merges
-      # solo. Declared FIRST: first matching group wins.
+      # cannot span ecosystems, so combine this PR with its cargo twin. Majors
+      # are grouped too, unlike the ordinary deps below, because that bump
+      # moves both halves. A minor or major split reddens the parity gate, a
+      # patch-only one passes by design, and a package with no counterpart
+      # (@tauri-apps/cli, tauri-build) opens solo. First matching group wins.
       tauri:
         patterns:
           - "@tauri-apps/*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
       # One PR for routine minor/patch bumps; majors stay separate.
@@ -73,6 +74,7 @@ updates:
           - "tauri-build"
           - "tauri-plugin-*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
       minor-and-patch:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,10 +2,9 @@ name: quality
 
 # Two jobs with deliberately opposite contracts.
 #
-# `guards` runs the mechanical convention checks and is meant to be registered
-# as a required status check on master's ruleset once this workflow lands there
-# — so it carries NO paths filter, because a paths-skipped required check sits
-# stuck "Expected" forever (GitHub required-checks docs).
+# `guards` runs the mechanical convention checks and IS a required status check
+# on master's ruleset — so it carries NO paths filter, because a paths-skipped
+# required check sits stuck "Expected" forever (GitHub required-checks docs).
 # The path-unfiltered push:master leg is the backstop re-validating the true
 # merged tree, since a PR green against a stale base merges stale-green.
 #

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 jobs:
-  # BLOCKING. The four scripts are Node-stdlib-only by design, so this job
+  # BLOCKING. The five scripts are Node-stdlib-only by design, so this job
   # needs no install step and stays a seconds-long gate on every PR.
   guards:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
           node-version: 24
 
       # One step per script so a failure names its own check in the UI. The same
-      # four scripts plus the self-tests below run locally via package.json's
+      # five scripts plus the self-tests below run locally via package.json's
       # `checks` alias — a new guard is added in BOTH places.
       - name: Banned frontend patterns
         run: node scripts/check-banned-patterns.mjs
@@ -58,6 +58,9 @@ jobs:
 
       - name: Rule-mirror drift
         run: node scripts/check-rule-mirrors.mjs
+
+      - name: Tauri npm/crate parity
+        run: node scripts/check-tauri-plugin-parity.mjs
 
       # Negative controls for the scanners themselves — their worst failure is a
       # silent fail-open, so the fixtures that prove each predicate still fires

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,14 +115,13 @@ pnpm run checks
 ```
 
 They run as the `guards` job in [`quality.yml`](.github/workflows/quality.yml),
-a required check on master. Between them they cover banned frontend UI
-and state patterns — hover-revealed row actions, hand-rolled modifier
-keys, `setQueryData(key, undefined)`, bare `.mutate(` calls in the
-converted trees, inline clip-measured tooltips — the Rust refspec-argv and
-sync-`#[tauri::command]` invariants, Tauri IPC drift (every registered command
-needs a caller, every `invoke()` a registration), drift between the files that
-restate the git-whitelist hard rule, and the major.minor parity of each Tauri
-package's npm and crate halves.
+a required check on master, and cover banned frontend UI and state patterns
+(hover-revealed row actions, hand-rolled modifier keys, `setQueryData(key,
+undefined)`, bare `.mutate(` calls in the converted trees, inline clip-measured
+tooltips), the Rust refspec-argv and sync-`#[tauri::command]` invariants,
+Tauri IPC drift (every registered command needs a caller, every `invoke()`
+a registration), drift between the files that restate the git-whitelist hard
+rule, and the major.minor parity of each Tauri package's npm and crate halves.
 
 The pattern and surface checks carry allowlists, and they ratchet one way
 (rule-mirror drift and Tauri parity carry none — there is nothing to exempt).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,21 +116,21 @@ pnpm run checks
 
 They run as the `guards` job in [`quality.yml`](.github/workflows/quality.yml),
 a required check on master, and cover banned frontend UI and state patterns
-(hover-revealed row actions, hand-rolled modifier keys, `setQueryData(key,
-undefined)`, bare `.mutate(` calls in the converted trees, inline clip-measured
+(hover-revealed row actions, hand-rolled modifier keys, bare `.mutate(` calls
+in the converted trees, `setQueryData(key, undefined)`, inline clip-measured
 tooltips), the Rust refspec-argv and sync-`#[tauri::command]` invariants,
 Tauri IPC drift (every registered command needs a caller, every `invoke()`
 a registration), drift between the files that restate the git-whitelist hard
 rule, and the major.minor parity of each Tauri package's npm and crate halves.
 
-The pattern and surface checks carry allowlists, and they ratchet one way
-(rule-mirror drift and Tauri parity carry none — there is nothing to exempt).
-Adding an entry is a reviewed change like any other: it needs an inline
-rationale naming what makes that site safe, and it isn't the way to quiet a
-fresh violation. The ratchet is enforced, not just documented — an entry that
-no longer suppresses anything (its site gone, or its command back in live use)
-fails the gate as a stale allowlist entry, so the PR that removes the site
-removes its entry too.
+The pattern, Rust-invariant, and surface checks carry allowlists, and they
+ratchet one way (rule-mirror drift and Tauri parity carry none — there is
+nothing to exempt). Adding an entry is a reviewed change like any other: it
+needs an inline rationale naming what makes that site safe, and it isn't the
+way to quiet a fresh violation. The ratchet is enforced, not just documented —
+an entry that no longer suppresses anything (its site gone, or its command back
+in live use) fails the gate as a stale allowlist entry, so the PR that removes
+the site removes its entry too.
 
 `knip` and `jscpd` run in the same workflow's `advisory` job — non-blocking on
 purpose. The job publishes unused-export and duplicate-code reports to the run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,8 @@ in the converted trees, `setQueryData(key, undefined)`, inline clip-measured
 tooltips), the Rust refspec-argv and sync-`#[tauri::command]` invariants,
 Tauri IPC drift (every registered command needs a caller, every `invoke()`
 a registration), drift between the files that restate the git-whitelist hard
-rule, and the major.minor parity of each Tauri package's npm and crate halves.
+rule, and the major.minor parity of each Tauri package's npm and crate halves,
+each declared npm half needing a crate half to compare against.
 
 The pattern, Rust-invariant, and surface checks carry allowlists, and they
 ratchet one way (rule-mirror drift and Tauri parity carry none — there is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,27 +105,33 @@ this standard in passing is welcome.
 
 ### Convention checks
 
-Three dependency-free Node scripts guard convention classes a past audit already
+Five dependency-free Node scripts guard convention classes a past audit already
 paid to close once. Run them before pushing:
 
 ```sh
-pnpm run checks   # banned patterns · Rust invariants · IPC surface drift · guard self-tests
+# banned patterns · Rust invariants · IPC surface drift ·
+# rule-mirror drift · Tauri npm/crate parity · guard self-tests
+pnpm run checks
 ```
 
 They run as the `guards` job in [`quality.yml`](.github/workflows/quality.yml),
-which is meant to be registered as a required check on master once it lands
-there. The checks cover banned frontend UI and state patterns (hover-revealed
-row actions, hand-rolled modifier keys, `setQueryData(key, undefined)`, bare
-`.mutate(` calls in the converted trees, inline clip-measured tooltips), the
-Rust refspec-argv and sync-`#[tauri::command]` invariants, and Tauri IPC drift —
-every registered command needs a caller, every `invoke()` a registration.
+a required check on master. Between them they cover banned frontend UI
+and state patterns — hover-revealed row actions, hand-rolled modifier
+keys, `setQueryData(key, undefined)`, bare `.mutate(` calls in the
+converted trees, inline clip-measured tooltips — the Rust refspec-argv and
+sync-`#[tauri::command]` invariants, Tauri IPC drift (every registered command
+needs a caller, every `invoke()` a registration), drift between the files that
+restate the git-whitelist hard rule, and the major.minor parity of each Tauri
+package's npm and crate halves.
 
-Each check carries an allowlist, and it ratchets one way. Adding an entry is a
-reviewed change like any other: it needs an inline rationale naming what makes
-that site safe, and it isn't the way to quiet a fresh violation. The ratchet is
-enforced, not just documented — an entry that no longer suppresses anything
-(its site gone, or its command back in live use) fails the gate as a stale
-allowlist entry, so the PR that removes the site removes its entry too.
+The pattern and surface checks carry allowlists, and they ratchet one way
+(rule-mirror drift and Tauri parity carry none — there is nothing to exempt).
+Adding an entry is a reviewed change like any other: it needs an inline
+rationale naming what makes that site safe, and it isn't the way to quiet a
+fresh violation. The ratchet is enforced, not just documented — an entry that
+no longer suppresses anything (its site gone, or its command back in live use)
+fails the gate as a stale allowlist entry, so the PR that removes the site
+removes its entry too.
 
 `knip` and `jscpd` run in the same workflow's `advisory` job — non-blocking on
 purpose. The job publishes unused-export and duplicate-code reports to the run

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "biome check --write ./src/ ./site/",
-    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs && node scripts/check-rule-mirrors.mjs && node --test \"scripts/*.test.mjs\"",
+    "checks": "node scripts/check-banned-patterns.mjs && node scripts/check-rust-invariants.mjs && node scripts/check-dead-surface.mjs && node scripts/check-rule-mirrors.mjs && node scripts/check-tauri-plugin-parity.mjs && node --test \"scripts/*.test.mjs\"",
     "preview": "vite preview",
     "changelog": "node scripts/changelog-draft.mjs",
     "changelog:preview": "node scripts/changelog-draft.mjs --preview",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 packages:
   - "site"
 
-# Don't install versions published less than 7 days ago (10080 minutes),
-# a supply-chain safety delay mirrored by Dependabot's cooldown in
-# .github/dependabot.yml.
+# Don't install versions published less than 3 days ago (4320 minutes), a
+# supply-chain safety delay. Dependabot's cooldown in .github/dependabot.yml
+# is the same idea on its own longer schedule — the two are not kept in step.
 # minimumReleaseAge: 10080
 # changed to 3 days
 minimumReleaseAge: 4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,6 @@ packages:
 # Don't install versions published less than 3 days ago (4320 minutes), a
 # supply-chain safety delay. Dependabot's cooldown in .github/dependabot.yml
 # is the same idea on its own longer schedule — the two are not kept in step.
-# minimumReleaseAge: 10080
-# changed to 3 days
 minimumReleaseAge: 4320
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 # Don't install versions published less than 3 days ago (4320 minutes), a
 # supply-chain safety delay. Dependabot's cooldown in .github/dependabot.yml
-# is the same idea on its own longer schedule — the two are not kept in step.
+# is the same idea on its own never-shorter schedule, not kept in step with it.
 minimumReleaseAge: 4320
 
 allowBuilds:

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// `tauri build` refuses to bundle when a Tauri plugin's npm half and Rust crate
+// half differ in major.minor, and nothing else in CI compares the two:
+// appimage-check.yml is paths-filtered to package.json and the Linux bundling
+// files, so a Cargo.lock-only bump never runs it, and release.yml fires on tag
+// push alone. A split pair therefore reaches master with the bundler broken and
+// zero signal — which is why this gate reads both lockfiles on every PR.
+//
+// Comparison is major.minor on the RESOLVED versions, mirroring tauri-cli's own
+// InstalledPackages::mismatched(): patch drift between the halves is legal.
+//
+// Only pairs where BOTH halves exist are compared — crate-only plugins
+// (tauri-plugin-fs, tauri-plugin-window-state, the tauri-* build crates) and
+// npm-only packages (@tauri-apps/cli) have no counterpart to disagree with.
+//
+// Run: node scripts/check-tauri-plugin-parity.mjs
+// GD_TAURI_PARITY_ROOT points the check at a copy of the tree, for an ad-hoc
+// negative control by hand: copy the lockfiles, skew one version, watch it go
+// red. The committed controls live in scripts/checks.test.mjs and drive the
+// predicates below in memory, touching no disk.
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const CARGO_LOCK = "src-tauri/Cargo.lock";
+export const PNPM_LOCK = "pnpm-lock.yaml";
+
+// The `\r?` is required: a Windows checkout materializes Cargo.lock with
+// CRLF under core.autocrlf, and an LF-only pattern would parse zero packages —
+// a gate that passes having compared nothing.
+const CRATE_BLOCK =
+  /\[\[package\]\]\r?\nname = "([^"]+)"\r?\nversion = "([^"]+)"/g;
+
+/** Every crate in a Cargo.lock, name → locked version. */
+export function parseCrateVersions(cargoLockText) {
+  const versions = new Map();
+  for (const [, name, version] of cargoLockText.matchAll(CRATE_BLOCK)) {
+    versions.set(name, version);
+  }
+  return versions;
+}
+
+/**
+ * The ROOT importer's direct dependencies in a pnpm lockfile, name → resolved
+ * version. Scope is deliberate: `packages:`/`snapshots:` hold every transitive
+ * copy of a name and a sibling importer (site/) resolves its own tree, while
+ * what tauri-cli compares is what the app itself installs.
+ */
+export function parseNpmVersions(pnpmLockText) {
+  const versions = new Map();
+  const lines = pnpmLockText.split(/\r?\n/);
+  const start = lines.findIndex((line) => /^ {2}\.:\s*$/.test(line));
+  if (start === -1) return versions;
+
+  let name = null;
+  for (const line of lines.slice(start + 1)) {
+    // Any non-blank line indented at or above the importer key ends the block —
+    // the next importer, or a top-level section.
+    if (line.trim() && !line.startsWith("   ")) break;
+    const entry = /^ {6}'?([^'\s:]+)'?:\s*$/.exec(line);
+    if (entry) {
+      name = entry[1];
+      continue;
+    }
+    // The resolved version, never the specifier: a range says nothing about
+    // what installed. Peer-resolution suffixes — `1.2.3(react@19.2.8)` — are
+    // not part of the version.
+    const resolved = /^ {8}version:\s*(\S+)/.exec(line);
+    if (resolved && name) {
+      versions.set(name, resolved[1].replace(/\(.*$/, ""));
+      name = null;
+    }
+  }
+  return versions;
+}
+
+/**
+ * The pair tauri-cli itself puts first (its list is `iter::once("tauri")` plus
+ * the plugin crates) and the one this repo can never legitimately be without,
+ * so its absence means a parser stopped matching rather than a clean tree.
+ */
+export const CORE_CRATE = "tauri";
+
+/** The npm half of a crate, or null when the crate has no npm counterpart. */
+export function npmNameFor(crateName) {
+  if (crateName === "tauri") return "@tauri-apps/api";
+  const plugin = /^tauri-plugin-(.+)$/.exec(crateName);
+  return plugin ? `@tauri-apps/plugin-${plugin[1]}` : null;
+}
+
+const majorMinor = (version) => version.split(".").slice(0, 2).join(".");
+
+/** Crates whose npm half is present in the lockfile, both versions carried. */
+export function pairedVersions(crates, npm) {
+  const pairs = [];
+  for (const [crate, crateVersion] of crates) {
+    const npmName = npmNameFor(crate);
+    if (!npmName) continue;
+    const npmVersion = npm.get(npmName);
+    if (!npmVersion) continue;
+    pairs.push({ crate, npm: npmName, crateVersion, npmVersion });
+  }
+  return pairs;
+}
+
+/** Paired halves whose major.minor disagree — what breaks `tauri build`. */
+export function mismatchedPairs(crates, npm) {
+  return pairedVersions(crates, npm).filter(
+    (p) => majorMinor(p.crateVersion) !== majorMinor(p.npmVersion),
+  );
+}
+
+/**
+ * The whole decision, so the CLI only renders it and every branch stays
+ * reachable from a fixture. `empty` and `missingCore` are the fail-CLOSED arms:
+ * a parser that stops matching — wholly, or far enough to lose the core pair —
+ * would otherwise print OK over comparisons it never made.
+ */
+export function verdict(crates, npm) {
+  const pairs = pairedVersions(crates, npm);
+  return {
+    pairs,
+    mismatched: mismatchedPairs(crates, npm),
+    empty: pairs.length === 0,
+    missingCore: !pairs.some((p) => p.crate === CORE_CRATE),
+  };
+}
+
+function main() {
+  const root = process.env.GD_TAURI_PARITY_ROOT
+    ? resolve(process.env.GD_TAURI_PARITY_ROOT)
+    : REPO_ROOT;
+
+  let crates;
+  let npm;
+  try {
+    crates = parseCrateVersions(readFileSync(join(root, CARGO_LOCK), "utf8"));
+    npm = parseNpmVersions(readFileSync(join(root, PNPM_LOCK), "utf8"));
+  } catch (err) {
+    process.stderr.write("tauri-parity: FAIL — cannot read a lockfile\n");
+    process.stderr.write(`    ${err.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { pairs, mismatched, empty, missingCore } = verdict(crates, npm);
+  if (empty) {
+    process.stderr.write(
+      "tauri-parity: FAIL — no tauri npm/crate pairs found in the lockfiles\n",
+    );
+    process.stderr.write(
+      `    check that ${CARGO_LOCK} and ${PNPM_LOCK} still parse: the block shapes this gate reads may have changed\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (missingCore) {
+    process.stderr.write(
+      `tauri-parity: FAIL — ${pairs.length} pairs found but \`${CORE_CRATE}\` <-> \`${npmNameFor(CORE_CRATE)}\` is not among them\n`,
+    );
+    process.stderr.write(
+      "    a partial parse skips real comparisons silently; confirm both halves are still declared, then check the block shapes this gate reads\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (mismatched.length === 0) {
+    for (const p of pairs) {
+      process.stdout.write(
+        `tauri-parity: OK ${p.crate} ${p.crateVersion} <-> ${p.npm} ${p.npmVersion}\n`,
+      );
+    }
+    process.stdout.write(
+      `tauri-parity: OK ${pairs.length} pairs aligned on major.minor\n`,
+    );
+    return;
+  }
+
+  process.stderr.write(
+    `tauri-parity: FAIL ${mismatched.length} of ${pairs.length} pairs differ in major.minor\n`,
+  );
+  for (const p of mismatched) {
+    process.stderr.write(
+      `  ${p.crate} ${p.crateVersion} (crate) vs ${p.npm} ${p.npmVersion} (npm)\n`,
+    );
+    // Both remedies name the OTHER half's minor: a caret range would resolve to
+    // whatever newer minor is published and land right back here.
+    process.stderr.write(
+      `    align both halves on one major.minor: \`pnpm add ${p.npm}@~${majorMinor(p.crateVersion)}.0\` pins npm to the crate's minor, or bring ${p.crate} to ${majorMinor(p.npmVersion)}.x in src-tauri/Cargo.toml and re-lock\n`,
+    );
+  }
+  // Not `process.exit`: it can truncate a pending pipe write, losing the very
+  // finding the failure is about on a CI runner.
+  process.exitCode = 1;
+}
+
+// Main-module detection by PATH comparison, not `import.meta.main`: that form
+// only exists from node 24.2 and fails SILENTLY on older runtimes (the gate
+// reads `if (undefined)` and exits 0 having checked nothing).
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -9,12 +9,14 @@
 // Comparison is major.minor on the RESOLVED versions, mirroring tauri-cli's own
 // InstalledPackages::mismatched(): patch drift between the halves is legal.
 //
-// Only pairs where BOTH halves exist HERE are compared: the build crates
-// (tauri-build, tauri-codegen, tauri-utils) ship no npm half at all, while
-// plugins this app uses from Rust alone (tauri-plugin-fs,
-// tauri-plugin-window-state) do publish a JS API — they are simply not
-// installed in package.json, so there is nothing to compare. @tauri-apps/cli
-// is the mirror case, an npm package with no crate dependency here.
+// The two directions are NOT symmetric. A crate with no npm half is skipped
+// and legitimately so: the build crates (tauri-build, tauri-codegen,
+// tauri-utils) publish none, and plugins this app drives from Rust alone
+// (tauri-plugin-fs, tauri-plugin-window-state) publish a JS API it simply does
+// not install. But a package.json-declared `@tauri-apps/*` whose name maps to a
+// crate owes a comparison and fails the gate when it produces none — a JS half
+// calling a plugin the Rust side never registers. @tauri-apps/cli maps to no
+// crate at all, so it stays out of the pairing entirely.
 //
 // Run: node scripts/check-tauri-plugin-parity.mjs
 // GD_TAURI_PARITY_ROOT points the check at a copy of the tree, for an ad-hoc
@@ -173,9 +175,12 @@ export function verdict(
     empty: pairs.length === 0,
     missingCore: !paired.has(CORE_CRATE),
     duplicated: [...duplicates].filter((name) => paired.has(name)).sort(),
+    // `paired` already requires both halves, so this covers a lost lockfile
+    // entry and a crate that was never declared at all. `crate !== null` is the
+    // only exemption: an npm package with no crate name owes no comparison.
     unpaired: declared.filter((name) => {
       const crate = crateNameFor(name);
-      return crate !== null && crates.has(crate) && !paired.has(crate);
+      return crate !== null && !paired.has(crate);
     }),
   };
 }
@@ -241,15 +246,19 @@ function main() {
   }
   if (unpaired.length > 0) {
     process.stderr.write(
-      `tauri-parity: FAIL — ${unpaired.length} declared package(s) have a crate half but produced no comparison\n`,
+      `tauri-parity: FAIL — ${unpaired.length} declared package(s) produced no comparison\n`,
     );
     for (const name of unpaired) {
+      const crate = crateNameFor(name);
+      const missing = crates.has(crate)
+        ? `${PNPM_LOCK} carries no root-importer entry for it`
+        : `${CARGO_LOCK} carries no \`${crate}\` block`;
       process.stderr.write(
-        `  ${name} (${PACKAGE_JSON}) <-> ${crateNameFor(name)} (${CARGO_LOCK}) — the ${PNPM_LOCK} half is missing\n`,
+        `  ${name} (${PACKAGE_JSON}) <-> ${crate} — ${missing}\n`,
       );
     }
     process.stderr.write(
-      `    re-lock if the dependency is genuinely gone; otherwise the root-importer block shape this gate reads has changed\n`,
+      `    supply the missing half, or drop the declaration if the dependency is genuinely gone; a half that IS present means the block shape this gate reads has changed\n`,
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -64,6 +64,37 @@ export function duplicateCrateNames(cargoLockText) {
   return duplicated;
 }
 
+// pnpm installs all three of these; peerDependencies is deliberately absent,
+// because an app does not install its peers by default and flagging one would
+// redden a required check over a package that was never meant to be present.
+const DECLARED_BLOCKS = ["dependencies", "devDependencies", "optionalDependencies"];
+
+// An npm: alias carries the real package name in the VALUE, so the key alone
+// cannot answer what is installed: `"x": "npm:@tauri-apps/plugin-store@^2.4.4"`.
+const ALIASED_NAME = /^npm:(@tauri-apps\/[^@]+)/;
+
+/**
+ * Declared `@tauri-apps/*` name → the package.json key it is declared under
+ * (itself, unless an npm: alias renamed it). A declared package that never
+ * reaches this map is a comparison the gate skips in silence, so both the key
+ * and the value are read.
+ */
+function tauriEntries(packageJsonText) {
+  const pkg = JSON.parse(packageJsonText);
+  const entries = new Map();
+  for (const block of DECLARED_BLOCKS) {
+    for (const [key, value] of Object.entries(pkg[block] ?? {})) {
+      if (key.startsWith("@tauri-apps/")) {
+        entries.set(key, key);
+        continue;
+      }
+      const aliased = typeof value === "string" ? ALIASED_NAME.exec(value) : null;
+      if (aliased) entries.set(aliased[1], key);
+    }
+  }
+  return entries;
+}
+
 /**
  * The `@tauri-apps/*` packages package.json declares. This is the robust half
  * of the expectation — real JSON, against a lockfile scan that depends on an
@@ -71,11 +102,18 @@ export function duplicateCrateNames(cargoLockText) {
  * gate owes.
  */
 export function declaredNpmPackages(packageJsonText) {
-  const pkg = JSON.parse(packageJsonText);
-  return [
-    ...Object.keys(pkg.dependencies ?? {}),
-    ...Object.keys(pkg.devDependencies ?? {}),
-  ].filter((name) => name.startsWith("@tauri-apps/"));
+  return [...tauriEntries(packageJsonText).keys()];
+}
+
+/**
+ * Declared packages an npm: alias renamed, real name → alias key. The alias is
+ * what the lockfile's root importer keys, so no pair can form for one — the
+ * gate cannot version-verify an aliased Tauri package and says so.
+ */
+export function declaredNpmAliases(packageJsonText) {
+  return new Map(
+    [...tauriEntries(packageJsonText)].filter(([name, key]) => name !== key),
+  );
 }
 
 /**
@@ -194,12 +232,15 @@ function main() {
   let npm;
   let duplicates;
   let declared;
+  let aliases;
   try {
     const cargoLock = readFileSync(join(root, CARGO_LOCK), "utf8");
     crates = parseCrateVersions(cargoLock);
     duplicates = duplicateCrateNames(cargoLock);
     npm = parseNpmVersions(readFileSync(join(root, PNPM_LOCK), "utf8"));
-    declared = declaredNpmPackages(readFileSync(join(root, PACKAGE_JSON), "utf8"));
+    const packageJson = readFileSync(join(root, PACKAGE_JSON), "utf8");
+    declared = declaredNpmPackages(packageJson);
+    aliases = declaredNpmAliases(packageJson);
   } catch (err) {
     process.stderr.write("tauri-parity: FAIL — cannot read a manifest\n");
     process.stderr.write(`    ${err.message}\n`);
@@ -250,15 +291,20 @@ function main() {
     );
     for (const name of unpaired) {
       const crate = crateNameFor(name);
-      const missing = crates.has(crate)
-        ? `${PNPM_LOCK} carries no root-importer entry for it`
-        : `${CARGO_LOCK} carries no \`${crate}\` block`;
+      let missing;
+      if (aliases.has(name)) {
+        missing = `installed under the alias \`${aliases.get(name)}\`, which no version comparison can reach`;
+      } else if (crates.has(crate)) {
+        missing = `${PNPM_LOCK} carries no root-importer entry for it`;
+      } else {
+        missing = `${CARGO_LOCK} carries no \`${crate}\` block`;
+      }
       process.stderr.write(
         `  ${name} (${PACKAGE_JSON}) <-> ${crate} — ${missing}\n`,
       );
     }
     process.stderr.write(
-      "    supply the missing half, or drop the declaration if the dependency is genuinely gone; a half that IS present means the block shape this gate reads has changed\n",
+      "    supply the missing half, drop the declaration if the dependency is genuinely gone, or declare an aliased package under its real name; a half that IS present means the block shape this gate reads has changed\n",
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -9,9 +9,12 @@
 // Comparison is major.minor on the RESOLVED versions, mirroring tauri-cli's own
 // InstalledPackages::mismatched(): patch drift between the halves is legal.
 //
-// Only pairs where BOTH halves exist are compared — crate-only plugins
-// (tauri-plugin-fs, tauri-plugin-window-state, the tauri-* build crates) and
-// npm-only packages (@tauri-apps/cli) have no counterpart to disagree with.
+// Only pairs where BOTH halves exist HERE are compared: the build crates
+// (tauri-build, tauri-codegen, tauri-utils) ship no npm half at all, while
+// plugins this app uses from Rust alone (tauri-plugin-fs,
+// tauri-plugin-window-state) do publish a JS API — they are simply not
+// installed in package.json, so there is nothing to compare. @tauri-apps/cli
+// is the mirror case, an npm package with no crate dependency here.
 //
 // Run: node scripts/check-tauri-plugin-parity.mjs
 // GD_TAURI_PARITY_ROOT points the check at a copy of the tree, for an ad-hoc
@@ -26,6 +29,7 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 export const CARGO_LOCK = "src-tauri/Cargo.lock";
 export const PNPM_LOCK = "pnpm-lock.yaml";
+export const PACKAGE_JSON = "package.json";
 
 // The `\r?` is required: a Windows checkout materializes Cargo.lock with
 // CRLF under core.autocrlf, and an LF-only pattern would parse zero packages —
@@ -40,6 +44,36 @@ export function parseCrateVersions(cargoLockText) {
     versions.set(name, version);
   }
   return versions;
+}
+
+/**
+ * Crate names carrying more than one block. A lockfile holding two versions of
+ * a name is ordinary (58 names do here today), but for a PAIRED crate the map
+ * above keeps whichever came last, so the comparison may describe a version the
+ * app does not link — not comparable, rather than comparable-and-fine.
+ */
+export function duplicateCrateNames(cargoLockText) {
+  const seen = new Set();
+  const duplicated = new Set();
+  for (const [, name] of cargoLockText.matchAll(CRATE_BLOCK)) {
+    if (seen.has(name)) duplicated.add(name);
+    seen.add(name);
+  }
+  return duplicated;
+}
+
+/**
+ * The `@tauri-apps/*` packages package.json declares. This is the robust half
+ * of the expectation — real JSON, against a lockfile scan that depends on an
+ * indentation-sensitive format — so it is what says how many comparisons the
+ * gate owes.
+ */
+export function declaredNpmPackages(packageJsonText) {
+  const pkg = JSON.parse(packageJsonText);
+  return [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ].filter((name) => name.startsWith("@tauri-apps/"));
 }
 
 /**
@@ -85,9 +119,16 @@ export const CORE_CRATE = "tauri";
 
 /** The npm half of a crate, or null when the crate has no npm counterpart. */
 export function npmNameFor(crateName) {
-  if (crateName === "tauri") return "@tauri-apps/api";
+  if (crateName === CORE_CRATE) return "@tauri-apps/api";
   const plugin = /^tauri-plugin-(.+)$/.exec(crateName);
   return plugin ? `@tauri-apps/plugin-${plugin[1]}` : null;
+}
+
+/** The crate half of an npm package — the inverse of `npmNameFor`. */
+export function crateNameFor(npmName) {
+  if (npmName === "@tauri-apps/api") return CORE_CRATE;
+  const plugin = /^@tauri-apps\/plugin-(.+)$/.exec(npmName);
+  return plugin ? `tauri-plugin-${plugin[1]}` : null;
 }
 
 const majorMinor = (version) => version.split(".").slice(0, 2).join(".");
@@ -114,17 +155,28 @@ export function mismatchedPairs(crates, npm) {
 
 /**
  * The whole decision, so the CLI only renders it and every branch stays
- * reachable from a fixture. `empty` and `missingCore` are the fail-CLOSED arms:
- * a parser that stops matching — wholly, or far enough to lose the core pair —
- * would otherwise print OK over comparisons it never made.
+ * reachable from a fixture. Everything but `mismatched` is a fail-CLOSED arm
+ * against a comparison that never happened: a parse that yields nothing, one
+ * that loses the core pair, a duplicated crate whose kept version is arbitrary,
+ * and a package.json-declared half that produced no comparison at all.
  */
-export function verdict(crates, npm) {
+export function verdict(
+  crates,
+  npm,
+  { duplicates = new Set(), declared = [] } = {},
+) {
   const pairs = pairedVersions(crates, npm);
+  const paired = new Set(pairs.map((p) => p.crate));
   return {
     pairs,
     mismatched: mismatchedPairs(crates, npm),
     empty: pairs.length === 0,
-    missingCore: !pairs.some((p) => p.crate === CORE_CRATE),
+    missingCore: !paired.has(CORE_CRATE),
+    duplicated: [...duplicates].filter((name) => paired.has(name)).sort(),
+    unpaired: declared.filter((name) => {
+      const crate = crateNameFor(name);
+      return crate !== null && crates.has(crate) && !paired.has(crate);
+    }),
   };
 }
 
@@ -135,17 +187,23 @@ function main() {
 
   let crates;
   let npm;
+  let duplicates;
+  let declared;
   try {
-    crates = parseCrateVersions(readFileSync(join(root, CARGO_LOCK), "utf8"));
+    const cargoLock = readFileSync(join(root, CARGO_LOCK), "utf8");
+    crates = parseCrateVersions(cargoLock);
+    duplicates = duplicateCrateNames(cargoLock);
     npm = parseNpmVersions(readFileSync(join(root, PNPM_LOCK), "utf8"));
+    declared = declaredNpmPackages(readFileSync(join(root, PACKAGE_JSON), "utf8"));
   } catch (err) {
-    process.stderr.write("tauri-parity: FAIL — cannot read a lockfile\n");
+    process.stderr.write("tauri-parity: FAIL — cannot read a manifest\n");
     process.stderr.write(`    ${err.message}\n`);
     process.exitCode = 1;
     return;
   }
 
-  const { pairs, mismatched, empty, missingCore } = verdict(crates, npm);
+  const { pairs, mismatched, empty, missingCore, duplicated, unpaired } =
+    verdict(crates, npm, { duplicates, declared });
   if (empty) {
     process.stderr.write(
       "tauri-parity: FAIL — no tauri npm/crate pairs found in the lockfiles\n",
@@ -162,6 +220,36 @@ function main() {
     );
     process.stderr.write(
       "    a partial parse skips real comparisons silently; confirm both halves are still declared, then check the block shapes this gate reads\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (duplicated.length > 0) {
+    process.stderr.write(
+      `tauri-parity: FAIL — ${duplicated.length} paired crate(s) carry more than one block in ${CARGO_LOCK}\n`,
+    );
+    for (const name of duplicated) {
+      process.stderr.write(
+        `  ${name} — which version the app links is ambiguous here, so the pair is not comparable\n`,
+      );
+    }
+    process.stderr.write(
+      "    unify the versions (a single block per paired crate) before this gate can speak to the pair\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (unpaired.length > 0) {
+    process.stderr.write(
+      `tauri-parity: FAIL — ${unpaired.length} declared package(s) have a crate half but produced no comparison\n`,
+    );
+    for (const name of unpaired) {
+      process.stderr.write(
+        `  ${name} (${PACKAGE_JSON}) <-> ${crateNameFor(name)} (${CARGO_LOCK}) — the ${PNPM_LOCK} half is missing\n`,
+      );
+    }
+    process.stderr.write(
+      `    re-lock if the dependency is genuinely gone; otherwise the root-importer block shape this gate reads has changed\n`,
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -67,32 +67,42 @@ export function duplicateCrateNames(cargoLockText) {
 // pnpm installs all three of these; peerDependencies is deliberately absent,
 // because an app does not install its peers by default and flagging one would
 // redden a required check over a package that was never meant to be present.
-const DECLARED_BLOCKS = ["dependencies", "devDependencies", "optionalDependencies"];
+const DECLARED_BLOCKS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+];
 
 // An npm: alias carries the real package name in the VALUE, so the key alone
-// cannot answer what is installed: `"x": "npm:@tauri-apps/plugin-store@^2.4.4"`.
+// cannot answer what is installed: `"x": "npm:@tauri-apps/plugin-store@^2.4"`.
 const ALIASED_NAME = /^npm:(@tauri-apps\/[^@]+)/;
 
 /**
- * Declared `@tauri-apps/*` name → the package.json key it is declared under
- * (itself, unless an npm: alias renamed it). A declared package that never
- * reaches this map is a comparison the gate skips in silence, so both the key
- * and the value are read.
+ * What package.json declares, read from the key AND the value: the
+ * `@tauri-apps/*` names, plus every alias that renames one. A declared package
+ * that never reaches this result is a comparison the gate skips in silence,
+ * and the two lists stay separate because one package can be declared both
+ * directly and under an alias — collapsing them would let the pair the direct
+ * declaration forms hide the alias.
  */
 function tauriEntries(packageJsonText) {
   const pkg = JSON.parse(packageJsonText);
-  const entries = new Map();
+  const declared = new Set();
+  const aliases = [];
   for (const block of DECLARED_BLOCKS) {
     for (const [key, value] of Object.entries(pkg[block] ?? {})) {
       if (key.startsWith("@tauri-apps/")) {
-        entries.set(key, key);
+        declared.add(key);
         continue;
       }
-      const aliased = typeof value === "string" ? ALIASED_NAME.exec(value) : null;
-      if (aliased) entries.set(aliased[1], key);
+      const aliased =
+        typeof value === "string" ? ALIASED_NAME.exec(value) : null;
+      if (!aliased) continue;
+      declared.add(aliased[1]);
+      aliases.push([aliased[1], key]);
     }
   }
-  return entries;
+  return { declared: [...declared], aliases };
 }
 
 /**
@@ -102,18 +112,18 @@ function tauriEntries(packageJsonText) {
  * gate owes.
  */
 export function declaredNpmPackages(packageJsonText) {
-  return [...tauriEntries(packageJsonText).keys()];
+  return tauriEntries(packageJsonText).declared;
 }
 
 /**
- * Declared packages an npm: alias renamed, real name → alias key. The alias is
- * what the lockfile's root importer keys, so no pair can form for one — the
- * gate cannot version-verify an aliased Tauri package and says so.
+ * Declared packages an npm: alias renames, as [real name, alias key] pairs.
+ * The lockfile's root importer keys an aliased install by its alias, so no
+ * comparison can reach it — reported on its own, independent of the pairing,
+ * because a second DIRECT declaration of the same package would otherwise pair
+ * cleanly and leave the aliased copy unverified in silence.
  */
 export function declaredNpmAliases(packageJsonText) {
-  return new Map(
-    [...tauriEntries(packageJsonText)].filter(([name, key]) => name !== key),
-  );
+  return tauriEntries(packageJsonText).aliases;
 }
 
 /**
@@ -198,12 +208,13 @@ export function mismatchedPairs(crates, npm) {
  * reachable from a fixture. Everything but `mismatched` is a fail-CLOSED arm
  * against a comparison that never happened: a parse that yields nothing, one
  * that loses the core pair, a duplicated crate whose kept version is arbitrary,
- * and a package.json-declared half that produced no comparison at all.
+ * an aliased declaration no comparison can reach, and a package.json-declared
+ * half that produced no comparison at all.
  */
 export function verdict(
   crates,
   npm,
-  { duplicates = new Set(), declared = [] } = {},
+  { duplicates = new Set(), declared = [], aliases = [] } = {},
 ) {
   const pairs = pairedVersions(crates, npm);
   const paired = new Set(pairs.map((p) => p.crate));
@@ -213,6 +224,10 @@ export function verdict(
     empty: pairs.length === 0,
     missingCore: !paired.has(CORE_CRATE),
     duplicated: [...duplicates].filter((name) => paired.has(name)).sort(),
+    // Deliberately independent of `paired`: an alias is unverifiable whether or
+    // not the same package is also declared directly, and the pair that direct
+    // declaration forms is exactly what would otherwise mask it.
+    aliased: [...aliases],
     // `paired` already requires both halves, so this covers a lost lockfile
     // entry and a crate that was never declared at all. `crate !== null` is the
     // only exemption: an npm package with no crate name owes no comparison.
@@ -248,8 +263,15 @@ function main() {
     return;
   }
 
-  const { pairs, mismatched, empty, missingCore, duplicated, unpaired } =
-    verdict(crates, npm, { duplicates, declared });
+  const {
+    pairs,
+    mismatched,
+    empty,
+    missingCore,
+    duplicated,
+    aliased,
+    unpaired,
+  } = verdict(crates, npm, { duplicates, declared, aliases });
   if (empty) {
     process.stderr.write(
       "tauri-parity: FAIL — no tauri npm/crate pairs found in the lockfiles\n",
@@ -285,26 +307,36 @@ function main() {
     process.exitCode = 1;
     return;
   }
+  if (aliased.length > 0) {
+    process.stderr.write(
+      `tauri-parity: FAIL — ${aliased.length} Tauri package(s) declared under an npm: alias\n`,
+    );
+    for (const [name, key] of aliased) {
+      process.stderr.write(
+        `  ${name} is installed as \`${key}\`, the name ${PNPM_LOCK} keys it by, so no comparison can reach it\n`,
+      );
+    }
+    process.stderr.write(
+      `    declare an aliased Tauri package under its real name in ${PACKAGE_JSON}; a direct declaration alongside the alias does not cover it\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   if (unpaired.length > 0) {
     process.stderr.write(
       `tauri-parity: FAIL — ${unpaired.length} declared package(s) produced no comparison\n`,
     );
     for (const name of unpaired) {
       const crate = crateNameFor(name);
-      let missing;
-      if (aliases.has(name)) {
-        missing = `installed under the alias \`${aliases.get(name)}\`, which no version comparison can reach`;
-      } else if (crates.has(crate)) {
-        missing = `${PNPM_LOCK} carries no root-importer entry for it`;
-      } else {
-        missing = `${CARGO_LOCK} carries no \`${crate}\` block`;
-      }
+      const missing = crates.has(crate)
+        ? `${PNPM_LOCK} carries no root-importer entry for it`
+        : `${CARGO_LOCK} carries no \`${crate}\` block`;
       process.stderr.write(
         `  ${name} (${PACKAGE_JSON}) <-> ${crate} — ${missing}\n`,
       );
     }
     process.stderr.write(
-      "    supply the missing half, drop the declaration if the dependency is genuinely gone, or declare an aliased package under its real name; a half that IS present means the block shape this gate reads has changed\n",
+      "    supply the missing half, or drop the declaration if the dependency is genuinely gone; a half that IS present means the block shape this gate reads has changed\n",
     );
     process.exitCode = 1;
     return;

--- a/scripts/check-tauri-plugin-parity.mjs
+++ b/scripts/check-tauri-plugin-parity.mjs
@@ -258,7 +258,7 @@ function main() {
       );
     }
     process.stderr.write(
-      `    supply the missing half, or drop the declaration if the dependency is genuinely gone; a half that IS present means the block shape this gate reads has changed\n`,
+      "    supply the missing half, or drop the declaration if the dependency is genuinely gone; a half that IS present means the block shape this gate reads has changed\n",
     );
     process.exitCode = 1;
     return;

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -2328,6 +2328,47 @@ test("declaredNpmPackages resolves an npm: alias to the real package name", () =
   assert.deepEqual([...declaredNpmAliases(forked)], []);
 });
 
+test("a direct declaration cannot mask an alias of the same package", () => {
+  // Both forms resolve, and pnpm keys the importer by each — the direct name
+  // and the alias. The pair the direct declaration forms is exactly what would
+  // swallow the alias if the two lists were one map.
+  const pkg = JSON.stringify({
+    dependencies: {
+      "@tauri-apps/api": "^2.11.1",
+      "@tauri-apps/plugin-store": "^2.4.4",
+      "store-alias": "npm:@tauri-apps/plugin-store@2.4.4",
+    },
+  });
+  assert.deepEqual(declaredNpmPackages(pkg), [
+    "@tauri-apps/api",
+    "@tauri-apps/plugin-store",
+  ]);
+  assert.deepEqual(declaredNpmAliases(pkg), [
+    ["@tauri-apps/plugin-store", "store-alias"],
+  ]);
+  const decided = verdict(
+    new Map([
+      ["tauri", "2.11.5"],
+      ["tauri-plugin-store", "2.4.4"],
+    ]),
+    new Map([
+      ["@tauri-apps/api", "2.11.1"],
+      ["@tauri-apps/plugin-store", "2.4.4"],
+      ["store-alias", "2.4.4"],
+    ]),
+    { declared: declaredNpmPackages(pkg), aliases: declaredNpmAliases(pkg) },
+  );
+  // Every other arm is clean — the direct half pairs and matches — so `aliased`
+  // is the only thing standing between this tree and a green gate.
+  assert.deepEqual(decided.mismatched, []);
+  assert.deepEqual(decided.unpaired, []);
+  assert.equal(decided.empty, false);
+  assert.equal(decided.missingCore, false);
+  assert.deepEqual(decided.aliased, [
+    ["@tauri-apps/plugin-store", "store-alias"],
+  ]);
+});
+
 test("an aliased declaration reaches the unpaired arm", () => {
   // The end of the chain both cells feed: the name is declared, the crate is
   // there, no pair can form under the alias — so the gate reports rather than
@@ -2348,9 +2389,14 @@ test("an aliased declaration reaches the unpaired arm", () => {
       ["@tauri-apps/api", "2.11.1"],
       ["tauri-store-alias", "2.4.4"],
     ]),
-    { declared: declaredNpmPackages(pkg) },
+    { declared: declaredNpmPackages(pkg), aliases: declaredNpmAliases(pkg) },
   );
   assert.deepEqual(decided.unpaired, ["@tauri-apps/plugin-store"]);
+  // Both arms see an alias-only declaration; the CLI renders `aliased` first
+  // because it names the cause rather than the symptom.
+  assert.deepEqual(decided.aliased, [
+    ["@tauri-apps/plugin-store", "tauri-store-alias"],
+  ]);
 });
 
 test("crateNameFor inverts the pairing and stops at the npm-only package", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -45,6 +45,9 @@ import {
   staleAllowlistEntries,
 } from "./check-rust-invariants.mjs";
 import {
+  crateNameFor,
+  declaredNpmPackages,
+  duplicateCrateNames,
   mismatchedPairs,
   npmNameFor,
   parseCrateVersions,
@@ -2201,11 +2204,98 @@ test("verdict clears only when the core pair is present and aligned", () => {
       ["@tauri-apps/api", "2.11.1"],
       ["@tauri-apps/plugin-http", "2.6.0"],
     ]),
+    { declared: ["@tauri-apps/api", "@tauri-apps/plugin-http"] },
   );
   assert.equal(clean.empty, false);
   assert.equal(clean.missingCore, false);
   assert.deepEqual(clean.mismatched, []);
+  assert.deepEqual(clean.duplicated, []);
+  assert.deepEqual(clean.unpaired, []);
   assert.equal(clean.pairs.length, 2);
+});
+
+test("duplicateCrateNames names only the crates carrying two blocks", () => {
+  const lock = cargoLock([
+    ["tauri", "2.11.5"],
+    ["windows-sys", "0.59.0"],
+    ["windows-sys", "0.60.2"],
+    ["tauri-plugin-http", "2.6.0"],
+  ]);
+  assert.deepEqual([...duplicateCrateNames(lock)], ["windows-sys"]);
+});
+
+test("verdict fails closed on a duplicated PAIRED crate only", () => {
+  const crates = new Map([
+    ["tauri", "2.11.5"],
+    ["tauri-plugin-http", "2.6.0"],
+  ]);
+  const npm = new Map([
+    ["@tauri-apps/api", "2.11.1"],
+    ["@tauri-apps/plugin-http", "2.6.0"],
+  ]);
+  // Two blocks for a compared crate: the parse kept one version arbitrarily, so
+  // the pair it reports may not be the one the app links.
+  assert.deepEqual(
+    verdict(crates, npm, { duplicates: new Set(["tauri-plugin-http"]) })
+      .duplicated,
+    ["tauri-plugin-http"],
+  );
+  // Duplication is ordinary for the crates this gate never compares.
+  assert.deepEqual(
+    verdict(crates, npm, {
+      duplicates: new Set(["windows-sys", "tauri-plugin-fs"]),
+    }).duplicated,
+    [],
+  );
+});
+
+test("declaredNpmPackages reads both dependency blocks, scoped to @tauri-apps", () => {
+  const pkg = JSON.stringify({
+    dependencies: { "@tauri-apps/api": "^2.11.1", zustand: "^5.0.15" },
+    devDependencies: { "@tauri-apps/cli": "^2.11.4", vite: "^8.2.1" },
+  });
+  assert.deepEqual(declaredNpmPackages(pkg), [
+    "@tauri-apps/api",
+    "@tauri-apps/cli",
+  ]);
+  // A manifest with neither block is not a crash — the arm simply expects
+  // nothing.
+  assert.deepEqual(declaredNpmPackages("{}"), []);
+});
+
+test("crateNameFor inverts the pairing and stops at the npm-only package", () => {
+  assert.equal(crateNameFor("@tauri-apps/api"), "tauri");
+  assert.equal(crateNameFor("@tauri-apps/plugin-store"), "tauri-plugin-store");
+  assert.equal(crateNameFor("@tauri-apps/cli"), null);
+  assert.equal(crateNameFor("zustand"), null);
+});
+
+test("verdict fails closed on a declared package that produced no comparison", () => {
+  const crates = new Map([
+    ["tauri", "2.11.5"],
+    ["tauri-plugin-http", "2.6.0"],
+  ]);
+  // The lockfile half lost one entry — a shape a format change makes, and one
+  // the pair COUNT cannot see: the remaining pairs still look healthy.
+  const degraded = verdict(crates, new Map([["@tauri-apps/api", "2.11.1"]]), {
+    declared: [
+      "@tauri-apps/api",
+      "@tauri-apps/plugin-http",
+      "@tauri-apps/cli",
+    ],
+  });
+  assert.equal(degraded.empty, false);
+  assert.equal(degraded.missingCore, false);
+  // @tauri-apps/cli has no crate half at all, so it is skipped, not flagged.
+  assert.deepEqual(degraded.unpaired, ["@tauri-apps/plugin-http"]);
+  // A declared package whose crate half is genuinely absent from Cargo.lock is
+  // also skipped: there is no comparison owed.
+  assert.deepEqual(
+    verdict(crates, new Map([["@tauri-apps/api", "2.11.1"]]), {
+      declared: ["@tauri-apps/api", "@tauri-apps/plugin-dialog"],
+    }).unpaired,
+    [],
+  );
 });
 
 test("mismatchedPairs skips a half with no counterpart", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -2095,9 +2095,8 @@ test("parseNpmVersions reads the root importer's resolved versions only", () => 
 
 test("parseNpmVersions yields nothing when there is no root importer", () => {
   // The degradation that feeds the `empty` fail-closed arm from the parser
-  // side: a lockfile whose `  .:` block this scan can no longer find still
-  // carries plenty of `version:` lines under `packages:`, and reading those
-  // would compare transitive copies the app never installs.
+  // side: no `  .:` importer block means no versions, and the transitive
+  // `packages:` copies are out of scope whatever they resolve to.
   const noImporter = [
     "lockfileVersion: '9.0'",
     "",
@@ -2303,13 +2302,22 @@ test("verdict fails closed on a declared package that produced no comparison", (
   });
   assert.equal(degraded.empty, false);
   assert.equal(degraded.missingCore, false);
-  // @tauri-apps/cli has no crate half at all, so it is skipped, not flagged.
+  // @tauri-apps/cli maps to no crate name, so it owes nothing and stays out.
   assert.deepEqual(degraded.unpaired, ["@tauri-apps/plugin-http"]);
-  // A declared package whose crate half is genuinely absent from Cargo.lock is
-  // also skipped: there is no comparison owed.
+  // A declared package whose crate is absent from Cargo.lock ENTIRELY is the
+  // same finding, not an exemption: a JS half calling a plugin the Rust side
+  // never registers is exactly what this arm is for.
   assert.deepEqual(
     verdict(crates, new Map([["@tauri-apps/api", "2.11.1"]]), {
       declared: ["@tauri-apps/api", "@tauri-apps/plugin-dialog"],
+    }).unpaired,
+    ["@tauri-apps/plugin-dialog"],
+  );
+  // The must-NOT-hit twin: the npm-only package stays out even when it is the
+  // only thing left to flag.
+  assert.deepEqual(
+    verdict(crates, new Map([["@tauri-apps/api", "2.11.1"]]), {
+      declared: ["@tauri-apps/api", "@tauri-apps/cli"],
     }).unpaired,
     [],
   );

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -1,4 +1,4 @@
-// Negative controls for the four guard scanners. Their worst failure mode is
+// Negative controls for the five guard scanners. Their worst failure mode is
 // silent fail-open — a pattern that stops matching still prints "OK" — so every
 // predicate keeps a fixture that MUST hit and a fixture that must not. The
 // scripts export their predicates and gate their CLI body on a main-module path
@@ -39,6 +39,13 @@ import {
   enclosingFn,
   staleAllowlistEntries,
 } from "./check-rust-invariants.mjs";
+import {
+  mismatchedPairs,
+  npmNameFor,
+  parseCrateVersions,
+  parseNpmVersions,
+  verdict,
+} from "./check-tauri-plugin-parity.mjs";
 
 // ------------------------------------------------------- check-banned-patterns
 
@@ -1951,4 +1958,216 @@ test("a mounted carrier, when present, still states the whole rule", () => {
       `mounted carrier lost the rule: ${carrier}`,
     );
   }
+});
+
+// --------------------------------------------------- check-tauri-plugin-parity
+
+/** Cargo.lock text in the block shape the gate reads, LF or CRLF on demand. */
+function cargoLock(entries, eol = "\n") {
+  return entries
+    .map(([name, version]) =>
+      ["[[package]]", `name = "${name}"`, `version = "${version}"`].join(eol),
+    )
+    .join(eol + eol);
+}
+
+/** Crate names the check reports, driven from two in-memory maps. */
+const splitCrates = (crates, npm) =>
+  mismatchedPairs(new Map(crates), new Map(npm)).map((p) => p.crate);
+
+test("parseCrateVersions reads the block shape under both line endings", () => {
+  // CRLF is not hypothetical: a Windows checkout materializes Cargo.lock that
+  // way under core.autocrlf, and an LF-only pattern would parse zero packages —
+  // the gate then passes having compared nothing.
+  const entries = [
+    ["tauri", "2.11.5"],
+    ["tauri-plugin-http", "2.6.0"],
+  ];
+  for (const eol of ["\n", "\r\n"]) {
+    assert.deepEqual(
+      [...parseCrateVersions(cargoLock(entries, eol))],
+      entries,
+      `should parse ${JSON.stringify(eol)} blocks`,
+    );
+  }
+});
+
+test("parseNpmVersions reads the root importer's resolved versions only", () => {
+  const lock = [
+    "lockfileVersion: '9.0'",
+    "",
+    "importers:",
+    "",
+    "  .:",
+    "    dependencies:",
+    "      '@tauri-apps/api':",
+    "        specifier: ^2.11.1",
+    "        version: 2.11.1",
+    "      zustand:",
+    "        specifier: ^5.0.15",
+    "        version: 5.0.15(react@19.2.8)",
+    "    devDependencies:",
+    "      '@tauri-apps/cli':",
+    "        specifier: ^2.11.4",
+    "        version: 2.11.4",
+    "",
+    "  site:",
+    "    dependencies:",
+    "      '@tauri-apps/api':",
+    "        specifier: ^1.0.0",
+    "        version: 1.0.0",
+    "",
+    "packages:",
+    "",
+    "  '@tauri-apps/api@9.9.9':",
+    "    resolution: {integrity: sha512-fixture}",
+  ].join("\n");
+  const npm = parseNpmVersions(lock);
+  // devDependencies count (that is where @tauri-apps/cli lives), the resolved
+  // version wins over the specifier, and a peer-resolution suffix is not part
+  // of the version.
+  assert.equal(npm.get("@tauri-apps/api"), "2.11.1");
+  assert.equal(npm.get("@tauri-apps/cli"), "2.11.4");
+  assert.equal(npm.get("zustand"), "5.0.15");
+  // The sibling importer and the transitive `packages:` section both carry the
+  // same name at a different version; either winning would compare a version
+  // the app never installs.
+  assert.equal(npm.size, 3);
+});
+
+test("npmNameFor pairs the two forms and nothing else", () => {
+  assert.equal(npmNameFor("tauri"), "@tauri-apps/api");
+  assert.equal(
+    npmNameFor("tauri-plugin-notification"),
+    "@tauri-apps/plugin-notification",
+  );
+  // The tauri-* build and runtime crates ship no npm half, and `tauri-plugin`
+  // itself is the plugin SDK, not a plugin.
+  for (const crate of [
+    "tauri-build",
+    "tauri-codegen",
+    "tauri-runtime-wry",
+    "tauri-utils",
+    "tauri-plugin",
+    "serde",
+  ]) {
+    assert.equal(npmNameFor(crate), null, `should not pair ${crate}`);
+  }
+});
+
+test("mismatchedPairs passes halves aligned on major.minor", () => {
+  assert.deepEqual(
+    splitCrates(
+      [["tauri-plugin-http", "2.6.0"]],
+      [["@tauri-apps/plugin-http", "2.6.0"]],
+    ),
+    [],
+  );
+  // Patch drift is legal — tauri-cli compares major and minor only, so flagging
+  // it would redden PRs whose bundle builds fine.
+  assert.deepEqual(
+    splitCrates(
+      [["tauri-plugin-http", "2.6.0"]],
+      [["@tauri-apps/plugin-http", "2.6.1"]],
+    ),
+    [],
+  );
+});
+
+test("mismatchedPairs flags a split in either direction", () => {
+  // Crate ahead: the Cargo.lock-only bump that ships a broken `tauri build`.
+  assert.deepEqual(
+    splitCrates(
+      [["tauri-plugin-http", "2.6.0"]],
+      [["@tauri-apps/plugin-http", "2.5.9"]],
+    ),
+    ["tauri-plugin-http"],
+  );
+  // npm ahead: the same break, reached from the other lockfile — a check that
+  // only looked one way would call this clean.
+  assert.deepEqual(
+    splitCrates(
+      [["tauri-plugin-http", "2.5.9"]],
+      [["@tauri-apps/plugin-http", "2.6.0"]],
+    ),
+    ["tauri-plugin-http"],
+  );
+  assert.deepEqual(
+    splitCrates([["tauri", "3.0.0"]], [["@tauri-apps/api", "2.6.0"]]),
+    ["tauri"],
+  );
+});
+
+test("mismatchedPairs carries both halves of the split it reports", () => {
+  assert.deepEqual(
+    mismatchedPairs(
+      new Map([["tauri", "2.11.5"]]),
+      new Map([["@tauri-apps/api", "2.10.1"]]),
+    ),
+    [
+      {
+        crate: "tauri",
+        npm: "@tauri-apps/api",
+        crateVersion: "2.11.5",
+        npmVersion: "2.10.1",
+      },
+    ],
+  );
+});
+
+test("verdict fails closed when the lockfiles yield no pairs at all", () => {
+  // The branch a broken parser lands in: nothing to compare is not a clean
+  // tree, because this repo always ships tauri on both sides.
+  const none = verdict(new Map(), new Map());
+  assert.equal(none.empty, true);
+  assert.deepEqual(none.pairs, []);
+  assert.deepEqual(none.mismatched, []);
+});
+
+test("verdict fails closed when the core pair is missing from a partial parse", () => {
+  // Partial degradation is the residual fail-open: plugins still pair, so the
+  // count looks healthy while the comparisons the gate exists for went missing.
+  const partial = verdict(
+    new Map([["tauri-plugin-http", "2.6.0"]]),
+    new Map([["@tauri-apps/plugin-http", "2.6.0"]]),
+  );
+  assert.equal(partial.empty, false);
+  assert.equal(partial.missingCore, true);
+  assert.deepEqual(partial.mismatched, []);
+});
+
+test("verdict clears only when the core pair is present and aligned", () => {
+  const clean = verdict(
+    new Map([
+      ["tauri", "2.11.5"],
+      ["tauri-plugin-http", "2.6.0"],
+    ]),
+    new Map([
+      ["@tauri-apps/api", "2.11.1"],
+      ["@tauri-apps/plugin-http", "2.6.0"],
+    ]),
+  );
+  assert.equal(clean.empty, false);
+  assert.equal(clean.missingCore, false);
+  assert.deepEqual(clean.mismatched, []);
+  assert.equal(clean.pairs.length, 2);
+});
+
+test("mismatchedPairs skips a half with no counterpart", () => {
+  // Crate-only plugins and the npm-only CLI have nothing to disagree with, so
+  // neither is a finding however far the versions sit apart.
+  assert.deepEqual(
+    splitCrates(
+      [
+        ["tauri-plugin-fs", "2.5.2"],
+        ["tauri-plugin-single-instance", "2.4.4"],
+      ],
+      [["@tauri-apps/cli", "2.11.4"]],
+    ),
+    [],
+  );
+  assert.deepEqual(
+    splitCrates([["tauri", "2.11.5"]], [["@tauri-apps/cli", "1.0.0"]]),
+    [],
+  );
 });

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -46,6 +46,7 @@ import {
 } from "./check-rust-invariants.mjs";
 import {
   crateNameFor,
+  declaredNpmAliases,
   declaredNpmPackages,
   duplicateCrateNames,
   mismatchedPairs,
@@ -2277,6 +2278,79 @@ test("declaredNpmPackages reads both dependency blocks, scoped to @tauri-apps", 
   // A manifest with neither block is not a crash — the arm simply expects
   // nothing.
   assert.deepEqual(declaredNpmPackages("{}"), []);
+});
+
+// One class, two cells: a declared Tauri package that never reaches `declared`
+// is a comparison the gate silently skips, and it can be lost either by the
+// BLOCK it sits in or by the KEY it is declared under. A new input path added
+// to the manifest scan belongs here.
+
+test("declaredNpmPackages counts optional deps and exempts peers", () => {
+  const pkg = JSON.stringify({
+    dependencies: { "@tauri-apps/api": "^2.11.1" },
+    optionalDependencies: { "@tauri-apps/plugin-shell": "^2.4.0" },
+    // pnpm does not install an app's peers, so flagging one would redden a
+    // required check over a package that was never meant to be there.
+    peerDependencies: { "@tauri-apps/plugin-fs": "^2.5.0" },
+  });
+  assert.deepEqual(declaredNpmPackages(pkg), [
+    "@tauri-apps/api",
+    "@tauri-apps/plugin-shell",
+  ]);
+});
+
+test("declaredNpmPackages resolves an npm: alias to the real package name", () => {
+  // The alias hides the package on BOTH sides at once: the key carries no
+  // `@tauri-apps/` prefix, and the lockfile's root importer keys the entry by
+  // the alias — so without reading the value, nothing is ever compared.
+  const pkg = JSON.stringify({
+    dependencies: {
+      "@tauri-apps/api": "^2.11.1",
+      "tauri-store-alias": "npm:@tauri-apps/plugin-store@^2.4.4",
+      "other-alias": "npm:left-pad@1.3.0",
+    },
+  });
+  assert.deepEqual(declaredNpmPackages(pkg), [
+    "@tauri-apps/api",
+    "@tauri-apps/plugin-store",
+  ]);
+  assert.deepEqual(
+    [...declaredNpmAliases(pkg)],
+    [["@tauri-apps/plugin-store", "tauri-store-alias"]],
+  );
+  // The mirror case keeps its scoped KEY, so the importer entry still matches
+  // and the garbage version lands in `mismatched` rather than here: it is a
+  // declaration under its own name, not an alias.
+  const forked = JSON.stringify({
+    dependencies: { "@tauri-apps/plugin-store": "npm:fork@1.0.0" },
+  });
+  assert.deepEqual(declaredNpmPackages(forked), ["@tauri-apps/plugin-store"]);
+  assert.deepEqual([...declaredNpmAliases(forked)], []);
+});
+
+test("an aliased declaration reaches the unpaired arm", () => {
+  // The end of the chain both cells feed: the name is declared, the crate is
+  // there, no pair can form under the alias — so the gate reports rather than
+  // passing over it.
+  const pkg = JSON.stringify({
+    dependencies: {
+      "@tauri-apps/api": "^2.11.1",
+      "tauri-store-alias": "npm:@tauri-apps/plugin-store@^2.4.4",
+    },
+  });
+  const decided = verdict(
+    new Map([
+      ["tauri", "2.11.5"],
+      ["tauri-plugin-store", "2.4.4"],
+    ]),
+    // What pnpm writes for an aliased install: the alias is the importer key.
+    new Map([
+      ["@tauri-apps/api", "2.11.1"],
+      ["tauri-store-alias", "2.4.4"],
+    ]),
+    { declared: declaredNpmPackages(pkg) },
+  );
+  assert.deepEqual(decided.unpaired, ["@tauri-apps/plugin-store"]);
 });
 
 test("crateNameFor inverts the pairing and stops at the npm-only package", () => {

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -2093,6 +2093,23 @@ test("parseNpmVersions reads the root importer's resolved versions only", () => 
   assert.equal(npm.size, 3);
 });
 
+test("parseNpmVersions yields nothing when there is no root importer", () => {
+  // The degradation that feeds the `empty` fail-closed arm from the parser
+  // side: a lockfile whose `  .:` block this scan can no longer find still
+  // carries plenty of `version:` lines under `packages:`, and reading those
+  // would compare transitive copies the app never installs.
+  const noImporter = [
+    "lockfileVersion: '9.0'",
+    "",
+    "packages:",
+    "",
+    "  '@tauri-apps/api@9.9.9':",
+    "    resolution: {integrity: sha512-fixture}",
+    "    version: 9.9.9",
+  ].join("\n");
+  assert.equal(parseNpmVersions(noImporter).size, 0);
+});
+
 test("npmNameFor pairs the two forms and nothing else", () => {
   assert.equal(npmNameFor("tauri"), "@tauri-apps/api");
   assert.equal(


### PR DESCRIPTION
`tauri build` refuses to bundle when a Tauri plugin's npm half and Rust crate half disagree on major.minor, and nothing in CI compared the two: `appimage-check.yml` is paths-filtered to `package.json` and the Linux bundling files, so a `Cargo.lock`-only bump never runs it, and `release.yml` fires on tag push alone. A split pair could therefore reach master with the bundler broken and no signal until a release. This adds a lockfile parity gate that runs on every PR, plus Dependabot grouping so both halves of a Tauri bump move together in the first place.

### Parity guard — `scripts/check-tauri-plugin-parity.mjs`

- Reads `src-tauri/Cargo.lock` and `pnpm-lock.yaml` directly (Node stdlib only, no install step) and compares the **resolved** versions of every crate that has an npm counterpart: `tauri` ↔ `@tauri-apps/api`, `tauri-plugin-*` ↔ `@tauri-apps/plugin-*` via `npmNameFor`.
- Compares **major.minor** only, mirroring tauri-cli's own `InstalledPackages::mismatched()` — patch drift between halves stays legal so the gate doesn't redden PRs whose bundle builds fine.
- `parseCrateVersions` matches `[[package]]` blocks with a `\r?` allowance, since a Windows checkout materializes `Cargo.lock` with CRLF and an LF-only pattern would parse zero packages.
- `parseNpmVersions` is scoped to the root importer (`.:`) and takes the `version:` line rather than the specifier, stripping peer-resolution suffixes like `(react@19.2.8)` — the sibling `site/` importer and the transitive `packages:` section carry the same names at versions the app never installs.
- Fails **closed** through `verdict`: `empty` (no pairs found at all) and `missingCore` (pairs found but `tauri` isn't among them) both exit non-zero, so a parser that stops matching can't print OK over comparisons it never made.
- Failure output names both halves and prints two concrete remedies per mismatch — a `pnpm add …@~<major.minor>.0` pin or a `src-tauri/Cargo.toml` bump plus re-lock. Uses `process.exitCode` rather than `process.exit` to avoid truncating the pending write on a CI runner.
- Main-module detection is a resolved-path comparison rather than `import.meta.main`, which only exists from node 24.2 and would silently evaluate to `undefined` on older runtimes.
- `GD_TAURI_PARITY_ROOT` points the check at a copy of the tree for an ad-hoc by-hand negative control.

### Negative controls — `scripts/checks.test.mjs`

- Drives the exported predicates in memory (no disk) across: LF and CRLF `Cargo.lock` blocks; root-importer scoping, including a `site:` importer and a `packages:` entry that must both be ignored; `npmNameFor` pairing and its non-pairs (`tauri-build`, `tauri-codegen`, `tauri-runtime-wry`, `tauri-utils`, `tauri-plugin`, `serde`).
- Covers both directions of a split (crate ahead and npm ahead), allowed patch drift, the reported pair carrying both halves, the `empty` and `missingCore` fail-closed arms, and halves with no counterpart (crate-only plugins, the npm-only `@tauri-apps/cli`).

### CI and local wiring

- Adds a `Tauri npm/crate parity` step to the blocking `guards` job in `.github/workflows/quality.yml`, one step per script so a failure names its own check.
- Adds the script to the `checks` alias in `package.json` so the same set runs locally.
- Updates the "four scripts" comments in `quality.yml` and the header of `checks.test.mjs` to five.

### Dependabot grouping — `.github/dependabot.yml`

- Adds a `tauri` group to the npm ecosystem matching `@tauri-apps/*` for minor and patch updates, declared **before** `minor-and-patch` because the first matching group wins.
- Adds the matching cargo-side `tauri` group for `tauri`, `tauri-build`, and `tauri-plugin-*`.
- Both groups carry a comment recording the operational consequence: a group cannot span ecosystems, and with the parity guard blocking, each half alone reddens its own merge ref — so the npm PR and its cargo twin need combining onto one branch to land.

No changelog fragment: the diff touches only `.github/`, `scripts/`, and `package.json`, with no `src/` or `src-tauri/` change and no user-facing effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks to ensure Tauri Rust crates and npm packages use matching major and minor versions.
  * Dependabot now groups related Tauri dependency updates across npm and Cargo ecosystems.

* **Documentation**
  * Updated contributor guidance and conventions to describe Tauri version parity checks and required quality checks.

* **Tests**
  * Added coverage for version matching, lockfile parsing, missing counterparts, duplicates, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->