### PR TITLE
feat(issues,pulls,github): show GitHub Projects field values on items

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ in one click.
   the browser. Labels and assignees on GitHub & GitLab (set them when you
   open a PR/MR or any time after), request reviewers across GitHub, GitLab &
   Bitbucket, see, link, and unlink an open PR's **GitHub Projects** in its
-  header, flip a PR between **draft and ready for review** either way on all
+  header alongside each board's **Status**, **Priority**, and **Iteration**
+  values, flip a PR between **draft and ready for review** either way on all
   three, and **create new PRs as drafts by default** (Settings → General).
 - **Linked issues**: link related issues when you open *or* edit a PR, as
   chips **auto-detected** from your branch name and commits (a `fix/123-…`
@@ -515,7 +516,9 @@ remote needed; publishable to GitHub, GitLab, or linked Jira in one click).
 Browse, create, and edit (drafting with AI from your repo's issue
 templates), react with emoji, and manage the shared metadata: labels,
 assignees, and milestones. On GitHub, add **projects** (GitHub Projects,
-repo and owner level), issue type, sub-issues, dependencies (blocked-by /
+repo and owner level) and read each board's **Status**, **Priority**,
+**Iteration**, dates and custom fields, a line per board under the chips.
+Also on GitHub: issue type, sub-issues, dependencies (blocked-by /
 blocking), and development links (linked and closing PRs and branches, plus
 create-a-branch); on GitLab, related issues. Close or reopen with a comment
 you've drafted posted alongside; duplicate, transfer (called *move* on

--- a/changelog.d/added-project-field-values.md
+++ b/changelog.d/added-project-field-values.md
@@ -1,0 +1,6 @@
+- **See where an issue or pull request stands on its GitHub Projects boards.** Under
+  the Projects chips, one line per board reads out that board's set fields: **Status**,
+  **Priority**, **Iteration** with the dates it covers, plus date, text, number, and
+  multi-select fields, each named beside its value. A board is named on its own line
+  once the item sits on more than one. GitHub only, and it uses the same `project` (or
+  `read:project`) sign-in scope the Projects picker already needs.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -325,6 +325,11 @@ export const capabilities: Capability[] = [
   {
     group: "Issues & discussions",
     label:
+      "Project field values — Status, Priority, Iteration & dates on issues and PRs",
+  },
+  {
+    group: "Issues & discussions",
+    label:
       "Issue activity timeline — labels, assignees, milestones, renames, linked PRs, mentions & state changes, with actor avatars",
   },
   {

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -12,6 +12,7 @@ pub mod pages;
 pub mod pr;
 pub mod pr_search;
 pub mod project;
+pub mod project_fields;
 pub mod release;
 pub mod repo_settings;
 pub mod rulesets;

--- a/src-tauri/src/github/project.rs
+++ b/src-tauri/src/github/project.rs
@@ -67,7 +67,7 @@ fn map_scope_error(e: AppError) -> AppError {
 
 /// A `ProjectV2` node, skipped entirely when it carries no id (the one field the
 /// mutations can't work without); the rest default rather than fail the read.
-fn project_ref(node: &Value) -> Option<ProjectV2Ref> {
+pub(super) fn project_ref(node: &Value) -> Option<ProjectV2Ref> {
     Some(ProjectV2Ref {
         id: node.get("id")?.as_str()?.to_string(),
         title: node

--- a/src-tauri/src/github/project.rs
+++ b/src-tauri/src/github/project.rs
@@ -84,7 +84,7 @@ fn project_ref(node: &Value) -> Option<ProjectV2Ref> {
     })
 }
 
-const PROJECT_FIELDS: &str = "id title number closed viewerCanUpdate";
+pub(super) const PROJECT_FIELDS: &str = "id title number closed viewerCanUpdate";
 
 /// `repositoryOwner` resolves a User or an Organization and both implement
 /// `ProjectV2Owner`, so one inline fragment covers owner-level projects for either.

--- a/src-tauri/src/github/project.rs
+++ b/src-tauri/src/github/project.rs
@@ -65,8 +65,10 @@ fn map_scope_error(e: AppError) -> AppError {
     e
 }
 
-/// A `ProjectV2` node, skipped entirely when it carries no id (the one field the
-/// mutations can't work without); the rest default rather than fail the read.
+/// A `ProjectV2` node, skipped entirely when it carries no id (the one field
+/// every caller keys on: mutations address a board by it, and the rail matches
+/// its field lines to the memberships by it); the rest default rather than fail
+/// the read.
 pub(super) fn project_ref(node: &Value) -> Option<ProjectV2Ref> {
     Some(ProjectV2Ref {
         id: node.get("id")?.as_str()?.to_string(),

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -78,7 +78,7 @@ pub struct SelectOptionRef {
 }
 
 const FIELDS_SCOPE_HINT: &str =
-    "GitHub project fields need the read:project scope. Run:  gh auth refresh -s project";
+    "GitHub project fields need the read:project (or project) scope. Run:  gh auth refresh -s project";
 
 fn map_scope_error(e: AppError) -> AppError {
     if let AppError::Gh(ref msg) = e {

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -77,71 +77,6 @@ pub struct SelectOptionRef {
     pub color: String,
 }
 
-#[derive(Serialize)]
-#[serde(
-    tag = "kind",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase"
-)]
-pub enum ProjectFieldDef {
-    SingleSelect {
-        id: String,
-        name: String,
-        options: Vec<FieldOptionDef>,
-        is_issue_field: bool,
-    },
-    MultiSelect {
-        id: String,
-        name: String,
-        options: Vec<FieldOptionDef>,
-        is_issue_field: bool,
-    },
-    Iteration {
-        id: String,
-        name: String,
-        iterations: Vec<IterationDef>,
-        completed_iterations: Vec<IterationDef>,
-    },
-    Text {
-        id: String,
-        name: String,
-        is_issue_field: bool,
-    },
-    Number {
-        id: String,
-        name: String,
-        is_issue_field: bool,
-    },
-    Date {
-        id: String,
-        name: String,
-        is_issue_field: bool,
-    },
-    System {
-        id: String,
-        name: String,
-        data_type: String,
-    },
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FieldOptionDef {
-    pub id: String,
-    pub name: String,
-    pub color: String,
-    pub description: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IterationDef {
-    pub id: String,
-    pub title: String,
-    pub start_date: String,
-    pub duration: u32,
-}
-
 const FIELDS_SCOPE_HINT: &str =
     "GitHub project fields need the read:project scope. Run:  gh auth refresh -s project";
 
@@ -180,20 +115,6 @@ fn item_field_values_query(field: &str) -> String {
            ... on IssueFieldDateValue{{ date: value }} \
          }} }} \
          }} }} }} }} }} }} }}"
-    )
-}
-
-fn project_fields_query() -> String {
-    format!(
-        "query($id:ID!){{ node(id:$id){{ ... on ProjectV2{{ fields(first:50){{ nodes{{ \
-         __typename {FIELD_COMMON} \
-         ... on ProjectV2SingleSelectField{{ options{{ id name color description }} }} \
-         ... on ProjectV2MultiSelectField{{ multiSelectOptions{{ id name color description }} }} \
-         ... on ProjectV2IterationField{{ configuration{{ \
-           iterations{{ id title startDate duration }} \
-           completedIterations{{ id title startDate duration }} \
-         }} }} \
-         }} }} }} }} }}"
     )
 }
 
@@ -264,10 +185,13 @@ fn parse_field_value(node: &Value) -> ProjectFieldValue {
             }
         }
         ("ProjectV2ItemFieldNumberValue" | "IssueFieldNumberValue", "NUMBER") => {
+            let Some(number) = value["number"].as_f64() else {
+                return ProjectFieldValue::Unknown { field_name };
+            };
             ProjectFieldValue::Number {
                 field_id,
                 field_name,
-                number: value["number"].as_f64().unwrap_or(0.0),
+                number,
                 is_issue_field,
             }
         }
@@ -315,83 +239,6 @@ fn parse_item_field_values(value: &Value, field: &str) -> Vec<ItemProjectFieldVa
         .collect()
 }
 
-fn field_options(value: &Value) -> Vec<FieldOptionDef> {
-    array(value)
-        .map(|node| FieldOptionDef {
-            id: text(node, "id"),
-            name: text(node, "name"),
-            color: text(node, "color"),
-            description: text(node, "description"),
-        })
-        .collect()
-}
-
-fn iterations(value: &Value) -> Vec<IterationDef> {
-    array(value)
-        .map(|node| IterationDef {
-            id: text(node, "id"),
-            title: text(node, "title"),
-            start_date: text(node, "startDate"),
-            duration: duration(node),
-        })
-        .collect()
-}
-
-const PROJECT_FIELDS_POINTER: &str = "/data/node/fields/nodes";
-
-fn parse_project_fields(value: &Value) -> Vec<ProjectFieldDef> {
-    value
-        .pointer(PROJECT_FIELDS_POINTER)
-        .into_iter()
-        .flat_map(array)
-        .filter_map(|node| {
-            let id = node.get("id")?.as_str()?.to_string();
-            let name = text(node, "name");
-            let is_issue_field = node["isIssueField"].as_bool().unwrap_or(false);
-            Some(match node["dataType"].as_str().unwrap_or_default() {
-                "SINGLE_SELECT" => ProjectFieldDef::SingleSelect {
-                    id,
-                    name,
-                    options: field_options(&node["options"]),
-                    is_issue_field,
-                },
-                "MULTI_SELECT" => ProjectFieldDef::MultiSelect {
-                    id,
-                    name,
-                    options: field_options(&node["multiSelectOptions"]),
-                    is_issue_field,
-                },
-                "ITERATION" => ProjectFieldDef::Iteration {
-                    id,
-                    name,
-                    iterations: iterations(&node["configuration"]["iterations"]),
-                    completed_iterations: iterations(&node["configuration"]["completedIterations"]),
-                },
-                "TEXT" => ProjectFieldDef::Text {
-                    id,
-                    name,
-                    is_issue_field,
-                },
-                "NUMBER" => ProjectFieldDef::Number {
-                    id,
-                    name,
-                    is_issue_field,
-                },
-                "DATE" => ProjectFieldDef::Date {
-                    id,
-                    name,
-                    is_issue_field,
-                },
-                _ => ProjectFieldDef::System {
-                    id,
-                    name,
-                    data_type: text(node, "dataType"),
-                },
-            })
-        })
-        .collect()
-}
-
 #[tauri::command]
 pub async fn gh_item_field_values(
     repo_path: String,
@@ -433,35 +280,6 @@ pub async fn gh_item_field_values(
     Ok(parse_item_field_values(&value, field))
 }
 
-#[tauri::command]
-pub async fn gh_project_fields(
-    repo_path: String,
-    project_id: String,
-) -> AppResult<Vec<ProjectFieldDef>> {
-    let query = project_fields_query();
-    let out = run_gh(
-        Some(&repo_path),
-        &[
-            "api",
-            "graphql",
-            "-f",
-            &format!("id={project_id}"),
-            "-f",
-            &format!("query={query}"),
-        ],
-        GH_NETWORK_TIMEOUT,
-    )
-    .await
-    .map_err(map_scope_error)?;
-    let value: Value = serde_json::from_str(&out.stdout_lossy()).map_err(|e| {
-        gh_unreadable(
-            "the project fields",
-            format!("could not parse the project's fields: {e}"),
-        )
-    })?;
-    Ok(parse_project_fields(&value))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -476,18 +294,6 @@ mod tests {
             {"__typename":"ProjectV2ItemFieldDateValue", "field":{"id":"due","name":"Due","dataType":"DATE","isIssueField":false}, "date":"2026-09-12"},
             {"__typename":"ProjectV2ItemFieldIterationValue", "field":{"id":"sprint","name":"Sprint","dataType":"ITERATION","isIssueField":false}, "title":"Sprint 1","startDate":"2026-09-01","duration":14}
         ])
-    }
-
-    fn field_defs() -> Value {
-        json!({"data":{"node":{"fields":{"nodes":[
-            {"__typename":"ProjectV2SingleSelectField","id":"status","name":"Status","dataType":"SINGLE_SELECT","isIssueField":true,"options":[{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}]},
-            {"__typename":"ProjectV2MultiSelectField","id":"teams","name":"Teams","dataType":"MULTI_SELECT","isIssueField":false,"multiSelectOptions":[{"id":"web","name":"Web","color":"BLUE","description":"Browser"}]},
-            {"__typename":"ProjectV2IterationField","id":"sprint","name":"Sprint","dataType":"ITERATION","configuration":{"iterations":[{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}],"completedIterations":[{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}]}},
-            {"__typename":"ProjectV2Field","id":"notes","name":"Notes","dataType":"TEXT","isIssueField":false},
-            {"__typename":"ProjectV2Field","id":"points","name":"Points","dataType":"NUMBER","isIssueField":false},
-            {"__typename":"ProjectV2Field","id":"due","name":"Due","dataType":"DATE","isIssueField":true},
-            {"__typename":"ProjectV2Field","id":"labels","name":"Labels","dataType":"LABELS"}
-        ]}}}})
     }
 
     fn assert_keys(value: &Value, expected: &[&str]) {
@@ -550,35 +356,6 @@ mod tests {
         ];
         for (value, (kind, keys)) in values.iter().zip(expected) {
             let wire = serde_json::to_value(value).expect("field value serializes");
-            assert_keys(&wire, keys);
-            assert_eq!(wire["kind"], kind);
-        }
-    }
-
-    #[test]
-    fn field_definition_wire_shapes_are_camel_case() {
-        let defs = parse_project_fields(&field_defs());
-        assert_eq!(defs.len(), 7);
-        let expected: [(&str, &[&str]); 7] = [
-            (
-                "singleSelect",
-                &["id", "isIssueField", "kind", "name", "options"],
-            ),
-            (
-                "multiSelect",
-                &["id", "isIssueField", "kind", "name", "options"],
-            ),
-            (
-                "iteration",
-                &["completedIterations", "id", "iterations", "kind", "name"],
-            ),
-            ("text", &["id", "isIssueField", "kind", "name"]),
-            ("number", &["id", "isIssueField", "kind", "name"]),
-            ("date", &["id", "isIssueField", "kind", "name"]),
-            ("system", &["dataType", "id", "kind", "name"]),
-        ];
-        for (def, (kind, keys)) in defs.iter().zip(expected) {
-            let wire = serde_json::to_value(def).expect("field definition serializes");
             assert_keys(&wire, keys);
             assert_eq!(wire["kind"], kind);
         }
@@ -721,13 +498,41 @@ mod tests {
         ] {
             assert!(parse_item_field_values(&response, "issue").is_empty());
         }
-        for response in [
-            json!({"data":{"node":{"fields":{"nodes":[]}}}}),
-            json!({"data":{"node":{"fields":null}}}),
-            json!({"data":{"node":null}}),
-            Value::Null,
-        ] {
-            assert!(parse_project_fields(&response).is_empty());
+    }
+
+    #[test]
+    fn numbers_distinguish_explicit_zero_from_unset_values() {
+        for bridge in [false, true] {
+            let typename = if bridge {
+                "IssueFieldNumberValue"
+            } else {
+                "ProjectV2ItemFieldNumberValue"
+            };
+            for (payload, expected) in [
+                (
+                    json!({"number":0.0}),
+                    json!({"kind":"number","fieldId":"points","fieldName":"Points","number":0.0,"isIssueField":bridge}),
+                ),
+                (
+                    json!({"number":null}),
+                    json!({"kind":"unknown","fieldName":"Points"}),
+                ),
+                (json!({}), json!({"kind":"unknown","fieldName":"Points"})),
+            ] {
+                let mut value = payload;
+                value["__typename"] = json!(typename);
+                let mut node = if bridge {
+                    json!({"__typename":"ProjectV2ItemIssueFieldValue","issueFieldValue":value})
+                } else {
+                    value
+                };
+                node["field"] = json!({"id":"points","name":"Points","dataType":"NUMBER"});
+                assert_eq!(
+                    serde_json::to_value(parse_field_value(&node))
+                        .expect("numeric value serializes"),
+                    expected
+                );
+            }
         }
     }
 
@@ -757,84 +562,11 @@ mod tests {
             assert_eq!(wire, json!({"kind":"unknown","fieldName":""}));
         }
         assert!(matches!(
-            parse_field_value(&json!({"__typename":"ProjectV2ItemFieldNumberValue","number":null})),
+            parse_field_value(
+                &json!({"__typename":"ProjectV2ItemFieldNumberValue","field":{"dataType":"NUMBER"},"number":null})
+            ),
             ProjectFieldValue::Unknown { .. }
         ));
-        let response = json!({"data":{"node":{"fields":{"nodes":[
-            {"id":"select","dataType":"SINGLE_SELECT","options":[{"id":"option","description":null}]},
-            {"id":"multi","dataType":"MULTI_SELECT","multiSelectOptions":null},
-            {"id":"iteration","dataType":"ITERATION","configuration":null},
-            {"id":"unknown"}, {"id":null}, null
-        ]}}}});
-        let defs = serde_json::to_value(parse_project_fields(&response))
-            .expect("partial definitions serialize");
-        assert_eq!(defs.as_array().expect("definitions array").len(), 4);
-        assert_eq!(defs[0]["options"][0]["description"], "");
-        assert_eq!(defs[1]["options"], json!([]));
-        assert_eq!(defs[2]["iterations"], json!([]));
-        assert_eq!(defs[2]["completedIterations"], json!([]));
-        assert_eq!(defs[3]["dataType"], "");
-    }
-
-    #[test]
-    fn definitions_keep_options_and_both_iteration_lists() {
-        let defs = serde_json::to_value(parse_project_fields(&field_defs()))
-            .expect("definitions serialize");
-        assert_eq!(
-            defs[0]["options"],
-            json!([{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}])
-        );
-        assert_eq!(defs[0]["isIssueField"], true);
-        assert_eq!(
-            defs[1]["options"],
-            json!([{"id":"web","name":"Web","color":"BLUE","description":"Browser"}])
-        );
-        assert_eq!(
-            defs[2]["iterations"],
-            json!([{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}])
-        );
-        assert_eq!(
-            defs[2]["completedIterations"],
-            json!([{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}])
-        );
-        assert_keys(
-            &defs[0]["options"][0],
-            &["color", "description", "id", "name"],
-        );
-        assert_keys(
-            &defs[2]["iterations"][0],
-            &["duration", "id", "startDate", "title"],
-        );
-    }
-
-    #[test]
-    fn system_and_future_data_types_stay_readable() {
-        for data_type in [
-            "ASSIGNEES",
-            "LABELS",
-            "MILESTONE",
-            "REPOSITORY",
-            "TITLE",
-            "TRACKS",
-            "TRACKED_BY",
-            "ISSUE_TYPE",
-            "PARENT_ISSUE",
-            "SUB_ISSUES_PROGRESS",
-            "CREATED",
-            "UPDATED",
-            "CLOSED",
-            "LINKED_PULL_REQUESTS",
-            "REVIEWERS",
-            "FUTURE_TYPE",
-        ] {
-            let response = json!({"data":{"node":{"fields":{"nodes":[{"__typename":"ProjectV2Field","id":"field","name":"System","dataType":data_type}]}}}});
-            let defs = serde_json::to_value(parse_project_fields(&response))
-                .expect("system field serializes");
-            assert_eq!(
-                defs,
-                json!([{"kind":"system","id":"field","name":"System","dataType":data_type}])
-            );
-        }
     }
 
     fn assert_query_fields(query: &str, paths: &[&str]) {
@@ -903,40 +635,6 @@ mod tests {
                 assert!(query.contains(fragment));
             }
         }
-    }
-
-    #[test]
-    fn every_definition_pointer_names_a_field_the_query_actually_asks_for() {
-        let query = project_fields_query();
-        assert_query_fields(
-            &query,
-            &[
-                PROJECT_FIELDS_POINTER,
-                "/id",
-                "/name",
-                "/dataType",
-                "/isIssueField",
-                "/options/id",
-                "/options/name",
-                "/options/color",
-                "/options/description",
-                "/multiSelectOptions/id",
-                "/multiSelectOptions/name",
-                "/multiSelectOptions/color",
-                "/multiSelectOptions/description",
-                "/configuration/iterations/id",
-                "/configuration/iterations/title",
-                "/configuration/iterations/startDate",
-                "/configuration/iterations/duration",
-                "/configuration/completedIterations/id",
-                "/configuration/completedIterations/title",
-                "/configuration/completedIterations/startDate",
-                "/configuration/completedIterations/duration",
-            ],
-        );
-        assert!(query.starts_with("query($id:ID!)"));
-        assert!(query.contains("node(id:$id)"));
-        assert!(query.contains("fields(first:50)"));
     }
 
     #[test]

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -1,4 +1,4 @@
-//! Projects v2 field values and definitions for issue and PR sidebars.
+//! Projects v2 field values for issue and PR sidebars.
 
 use serde::Serialize;
 use serde_json::Value;
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::error::{AppError, AppResult};
 use crate::github::gh_unreadable;
 use crate::github::issue::repo_owner_name;
-use crate::github::project::{ProjectV2Ref, PROJECT_FIELDS};
+use crate::github::project::{project_ref, ProjectV2Ref, PROJECT_FIELDS};
 use crate::github::runner::{run_gh, GH_NETWORK_TIMEOUT};
 
 #[derive(Serialize)]
@@ -224,13 +224,7 @@ fn parse_item_field_values(value: &Value, field: &str) -> Vec<ItemProjectFieldVa
             let project = node.get("project")?;
             Some(ItemProjectFieldValues {
                 item_id: node.get("id")?.as_str()?.to_string(),
-                project: ProjectV2Ref {
-                    id: project.get("id")?.as_str()?.to_string(),
-                    title: text(project, "title"),
-                    number: project["number"].as_u64().unwrap_or(0),
-                    closed: project["closed"].as_bool().unwrap_or(false),
-                    viewer_can_update: project["viewerCanUpdate"].as_bool().unwrap_or(false),
-                },
+                project: project_ref(project)?,
                 values: array(&node["fieldValues"]["nodes"])
                     .map(parse_field_value)
                     .collect(),

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -1,0 +1,962 @@
+//! Projects v2 field values and definitions for issue and PR sidebars.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+use crate::github::gh_unreadable;
+use crate::github::issue::repo_owner_name;
+use crate::github::project::{ProjectV2Ref, PROJECT_FIELDS};
+use crate::github::runner::{run_gh, GH_NETWORK_TIMEOUT};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemProjectFieldValues {
+    pub item_id: String,
+    pub project: ProjectV2Ref,
+    pub values: Vec<ProjectFieldValue>,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum ProjectFieldValue {
+    SingleSelect {
+        field_id: String,
+        field_name: String,
+        option_id: String,
+        name: String,
+        color: String,
+        is_issue_field: bool,
+    },
+    MultiSelect {
+        field_id: String,
+        field_name: String,
+        options: Vec<SelectOptionRef>,
+        is_issue_field: bool,
+    },
+    Text {
+        field_id: String,
+        field_name: String,
+        text: String,
+        is_issue_field: bool,
+    },
+    Number {
+        field_id: String,
+        field_name: String,
+        number: f64,
+        is_issue_field: bool,
+    },
+    Date {
+        field_id: String,
+        field_name: String,
+        date: String,
+        is_issue_field: bool,
+    },
+    Iteration {
+        field_id: String,
+        field_name: String,
+        title: String,
+        start_date: String,
+        duration: u32,
+        is_issue_field: bool,
+    },
+    Unknown {
+        field_name: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectOptionRef {
+    pub id: String,
+    pub name: String,
+    pub color: String,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum ProjectFieldDef {
+    SingleSelect {
+        id: String,
+        name: String,
+        options: Vec<FieldOptionDef>,
+        is_issue_field: bool,
+    },
+    MultiSelect {
+        id: String,
+        name: String,
+        options: Vec<FieldOptionDef>,
+        is_issue_field: bool,
+    },
+    Iteration {
+        id: String,
+        name: String,
+        iterations: Vec<IterationDef>,
+        completed_iterations: Vec<IterationDef>,
+    },
+    Text {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    Number {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    Date {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    System {
+        id: String,
+        name: String,
+        data_type: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldOptionDef {
+    pub id: String,
+    pub name: String,
+    pub color: String,
+    pub description: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IterationDef {
+    pub id: String,
+    pub title: String,
+    pub start_date: String,
+    pub duration: u32,
+}
+
+const FIELDS_SCOPE_HINT: &str =
+    "GitHub project fields need the read:project scope. Run:  gh auth refresh -s project";
+
+fn map_scope_error(e: AppError) -> AppError {
+    if let AppError::Gh(ref msg) = e {
+        let lower = msg.to_lowercase();
+        if lower.contains("required scopes") || lower.contains("read:project") {
+            return AppError::Gh(FIELDS_SCOPE_HINT.to_string());
+        }
+    }
+    e
+}
+
+const FIELD_COMMON: &str = "... on ProjectV2FieldCommon { id name dataType isIssueField }";
+
+// The IssueField*Value arms alias their `value` scalar (`text: value`, …) so
+// classic and bridge values parse by the same keys and String/Float response
+// names stay disjoint.
+fn item_field_values_query(field: &str) -> String {
+    format!(
+        "query($owner:String!,$name:String!,$number:Int!){{ \
+         repository(owner:$owner,name:$name){{ {field}(number:$number){{ \
+         projectItems(first:20, includeArchived:true){{ nodes{{ id project{{ {PROJECT_FIELDS} }} \
+         fieldValues(first:50){{ nodes{{ __typename \
+         ... on ProjectV2ItemFieldSingleSelectValue{{ field{{ {FIELD_COMMON} }} name optionId color }} \
+         ... on ProjectV2ItemFieldMultiSelectValue{{ field{{ {FIELD_COMMON} }} options{{ id name color }} }} \
+         ... on ProjectV2ItemFieldTextValue{{ field{{ {FIELD_COMMON} }} text }} \
+         ... on ProjectV2ItemFieldNumberValue{{ field{{ {FIELD_COMMON} }} number }} \
+         ... on ProjectV2ItemFieldDateValue{{ field{{ {FIELD_COMMON} }} date }} \
+         ... on ProjectV2ItemFieldIterationValue{{ field{{ {FIELD_COMMON} }} title startDate duration }} \
+         ... on ProjectV2ItemIssueFieldValue{{ field{{ {FIELD_COMMON} }} issueFieldValue{{ __typename \
+           ... on IssueFieldSingleSelectValue{{ name optionId color }} \
+           ... on IssueFieldMultiSelectValue{{ options{{ id name color }} }} \
+           ... on IssueFieldTextValue{{ text: value }} \
+           ... on IssueFieldNumberValue{{ number: value }} \
+           ... on IssueFieldDateValue{{ date: value }} \
+         }} }} \
+         }} }} }} }} }} }} }}"
+    )
+}
+
+fn project_fields_query() -> String {
+    format!(
+        "query($id:ID!){{ node(id:$id){{ ... on ProjectV2{{ fields(first:50){{ nodes{{ \
+         __typename {FIELD_COMMON} \
+         ... on ProjectV2SingleSelectField{{ options{{ id name color description }} }} \
+         ... on ProjectV2MultiSelectField{{ multiSelectOptions{{ id name color description }} }} \
+         ... on ProjectV2IterationField{{ configuration{{ \
+           iterations{{ id title startDate duration }} \
+           completedIterations{{ id title startDate duration }} \
+         }} }} \
+         }} }} }} }} }}"
+    )
+}
+
+fn text(node: &Value, key: &str) -> String {
+    node.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn array(value: &Value) -> impl Iterator<Item = &Value> {
+    value.as_array().into_iter().flatten()
+}
+
+fn duration(node: &Value) -> u32 {
+    node.get("duration")
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
+        .unwrap_or(0)
+}
+
+fn parse_field_value(node: &Value) -> ProjectFieldValue {
+    let field = &node["field"];
+    let field_id = text(field, "id");
+    let field_name = text(field, "name");
+    let bridge = node["__typename"] == "ProjectV2ItemIssueFieldValue";
+    let is_issue_field = bridge || field["isIssueField"].as_bool().unwrap_or(false);
+    let value = if bridge {
+        &node["issueFieldValue"]
+    } else {
+        node
+    };
+    match (
+        value["__typename"].as_str().unwrap_or_default(),
+        field["dataType"].as_str().unwrap_or_default(),
+    ) {
+        (
+            "ProjectV2ItemFieldSingleSelectValue" | "IssueFieldSingleSelectValue",
+            "SINGLE_SELECT",
+        ) => ProjectFieldValue::SingleSelect {
+            field_id,
+            field_name,
+            option_id: text(value, "optionId"),
+            name: text(value, "name"),
+            color: text(value, "color"),
+            is_issue_field,
+        },
+        ("ProjectV2ItemFieldMultiSelectValue" | "IssueFieldMultiSelectValue", "MULTI_SELECT") => {
+            ProjectFieldValue::MultiSelect {
+                field_id,
+                field_name,
+                options: array(&value["options"])
+                    .map(|option| SelectOptionRef {
+                        id: text(option, "id"),
+                        name: text(option, "name"),
+                        color: text(option, "color"),
+                    })
+                    .collect(),
+                is_issue_field,
+            }
+        }
+        ("ProjectV2ItemFieldTextValue" | "IssueFieldTextValue", "TEXT") => {
+            ProjectFieldValue::Text {
+                field_id,
+                field_name,
+                text: text(value, "text"),
+                is_issue_field,
+            }
+        }
+        ("ProjectV2ItemFieldNumberValue" | "IssueFieldNumberValue", "NUMBER") => {
+            ProjectFieldValue::Number {
+                field_id,
+                field_name,
+                number: value["number"].as_f64().unwrap_or(0.0),
+                is_issue_field,
+            }
+        }
+        ("ProjectV2ItemFieldDateValue" | "IssueFieldDateValue", "DATE") => {
+            ProjectFieldValue::Date {
+                field_id,
+                field_name,
+                date: text(value, "date"),
+                is_issue_field,
+            }
+        }
+        ("ProjectV2ItemFieldIterationValue", "ITERATION") => ProjectFieldValue::Iteration {
+            field_id,
+            field_name,
+            title: text(value, "title"),
+            start_date: text(value, "startDate"),
+            duration: duration(value),
+            is_issue_field,
+        },
+        _ => ProjectFieldValue::Unknown { field_name },
+    }
+}
+
+fn parse_item_field_values(value: &Value, field: &str) -> Vec<ItemProjectFieldValues> {
+    value
+        .pointer(&format!("/data/repository/{field}/projectItems/nodes"))
+        .into_iter()
+        .flat_map(array)
+        .filter_map(|node| {
+            let project = node.get("project")?;
+            Some(ItemProjectFieldValues {
+                item_id: node.get("id")?.as_str()?.to_string(),
+                project: ProjectV2Ref {
+                    id: project.get("id")?.as_str()?.to_string(),
+                    title: text(project, "title"),
+                    number: project["number"].as_u64().unwrap_or(0),
+                    closed: project["closed"].as_bool().unwrap_or(false),
+                    viewer_can_update: project["viewerCanUpdate"].as_bool().unwrap_or(false),
+                },
+                values: array(&node["fieldValues"]["nodes"])
+                    .map(parse_field_value)
+                    .collect(),
+            })
+        })
+        .collect()
+}
+
+fn field_options(value: &Value) -> Vec<FieldOptionDef> {
+    array(value)
+        .map(|node| FieldOptionDef {
+            id: text(node, "id"),
+            name: text(node, "name"),
+            color: text(node, "color"),
+            description: text(node, "description"),
+        })
+        .collect()
+}
+
+fn iterations(value: &Value) -> Vec<IterationDef> {
+    array(value)
+        .map(|node| IterationDef {
+            id: text(node, "id"),
+            title: text(node, "title"),
+            start_date: text(node, "startDate"),
+            duration: duration(node),
+        })
+        .collect()
+}
+
+const PROJECT_FIELDS_POINTER: &str = "/data/node/fields/nodes";
+
+fn parse_project_fields(value: &Value) -> Vec<ProjectFieldDef> {
+    value
+        .pointer(PROJECT_FIELDS_POINTER)
+        .into_iter()
+        .flat_map(array)
+        .filter_map(|node| {
+            let id = node.get("id")?.as_str()?.to_string();
+            let name = text(node, "name");
+            let is_issue_field = node["isIssueField"].as_bool().unwrap_or(false);
+            Some(match node["dataType"].as_str().unwrap_or_default() {
+                "SINGLE_SELECT" => ProjectFieldDef::SingleSelect {
+                    id,
+                    name,
+                    options: field_options(&node["options"]),
+                    is_issue_field,
+                },
+                "MULTI_SELECT" => ProjectFieldDef::MultiSelect {
+                    id,
+                    name,
+                    options: field_options(&node["multiSelectOptions"]),
+                    is_issue_field,
+                },
+                "ITERATION" => ProjectFieldDef::Iteration {
+                    id,
+                    name,
+                    iterations: iterations(&node["configuration"]["iterations"]),
+                    completed_iterations: iterations(&node["configuration"]["completedIterations"]),
+                },
+                "TEXT" => ProjectFieldDef::Text {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                "NUMBER" => ProjectFieldDef::Number {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                "DATE" => ProjectFieldDef::Date {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                _ => ProjectFieldDef::System {
+                    id,
+                    name,
+                    data_type: text(node, "dataType"),
+                },
+            })
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub async fn gh_item_field_values(
+    repo_path: String,
+    kind: String,
+    number: u64,
+    lens: Option<String>,
+) -> AppResult<Vec<ItemProjectFieldValues>> {
+    let field = match kind.as_str() {
+        "issue" => "issue",
+        "pr" => "pullRequest",
+        _ => return Err(AppError::InvalidArgument(format!("unknown kind: {kind}"))),
+    };
+    let (owner, name) = repo_owner_name(&repo_path, lens.as_deref()).await?;
+    let query = item_field_values_query(field);
+    let out = run_gh(
+        Some(&repo_path),
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &format!("owner={owner}"),
+            "-f",
+            &format!("name={name}"),
+            "-F",
+            &format!("number={number}"),
+            "-f",
+            &format!("query={query}"),
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await
+    .map_err(map_scope_error)?;
+    let value: Value = serde_json::from_str(&out.stdout_lossy()).map_err(|e| {
+        gh_unreadable(
+            "the project field values",
+            format!("could not parse the item's project field values: {e}"),
+        )
+    })?;
+    Ok(parse_item_field_values(&value, field))
+}
+
+#[tauri::command]
+pub async fn gh_project_fields(
+    repo_path: String,
+    project_id: String,
+) -> AppResult<Vec<ProjectFieldDef>> {
+    let query = project_fields_query();
+    let out = run_gh(
+        Some(&repo_path),
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &format!("id={project_id}"),
+            "-f",
+            &format!("query={query}"),
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await
+    .map_err(map_scope_error)?;
+    let value: Value = serde_json::from_str(&out.stdout_lossy()).map_err(|e| {
+        gh_unreadable(
+            "the project fields",
+            format!("could not parse the project's fields: {e}"),
+        )
+    })?;
+    Ok(parse_project_fields(&value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn custom_values() -> Value {
+        json!([
+            {"__typename":"ProjectV2ItemFieldSingleSelectValue", "field":{"id":"status","name":"Status","dataType":"SINGLE_SELECT","isIssueField":false}, "optionId":"done","name":"Done","color":"GREEN"},
+            {"__typename":"ProjectV2ItemFieldMultiSelectValue", "field":{"id":"teams","name":"Teams","dataType":"MULTI_SELECT","isIssueField":false}, "options":[{"id":"web","name":"Web","color":"BLUE"}]},
+            {"__typename":"ProjectV2ItemFieldTextValue", "field":{"id":"notes","name":"Notes","dataType":"TEXT","isIssueField":false}, "text":"Ship it"},
+            {"__typename":"ProjectV2ItemFieldNumberValue", "field":{"id":"points","name":"Points","dataType":"NUMBER","isIssueField":false}, "number":2.5},
+            {"__typename":"ProjectV2ItemFieldDateValue", "field":{"id":"due","name":"Due","dataType":"DATE","isIssueField":false}, "date":"2026-09-12"},
+            {"__typename":"ProjectV2ItemFieldIterationValue", "field":{"id":"sprint","name":"Sprint","dataType":"ITERATION","isIssueField":false}, "title":"Sprint 1","startDate":"2026-09-01","duration":14}
+        ])
+    }
+
+    fn field_defs() -> Value {
+        json!({"data":{"node":{"fields":{"nodes":[
+            {"__typename":"ProjectV2SingleSelectField","id":"status","name":"Status","dataType":"SINGLE_SELECT","isIssueField":true,"options":[{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}]},
+            {"__typename":"ProjectV2MultiSelectField","id":"teams","name":"Teams","dataType":"MULTI_SELECT","isIssueField":false,"multiSelectOptions":[{"id":"web","name":"Web","color":"BLUE","description":"Browser"}]},
+            {"__typename":"ProjectV2IterationField","id":"sprint","name":"Sprint","dataType":"ITERATION","configuration":{"iterations":[{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}],"completedIterations":[{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}]}},
+            {"__typename":"ProjectV2Field","id":"notes","name":"Notes","dataType":"TEXT","isIssueField":false},
+            {"__typename":"ProjectV2Field","id":"points","name":"Points","dataType":"NUMBER","isIssueField":false},
+            {"__typename":"ProjectV2Field","id":"due","name":"Due","dataType":"DATE","isIssueField":true},
+            {"__typename":"ProjectV2Field","id":"labels","name":"Labels","dataType":"LABELS"}
+        ]}}}})
+    }
+
+    fn assert_keys(value: &Value, expected: &[&str]) {
+        let obj = value.as_object().expect("wire value is an object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, expected);
+    }
+
+    #[test]
+    fn field_value_wire_shapes_are_camel_case() {
+        let fixtures = custom_values();
+        let mut values: Vec<ProjectFieldValue> = array(&fixtures).map(parse_field_value).collect();
+        values.push(ProjectFieldValue::Unknown {
+            field_name: "Future".into(),
+        });
+        assert_eq!(values.len(), 7);
+        let expected: [(&str, &[&str]); 7] = [
+            (
+                "singleSelect",
+                &[
+                    "color",
+                    "fieldId",
+                    "fieldName",
+                    "isIssueField",
+                    "kind",
+                    "name",
+                    "optionId",
+                ],
+            ),
+            (
+                "multiSelect",
+                &["fieldId", "fieldName", "isIssueField", "kind", "options"],
+            ),
+            (
+                "text",
+                &["fieldId", "fieldName", "isIssueField", "kind", "text"],
+            ),
+            (
+                "number",
+                &["fieldId", "fieldName", "isIssueField", "kind", "number"],
+            ),
+            (
+                "date",
+                &["date", "fieldId", "fieldName", "isIssueField", "kind"],
+            ),
+            (
+                "iteration",
+                &[
+                    "duration",
+                    "fieldId",
+                    "fieldName",
+                    "isIssueField",
+                    "kind",
+                    "startDate",
+                    "title",
+                ],
+            ),
+            ("unknown", &["fieldName", "kind"]),
+        ];
+        for (value, (kind, keys)) in values.iter().zip(expected) {
+            let wire = serde_json::to_value(value).expect("field value serializes");
+            assert_keys(&wire, keys);
+            assert_eq!(wire["kind"], kind);
+        }
+    }
+
+    #[test]
+    fn field_definition_wire_shapes_are_camel_case() {
+        let defs = parse_project_fields(&field_defs());
+        assert_eq!(defs.len(), 7);
+        let expected: [(&str, &[&str]); 7] = [
+            (
+                "singleSelect",
+                &["id", "isIssueField", "kind", "name", "options"],
+            ),
+            (
+                "multiSelect",
+                &["id", "isIssueField", "kind", "name", "options"],
+            ),
+            (
+                "iteration",
+                &["completedIterations", "id", "iterations", "kind", "name"],
+            ),
+            ("text", &["id", "isIssueField", "kind", "name"]),
+            ("number", &["id", "isIssueField", "kind", "name"]),
+            ("date", &["id", "isIssueField", "kind", "name"]),
+            ("system", &["dataType", "id", "kind", "name"]),
+        ];
+        for (def, (kind, keys)) in defs.iter().zip(expected) {
+            let wire = serde_json::to_value(def).expect("field definition serializes");
+            assert_keys(&wire, keys);
+            assert_eq!(wire["kind"], kind);
+        }
+    }
+
+    #[test]
+    fn all_custom_values_keep_their_display_data() {
+        let fixtures = custom_values();
+        let values: Vec<_> = array(&fixtures).map(parse_field_value).collect();
+        let wire = serde_json::to_value(values).expect("values serialize");
+        assert_eq!(
+            wire,
+            json!([
+                {"kind":"singleSelect","fieldId":"status","fieldName":"Status","optionId":"done","name":"Done","color":"GREEN","isIssueField":false},
+                {"kind":"multiSelect","fieldId":"teams","fieldName":"Teams","options":[{"id":"web","name":"Web","color":"BLUE"}],"isIssueField":false},
+                {"kind":"text","fieldId":"notes","fieldName":"Notes","text":"Ship it","isIssueField":false},
+                {"kind":"number","fieldId":"points","fieldName":"Points","number":2.5,"isIssueField":false},
+                {"kind":"date","fieldId":"due","fieldName":"Due","date":"2026-09-12","isIssueField":false},
+                {"kind":"iteration","fieldId":"sprint","fieldName":"Sprint","title":"Sprint 1","startDate":"2026-09-01","duration":14,"isIssueField":false}
+            ])
+        );
+    }
+
+    #[test]
+    fn issue_field_bridges_use_the_wrapper_identity() {
+        let cases = [
+            (
+                "SINGLE_SELECT",
+                json!({"__typename":"IssueFieldSingleSelectValue","name":"High","optionId":"high","color":"RED","value":"High"}),
+                json!({"kind":"singleSelect","optionId":"high","name":"High","color":"RED"}),
+            ),
+            (
+                "MULTI_SELECT",
+                json!({"__typename":"IssueFieldMultiSelectValue","options":[{"id":"web","name":"Web","color":"BLUE"}]}),
+                json!({"kind":"multiSelect","options":[{"id":"web","name":"Web","color":"BLUE"}]}),
+            ),
+            (
+                "TEXT",
+                json!({"__typename":"IssueFieldTextValue","text":"Notes"}),
+                json!({"kind":"text","text":"Notes"}),
+            ),
+            (
+                "NUMBER",
+                json!({"__typename":"IssueFieldNumberValue","number":3.5}),
+                json!({"kind":"number","number":3.5}),
+            ),
+            (
+                "DATE",
+                json!({"__typename":"IssueFieldDateValue","date":"2026-09-12"}),
+                json!({"kind":"date","date":"2026-09-12"}),
+            ),
+        ];
+        for (data_type, inner, mut expected) in cases {
+            let node = json!({"__typename":"ProjectV2ItemIssueFieldValue","field":{"id":"org-field","name":"Org field","dataType":data_type,"isIssueField":false},"issueFieldValue":inner});
+            expected["fieldId"] = json!("org-field");
+            expected["fieldName"] = json!("Org field");
+            expected["isIssueField"] = json!(true);
+            assert_eq!(
+                serde_json::to_value(parse_field_value(&node)).expect("bridge serializes"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn system_and_future_values_are_unknown() {
+        for node in [
+            json!({"__typename":"ProjectV2ItemFieldLabelValue"}),
+            json!({"__typename":"ProjectV2ItemFieldTextValue","field":{"name":"Title","dataType":"TITLE"},"text":"An item's own title"}),
+            json!({"__typename":"FutureProjectValue","field":{"name":"Future"}}),
+            json!({"__typename":"FutureProjectValue"}),
+            json!({"__typename":"ProjectV2ItemIssueFieldValue","field":{"name":"Org"},"issueFieldValue":{"__typename":"FutureIssueValue"}}),
+            json!({"__typename":"ProjectV2ItemIssueFieldValue","field":{"name":"Priority","dataType":"TEXT"},"issueFieldValue":{"__typename":"IssueFieldSingleSelectValue","optionId":"high","name":"High","color":"RED"}}),
+        ] {
+            let expected_name = text(&node["field"], "name");
+            assert_eq!(
+                serde_json::to_value(parse_field_value(&node)).expect("unknown serializes"),
+                json!({"kind":"unknown","fieldName":expected_name})
+            );
+        }
+    }
+
+    #[test]
+    fn custom_values_require_matching_data_types() {
+        for node in array(&custom_values()) {
+            let mismatched_type = if node["field"]["dataType"] == "TEXT" {
+                "NUMBER"
+            } else {
+                "TEXT"
+            };
+            for field in [
+                json!({"name":"Custom","dataType":mismatched_type}),
+                json!({"name":"Custom","dataType":"FUTURE_TYPE"}),
+                json!({"name":"Custom","dataType":null}),
+                json!({"name":"Custom"}),
+            ] {
+                let mut node = node.clone();
+                node["field"] = field;
+                assert_eq!(
+                    serde_json::to_value(parse_field_value(&node)).expect("unknown serializes"),
+                    json!({"kind":"unknown","fieldName":"Custom"})
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn item_in_two_projects_preserves_memberships_and_values() {
+        for field in ["issue", "pullRequest"] {
+            let response = json!({"data":{"repository":{field:{"projectItems":{"nodes":[
+                {"id":"item-a","project":{"id":"project-a","title":"Roadmap","number":3,"closed":false,"viewerCanUpdate":true},"fieldValues":{"nodes":custom_values()}},
+                {"id":"item-b","project":{"id":"project-b","title":"Backlog","number":4,"closed":true,"viewerCanUpdate":false},"fieldValues":{"nodes":[]}}
+            ]}}}}});
+            let items = parse_item_field_values(&response, field);
+            assert_eq!(items.len(), 2);
+            assert_eq!(items[0].item_id, "item-a");
+            assert_eq!(items[0].project.id, "project-a");
+            assert_eq!(items[0].values.len(), 6);
+            assert!(items[0].project.viewer_can_update);
+            assert_eq!(items[1].item_id, "item-b");
+            assert_eq!(items[1].project.id, "project-b");
+            assert!(items[1].project.closed);
+            assert!(items[1].values.is_empty());
+            let wire = serde_json::to_value(&items[0]).expect("membership serializes");
+            assert_keys(&wire, &["itemId", "project", "values"]);
+            assert_keys(
+                &wire["project"],
+                &["closed", "id", "number", "title", "viewerCanUpdate"],
+            );
+        }
+    }
+
+    #[test]
+    fn empty_and_absent_connections_are_empty() {
+        for response in [
+            json!({"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}),
+            json!({"data":{"repository":{"issue":{"projectItems":null}}}}),
+            json!({"data":{"repository":null}}),
+            Value::Null,
+        ] {
+            assert!(parse_item_field_values(&response, "issue").is_empty());
+        }
+        for response in [
+            json!({"data":{"node":{"fields":{"nodes":[]}}}}),
+            json!({"data":{"node":{"fields":null}}}),
+            json!({"data":{"node":null}}),
+            Value::Null,
+        ] {
+            assert!(parse_project_fields(&response).is_empty());
+        }
+    }
+
+    #[test]
+    fn absent_optional_subfields_are_tolerated() {
+        let response = json!({"data":{"repository":{"issue":{"projectItems":{"nodes":[
+            {"id":"item","project":{"id":"project","title":null}},
+            {"id":"missing-project"}, {"project":{"id":"missing-item"}}, null
+        ]}}}}});
+        let items = parse_item_field_values(&response, "issue");
+        assert_eq!(items.len(), 1);
+        assert!(items[0].project.title.is_empty());
+        assert!(items[0].values.is_empty());
+        for typename in [
+            "ProjectV2ItemFieldSingleSelectValue",
+            "ProjectV2ItemFieldMultiSelectValue",
+            "ProjectV2ItemFieldTextValue",
+            "ProjectV2ItemFieldNumberValue",
+            "ProjectV2ItemFieldDateValue",
+            "ProjectV2ItemFieldIterationValue",
+            "ProjectV2ItemIssueFieldValue",
+        ] {
+            let wire = serde_json::to_value(parse_field_value(
+                &json!({"__typename":typename,"field":null,"options":null,"issueFieldValue":null}),
+            ))
+            .expect("partial field serializes");
+            assert_eq!(wire, json!({"kind":"unknown","fieldName":""}));
+        }
+        assert!(matches!(
+            parse_field_value(&json!({"__typename":"ProjectV2ItemFieldNumberValue","number":null})),
+            ProjectFieldValue::Unknown { .. }
+        ));
+        let response = json!({"data":{"node":{"fields":{"nodes":[
+            {"id":"select","dataType":"SINGLE_SELECT","options":[{"id":"option","description":null}]},
+            {"id":"multi","dataType":"MULTI_SELECT","multiSelectOptions":null},
+            {"id":"iteration","dataType":"ITERATION","configuration":null},
+            {"id":"unknown"}, {"id":null}, null
+        ]}}}});
+        let defs = serde_json::to_value(parse_project_fields(&response))
+            .expect("partial definitions serialize");
+        assert_eq!(defs.as_array().expect("definitions array").len(), 4);
+        assert_eq!(defs[0]["options"][0]["description"], "");
+        assert_eq!(defs[1]["options"], json!([]));
+        assert_eq!(defs[2]["iterations"], json!([]));
+        assert_eq!(defs[2]["completedIterations"], json!([]));
+        assert_eq!(defs[3]["dataType"], "");
+    }
+
+    #[test]
+    fn definitions_keep_options_and_both_iteration_lists() {
+        let defs = serde_json::to_value(parse_project_fields(&field_defs()))
+            .expect("definitions serialize");
+        assert_eq!(
+            defs[0]["options"],
+            json!([{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}])
+        );
+        assert_eq!(defs[0]["isIssueField"], true);
+        assert_eq!(
+            defs[1]["options"],
+            json!([{"id":"web","name":"Web","color":"BLUE","description":"Browser"}])
+        );
+        assert_eq!(
+            defs[2]["iterations"],
+            json!([{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}])
+        );
+        assert_eq!(
+            defs[2]["completedIterations"],
+            json!([{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}])
+        );
+        assert_keys(
+            &defs[0]["options"][0],
+            &["color", "description", "id", "name"],
+        );
+        assert_keys(
+            &defs[2]["iterations"][0],
+            &["duration", "id", "startDate", "title"],
+        );
+    }
+
+    #[test]
+    fn system_and_future_data_types_stay_readable() {
+        for data_type in [
+            "ASSIGNEES",
+            "LABELS",
+            "MILESTONE",
+            "REPOSITORY",
+            "TITLE",
+            "TRACKS",
+            "TRACKED_BY",
+            "ISSUE_TYPE",
+            "PARENT_ISSUE",
+            "SUB_ISSUES_PROGRESS",
+            "CREATED",
+            "UPDATED",
+            "CLOSED",
+            "LINKED_PULL_REQUESTS",
+            "REVIEWERS",
+            "FUTURE_TYPE",
+        ] {
+            let response = json!({"data":{"node":{"fields":{"nodes":[{"__typename":"ProjectV2Field","id":"field","name":"System","dataType":data_type}]}}}});
+            let defs = serde_json::to_value(parse_project_fields(&response))
+                .expect("system field serializes");
+            assert_eq!(
+                defs,
+                json!([{"kind":"system","id":"field","name":"System","dataType":data_type}])
+            );
+        }
+    }
+
+    fn assert_query_fields(query: &str, paths: &[&str]) {
+        let tokens: Vec<_> = query
+            .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .filter(|s| !s.is_empty())
+            .collect();
+        for path in paths {
+            for segment in path.split('/').filter(|s| !s.is_empty() && *s != "data") {
+                assert!(
+                    tokens.contains(&segment),
+                    "query no longer asks for `{segment}` (pointer {path})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_item_pointer_names_a_field_the_query_actually_asks_for() {
+        for field in ["issue", "pullRequest"] {
+            let query = item_field_values_query(field);
+            for segment in ["repository", field, "projectItems", "fieldValues"] {
+                assert!(
+                    query.contains(&format!("{segment}(")),
+                    "query no longer asks for `{segment}`"
+                );
+            }
+            assert_query_fields(
+                &query,
+                &[
+                    &format!("/data/repository/{field}/projectItems/nodes"),
+                    "/id",
+                    "/project/id",
+                    "/project/title",
+                    "/project/number",
+                    "/project/closed",
+                    "/project/viewerCanUpdate",
+                    "/fieldValues/nodes/__typename",
+                    "/field/id",
+                    "/field/name",
+                    "/field/dataType",
+                    "/field/isIssueField",
+                    "/optionId",
+                    "/name",
+                    "/color",
+                    "/options/id",
+                    "/options/name",
+                    "/options/color",
+                    "/text",
+                    "/number",
+                    "/date",
+                    "/title",
+                    "/startDate",
+                    "/duration",
+                    "/issueFieldValue/__typename",
+                ],
+            );
+            assert!(query.contains(PROJECT_FIELDS));
+            assert!(query.contains("projectItems(first:20, includeArchived:true)"));
+            assert!(query.contains("fieldValues(first:50)"));
+            for fragment in [
+                "... on IssueFieldTextValue{ text: value }",
+                "... on IssueFieldNumberValue{ number: value }",
+                "... on IssueFieldDateValue{ date: value }",
+            ] {
+                assert!(query.contains(fragment));
+            }
+        }
+    }
+
+    #[test]
+    fn every_definition_pointer_names_a_field_the_query_actually_asks_for() {
+        let query = project_fields_query();
+        assert_query_fields(
+            &query,
+            &[
+                PROJECT_FIELDS_POINTER,
+                "/id",
+                "/name",
+                "/dataType",
+                "/isIssueField",
+                "/options/id",
+                "/options/name",
+                "/options/color",
+                "/options/description",
+                "/multiSelectOptions/id",
+                "/multiSelectOptions/name",
+                "/multiSelectOptions/color",
+                "/multiSelectOptions/description",
+                "/configuration/iterations/id",
+                "/configuration/iterations/title",
+                "/configuration/iterations/startDate",
+                "/configuration/iterations/duration",
+                "/configuration/completedIterations/id",
+                "/configuration/completedIterations/title",
+                "/configuration/completedIterations/startDate",
+                "/configuration/completedIterations/duration",
+            ],
+        );
+        assert!(query.starts_with("query($id:ID!)"));
+        assert!(query.contains("node(id:$id)"));
+        assert!(query.contains("fields(first:50)"));
+    }
+
+    #[test]
+    fn scope_failures_get_the_family_hint_and_other_errors_survive() {
+        for raw in [
+            "GraphQL: Your token has not been granted the required scopes to execute this query.",
+            "missing scope read:project",
+        ] {
+            let AppError::Gh(message) = map_scope_error(AppError::Gh(raw.into())) else {
+                panic!("expected Gh error");
+            };
+            assert_eq!(message, FIELDS_SCOPE_HINT);
+        }
+        let AppError::Gh(message) = map_scope_error(AppError::Gh("connection reset".into())) else {
+            panic!("expected Gh error");
+        };
+        assert_eq!(message, "connection reset");
+        assert!(matches!(
+            map_scope_error(AppError::InvalidArgument("required scopes".into())),
+            AppError::InvalidArgument(_)
+        ));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -571,6 +571,8 @@ pub fn run() {
             github::project::gh_projects_available,
             github::project::gh_item_projects,
             github::project::gh_edit_item_projects,
+            github::project_fields::gh_item_field_values,
+            github::project_fields::gh_project_fields,
             github::discussion::gh_discussion_categories,
             github::discussion::gh_discussion_list,
             github::discussion::gh_discussion_view,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -572,7 +572,6 @@ pub fn run() {
             github::project::gh_item_projects,
             github::project::gh_edit_item_projects,
             github::project_fields::gh_item_field_values,
-            github::project_fields::gh_project_fields,
             github::discussion::gh_discussion_categories,
             github::discussion::gh_discussion_list,
             github::discussion::gh_discussion_view,

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -136,7 +136,12 @@ function fieldValueNode(value: ProjectFieldValue): ReactNode {
       );
     }
     case "number":
-      return Number.isFinite(value.number) ? value.number : null;
+      // Locale-grouped, so a number field doesn't read as raw output beside the
+      // locale-formatted dates on the same line. The fraction cap is explicit:
+      // the default rounds to 3 digits, rendering 0.0001 as 0.
+      return Number.isFinite(value.number)
+        ? value.number.toLocaleString(undefined, { maximumFractionDigits: 20 })
+        : null;
     case "date":
       return value.date === "" ? null : formatFieldDate(value.date);
     case "iteration": {
@@ -164,6 +169,8 @@ function renderableParts(entry: ItemProjectFieldValues): FieldPart[] {
   for (const value of entry.values) {
     const node = fieldValueNode(value);
     if (node === null) continue;
+    // `unknown` is the only arm without a `fieldId`, and it always renders null —
+    // the guard is here because TS can't narrow the union through that filter.
     const id = "fieldId" in value ? value.fieldId : value.fieldName;
     parts.push({ key: `${value.kind}-${id}`, name: value.fieldName, node });
   }
@@ -247,22 +254,50 @@ export function ProjectFieldValues({
   // Same key as the picker's own read, so this shares that cache rather than
   // paying a second fetch to learn whether the item is on any board at all.
   const memberships = useItemProjects(repoPath, kind, number, canRead, lens);
-  const values = useItemFieldValues(repoPath, kind, number, canRead, lens);
+  // Cached memberships are what prove a board exists — a read that has never
+  // produced data (pending, or failed) leaves this whole block silent, the picker
+  // above owning that failure's wording and its Retry. Boardless is the common
+  // case, so gating the values query here is also what keeps it from spawning a
+  // `gh` call per issue nobody has put on a board.
+  const boardsKnown = (memberships.data?.length ?? 0) > 0;
+  const values = useItemFieldValues(
+    repoPath,
+    kind,
+    number,
+    canRead && boardsKnown,
+    lens,
+  );
 
-  const settled = values.isSuccess;
-  const entries = settled ? (values.data ?? []) : [];
+  // Keyed on CACHED DATA, never on query status, matching the chips above: a
+  // failed background refetch flips the status to error while the data it already
+  // served is still good, and lines that vanish under a gh hiccup would leave the
+  // chips standing over an empty rail.
+  //
+  // Filtered by the picker's memberships, which are the truth for WHICH boards
+  // exist: an unlink empties them optimistically, and unlinking the LAST one
+  // disables this query — an invalidate neither refetches nor clears a disabled
+  // query, so its cache outlives the boards it describes. Lines render only for
+  // boards the item is still on, which also drops a partial unlink's stale line
+  // ahead of the refetch rather than after it.
+  const membershipIds = new Set(
+    (memberships.data ?? []).map((item) => item.project.id),
+  );
+  const entries = (values.data ?? []).filter((entry) =>
+    membershipIds.has(entry.project.id),
+  );
   const lines = entries
     .map((entry) => ({ entry, parts: renderableParts(entry) }))
     .filter((line) => line.parts.length > 0);
-  // One entry per board membership, so this counts BOARDS, not lines: an item on
-  // three boards where only one has set fields still needs that line named.
+  // Counts LIVE boards, not lines: an item on three boards where only one has set
+  // fields still needs that line named, and an unlinked board stops counting the
+  // moment its chip goes.
   const showTitles = entries.length > 1;
-  const loading = canRead && !settled && values.error === null;
-  // Both the skeleton and the error line are claims that a line is coming, so both
-  // wait on PROVEN boards. A pending memberships read would flash either one onto
-  // a boardless item; a failed one belongs to the picker above, which owns that
-  // error's wording and its Retry.
-  const boardsKnown = memberships.isSuccess && memberships.data.length > 0;
+  // A disabled query is not loading — it is the resolved "no boards" answer.
+  const loading =
+    canRead &&
+    boardsKnown &&
+    values.data === undefined &&
+    values.error === null;
 
   const content = (() => {
     switch (true) {
@@ -272,15 +307,19 @@ export function ProjectFieldValues({
             {lines.map(({ entry, parts }) => (
               <ProjectFieldLine
                 key={entry.itemId}
+                // A board GitHub reports with no title arrives as `""`, which as a
+                // prefix is an empty span and a leading middot.
+                showTitle={showTitles && entry.project.title !== ""}
                 title={entry.project.title}
-                showTitle={showTitles}
                 parts={parts}
               />
             ))}
           </div>
         );
-      case loading && boardsKnown:
+      case loading:
         return <Skeleton className="h-4 w-40" aria-hidden />;
+      // Still board-gated: a disabled query keeps whatever error it last cached,
+      // and an item whose boards have since gone stays silent.
       case values.error !== null && boardsKnown:
         return (
           <span className="inline-flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -38,7 +38,7 @@ const OPTION_COLORS: Record<string, string> = {
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 function optionColor(color: string): string {
-  return OPTION_COLORS[color?.toUpperCase()] ?? OPTION_COLORS.GRAY;
+  return OPTION_COLORS[color.toUpperCase()] ?? OPTION_COLORS.GRAY;
 }
 
 /** A project date field as a LOCAL date: a bare `YYYY-MM-DD` parses as UTC
@@ -248,7 +248,8 @@ export function ProjectFieldValues({
   /** The origin|upstream lens the parent PR/issue surface resolved. */
   lens: RemoteLens;
   /** Emit a label cell and a value cell as two SIBLING elements for a caller's
-   *  label/value grid. Default renders the bare block. */
+   *  label/value grid. Default renders the rail form, which labels itself above
+   *  the lines. */
   cells?: boolean;
 }) {
   const host = useActiveGhHost();
@@ -339,7 +340,18 @@ export function ProjectFieldValues({
   })();
 
   if (content === null) return null;
-  if (!cells) return content;
+  // The rail form carries its OWN heading rather than taking the row list's: this
+  // block renders nothing on a boardless item, and a host-supplied heading would
+  // be left standing over it.
+  if (!cells)
+    return (
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium text-muted-foreground">
+          {FIELD_LABEL}
+        </p>
+        {content}
+      </div>
+    );
   return (
     <>
       <MetaFieldLabel>{FIELD_LABEL}</MetaFieldLabel>

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -1,0 +1,315 @@
+import type { ReactNode } from "react";
+import { MetaFieldLabel, MetaValueCell } from "@/components/meta-field-cells";
+import { Skeleton } from "@/components/ui/skeleton";
+import { clipTitle, clipTitleFromText } from "@/lib/clip-title";
+import { presentError } from "@/lib/error-summary";
+import { useActiveGhHost } from "@/lib/git/host";
+import {
+  useGhScopes,
+  useItemFieldValues,
+  useItemProjects,
+} from "@/lib/git/queries";
+import type {
+  ItemProjectFieldValues,
+  ProjectFieldValue,
+  RemoteLens,
+} from "@/lib/git/types";
+import { parseableDate } from "@/lib/time";
+import { projectScopeMissing } from "./ProjectsPopover";
+
+const FIELD_LABEL = "Project fields";
+
+/** GitHub select-option color NAMES → a dot hex. Data colours in a rail that has
+ *  to stay quiet, so they sit well under the semantic state tokens' chroma; an
+ *  unmapped name takes the neutral dot, and the option's name renders beside every
+ *  one of them. */
+const OPTION_COLORS: Record<string, string> = {
+  GRAY: "#8b8b93",
+  BLUE: "#6a8fc0",
+  GREEN: "#5f9c78",
+  YELLOW: "#b09a4e",
+  ORANGE: "#bd8353",
+  RED: "#bd6c6c",
+  PINK: "#b9739a",
+  PURPLE: "#8d80ba",
+};
+
+/** GitHub's Date scalar, which carries no zone. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function optionColor(color: string): string {
+  return OPTION_COLORS[color?.toUpperCase()] ?? OPTION_COLORS.GRAY;
+}
+
+/** A project date field as a LOCAL date: a bare `YYYY-MM-DD` parses as UTC
+ *  midnight, which renders a day early everywhere west of Greenwich. */
+function parseFieldDate(date: string): Date | null {
+  const iso = DATE_ONLY.test(date) ? `${date}T00:00:00` : date;
+  return parseableDate(iso) ? new Date(iso) : null;
+}
+
+/** A date field in the user's locale, falling back to the raw forge string when it
+ *  can't be read — never "Invalid Date". */
+function formatFieldDate(date: string): string {
+  const parsed = parseFieldDate(date);
+  if (parsed === null) return date;
+  return parsed.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function shortDay(date: Date, withYear: boolean): string {
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+  };
+  if (withYear) options.year = "numeric";
+  return date.toLocaleDateString(undefined, options);
+}
+
+/** An iteration's span, start through its last day. `""` when the start can't be
+ *  read or the duration isn't a usable day count — the title alone still names it.
+ *  A span crossing New Year carries the year on BOTH ends: "Dec 28 – Jan 10" reads
+ *  backwards without it. */
+function iterationRange(startDate: string, duration: number): string {
+  const start = parseFieldDate(startDate);
+  if (start === null || !Number.isFinite(duration) || duration < 1) return "";
+  const end = new Date(start);
+  end.setDate(end.getDate() + Math.round(duration) - 1);
+  const spansYears = start.getFullYear() !== end.getFullYear();
+  return `${shortDay(start, spansYears)} – ${shortDay(end, spansYears)}`;
+}
+
+/** One select option. The dot is decorative and the name carries the value, so
+ *  nothing here rests on the colour. */
+function OptionValue({ name, color }: { name: string; color: string }) {
+  return (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+      <span
+        aria-hidden
+        className="size-1.5 shrink-0 rounded-full"
+        style={{ backgroundColor: optionColor(color) }}
+      />
+      <span className="truncate" onMouseEnter={clipTitleFromText}>
+        {name}
+      </span>
+    </span>
+  );
+}
+
+/** One field's value, or `null` when there's nothing to show — an unset field, or
+ *  a kind this build has no rendering for. A name with no value beside it reads as
+ *  a broken render, so both cases drop the whole entry rather than the value. */
+function fieldValueNode(value: ProjectFieldValue): ReactNode {
+  switch (value.kind) {
+    case "singleSelect":
+      return value.name ? (
+        <OptionValue name={value.name} color={value.color} />
+      ) : null;
+    case "multiSelect": {
+      const options = value.options.filter((option) => option.name);
+      return options.length === 0 ? null : (
+        <span className="inline-flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
+          {options.map((option) => (
+            <OptionValue
+              key={option.id}
+              name={option.name}
+              color={option.color}
+            />
+          ))}
+        </span>
+      );
+    }
+    case "text": {
+      const text = value.text.trim();
+      return text === "" ? null : (
+        // Capped rather than free-flowing: one long note would otherwise set the
+        // whole line's width and push every other field off it.
+        <span
+          className="inline-block max-w-40 truncate align-bottom"
+          onMouseEnter={clipTitle(text)}
+        >
+          {text}
+        </span>
+      );
+    }
+    case "number":
+      return Number.isFinite(value.number) ? value.number : null;
+    case "date":
+      return value.date === "" ? null : formatFieldDate(value.date);
+    case "iteration": {
+      const range = iterationRange(value.startDate, value.duration);
+      if (value.title === "" && range === "") return null;
+      return (
+        <>
+          {value.title}
+          {range === "" ? null : (
+            <span className="text-muted-foreground"> ({range})</span>
+          )}
+        </>
+      );
+    }
+    // `unknown`, and any kind a later backend adds: silent rather than guessed at.
+    default:
+      return null;
+  }
+}
+
+type FieldPart = { key: string; name: string; node: ReactNode };
+
+function renderableParts(entry: ItemProjectFieldValues): FieldPart[] {
+  const parts: FieldPart[] = [];
+  for (const value of entry.values) {
+    const node = fieldValueNode(value);
+    if (node === null) continue;
+    const id = "fieldId" in value ? value.fieldId : value.fieldName;
+    parts.push({ key: `${value.kind}-${id}`, name: value.fieldName, node });
+  }
+  return parts;
+}
+
+/** One board's set fields, as a single line: muted field name, then its value,
+ *  middot-separated. The project's own title prefixes the line only when the item
+ *  sits on more than one board — with one, the Projects chips above already named
+ *  it. */
+function ProjectFieldLine({
+  title,
+  showTitle,
+  parts,
+}: {
+  title: string;
+  showTitle: boolean;
+  parts: FieldPart[];
+}) {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 text-[11px]">
+      {showTitle ? (
+        <span
+          className="min-w-0 max-w-full truncate font-medium"
+          onMouseEnter={clipTitle(title)}
+        >
+          {title}
+        </span>
+      ) : null}
+      {parts.map((part, i) => (
+        <span
+          key={part.key}
+          className="inline-flex min-w-0 max-w-full items-center gap-x-1.5"
+        >
+          {/* Separates the previous field from this one; the gap already reads as
+              a break for a screen reader, so the glyph itself is decorative. */}
+          {i > 0 || showTitle ? (
+            <span aria-hidden className="text-muted-foreground/60">
+              ·
+            </span>
+          ) : null}
+          <span className="text-muted-foreground">{part.name}</span>
+          <span className="min-w-0">{part.node}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The read-only view of an item's GitHub Projects field values — one line per
+ * board, under the Projects picker on both the issue rail and the PR header grid.
+ * Nothing renders until there is something to say: no memberships, no set fields,
+ * or no GitHub, and the block is absent entirely rather than showing empty chrome.
+ * Reads only — the picker above owns the memberships, and the fields themselves
+ * aren't editable here.
+ */
+export function ProjectFieldValues({
+  repoPath,
+  enabled,
+  kind,
+  number,
+  lens,
+  cells = false,
+}: {
+  repoPath: string;
+  /** Gates the reads, matching the Projects picker's own gate — the real gate is
+   *  upstream and deliberately forgiving about a not-yet-identified provider. */
+  enabled: boolean;
+  kind: "issue" | "pr";
+  number: number;
+  /** The origin|upstream lens the parent PR/issue surface resolved. */
+  lens: RemoteLens;
+  /** Emit a label cell and a value cell as two SIBLING elements for a caller's
+   *  label/value grid. Default renders the bare block. */
+  cells?: boolean;
+}) {
+  const host = useActiveGhHost();
+  const scopes = useGhScopes(host);
+  const canRead = enabled && !projectScopeMissing(scopes.data);
+  // Same key as the picker's own read, so this shares that cache rather than
+  // paying a second fetch to learn whether the item is on any board at all.
+  const memberships = useItemProjects(repoPath, kind, number, canRead, lens);
+  const values = useItemFieldValues(repoPath, kind, number, canRead, lens);
+
+  const settled = values.isSuccess;
+  const entries = settled ? (values.data ?? []) : [];
+  const lines = entries
+    .map((entry) => ({ entry, parts: renderableParts(entry) }))
+    .filter((line) => line.parts.length > 0);
+  // One entry per board membership, so this counts BOARDS, not lines: an item on
+  // three boards where only one has set fields still needs that line named.
+  const showTitles = entries.length > 1;
+  const loading = canRead && !settled && values.error === null;
+  // Both the skeleton and the error line are claims that a line is coming, so both
+  // wait on PROVEN boards. A pending memberships read would flash either one onto
+  // a boardless item; a failed one belongs to the picker above, which owns that
+  // error's wording and its Retry.
+  const boardsKnown = memberships.isSuccess && memberships.data.length > 0;
+
+  const content = (() => {
+    switch (true) {
+      case lines.length > 0:
+        return (
+          <div className="flex w-full min-w-0 flex-col gap-0.5">
+            {lines.map(({ entry, parts }) => (
+              <ProjectFieldLine
+                key={entry.itemId}
+                title={entry.project.title}
+                showTitle={showTitles}
+                parts={parts}
+              />
+            ))}
+          </div>
+        );
+      case loading && boardsKnown:
+        return <Skeleton className="h-4 w-40" aria-hidden />;
+      case values.error !== null && boardsKnown:
+        return (
+          <span className="inline-flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
+            {presentError(values.error).summary}
+            {/* Named in full: on the issue rail this block carries no field label
+                for a reader to fall back on. */}
+            <button
+              type="button"
+              aria-label={`Retry loading ${FIELD_LABEL.toLowerCase()}`}
+              className="cursor-pointer underline hover:text-foreground"
+              onClick={() => values.refetch()}
+            >
+              Retry
+            </button>
+          </span>
+        );
+      default:
+        return null;
+    }
+  })();
+
+  if (content === null) return null;
+  if (!cells) return content;
+  return (
+    <>
+      <MetaFieldLabel>{FIELD_LABEL}</MetaFieldLabel>
+      <MetaValueCell label={FIELD_LABEL} busy={lines.length === 0 && loading}>
+        {content}
+      </MetaValueCell>
+    </>
+  );
+}

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -323,8 +323,6 @@ export function ProjectFieldValues({
         return (
           <span className="inline-flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
             {presentError(values.error).summary}
-            {/* Named in full: on the issue rail this block carries no field label
-                for a reader to fall back on. */}
             <button
               type="button"
               aria-label={`Retry loading ${FIELD_LABEL.toLowerCase()}`}

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -78,6 +78,9 @@ function iterationRange(startDate: string, duration: number): string {
   if (start === null || !Number.isFinite(duration) || duration < 1) return "";
   const end = new Date(start);
   end.setDate(end.getDate() + Math.round(duration) - 1);
+  // A duration past Date's range lands an Invalid Date, whose formatted form is
+  // the literal string this module's date handling promises never to show.
+  if (Number.isNaN(end.getTime())) return "";
   const spansYears = start.getFullYear() !== end.getFullYear();
   return `${shortDay(start, spansYears)} – ${shortDay(end, spansYears)}`;
 }
@@ -270,21 +273,17 @@ export function ProjectFieldValues({
 
   // Keyed on CACHED DATA, never on query status, matching the chips above: a
   // failed background refetch flips the status to error while the data it already
-  // served is still good, and lines that vanish under a gh hiccup would leave the
-  // chips standing over an empty rail.
-  //
-  // Filtered by the picker's memberships, which are the truth for WHICH boards
-  // exist: an unlink empties them optimistically, and unlinking the LAST one
-  // disables this query — an invalidate neither refetches nor clears a disabled
-  // query, so its cache outlives the boards it describes. Lines render only for
-  // boards the item is still on, which also drops a partial unlink's stale line
-  // ahead of the refetch rather than after it.
+  // served is still good.
   const membershipIds = new Set(
     (memberships.data ?? []).map((item) => item.project.id),
   );
-  const entries = (values.data ?? []).filter((entry) =>
-    membershipIds.has(entry.project.id),
-  );
+  // Gated on live memberships AND the scope gate, because a cache outlives the
+  // gate that filled it: either one going away disables this query, which an
+  // invalidate can then neither refetch nor clear. The picker's chips and its
+  // scope-gap block are what the rail has to agree with.
+  const entries = canRead
+    ? (values.data ?? []).filter((entry) => membershipIds.has(entry.project.id))
+    : [];
   const lines = entries
     .map((entry) => ({ entry, parts: renderableParts(entry) }))
     .filter((line) => line.parts.length > 0);
@@ -318,9 +317,9 @@ export function ProjectFieldValues({
         );
       case loading:
         return <Skeleton className="h-4 w-40" aria-hidden />;
-      // Still board-gated: a disabled query keeps whatever error it last cached,
-      // and an item whose boards have since gone stays silent.
-      case values.error !== null && boardsKnown:
+      // Still gated: a disabled query keeps whatever error it last cached, so an
+      // item whose boards — or whose scope — have since gone stays silent.
+      case canRead && values.error !== null && boardsKnown:
         return (
           <span className="inline-flex flex-wrap items-center gap-x-1.5 text-[11px] text-muted-foreground">
             {presentError(values.error).summary}

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -23,6 +23,7 @@ import {
   useItemProjects,
 } from "@/lib/git/queries";
 import type {
+  GhScopes,
   ProjectItemRemove,
   ProjectV2Ref,
   RemoteLens,
@@ -41,6 +42,20 @@ const DISCARDED_NOTICE =
 
 function sameIds(a: Set<string>, b: Set<string>): boolean {
   return a.size === b.size && [...a].every((id) => b.has(id));
+}
+
+/** Whether the signed-in GitHub token provably can't read Projects, which gates
+ *  every Projects read. Only a classic token has readable scopes; a
+ *  fine-grained/App token reports none, so an absent `project` there is
+ *  unknowable, not missing — those fire the reads and let the backend's own scope
+ *  hint speak if it really is absent. Shared so no Projects surface can drift into
+ *  firing reads another one withholds. */
+export function projectScopeMissing(scopes: GhScopes | undefined): boolean {
+  return (
+    scopes?.classic === true &&
+    !scopes.scopes.includes("project") &&
+    !scopes.scopes.includes("read:project")
+  );
 }
 
 /** A closed board still holds items, so its rows and chips stay — the state rides
@@ -90,13 +105,7 @@ export function ProjectsPopover({
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
-  // Only a classic token has readable scopes; a fine-grained/App token reports
-  // none, so an absent `project` there is unknowable, not missing — fire the
-  // reads and let the backend's own scope hint speak if it really is absent.
-  const classicMissing =
-    scopes.data?.classic === true &&
-    !scopes.data.scopes.includes("project") &&
-    !scopes.data.scopes.includes("read:project");
+  const classicMissing = projectScopeMissing(scopes.data);
   // Read-only classic token: the reads work, every write 403s. Hold the rows
   // rather than letting each toggle round-trip to a rollback + toast.
   const readOnlyScope =

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1070,7 +1070,8 @@ leaving the app — see *Conflicts with the base branch* below.
 
 An open pull request gets a **Projects** picker alongside its **labels**, **assignees**, and
 **reviewers**: chips for the **GitHub Projects** it belongs to, and a popup to link or
-unlink it (see *Issues*).
+unlink it. Under the chips, a **Project fields** row reads out where the pull request
+stands on each of those boards (see *Issues*).
 
 The list toolbar's **All | Mine | Needs review** switch scopes the list in one click:
 **Mine** is everything assigned to you or awaiting your review, and **Needs review** is
@@ -1743,11 +1744,15 @@ duplicates, and same-project mentions.
   issue.
 - **Projects** — chips in the side rail show which **GitHub Projects** the issue belongs to,
   and a picker links or unlinks it across the repository's projects and the owner's; your
-  changes apply when the picker closes. GitHub only, and changing anything needs the
-  \`project\` scope: with just \`read:project\` the boards still show but every row is locked,
-  and with neither the picker says so and helps you get it — when your sign-in's scopes are
-  readable, that's a one-click **Reconnect GitHub…** plus a copyable \`gh auth refresh\`
-  command already pointed at your host.
+  changes apply when the picker closes. Below the chips, one line per board reads out where
+  the issue stands: **Status**, **Priority**, **Iteration** (with the dates it covers), plus
+  date, text, number, and multi-select fields, each named beside its value. A board is named
+  on its own line once the issue sits on more than one. Those values are read-only here;
+  change them on the board itself. GitHub only, and changing anything needs the \`project\`
+  scope: with just \`read:project\` the boards still show but every row is locked, and with
+  neither the picker says so and helps you get it — when your sign-in's scopes are readable,
+  that's a one-click **Reconnect GitHub…** plus a copyable \`gh auth refresh\` command
+  already pointed at your host.
 
 As on the Pull Requests tab, these follow your access on the repository: an action you
 don't have the access for — a lighter tier for labels, assignees, milestones, and

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -20,6 +20,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { LabelsPopover } from "@/features/conversations/LabelsPopover";
+import { ProjectFieldValues } from "@/features/conversations/ProjectFieldValues";
 import { ProjectsPopover } from "@/features/conversations/ProjectsPopover";
 import { AuthorAvatar, LabelChip } from "@/features/conversations/Thread";
 import {
@@ -275,6 +276,19 @@ export function IssueSidebar({
           contentId={issue.id}
           lens={lens}
           disabledReason={pickerDisabledReason}
+        />
+      ),
+    },
+    {
+      key: "project-fields",
+      when: canWrite,
+      render: () => (
+        <ProjectFieldValues
+          repoPath={repoPath}
+          enabled
+          kind="issue"
+          number={number}
+          lens={lens}
         />
       ),
     },

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -281,7 +281,6 @@ export function IssueSidebar({
     },
     {
       key: "project-fields",
-      heading: "Project fields",
       when: canWrite,
       render: () => (
         <ProjectFieldValues

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -281,6 +281,7 @@ export function IssueSidebar({
     },
     {
       key: "project-fields",
+      heading: "Project fields",
       when: canWrite,
       render: () => (
         <ProjectFieldValues

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -61,6 +61,7 @@ import {
   useEditTitleBody,
 } from "@/features/conversations/EditTitleBodyDialog";
 import { LabelsPopover } from "@/features/conversations/LabelsPopover";
+import { ProjectFieldValues } from "@/features/conversations/ProjectFieldValues";
 import { ProjectsPopover } from "@/features/conversations/ProjectsPopover";
 import { makeQuoteReply } from "@/features/conversations/quoteReply";
 import { ReactionBar } from "@/features/conversations/ReactionBar";
@@ -2468,6 +2469,19 @@ export function RemotePrView({
         contentId={pr.id}
         lens={lens}
         disabledReason={pickerReason}
+      />,
+    );
+    // Read-only field values under the picker, on the same gate: they come from
+    // the same boards, so wherever the chips are, the fields belong.
+    metaCells.push(
+      <ProjectFieldValues
+        key={`project-fields-${entityKey}`}
+        cells
+        repoPath={repoPath}
+        enabled
+        kind="pr"
+        number={number}
+        lens={lens}
       />,
     );
   }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -93,6 +93,7 @@ import type {
   IssueRelation,
   IssueRelations,
   IssueType,
+  ItemProjectFieldValues,
   MergePreview,
   Milestone,
   MyTeams,
@@ -2493,6 +2494,22 @@ export const ghItemProjects = (
   lens: RemoteLens,
 ) =>
   invoke<ProjectItemRef[]>("gh_item_projects", {
+    repoPath,
+    kind,
+    number,
+    lens,
+  });
+
+/** One issue/PR's project field values, one entry per board it belongs to. Same
+ *  scope need as the memberships read, and the same per-board shape, so the two
+ *  line up membership-for-membership. */
+export const ghItemFieldValues = (
+  repoPath: string,
+  kind: "issue" | "pr",
+  number: number,
+  lens: RemoteLens,
+) =>
+  invoke<ItemProjectFieldValues[]>("gh_item_field_values", {
     repoPath,
     kind,
     number,

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -3198,9 +3198,9 @@ export function useAccountsHealth() {
  *  token scopes (a reconnect can grant new ones), and the repo-settings lists a
  *  scope hint sends users here from — secrets, variables and webhooks all fail
  *  closed on a missing scope, so their error cards must retry the call themselves,
- *  as do the three GitHub Projects reads — catalog, memberships and field values —
- *  (a granted `project` scope has to light the picker and the rail's field lines up
- *  without a restart), and the work inbox's sources probe plus its pages
+ *  as do the three GitHub Projects reads (catalog, memberships and field values): a
+ *  granted `project` scope has to light the picker and the rail's field lines up
+ *  without a restart, and the work inbox's sources probe plus its pages
  *  (a `login` mode reconnect is how a forge becomes a source in the first place).
  *  Call from a reconnect's `finished: ok` handler. */
 export function useInvalidateAfterReconnect() {

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2570,12 +2570,16 @@ export function useEditItemProjects(
     // settles, which is what lets the picker's trigger stay held across the
     // refetch rather than freeing while the cache still holds `pending:` ids.
     // `invalidateQueries` resolves even when the refetch errors, so there is no
-    // stuck-trigger mode. The field values hang off these memberships, but their
-    // refetch stays UNAWAITED: the rail already filters its lines by the live
-    // memberships, so it is correct the moment this patch lands, and holding the
-    // trigger for the heavier read would only lengthen the wait.
+    // stuck-trigger mode.
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: fieldsKey });
+      // The fields read stays UNAWAITED — the rail filters its lines by the live
+      // memberships, so it is already correct — but has to be CANCELLED first: a
+      // first link enables that query mid-mutation, and query-core dedupes a
+      // fetch whose data is still undefined by REUSING the in-flight promise
+      // instead of cancelling it, landing the pre-link empty read as fresh.
+      void queryClient
+        .cancelQueries({ queryKey: fieldsKey })
+        .then(() => queryClient.invalidateQueries({ queryKey: fieldsKey }));
       return queryClient.invalidateQueries({ queryKey: key });
     },
   });

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2570,14 +2570,14 @@ export function useEditItemProjects(
     // settles, which is what lets the picker's trigger stay held across the
     // refetch rather than freeing while the cache still holds `pending:` ids.
     // `invalidateQueries` resolves even when the refetch errors, so there is no
-    // stuck-trigger mode. The field values hang off the memberships this just
-    // changed, so an unlinked board's line must go with its chip rather than
-    // outliving it for the rest of that cache's staleTime.
-    onSettled: () =>
-      Promise.all([
-        queryClient.invalidateQueries({ queryKey: key }),
-        queryClient.invalidateQueries({ queryKey: fieldsKey }),
-      ]),
+    // stuck-trigger mode. The field values hang off these memberships, but their
+    // refetch stays UNAWAITED: the rail already filters its lines by the live
+    // memberships, so it is correct the moment this patch lands, and holding the
+    // trigger for the heavier read would only lengthen the wait.
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: fieldsKey });
+      return queryClient.invalidateQueries({ queryKey: key });
+    },
   });
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2481,6 +2481,35 @@ export function useItemProjects(
   });
 }
 
+const itemFieldValuesKey = (
+  repo: string,
+  lens: RemoteLens,
+  kind: "issue" | "pr",
+  number: number,
+) => ["repo", repo, "item-field-values", lens, kind, number] as const;
+
+/** One issue/PR's project field values, per board. Same axes, staleTime and
+ *  `retry: false` as {@link useItemProjects} — it reads the same boards through the
+ *  same token scope, so a missing `project` scope fails both the same way and no
+ *  retry fixes it. No `placeholderData` either: the rail can't show one item's
+ *  fields under another's, so a retained set would have to be suppressed on
+ *  arrival, leaving only the stale copy it pins in cache. */
+export function useItemFieldValues(
+  repo: string,
+  kind: "issue" | "pr",
+  number: number,
+  enabled: boolean,
+  lens: RemoteLens,
+) {
+  return useQuery({
+    queryKey: itemFieldValuesKey(repo, lens, kind, number),
+    queryFn: () => api.ghItemFieldValues(repo, kind, number, lens),
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 /** The picker's batched link/unlink, with an optimistic patch of the memberships
  *  cache. Adds land as `pending:`-prefixed placeholder item ids — the real item id
  *  only exists once GitHub creates the item, and `onSettled`'s refetch supplies
@@ -2493,6 +2522,7 @@ export function useEditItemProjects(
 ) {
   const queryClient = useQueryClient();
   const key = itemProjectsKey(repo, lens, kind, number);
+  const fieldsKey = itemFieldValuesKey(repo, lens, kind, number);
   return useMutation({
     mutationFn: (args: {
       contentId: string;
@@ -2540,8 +2570,14 @@ export function useEditItemProjects(
     // settles, which is what lets the picker's trigger stay held across the
     // refetch rather than freeing while the cache still holds `pending:` ids.
     // `invalidateQueries` resolves even when the refetch errors, so there is no
-    // stuck-trigger mode.
-    onSettled: () => queryClient.invalidateQueries({ queryKey: key }),
+    // stuck-trigger mode. The field values hang off the memberships this just
+    // changed, so an unlinked board's line must go with its chip rather than
+    // outliving it for the rest of that cache's staleTime.
+    onSettled: () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: key }),
+        queryClient.invalidateQueries({ queryKey: fieldsKey }),
+      ]),
   });
 }
 
@@ -3162,8 +3198,9 @@ export function useAccountsHealth() {
  *  token scopes (a reconnect can grant new ones), and the repo-settings lists a
  *  scope hint sends users here from — secrets, variables and webhooks all fail
  *  closed on a missing scope, so their error cards must retry the call themselves,
- *  as do the two GitHub Projects reads (a granted `project` scope has to light the
- *  picker up without a restart), and the work inbox's sources probe plus its pages
+ *  as do the three GitHub Projects reads — catalog, memberships and field values —
+ *  (a granted `project` scope has to light the picker and the rail's field lines up
+ *  without a restart), and the work inbox's sources probe plus its pages
  *  (a `login` mode reconnect is how a forge becomes a source in the first place).
  *  Call from a reconnect's `finished: ok` handler. */
 export function useInvalidateAfterReconnect() {
@@ -3183,7 +3220,8 @@ export function useInvalidateAfterReconnect() {
           q.queryKey[2] === "variables" ||
           q.queryKey[2] === "webhooks" ||
           q.queryKey[2] === "projects-available" ||
-          q.queryKey[2] === "item-projects"),
+          q.queryKey[2] === "item-projects" ||
+          q.queryKey[2] === "item-field-values"),
     });
     // A `login` here is a real source change for the work inbox — its probe gates
     // each forge's leg on a 5-minute window, so without this a session signed in

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -2320,6 +2320,71 @@ export interface ProjectItemRemove {
   itemId: string;
 }
 
+/** One project field's value on an item, tagged by the field's kind. `isIssueField`
+ *  marks a value GitHub owns on the issue/PR itself (assignees, labels, milestone,
+ *  …) rather than a board-defined field — it rides the wire for the editor, which
+ *  can't write those here. A kind this build doesn't know arrives as `unknown`,
+ *  carrying only the name it was given. */
+export type ProjectFieldValue =
+  | {
+      kind: "singleSelect";
+      fieldId: string;
+      fieldName: string;
+      optionId: string;
+      name: string;
+      /** GitHub color NAME (GRAY/BLUE/GREEN/YELLOW/ORANGE/RED/PINK/PURPLE). */
+      color: string;
+      isIssueField: boolean;
+    }
+  | {
+      kind: "multiSelect";
+      fieldId: string;
+      fieldName: string;
+      options: { id: string; name: string; color: string }[];
+      isIssueField: boolean;
+    }
+  | {
+      kind: "text";
+      fieldId: string;
+      fieldName: string;
+      text: string;
+      isIssueField: boolean;
+    }
+  | {
+      kind: "number";
+      fieldId: string;
+      fieldName: string;
+      number: number;
+      isIssueField: boolean;
+    }
+  | {
+      kind: "date";
+      fieldId: string;
+      fieldName: string;
+      /** A bare `YYYY-MM-DD` as GitHub's Date scalar sends it — no zone. */
+      date: string;
+      isIssueField: boolean;
+    }
+  | {
+      kind: "iteration";
+      fieldId: string;
+      fieldName: string;
+      title: string;
+      startDate: string;
+      /** Length in DAYS, so the last day is `startDate + duration - 1`. */
+      duration: number;
+      isIssueField: boolean;
+    }
+  | { kind: "unknown"; fieldName: string };
+
+/** One board's field values for an item. `itemId` addresses the membership the
+ *  values hang off, which is what a write would target. */
+export interface ItemProjectFieldValues {
+  itemId: string;
+  project: ProjectV2Ref;
+  values: ProjectFieldValue[];
+}
+
 export interface Reaction {
   /** GitHub ReactionContent enum value (THUMBS_UP, HEART, ROCKET, …). */
   content: string;


### PR DESCRIPTION
Issues and pull requests already show *which* GitHub Projects boards they belong to, but not where they stand on them. This adds a read-only readout under the Projects chips — one line per board with that board's set fields (Status, Priority, Iteration with its dates, plus date, text, number and multi-select fields), so the board's state is visible without leaving the item.

### Backend (Tauri)

- Adds `src-tauri/src/github/project_fields.rs` with one command, `gh_item_field_values` (an item's values, one entry per board it sits on), registered in `src-tauri/src/lib.rs` and `src-tauri/src/github/mod.rs`. (A second command for board field definitions was pulled pre-open: the dead-surface CI guard rejects registered commands with no caller, so it lands in the editor slice with its consumer.)
- Models values as a `serde`-tagged enum (`ProjectFieldValue`) with `rename_all_fields = "camelCase"`, so unknown field kinds degrade to an `unknown` arm carrying just the name rather than dropping out.
- The item query covers both classic `ProjectV2ItemField*Value` arms and the `ProjectV2ItemIssueFieldValue` bridge, aliasing the `IssueField*Value` `value` scalars (`text: value`, `number: value`, `date: value`) so both shapes parse through the same keys; `parse_field_value` requires the value's `__typename` and the field's `dataType` to agree before it commits to a kind.
- `map_scope_error` rewrites `required scopes` / `read:project` failures into a `gh auth refresh -s project` hint; non-scope errors pass through untouched.
- Tests pin the camelCase wire shape of every enum arm (key-sorted assertions), the pointer-vs-query tripwire for the item query, bridge normalization, unknown-typename and mismatched-dataType tolerance, null/absent-value handling (absent numbers are `unknown`, explicit zeros are real), and empty/absent connections.

### Frontend

- `ProjectFieldValues` renders one compact line per board membership — muted field name beside each value, select options as muted color dots with the option name (dots `aria-hidden`), iterations as title + date range, dates locale-formatted with a `parseableDate` gate, long text clipped with the only-when-clipped tooltip idiom. The board title prefixes a line only when the item sits on more than one board.
- Mounts under the Projects picker on the issue rail and (in `cells` form) the PR header grid, on the picker's exact gates; the block renders nothing when there is nothing to say — no memberships, no set fields, or no GitHub.
- `useItemFieldValues` mirrors `useItemProjects` (same key axes, `retry: false`); the picker's link/unlink mutation and the reconnect flow co-invalidate the new cache; the classic-token scope gate is extracted to a shared `projectScopeMissing` so the two surfaces can't drift.
- Loading shows a single-line skeleton only once memberships are known to exist; a values failure shows a quiet inline Retry only in that same proven-boards state.

### Docs

README Features bullet, site capabilities entry, in-app guide (Issues + PR sections), and a `changelog.d/added-project-field-values.md` fragment.

### Verification

Full cargo suite + clippy `-D warnings`, `pnpm build`, site build, LF-normalized biome CI gates, the repo guards suite (`pnpm run checks`), live execution of the GraphQL document against the real API, and a live UI drive of both surfaces against a fixture project with every field kind set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Display GitHub Projects field values on issues and pull requests.
  - Show status, priority, iteration, dates, text, number, and selection fields for each linked project board.
  - Support multiple linked boards with clear per-board details.
  - Handle loading, empty, retryable error, and unavailable-permission states.

- **Documentation**
  - Added guidance on project field displays and required authorization scopes.
  - Updated capability and help documentation for project field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->