### PR TITLE
feat(notifications): add per-source channels and repo overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,13 +1023,12 @@ review via its subscription login. The full list is under
   clearable history that survives a restart, so a review that finishes
   while you're away is never a missed click. Open it from the command
   palette; which events show follows your notification settings, where
-  each source sets its inbox and desktop channels independently, with
-  per-repository overrides. A cancelled or failed **automated** review also
-  lingers in a **Stopped** group with one-click **Re-run** (re-firing
-  exactly that run's mode) and **Dismiss**, so a stopped automation isn't a
-  dead end. The *review failed* notification row itself states why the run
-  failed, and for automated runs carries the same one-click **Re-run**
-  right on the row.
+  each source sets its inbox and desktop channels independently. A
+  cancelled or failed **automated** review also lingers in a **Stopped**
+  group with one-click **Re-run** (re-firing exactly that run's mode) and
+  **Dismiss**, so a stopped automation isn't a dead end. The *review
+  failed* notification row itself states why the run failed, and for
+  automated runs carries the same one-click **Re-run** right on the row.
 - **Environment check**: a Settings → **About** panel reports your
   app/OS/Tauri versions and the status of every CLI GitDesktop uses (git,
   the GitHub & GitLab CLIs, Claude Code, Codex): installed?, version,

--- a/README.md
+++ b/README.md
@@ -1013,19 +1013,23 @@ review via its subscription login. The full list is under
   confirming the modes and the posted comment before spending a model call.
 - **Integrations**: open in any editor or terminal (auto-detected, point at
   any executable, or set a full custom command with a `{path}` placeholder),
-  and tunable OS notifications for PR activity, checks, and CI runs.
+  and per-source notification controls that send each kind of event to the
+  activity inbox, your desktop, both, or neither, with per-repository
+  overrides.
 - **Activity and notifications**: a persistent bell in the header collects
   terminal events (a finished review, checks passing/failing, a PR
   approved/commented/merged, a review requested from you, a completed CI
   run, or a finished agent / research / plan run) into a clickable,
   clearable history that survives a restart, so a review that finishes
   while you're away is never a missed click. Open it from the command
-  palette; which events show follows your notification settings. A
-  cancelled or failed **automated** review also lingers in a **Stopped**
-  group with one-click **Re-run** (re-firing exactly that run's mode) and
-  **Dismiss**, so a stopped automation isn't a dead end. The *review
-  failed* notification row itself states why the run failed, and for
-  automated runs carries the same one-click **Re-run** right on the row.
+  palette; which events show follows your notification settings, where
+  each source sets its inbox and desktop channels independently, with
+  per-repository overrides. A cancelled or failed **automated** review also
+  lingers in a **Stopped** group with one-click **Re-run** (re-firing
+  exactly that run's mode) and **Dismiss**, so a stopped automation isn't a
+  dead end. The *review failed* notification row itself states why the run
+  failed, and for automated runs carries the same one-click **Re-run**
+  right on the row.
 - **Environment check**: a Settings → **About** panel reports your
   app/OS/Tauri versions and the status of every CLI GitDesktop uses (git,
   the GitHub & GitLab CLIs, Claude Code, Codex): installed?, version,

--- a/changelog.d/added-notification-controls.md
+++ b/changelog.d/added-notification-controls.md
@@ -1,0 +1,5 @@
+- **Per-source notification controls.** Every kind of event carries its own pair
+  of checkboxes: a row in the activity inbox, a desktop ping, both, or neither.
+  Agent sessions, plans, and research join the list, CI checks choose whether
+  they watch just your pull requests or every open one, and **Customize…** sets
+  any of it per repository, down to muting a whole repo in one click.

--- a/scripts/check-banned-patterns.mjs
+++ b/scripts/check-banned-patterns.mjs
@@ -464,6 +464,35 @@ const ONERROR_SETTINGS_REFETCH_RE = new RegExp(
   "g",
 );
 
+// The routes around the notification gate, each matched at its IMPORT. Every
+// module specifier is anchored on its trailing PATH SEGMENT rather than on the
+// alias spelling, because `@/lib/stores/notifications`, `./notifications` and
+// `../stores/notifications` all resolve to the same module and a producer may
+// legitimately sit in either directory (repo-description-generation.ts already
+// imports `./notifications` for an unrelated helper). No other module under
+// src/ ends in `/notifications` or `/notify`, so the segment anchor costs no
+// precision; a future one would need the banned identifier to report at all.
+//
+// The inbox route keys on the `pushNotification` identifier inside the
+// specifier list, so the type-only and helper exports the same module carries
+// (NotificationKind, NotificationTone, NotificationTarget, repoNameFromPath)
+// stay legal; `[^}]*` cannot cross the import's own closing brace, so a
+// neighbouring import can never supply the token. A NAMESPACE import defeats
+// that specifier match outright — `notifs.pushNotification(row)` names nothing
+// at the import — so it takes its own arm, module path alone. The OS route
+// needs neither: every export of the notify module is a direct ping, so the
+// module path alone covers its specifier and namespace forms together.
+//
+// All three run over the whole-file view: the formatter puts each specifier on
+// its own line. Accepted evasions, zero instances today: a dynamic `import()`
+// of either module (no `from` clause), and a re-export chain through a third
+// module.
+const PUSH_NOTIFICATION_IMPORT_RE =
+  /\bimport\s+(?:type\s+)?\{[^}]*\bpushNotification\b[^}]*\}\s*from\s*["'][^"']*\/notifications["']/g;
+const NOTIFICATIONS_NAMESPACE_IMPORT_RE =
+  /\bimport\s+\*\s+as\s+[\w$]+\s+from\s*["'][^"']*\/notifications["']/g;
+const NOTIFY_MODULE_IMPORT_RE = /\bfrom\s*["'][^"']*\/notify["']/g;
+
 export const CHECKS = [
   {
     name: "hover-reveal",
@@ -802,6 +831,23 @@ export const CHECKS = [
     allowlist: [],
     message:
       "a menu/popover trigger that carries its disabled reason on a titled wrapper is hover-only — a natively disabled trigger leaves the tab order, so keyboard and screen-reader users reach neither the control nor the reason; compose `<Trigger render={<DisabledReasonButton disabled reason/>}>` instead (src/components/disabled-reason-button.tsx), which holds the reason on a focusable aria-disabled button whose own useButton swallows activation; a site that genuinely cannot take the primitive needs an allowlist entry with rationale",
+  },
+  {
+    name: "ungated-notification-producer",
+    // emit.ts IS the gate, so it holds both imports by definition.
+    appliesTo: (file) => file !== "src/lib/notifications/emit.ts",
+    scan: anyOf([
+      perFile(PUSH_NOTIFICATION_IMPORT_RE),
+      perFile(NOTIFICATIONS_NAMESPACE_IMPORT_RE),
+      perFile(NOTIFY_MODULE_IMPORT_RE),
+    ]),
+    // Empty by construction: every producer routes through emit, and the one
+    // exception is excluded by appliesTo rather than listed here. The inbox
+    // module itself needs no entry either — it cannot import itself, so an
+    // entry naming it would read stale on the first run.
+    allowlist: [],
+    message:
+      "notifications are delivered by emitNotification (src/lib/notifications/emit.ts) alone — it resolves each source's channels against the global prefs AND the repo's override, mutes the OS ping for AI kinds while AI is hidden, and dedupes both channels together; a producer reaching pushNotification or @/lib/notify directly ships a surface the user cannot turn off (the sessions, plan, and research producers were ungated exactly that way), so route it through emit or add an allowlist entry with rationale",
   },
 ];
 

--- a/scripts/checks.test.mjs
+++ b/scripts/checks.test.mjs
@@ -82,6 +82,7 @@ const nullFallback = scanner("null-suspense-fallback");
 const bareGroupLabel = scanner("bare-group-label");
 const unguardedDispatcher = scanner("unguarded-binding-dispatcher");
 const titledDisabledTrigger = scanner("titled-disabled-trigger");
+const ungatedProducer = scanner("ungated-notification-producer");
 
 test("hover-reveal catches every Tailwind spelling of the idiom", () => {
   for (const classes of [
@@ -1273,6 +1274,128 @@ test("titled-disabled-trigger reports every site now that the allowlist is empty
     "src/features/conversations/ProjectsPopover.tsx:1",
     "src/features/issues/SomeNewPicker.tsx:1",
   ]);
+});
+
+test("ungated-notification-producer flags both routes around the gate", () => {
+  // The inbox route, in the spellings the seven producers shipped in: the lone
+  // import, the mixed one, and the formatter-wrapped specifier list.
+  assert.deepEqual(
+    ungatedProducer(
+      'import { pushNotification } from "@/lib/stores/notifications";',
+    ),
+    [1],
+  );
+  assert.deepEqual(
+    ungatedProducer(
+      'import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";',
+    ),
+    [1],
+  );
+  const wrapped = [
+    "import {",
+    "  type NotificationKind,",
+    "  type NotificationTone,",
+    "  pushNotification,",
+    "  repoNameFromPath,",
+    '} from "@/lib/stores/notifications";',
+  ].join("\n");
+  assert.deepEqual(ungatedProducer(wrapped), [1]);
+  // A rename still reaches the same function, so the specifier's SOURCE name is
+  // what the pattern keys on.
+  assert.deepEqual(
+    ungatedProducer(
+      'import { pushNotification as push } from "@/lib/stores/notifications";',
+    ),
+    [1],
+  );
+  // The OS route: every export of the notify module is a direct ping, so the
+  // module path alone is the match — specifier and namespace forms together.
+  for (const source of [
+    'import { notify } from "@/lib/notify";',
+    'import { notifyIfUnfocused } from "@/lib/notify";',
+    'import { notify, notifyIfUnfocused } from "@/lib/notify";',
+    'import * as pings from "@/lib/notify";',
+  ])
+    assert.deepEqual(ungatedProducer(source), [1], `should flag ${source}`);
+  // A file taking both routes reports each on its own line.
+  const both = [
+    'import { notifyIfUnfocused } from "@/lib/notify";',
+    'import { pushNotification } from "@/lib/stores/notifications";',
+  ].join("\n");
+  assert.deepEqual(
+    ungatedProducer(both).sort((a, b) => a - b),
+    [1, 2],
+  );
+});
+
+test("ungated-notification-producer sees past the alias into relative spellings", () => {
+  // Both modules are reachable by path as well as by alias, and a producer may
+  // legitimately sit in either directory — src/lib/stores/ already spells the
+  // inbox module `./notifications` for an unrelated helper. Anchoring on the
+  // trailing path segment is what keeps the alias from being the whole gate.
+  for (const source of [
+    'import { pushNotification } from "./notifications";',
+    'import { pushNotification } from "../stores/notifications";',
+    'import { pushNotification } from "../../lib/stores/notifications";',
+    'import { pushNotification, repoNameFromPath } from "./notifications";',
+    'import { notify } from "./notify";',
+    'import { notifyIfUnfocused } from "../notify";',
+    'import { notifyIfUnfocused } from "../../lib/notify";',
+  ])
+    assert.deepEqual(ungatedProducer(source), [1], `should flag ${source}`);
+});
+
+test("ungated-notification-producer flags a namespace import of the inbox module", () => {
+  // `notifs.pushNotification(row)` names nothing at the import, so the
+  // specifier arm cannot see it — hence its own arm, in every spelling.
+  for (const source of [
+    'import * as notifs from "@/lib/stores/notifications";',
+    'import * as notifs from "./notifications";',
+    'import * as inbox from "../stores/notifications";',
+  ])
+    assert.deepEqual(ungatedProducer(source), [1], `should flag ${source}`);
+  // The namespace arm is scoped to the inbox module: a namespace import of any
+  // OTHER module, the gate's own neighbours included, is ordinary.
+  for (const source of [
+    'import * as overrides from "@/lib/notifications/overrides";',
+    'import * as api from "@/lib/settings/api";',
+  ])
+    assert.deepEqual(ungatedProducer(source), [], `should ignore ${source}`);
+});
+
+test("ungated-notification-producer leaves the gate's own siblings alone", () => {
+  for (const source of [
+    // The converted producer's imports: the gate, the resolution helpers, and
+    // the type-only / helper exports the inbox module also carries.
+    'import { emitNotification } from "@/lib/notifications/emit";',
+    'import { repoNameFromPath } from "@/lib/stores/notifications";',
+    'import type { NotificationTarget } from "@/lib/stores/notifications";',
+    'import { type NotificationKind, repoNameFromPath } from "@/lib/stores/notifications";',
+    // The RELATIVE spellings of those same legal imports — the segment anchor
+    // widened the module match, never the identifier one. The first line is
+    // src/lib/stores/repo-description-generation.ts's real import.
+    'import { repoNameFromPath } from "./notifications";',
+    'import type { NotificationKind } from "../stores/notifications";',
+    // A neighbouring import cannot supply the token: `[^}]*` stops at the
+    // import's own closing brace.
+    'import { pushNotification } from "@/lib/stores/other";\nimport { repoNameFromPath } from "@/lib/stores/notifications";',
+    // A CALL with no import of its own is emit.ts's own shape — the check is
+    // anchored on the import, which is what a producer cannot avoid.
+    "if (channels.inApp) pushNotification(row);",
+    // The comment naming the banned route is what comment stripping keeps clean.
+    '// never import { notifyIfUnfocused } from "@/lib/notify" in a producer',
+  ])
+    assert.deepEqual(ungatedProducer(source), [], `should ignore ${source}`);
+});
+
+test("ungated-notification-producer exempts the gate module only", () => {
+  const { appliesTo } = CHECKS.find(
+    (c) => c.name === "ungated-notification-producer",
+  );
+  assert.equal(appliesTo("src/lib/notifications/emit.ts"), false);
+  assert.equal(appliesTo("src/lib/notifications/overrides.ts"), true);
+  assert.equal(appliesTo("src/lib/stores/notifications.ts"), true);
+  assert.equal(appliesTo("src/features/sessions/store.ts"), true);
 });
 
 test("an allowlist entry whose file no longer has the pattern is stale", () => {

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -464,6 +464,11 @@ export const capabilities: Capability[] = [
       "Activity & notifications inbox — never miss a finished review or check",
     highlight: true,
   },
+  {
+    group: "Repository & workspace",
+    label:
+      "Per-source notification controls — in-app vs OS channels, per-repo overrides",
+  },
   { group: "Repository & workspace", label: "Environment & CLI health check" },
   {
     group: "Repository & workspace",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,10 @@ import { AutomationResultDialog } from "@/features/automations/AutomationResultD
 import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
 import { MyWorkScreen } from "@/features/mywork/MyWorkScreen";
+import {
+  RepoNotificationsDialogHost,
+  useRepoNotificationsDialog,
+} from "@/features/notifications/RepoNotificationsDialog";
 import { RepositoryView } from "@/features/repository/RepositoryView";
 import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { SettingsScreen } from "@/features/settings/SettingsScreen";
@@ -49,6 +53,8 @@ function App() {
   const openExplore = useUiStore((s) => s.openExplore);
   const openMyWork = useUiStore((s) => s.openMyWork);
   const toggleActivity = useUiStore((s) => s.toggleActivity);
+  const repoPath = useUiStore((s) => s.repoPath);
+  const openRepoNotifications = useRepoNotificationsDialog((s) => s.open);
   const gitInstalled = useGitInstalled();
   const queryClient = useQueryClient();
   const settings = useSettings();
@@ -194,6 +200,19 @@ function App() {
     !settings.data?.hideAi,
   );
   useHotkeyAction("browse-mcp-registry", openMcpBrowse, !settings.data?.hideAi);
+  useHotkeyAction("open-notifications-settings", () =>
+    openSettings("notifications"),
+  );
+  // The palette closes before it dispatches, so the repo is re-read at fire
+  // time rather than captured — a switch between the two is still honored.
+  useHotkeyAction(
+    "open-repo-notification-settings",
+    () => {
+      const path = useUiStore.getState().repoPath;
+      if (path) openRepoNotifications(path);
+    },
+    Boolean(repoPath),
+  );
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("open-explore", openExplore);
   useHotkeyAction("open-my-work", openMyWork);
@@ -261,6 +280,7 @@ function App() {
       </div>
       <AutomationResultDialog />
       <AutomationHistoryDialogHost />
+      <RepoNotificationsDialogHost />
       <CloneRepoDialog open={cloneOpen} onOpenChange={setCloneOpen} />
       <CreateRepoDialog open={createOpen} onOpenChange={setCreateOpen} />
       <ConfirmDialogHost />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,10 +73,9 @@ function App() {
   const screenModalOpen = useModalGateOpen();
   const dialogOpen = cloneOpen || createOpen || screenModalOpen;
 
-  // A mounted settings form publishes its notifications draft; the verdict is
-  // screen-scoped, so leaving Settings retires it. The section can't do this
-  // itself — it unmounts on every panel switch, while the draft it published is
-  // still live in the form.
+  // SettingsScreen publishes its notifications draft while it is up; the verdict
+  // is screen-scoped, so leaving Settings retires it here — the publisher can't,
+  // having unmounted by the time the view changes.
   useEffect(() => {
     if (view !== "settings") clearNotificationsDraft();
   }, [view, clearNotificationsDraft]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,8 +216,10 @@ function App() {
     !settings.data?.hideAi,
   );
   useHotkeyAction("browse-mcp-registry", openMcpBrowse, !settings.data?.hideAi);
-  useHotkeyAction("open-notifications-settings", () =>
-    openSettings("notifications"),
+  useHotkeyAction(
+    "open-notifications-settings",
+    () => openSettings("notifications"),
+    gitInstalled.isSuccess && !dialogOpen,
   );
   // The palette closes before it dispatches, so both the repo and the settings
   // draft are re-read at fire time rather than captured — the dialog's
@@ -237,7 +239,7 @@ function App() {
         return;
       openRepoNotifications(path);
     },
-    Boolean(repoPath) && !notificationsDraftHeld,
+    Boolean(repoPath) && !notificationsDraftHeld && !dialogOpen,
   );
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("open-explore", openExplore);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,9 +73,9 @@ function App() {
   const screenModalOpen = useModalGateOpen();
   const dialogOpen = cloneOpen || createOpen || screenModalOpen;
 
-  // SettingsScreen publishes its notifications draft while it is up; the verdict
-  // is screen-scoped, so leaving Settings retires it here — the publisher can't,
-  // having unmounted by the time the view changes.
+  // SettingsScreen publishes its notifications draft while it is up, and the
+  // verdict is screen-scoped: App owns the screen's lifetime, so leaving
+  // Settings retires it here.
   useEffect(() => {
     if (view !== "settings") clearNotificationsDraft();
   }, [view, clearNotificationsDraft]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,7 @@ import { AutomationResultDialog } from "@/features/automations/AutomationResultD
 import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
 import { MyWorkScreen } from "@/features/mywork/MyWorkScreen";
-import {
-  notificationsDraftOutOfSync,
-  RepoNotificationsDialogHost,
-  useNotificationsDraft,
-  useRepoNotificationsDialog,
-} from "@/features/notifications/RepoNotificationsDialog";
+import { RepoNotificationsDialogHost } from "@/features/notifications/RepoNotificationsDialog";
 import { RepositoryView } from "@/features/repository/RepositoryView";
 import { usePickAndOpenRepo } from "@/features/repository/useOpenRepoByPath";
 import { SettingsScreen } from "@/features/settings/SettingsScreen";
@@ -37,6 +32,11 @@ import { useGitInstalled, usePrefetchMyWorkSources } from "@/lib/git/queries";
 import { useHotkeyAction, useHotkeysListener } from "@/lib/hotkeys/hotkeys";
 import { useModalGateOpen } from "@/lib/hotkeys/modal-gate";
 import { MCP_WRITABLE_STORES } from "@/lib/mcp-writable-stores";
+import {
+  notificationsDraftOutOfSync,
+  useNotificationsDraft,
+  useRepoNotificationsDialog,
+} from "@/lib/notifications/matrix";
 import {
   useApplyTheme,
   useSaveSettings,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,9 @@ import { ExploreScreen } from "@/features/explore/ExploreScreen";
 import { HelpScreen } from "@/features/help/HelpScreen";
 import { MyWorkScreen } from "@/features/mywork/MyWorkScreen";
 import {
+  notificationsDraftOutOfSync,
   RepoNotificationsDialogHost,
+  useNotificationsDraft,
   useRepoNotificationsDialog,
 } from "@/features/notifications/RepoNotificationsDialog";
 import { RepositoryView } from "@/features/repository/RepositoryView";
@@ -55,6 +57,8 @@ function App() {
   const toggleActivity = useUiStore((s) => s.toggleActivity);
   const repoPath = useUiStore((s) => s.repoPath);
   const openRepoNotifications = useRepoNotificationsDialog((s) => s.open);
+  const publishedNotificationsDraft = useNotificationsDraft((s) => s.signature);
+  const clearNotificationsDraft = useNotificationsDraft((s) => s.clear);
   const gitInstalled = useGitInstalled();
   const queryClient = useQueryClient();
   const settings = useSettings();
@@ -68,6 +72,18 @@ function App() {
   // Screens with their own modals (e.g. Explore's clone dialog) register there.
   const screenModalOpen = useModalGateOpen();
   const dialogOpen = cloneOpen || createOpen || screenModalOpen;
+
+  // A mounted settings form publishes its notifications draft; the verdict is
+  // screen-scoped, so leaving Settings retires it. The section can't do this
+  // itself — it unmounts on every panel switch, while the draft it published is
+  // still live in the form.
+  useEffect(() => {
+    if (view !== "settings") clearNotificationsDraft();
+  }, [view, clearNotificationsDraft]);
+  const notificationsDraftHeld = notificationsDraftOutOfSync(
+    publishedNotificationsDraft,
+    settings.data?.notifications,
+  );
 
   // The dialogs live above the view switch, so navigation doesn't unmount them
   // (e.g. the clone dialog's "Open Settings → Accounts") — close them when the
@@ -203,15 +219,25 @@ function App() {
   useHotkeyAction("open-notifications-settings", () =>
     openSettings("notifications"),
   );
-  // The palette closes before it dispatches, so the repo is re-read at fire
-  // time rather than captured — a switch between the two is still honored.
+  // The palette closes before it dispatches, so both the repo and the settings
+  // draft are re-read at fire time rather than captured — the dialog's
+  // mint-on-match baseline is the SAVED matrix, so it must not open over a
+  // settings form still holding notification edits.
   useHotkeyAction(
     "open-repo-notification-settings",
     () => {
       const path = useUiStore.getState().repoPath;
-      if (path) openRepoNotifications(path);
+      if (!path) return;
+      if (
+        notificationsDraftOutOfSync(
+          useNotificationsDraft.getState().signature,
+          settings.data?.notifications,
+        )
+      )
+        return;
+      openRepoNotifications(path);
     },
-    Boolean(repoPath),
+    Boolean(repoPath) && !notificationsDraftHeld,
   );
   useHotkeyAction("show-help", openHelp);
   useHotkeyAction("open-explore", openExplore);

--- a/src/features/actions/useRunNotifications.ts
+++ b/src/features/actions/useRunNotifications.ts
@@ -10,9 +10,11 @@ import {
   isRunActive,
   type WorkflowRun,
 } from "@/lib/github/actions";
-import { notifyIfUnfocused } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
+import { anyChannelOn } from "@/lib/notifications/overrides";
+import { useRepoNotificationOverride } from "@/lib/notifications/queries";
 import { useSettings } from "@/lib/settings/queries";
-import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
+import { repoNameFromPath } from "@/lib/stores/notifications";
 import { isFailureConclusion, statusLabel } from "./status";
 
 /**
@@ -26,13 +28,17 @@ export function useRunNotifications(repoPath: string) {
   const gh = useForgeStatus(repoPath);
   const status = useRepoStatus(repoPath);
   const branch = status.data?.branch.name ?? null;
+  const override = useRepoNotificationOverride(repoPath);
   // Polled for any provider whose CI read is built — GitHub Actions and GitLab
   // pipelines both map onto the same neutral run shape the diff below reads.
+  // The poll shares the emit gate's resolution, so a state that would deliver on
+  // no channel makes no background call; unloaded settings poll nothing.
   const enabled =
     repoPath !== "" &&
     forgeFeatureReady(gh.data, "ci") &&
     Boolean(branch) &&
-    Boolean(settings.data?.notifications.actionRuns);
+    settings.data !== undefined &&
+    anyChannelOn(settings.data.notifications, override, ["actionRuns"]);
 
   const poll = useQuery({
     queryKey: ["repo", repoPath, "actions", "notify", branch ?? ""] as const,
@@ -70,17 +76,20 @@ export function useRunNotifications(repoPath: string) {
         const bad = isFailureConclusion(run.conclusion);
         if (!ok && !bad) continue; // skipped/cancelled/neutral: stay quiet
         const title = `${run.workflowName} ${statusLabel(run.status, run.conclusion).toLowerCase()} on ${run.headBranch}`;
-        pushNotification({
-          kind: "ci-run",
-          tone: ok ? "success" : "danger",
-          title,
-          subtitle: run.displayTitle,
-          repoPath,
-          repoName: repoNameFromPath(repoPath),
-          target: { type: "run", runId: run.id },
-          dedupeKey: `run:${run.id}:${run.conclusion}`,
+        emitNotification({
+          source: "actionRuns",
+          row: {
+            kind: "ci-run",
+            tone: ok ? "success" : "danger",
+            title,
+            subtitle: run.displayTitle,
+            repoPath,
+            repoName: repoNameFromPath(repoPath),
+            target: { type: "run", runId: run.id },
+            dedupeKey: `run:${run.id}:${run.conclusion}`,
+          },
+          os: { title, body: run.displayTitle, focus: "unfocused" },
         });
-        void notifyIfUnfocused(title, run.displayTitle);
       }
     }
   });

--- a/src/features/actions/useRunNotifications.ts
+++ b/src/features/actions/useRunNotifications.ts
@@ -31,8 +31,9 @@ export function useRunNotifications(repoPath: string) {
   const override = useRepoNotificationOverride(repoPath);
   // Polled for any provider whose CI read is built — GitHub Actions and GitLab
   // pipelines both map onto the same neutral run shape the diff below reads.
-  // The poll shares the emit gate's resolution, so a state that would deliver on
-  // no channel makes no background call; unloaded settings poll nothing.
+  // Shares the emit gate's resolution once the override is in hand: it reads undefined
+  // until the overrides query resolves, so a muted repo can still fire its first poll.
+  // Delivery stays correct regardless — emit re-reads the override itself.
   const enabled =
     repoPath !== "" &&
     forgeFeatureReady(gh.data, "ci") &&

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2796,11 +2796,21 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
 - **MCP servers** — register Model Context Protocol servers (secrets in your OS keychain)
   that agent sessions can opt into.
 - **Automations** — AI actions that run on triggers.
-{{/ai}}- **Notifications** — opt into OS notifications (sent only when the window isn't
-  focused) for PR activity, CI checks, reviews on your PRs, and workflow runs finishing.
-  Whatever you enable here also lands in the header's **Activity & notifications** bell — a
-  persistent, click-to-open history (it survives a restart) so a finished review or a PR
-  update is never a missed moment. Open it from the command palette
+{{/ai}}- **Notifications** — pick, for each source, where its events land: a row in the
+  header's **Activity & notifications** bell, an OS notification, both, or neither (a
+  source with both boxes clear records nothing). OS notifications are sent only while the
+  window isn't focused{{ai}}, apart from **Agent tasks finish**, which pings even while
+  you're working elsewhere in the app{{/ai}}. The sources are **CI checks finish (pass or
+  fail)** (which also carries a **Watch** choice of *My pull requests only* or *All open
+  pull requests*), **Pull requests opened, merged, or closed**, **Reviews on my pull
+  requests**, and **Workflow runs finish on the current branch**{{ai}}, plus **AI reviews
+  I start**, **Automation results**, and **Agent tasks finish**{{/ai}}. **Customize…**
+  opens the per-repository overrides: **Mute this repository** silences every source for
+  that repo, or set single cells and its **Watch** choice, with anything you leave alone
+  following your global settings. *Notification settings* and *Repository notification
+  settings* in the command palette open each directly.
+  The bell is a persistent, click-to-open history (it survives a restart) so a finished
+  review or a PR update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump
   to it, arrow-key through the list, and clear items or mark all read. A
   pull-request entry opens that PR on the tab its event happened on, under the
@@ -2810,9 +2820,10 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   **automated** review or security audit is cancelled or fails, it stays in the popover
   under a **Stopped** group with **Re-run** (re-fires exactly that run's mode) and
   **Dismiss** — a stopped row notes how long it ran before it stopped — and a failed
-  automated run also lands a *review failed* row in the inbox (gated on the automations
-  notification preference) that shows why it failed and offers a one-click **Re-run** right
-  from the row, matching manual-run failures (which show their reason too).{{/ai}}
+  automated run also lands a *review failed* row in the inbox (whenever the **Automation
+  results** source keeps its in-app channel on) that shows why it failed and offers a
+  one-click **Re-run** right from the row, matching manual-run failures (which show their
+  reason too).{{/ai}}
 - **Keyboard** — rebind any shortcut, with live key-capture, filterable by name, category,
   or key.
 - **Accounts** — your **GitHub** and **GitLab** sign-ins and your **Bitbucket**

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -2806,9 +2806,9 @@ Open **Settings** from the header gear (or {{kbd:open-settings}}). Sections:
   requests**, and **Workflow runs finish on the current branch**{{ai}}, plus **AI reviews
   I start**, **Automation results**, and **Agent tasks finish**{{/ai}}. **Customize…**
   opens the per-repository overrides: **Mute this repository** silences every source for
-  that repo, or set single cells and its **Watch** choice, with anything you leave alone
-  following your global settings. *Notification settings* and *Repository notification
-  settings* in the command palette open each directly.
+  that repo, or you can set individual cells and the CI-checks **Watch** choice, with
+  anything you leave alone following your global settings. *Notification settings* and
+  *Repository notification settings* in the command palette open each directly.
   The bell is a persistent, click-to-open history (it survives a restart) so a finished
   review or a PR update is never a missed moment. Open it from the command palette
   ({{kbd:command-palette}} → *Activity & notifications*), click an entry to jump

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -6,7 +6,6 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
-import { create } from "zustand";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { SelectClipText } from "@/components/select-clip-text";
 import { Button } from "@/components/ui/button";
@@ -31,6 +30,20 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { clipTitleFromText } from "@/lib/clip-title";
 import { useRepoIdentity } from "@/lib/git/queries";
 import {
+  CHANNEL_LABELS,
+  CHANNELS,
+  CHECK_SCOPE_LABELS,
+  CHECKS_OFF_WATCH_REASON,
+  type Channel,
+  channelAriaLabel,
+  notificationRows,
+  overrideCount,
+  SOURCE_DESCRIPTIONS,
+  SOURCE_LABELS,
+  sortedJson,
+  useRepoNotificationsDialog,
+} from "@/lib/notifications/matrix";
+import {
   effectiveChannels,
   effectiveChecksScope,
   overrideEntry,
@@ -40,12 +53,10 @@ import {
   useNotificationOverrides,
   useSaveRepoNotificationOverride,
 } from "@/lib/notifications/queries";
-import {
-  type ChannelPrefs,
-  NOTIFICATION_SOURCES,
-  type NotificationSettings,
-  type NotificationSource,
-  type PrCheckScopeFilter,
+import type {
+  ChannelPrefs,
+  NotificationSource,
+  PrCheckScopeFilter,
 } from "@/lib/settings/api";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import { toastError } from "@/lib/toast";
@@ -54,75 +65,21 @@ import { useRetained } from "@/lib/use-retained";
 import { useSeedOnOpen } from "@/lib/use-seed-on-open";
 import { cn } from "@/lib/utils";
 
-// ── Shared vocabulary (imported by Settings → Notifications) ────────────────
-
-/** Delivery channels in column order; the matrix's DOM order is row-major over
- *  this list, so the tab order matches what a reader hears. */
-export const CHANNELS = ["inApp", "os"] as const;
-export type Channel = (typeof CHANNELS)[number];
-
-export const CHANNEL_LABELS: Record<Channel, string> = {
-  inApp: "In-app",
-  os: "OS",
-};
-
-/** Spoken channel word inside a cell's aria-label — the column header is a
- *  `<th scope="col">`, but a checkbox still needs a name of its own. */
-const CHANNEL_ARIA: Record<Channel, string> = {
-  inApp: "in-app",
-  os: "OS",
-};
-
-/** Record-typed against the manifest, so a new source can't ship label-less. */
-export const SOURCE_LABELS: Record<NotificationSource, string> = {
-  prChecks: "CI checks finish (pass or fail)",
-  prActivity: "Pull requests opened, merged, or closed",
-  prReviews: "Reviews on my pull requests",
-  actionRuns: "Workflow runs finish on the current branch",
-  reviews: "AI reviews I start",
-  automations: "Automation results",
-  agents: "Agent tasks finish",
-};
-
-/** Second line under a row's label; a source with nothing to add carries none. */
-export const SOURCE_DESCRIPTIONS: Partial<Record<NotificationSource, string>> =
-  {
-    prReviews:
-      "Approvals, change requests, comments, and requests for your review",
-    reviews: "A review or security audit finishing in the background",
-    automations: "Automated reviews ready, posted, or failed",
-    agents: "Sessions, plans, and research",
-  };
-
-/** Sources hidden with the AI surfaces. */
-const AI_SOURCES: ReadonlySet<NotificationSource> = new Set<NotificationSource>(
-  ["reviews", "automations", "agents"],
-);
-
-export const CHECK_SCOPE_LABELS: Record<PrCheckScopeFilter, string> = {
-  mine: "My pull requests only",
-  all: "All open pull requests",
-};
-
-/** The rows the matrix renders, in manifest order. Hidden AI rows keep whatever
- *  the draft holds — they are omitted from the view, never rewritten. */
-export function notificationRows(
-  aiEnabled: boolean,
-): readonly NotificationSource[] {
-  return aiEnabled
-    ? NOTIFICATION_SOURCES
-    : NOTIFICATION_SOURCES.filter((source) => !AI_SOURCES.has(source));
-}
-
-export function channelAriaLabel(rowLabel: string, channel: Channel): string {
-  return `${rowLabel} — ${CHANNEL_ARIA[channel]}`;
-}
-
-/** The source × channel grid. A real table with scoped headers: the row and
- *  column headers ARE the a11y wiring, which is why no LabeledGroup wraps it. */
-export function MatrixTable({ children }: { children: ReactNode }) {
+/** The source × channel grid. A real table with scoped headers: the caption
+ *  names it for table navigation, and the row and column headers ARE the rest of
+ *  the a11y wiring — which is why no LabeledGroup wraps it. */
+export function MatrixTable({
+  caption,
+  children,
+}: {
+  /** Names the table for assistive tech; required, since a reader landing on an
+   *  unnamed grid has nothing to tell it apart from the other one. */
+  caption: string;
+  children: ReactNode;
+}) {
   return (
     <table className="w-full border-collapse text-xs">
+      <caption className="sr-only">{caption}</caption>
       <thead>
         <tr>
           <th className="w-full" />
@@ -184,11 +141,6 @@ const OVERRIDDEN_CHIP = (
     overridden
   </span>
 );
-
-/** Why the scope picker is held while the CI-checks source delivers nowhere.
- *  Shared so the global matrix and the per-repo dialog say the same sentence. */
-export const CHECKS_OFF_WATCH_REASON =
-  "Turn on a CI checks channel to choose which pull requests to watch";
 
 /**
  * Which pull requests the CI-checks source watches. Composed from the Select
@@ -280,73 +232,7 @@ export function WatchRow(props: ComponentProps<typeof WatchSelect>) {
   );
 }
 
-// ── Open-state store + host ─────────────────────────────────────────────────
-
-interface RepoNotificationsDialogState {
-  /** Repo path whose notifications are open, or null when closed. */
-  repoPath: string | null;
-  /** Bumped by every `open()`. An awaited save that outlived its own dialog
-   *  compares this to tell "still my dialog" from "a later one for the same
-   *  repo" — the repo path alone can't, and the two hold different edits. */
-  generation: number;
-  open: (repoPath: string) => void;
-  close: () => void;
-}
-
-/** Open-state for the one mounted {@link RepoNotificationsDialogHost}, so the
- *  settings footer, the overrides audit list, and the command palette all reach
- *  the same dialog without threading props or mounting a second copy. */
-export const useRepoNotificationsDialog =
-  create<RepoNotificationsDialogState>()((set) => ({
-    repoPath: null,
-    generation: 0,
-    open: (repoPath) =>
-      set((s) => ({ repoPath, generation: s.generation + 1 })),
-    close: () => set({ repoPath: null }),
-  }));
-
-interface NotificationsDraftState {
-  /** Fingerprint of the notifications slice a MOUNTED settings form holds, or
-   *  null when no settings screen is on. */
-  signature: string | null;
-  publish: (signature: string) => void;
-  clear: () => void;
-}
-
-/** What a live settings form is holding for notifications, so routes into the
- *  per-repo dialog that render OUTSIDE the form (the command palette) can see
- *  it. Screen-scoped, not panel-scoped: the draft survives a panel switch, so
- *  the section never clears on unmount and App retires it on leaving Settings —
- *  a flag that outlived its screen would hold the palette action shut forever. */
-export const useNotificationsDraft = create<NotificationsDraftState>()(
-  (set) => ({
-    signature: null,
-    publish: (signature) => set({ signature }),
-    clear: () => set({ signature: null }),
-  }),
-);
-
-/**
- * Whether a live settings form holds notification edits the store hasn't taken
- * yet. Per-repo overrides are minted against the SAVED matrix, so opening the
- * dialog over an unsaved draft lets a user "change" a cell the dialog already
- * reads as global — it stores nothing, and the pending Save then moves the
- * global underneath it.
- *
- * The published signature carries the draft it was produced under and is
- * compared against the live saved value rather than cleared by every writer, so
- * a Save from another panel resolves it on its own. A Discard from another
- * panel can't be seen — the section is unmounted — and leaves the verdict set
- * until the screen closes: the fail-safe direction, since the section's own
- * Customize button stays correct and reachable.
- */
-export function notificationsDraftOutOfSync(
-  published: string | null,
-  saved: NotificationSettings | undefined,
-): boolean {
-  if (published === null || saved === undefined) return false;
-  return published !== notificationsSignature(saved);
-}
+// ── Dialog + host ───────────────────────────────────────────────────────────
 
 const EMPTY_OVERRIDE: RepoNotificationOverride = {};
 
@@ -383,41 +269,6 @@ function OverridesLoadFailed({ onRetry }: { onRetry: () => void }) {
       </Button>
     </div>
   );
-}
-
-function sortedJson(value: unknown): string {
-  return JSON.stringify(value, (_key, val) =>
-    val && typeof val === "object" && !Array.isArray(val)
-      ? Object.fromEntries(
-          Object.keys(val as Record<string, unknown>)
-            .sort()
-            .map((k) => [k, (val as Record<string, unknown>)[k]]),
-        )
-      : val,
-  );
-}
-
-/** Key-order-insensitive fingerprint of the global notification settings. The
- *  dialog's mint/drop-on-match baseline is the SAVED value, so the settings
- *  screen compares its draft against this to know when the two disagree. */
-export function notificationsSignature(value: NotificationSettings): string {
-  return sortedJson(value);
-}
-
-/** How many individual settings an override pins — each channel field plus the
- *  scope. The Reset gate and the settings footer's status line both count it. */
-export function overrideCount(
-  override: RepoNotificationOverride | undefined,
-): number {
-  if (!override) return 0;
-  let count = override.prChecksScope === undefined ? 0 : 1;
-  for (const source of NOTIFICATION_SOURCES) {
-    const cell = override.sources?.[source];
-    if (!cell) continue;
-    if (cell.inApp !== undefined) count += 1;
-    if (cell.os !== undefined) count += 1;
-  }
-  return count;
 }
 
 /**
@@ -645,7 +496,7 @@ function RepoNotificationsBody({
                 {mutedReason}
               </p>
             ) : null}
-            <MatrixTable>
+            <MatrixTable caption="Notification channels for this repository">
               {rows.map((source) => {
                 const channels = effectiveChannels(global, draft, source);
                 const label = SOURCE_LABELS[source];

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -260,11 +260,11 @@ function bodyState({
 /** Either side of the baseline failed to load. Offers the retry rather than a
  *  dead dialog: neither loader memoizes its rejection, so a storage hiccup can
  *  genuinely clear. */
-function OverridesLoadFailed({ onRetry }: { onRetry: () => void }) {
+function BaselineLoadFailed({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="space-y-2">
       <p className="text-xs text-muted-foreground">
-        Couldn't load this repository's overrides.
+        Couldn't load your notification settings.
       </p>
       <Button variant="outline" size="xs" onClick={onRetry}>
         Retry
@@ -472,7 +472,7 @@ function RepoNotificationsBody({
   // while there is no baseline to save against.
   function saveBlockedReason(): string | null {
     if (save.isPending) return "Saving…";
-    if (state === "error") return "Couldn't load this repository's overrides";
+    if (state === "error") return "Couldn't load your notification settings";
     if (!dirty) return "No changes to save";
     return null;
   }
@@ -486,7 +486,7 @@ function RepoNotificationsBody({
         {/* Retries BOTH halves: the arm fires for either failure, and refetching
             only one leaves the other's error in place. */}
         {state === "error" && (
-          <OverridesLoadFailed
+          <BaselineLoadFailed
             onRetry={() => {
               overrides.refetch();
               settings.refetch();

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -1,0 +1,600 @@
+import {
+  type ComponentProps,
+  Fragment,
+  type ReactNode,
+  useId,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import { create } from "zustand";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { SelectClipText } from "@/components/select-clip-text";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { clipTitleFromText } from "@/lib/clip-title";
+import { useRepoIdentity } from "@/lib/git/queries";
+import {
+  effectiveChannels,
+  effectiveChecksScope,
+  overrideEntry,
+  type RepoNotificationOverride,
+} from "@/lib/notifications/overrides";
+import {
+  useNotificationOverrides,
+  useSaveRepoNotificationOverride,
+} from "@/lib/notifications/queries";
+import {
+  type ChannelPrefs,
+  NOTIFICATION_SOURCES,
+  type NotificationSettings,
+  type NotificationSource,
+  type PrCheckScopeFilter,
+} from "@/lib/settings/api";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
+import { toastError } from "@/lib/toast";
+import { ARIA_DISABLED_CLASS } from "@/lib/use-disabled-reason";
+import { useRetained } from "@/lib/use-retained";
+import { useSeedOnOpen } from "@/lib/use-seed-on-open";
+import { cn } from "@/lib/utils";
+
+// ── Shared vocabulary (imported by Settings → Notifications) ────────────────
+
+/** Delivery channels in column order; the matrix's DOM order is row-major over
+ *  this list, so the tab order matches what a reader hears. */
+export const CHANNELS = ["inApp", "os"] as const;
+export type Channel = (typeof CHANNELS)[number];
+
+export const CHANNEL_LABELS: Record<Channel, string> = {
+  inApp: "In-app",
+  os: "OS",
+};
+
+/** Spoken channel word inside a cell's aria-label — the column header is a
+ *  `<th scope="col">`, but a checkbox still needs a name of its own. */
+const CHANNEL_ARIA: Record<Channel, string> = {
+  inApp: "in-app",
+  os: "OS",
+};
+
+/** Record-typed against the manifest, so a new source can't ship label-less. */
+export const SOURCE_LABELS: Record<NotificationSource, string> = {
+  prChecks: "CI checks finish (pass or fail)",
+  prActivity: "Pull requests opened, merged, or closed",
+  prReviews: "Reviews on my pull requests",
+  actionRuns: "Workflow runs finish on the current branch",
+  reviews: "AI reviews I start",
+  automations: "Automation results",
+  agents: "Agent tasks finish",
+};
+
+/** Second line under a row's label; a source with nothing to add carries none. */
+export const SOURCE_DESCRIPTIONS: Partial<Record<NotificationSource, string>> =
+  {
+    prReviews:
+      "Approvals, change requests, comments, and requests for your review",
+    reviews: "A review or security audit finishing in the background",
+    automations: "Automated reviews ready, posted, or failed",
+    agents: "Sessions, plans, and research",
+  };
+
+/** Sources hidden with the AI surfaces. */
+const AI_SOURCES: ReadonlySet<NotificationSource> = new Set<NotificationSource>(
+  ["reviews", "automations", "agents"],
+);
+
+export const CHECK_SCOPE_LABELS: Record<PrCheckScopeFilter, string> = {
+  mine: "My pull requests only",
+  all: "All open pull requests",
+};
+
+/** The rows the matrix renders, in manifest order. Hidden AI rows keep whatever
+ *  the draft holds — they are omitted from the view, never rewritten. */
+export function notificationRows(
+  aiEnabled: boolean,
+): readonly NotificationSource[] {
+  return aiEnabled
+    ? NOTIFICATION_SOURCES
+    : NOTIFICATION_SOURCES.filter((source) => !AI_SOURCES.has(source));
+}
+
+export function channelAriaLabel(rowLabel: string, channel: Channel): string {
+  return `${rowLabel} — ${CHANNEL_ARIA[channel]}`;
+}
+
+/** The source × channel grid. A real table with scoped headers: the row and
+ *  column headers ARE the a11y wiring, which is why no LabeledGroup wraps it. */
+export function MatrixTable({ children }: { children: ReactNode }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr>
+          <th className="w-full" />
+          {CHANNELS.map((channel) => (
+            <th
+              key={channel}
+              scope="col"
+              className="px-2 pb-1 text-center align-bottom font-medium whitespace-nowrap text-muted-foreground"
+            >
+              {CHANNEL_LABELS[channel]}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+/** A row's label cell — the `<th scope="row">` every cell in the row is named
+ *  by, plus its optional muted description line. */
+export function RowLabelCell({
+  label,
+  description,
+  chip,
+  className,
+}: {
+  label: ReactNode;
+  description?: ReactNode;
+  /** Muted word-chip (never color alone) marking the row as overridden. */
+  chip?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <th
+      scope="row"
+      className={cn("py-1.5 pr-2 text-left font-normal", className)}
+    >
+      <span className="flex items-center gap-1.5">
+        <span>{label}</span>
+        {chip}
+      </span>
+      {description ? (
+        <span className="mt-0.5 block text-[11px] font-normal text-muted-foreground">
+          {description}
+        </span>
+      ) : null}
+    </th>
+  );
+}
+
+/** Cell wrapper, so every checkbox sits in the same box in both matrices. */
+export function MatrixCell({ children }: { children: ReactNode }) {
+  return <td className="px-2 py-1.5 text-center align-top">{children}</td>;
+}
+
+const OVERRIDDEN_CHIP = (
+  <span className="border px-1 text-[10px] text-muted-foreground">
+    overridden
+  </span>
+);
+
+/** Why the scope picker is held while the CI-checks source delivers nowhere.
+ *  Shared so the global matrix and the per-repo dialog say the same sentence. */
+export const CHECKS_OFF_WATCH_REASON =
+  "Turn on a CI checks channel to choose which pull requests to watch";
+
+/**
+ * Which pull requests the CI-checks source watches. Composed from the Select
+ * primitives rather than SelectField for two reasons the wrapper can't serve:
+ * the reason has to reach the trigger through `aria-describedby`, and a held
+ * picker must stay in the tab order — Base UI's `disabled` sets `tabIndex={-1}`
+ * on the trigger, which would put the control and its reason out of reach.
+ * `readOnly` locks the value (including closed-trigger typeahead) but still
+ * lets the popup open, so the open state is controlled and gated here too.
+ */
+function WatchSelect({
+  value,
+  onValueChange,
+  disabledReason,
+  sharedReasonId,
+  chip,
+}: {
+  value: PrCheckScopeFilter;
+  onValueChange: (value: PrCheckScopeFilter) => void;
+  /** Non-null holds the select and renders the reason as a visible line. */
+  disabledReason?: string | null;
+  /** Id of a reason line the caller already shows for a whole group of
+   *  controls; set, the select points at that instead of printing a copy. */
+  sharedReasonId?: string;
+  chip?: ReactNode;
+}) {
+  const id = useId();
+  const ownReasonId = useId();
+  const reasonId = sharedReasonId ?? ownReasonId;
+  const held = !!disabledReason;
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-1">
+      <span className="flex items-center gap-1.5">
+        <Label htmlFor={id}>Watch</Label>
+        {chip}
+      </span>
+      <Select
+        items={CHECK_SCOPE_LABELS}
+        value={value}
+        onValueChange={(v) => {
+          if (v) onValueChange(v as PrCheckScopeFilter);
+        }}
+        readOnly={held}
+        open={open}
+        onOpenChange={(next) => {
+          if (!held) setOpen(next);
+        }}
+      >
+        <SelectTrigger
+          id={id}
+          size="sm"
+          className={cn("w-full", ARIA_DISABLED_CLASS)}
+          aria-disabled={held || undefined}
+          aria-describedby={held ? reasonId : undefined}
+        >
+          <SelectValue onMouseEnter={clipTitleFromText} />
+        </SelectTrigger>
+        <SelectContent>
+          {(Object.keys(CHECK_SCOPE_LABELS) as PrCheckScopeFilter[]).map(
+            (scope) => (
+              <SelectItem key={scope} value={scope}>
+                <SelectClipText>{CHECK_SCOPE_LABELS[scope]}</SelectClipText>
+              </SelectItem>
+            ),
+          )}
+        </SelectContent>
+      </Select>
+      {disabledReason && !sharedReasonId ? (
+        <p id={ownReasonId} className="text-[11px] text-muted-foreground">
+          {disabledReason}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** The Watch picker as a matrix sub-row, indented under the CI-checks row it
+ *  qualifies. The channel columns stay empty: the scope is orthogonal to the
+ *  channels, so it has no cell of its own to fill. */
+export function WatchRow(props: ComponentProps<typeof WatchSelect>) {
+  return (
+    <tr>
+      <td className="py-1.5 pr-2 pl-4">
+        <WatchSelect {...props} />
+      </td>
+      <td colSpan={CHANNELS.length} />
+    </tr>
+  );
+}
+
+// ── Open-state store + host ─────────────────────────────────────────────────
+
+interface RepoNotificationsDialogState {
+  /** Repo path whose notifications are open, or null when closed. */
+  repoPath: string | null;
+  open: (repoPath: string) => void;
+  close: () => void;
+}
+
+/** Open-state for the one mounted {@link RepoNotificationsDialogHost}, so the
+ *  settings footer, the overrides audit list, and the command palette all reach
+ *  the same dialog without threading props or mounting a second copy. */
+export const useRepoNotificationsDialog =
+  create<RepoNotificationsDialogState>()((set) => ({
+    repoPath: null,
+    open: (repoPath) => set({ repoPath }),
+    close: () => set({ repoPath: null }),
+  }));
+
+const EMPTY_OVERRIDE: RepoNotificationOverride = {};
+
+function sortedJson(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.fromEntries(
+          Object.keys(val as Record<string, unknown>)
+            .sort()
+            .map((k) => [k, (val as Record<string, unknown>)[k]]),
+        )
+      : val,
+  );
+}
+
+/** Key-order-insensitive fingerprint of the global notification settings. The
+ *  dialog's mint/drop-on-match baseline is the SAVED value, so the settings
+ *  screen compares its draft against this to know when the two disagree. */
+export function notificationsSignature(value: NotificationSettings): string {
+  return sortedJson(value);
+}
+
+/** How many individual settings an override pins — each channel field plus the
+ *  scope. The Reset gate and the settings footer's status line both count it. */
+export function overrideCount(
+  override: RepoNotificationOverride | undefined,
+): number {
+  if (!override) return 0;
+  let count = override.prChecksScope === undefined ? 0 : 1;
+  for (const source of NOTIFICATION_SOURCES) {
+    const cell = override.sources?.[source];
+    if (!cell) continue;
+    if (cell.inApp !== undefined) count += 1;
+    if (cell.os !== undefined) count += 1;
+  }
+  return count;
+}
+
+/**
+ * One repository's notification overrides: per-cell adjustments on top of the
+ * global matrix. Edited as a draft behind Cancel / Save changes; a cell edited
+ * back to the global value drops its override (inherits again).
+ */
+export function RepoNotificationsDialogHost() {
+  const repoPath = useRepoNotificationsDialog((s) => s.repoPath);
+  const close = useRepoNotificationsDialog((s) => s.close);
+  // Retained so the body keeps its repo through the close fade instead of
+  // blanking the dialog as it animates out.
+  const shownRepo = useRetained(repoPath);
+
+  return (
+    <Dialog
+      open={repoPath !== null}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      {/* Capped flex column: the header and footer stay pinned while the mute
+          row, the matrix, and the Watch select scroll as one body. */}
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Repository notifications</DialogTitle>
+          <DialogDescription>
+            What notifies from this repository. Cells start from your defaults
+            in Settings → Notifications; change one here to override it for this
+            repository only.
+          </DialogDescription>
+        </DialogHeader>
+        {shownRepo !== null && (
+          <RepoNotificationsBody
+            // A repo switch while the dialog is open must not carry the draft
+            // across; the key makes that structural rather than an effect.
+            key={shownRepo}
+            repoPath={shownRepo}
+            open={repoPath !== null}
+            onClose={close}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RepoNotificationsBody({
+  repoPath,
+  open,
+  onClose,
+}: {
+  repoPath: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const aiEnabled = useAiEnabled();
+  const settings = useSettings();
+  const overrides = useNotificationOverrides();
+  const save = useSaveRepoNotificationOverride(repoPath);
+  // One reason line for the whole muted group — the grid's cells and the Watch
+  // select all point at it rather than each repeating the sentence.
+  const mutedReasonId = useId();
+  // Worktree-stable identity, so a linked worktree edits the same entry as its
+  // main checkout; the raw path stands in while it resolves.
+  const identity = useRepoIdentity(repoPath).data;
+
+  const saved = overrides.data
+    ? (overrideEntry(overrides.data, identity ?? repoPath, repoPath) ??
+      EMPTY_OVERRIDE)
+    : EMPTY_OVERRIDE;
+
+  // null = untouched, so the draft follows the saved override (and any refetch
+  // of it) until the user's first edit — no seeding effect to race the query.
+  const [edited, setEdited] = useState<RepoNotificationOverride | null>(null);
+  useSeedOnOpen(open, () => setEdited(null));
+
+  const draft = edited ?? saved;
+  const dirty = edited !== null && sortedJson(edited) !== sortedJson(saved);
+  const global = settings.data?.notifications;
+  const rows = notificationRows(aiEnabled);
+  const muted = draft.muted === true;
+  const mutedReason = muted
+    ? "Muted — nothing from this repository notifies."
+    : null;
+  // The scope is held for the same reason it is in the global matrix — a source
+  // delivering on no channel has nothing to watch — read off the EFFECTIVE
+  // channels so an inherited pair counts. Muting zeroes both, so it is tested
+  // first and its sentence wins.
+  const checksChannels = global
+    ? effectiveChannels(global, draft, "prChecks")
+    : null;
+  const watchReason =
+    mutedReason ??
+    (checksChannels && !checksChannels.inApp && !checksChannels.os
+      ? CHECKS_OFF_WATCH_REASON
+      : null);
+
+  function patch(
+    mutate: (current: RepoNotificationOverride) => RepoNotificationOverride,
+  ) {
+    setEdited((current) => mutate(current ?? saved));
+  }
+
+  function toggleMuted(next: boolean) {
+    patch((current) => {
+      const out = { ...current };
+      if (next) out.muted = true;
+      else delete out.muted;
+      return out;
+    });
+  }
+
+  // An override is stored only where the resulting cell differs from the global
+  // value; edited back to match, the field is dropped and the cell inherits.
+  function patchCell(
+    source: NotificationSource,
+    channel: Channel,
+    next: boolean,
+  ) {
+    if (!global) return;
+    patch((current) => {
+      const sources = { ...(current.sources ?? {}) };
+      const cell: Partial<ChannelPrefs> = { ...sources[source] };
+      if (next === global.sources[source][channel]) delete cell[channel];
+      else cell[channel] = next;
+      if (cell.inApp === undefined && cell.os === undefined)
+        delete sources[source];
+      else sources[source] = cell;
+      const out = { ...current };
+      if (Object.keys(sources).length === 0) delete out.sources;
+      else out.sources = sources;
+      return out;
+    });
+  }
+
+  function setScope(next: PrCheckScopeFilter) {
+    if (!global) return;
+    patch((current) => {
+      const out = { ...current };
+      if (next === global.prChecksScope) delete out.prChecksScope;
+      else out.prChecksScope = next;
+      return out;
+    });
+  }
+
+  async function doSave() {
+    try {
+      await save.mutateAsync(draft);
+      toast.success("Repository notifications saved");
+      onClose();
+    } catch (e) {
+      toastError(e);
+    }
+  }
+
+  const hasOverrides = muted || overrideCount(draft) > 0;
+
+  return (
+    <>
+      {/* overflow-x-hidden alongside overflow-y-auto so the vertical scrollbar's
+          width can't induce a phantom horizontal one. */}
+      <div className="min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto pr-1">
+        {!global || overrides.isPending ? (
+          <Skeleton className="h-40 w-full" />
+        ) : (
+          <>
+            <label className="flex cursor-pointer items-center gap-2 text-xs">
+              <Checkbox
+                checked={muted}
+                onCheckedChange={(checked) => toggleMuted(checked === true)}
+              />
+              Mute this repository
+            </label>
+            {mutedReason ? (
+              <p
+                id={mutedReasonId}
+                className="text-[11px] text-muted-foreground"
+              >
+                {mutedReason}
+              </p>
+            ) : null}
+            <MatrixTable>
+              {rows.map((source) => {
+                const channels = effectiveChannels(global, draft, source);
+                const label = SOURCE_LABELS[source];
+                return (
+                  <Fragment key={source}>
+                    <tr>
+                      <RowLabelCell
+                        label={label}
+                        description={SOURCE_DESCRIPTIONS[source]}
+                        chip={draft.sources?.[source] ? OVERRIDDEN_CHIP : null}
+                      />
+                      {CHANNELS.map((channel) => (
+                        <MatrixCell key={channel}>
+                          {/* Held, never natively disabled: a disabled checkbox
+                              leaves the tab order and takes its reason with it.
+                              `readOnly` is the primitive's own interaction
+                              block and keeps the cell focusable. */}
+                          <Checkbox
+                            checked={channels[channel]}
+                            readOnly={muted}
+                            aria-disabled={muted || undefined}
+                            aria-label={channelAriaLabel(label, channel)}
+                            aria-describedby={muted ? mutedReasonId : undefined}
+                            className={ARIA_DISABLED_CLASS}
+                            onCheckedChange={(checked) =>
+                              patchCell(source, channel, checked === true)
+                            }
+                          />
+                        </MatrixCell>
+                      ))}
+                    </tr>
+                    {source === "prChecks" && (
+                      <WatchRow
+                        value={effectiveChecksScope(global, draft)}
+                        onValueChange={setScope}
+                        disabledReason={watchReason}
+                        sharedReasonId={muted ? mutedReasonId : undefined}
+                        chip={
+                          draft.prChecksScope !== undefined
+                            ? OVERRIDDEN_CHIP
+                            : null
+                        }
+                      />
+                    )}
+                  </Fragment>
+                );
+              })}
+            </MatrixTable>
+            <div className="flex justify-end">
+              <DisabledReasonButton
+                variant="ghost"
+                size="xs"
+                onClick={() => setEdited(EMPTY_OVERRIDE)}
+                disabled={!hasOverrides}
+                reason="No overrides to reset"
+                title="Remove all overrides and inherit the global defaults"
+              >
+                Reset to global defaults
+              </DisabledReasonButton>
+            </div>
+          </>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <DisabledReasonButton
+          // Below `sm` the footer stacks and stretches the wrapper span; the
+          // Button fills it to match the stretched Cancel beside it.
+          className="w-full"
+          onClick={doSave}
+          disabled={!dirty || save.isPending}
+          reason={save.isPending ? "Saving…" : "No changes to save"}
+        >
+          Save changes
+        </DisabledReasonButton>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -257,9 +257,10 @@ function bodyState({
   return "ready";
 }
 
-/** Either side of the baseline failed to load. Offers the retry rather than a
- *  dead dialog: neither loader memoizes its rejection, so a storage hiccup can
- *  genuinely clear. */
+/** Either half of the baseline failed to load. Retry is worth offering: the
+ *  overrides loader clears its memo on a rejected load, and a settings read that
+ *  failed at `store.get` retries too — only a rejected settings `load()` stays
+ *  pinned until relaunch. */
 function BaselineLoadFailed({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="space-y-2">

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -285,6 +285,10 @@ export function WatchRow(props: ComponentProps<typeof WatchSelect>) {
 interface RepoNotificationsDialogState {
   /** Repo path whose notifications are open, or null when closed. */
   repoPath: string | null;
+  /** Bumped by every `open()`. An awaited save that outlived its own dialog
+   *  compares this to tell "still my dialog" from "a later one for the same
+   *  repo" — the repo path alone can't, and the two hold different edits. */
+  generation: number;
   open: (repoPath: string) => void;
   close: () => void;
 }
@@ -295,11 +299,91 @@ interface RepoNotificationsDialogState {
 export const useRepoNotificationsDialog =
   create<RepoNotificationsDialogState>()((set) => ({
     repoPath: null,
-    open: (repoPath) => set({ repoPath }),
+    generation: 0,
+    open: (repoPath) =>
+      set((s) => ({ repoPath, generation: s.generation + 1 })),
     close: () => set({ repoPath: null }),
   }));
 
+interface NotificationsDraftState {
+  /** Fingerprint of the notifications slice a MOUNTED settings form holds, or
+   *  null when no settings screen is on. */
+  signature: string | null;
+  publish: (signature: string) => void;
+  clear: () => void;
+}
+
+/** What a live settings form is holding for notifications, so routes into the
+ *  per-repo dialog that render OUTSIDE the form (the command palette) can see
+ *  it. Screen-scoped, not panel-scoped: the draft survives a panel switch, so
+ *  the section never clears on unmount and App retires it on leaving Settings —
+ *  a flag that outlived its screen would hold the palette action shut forever. */
+export const useNotificationsDraft = create<NotificationsDraftState>()(
+  (set) => ({
+    signature: null,
+    publish: (signature) => set({ signature }),
+    clear: () => set({ signature: null }),
+  }),
+);
+
+/**
+ * Whether a live settings form holds notification edits the store hasn't taken
+ * yet. Per-repo overrides are minted against the SAVED matrix, so opening the
+ * dialog over an unsaved draft lets a user "change" a cell the dialog already
+ * reads as global — it stores nothing, and the pending Save then moves the
+ * global underneath it.
+ *
+ * The published signature carries the draft it was produced under and is
+ * compared against the live saved value rather than cleared by every writer, so
+ * a Save from another panel resolves it on its own. A Discard from another
+ * panel can't be seen — the section is unmounted — and leaves the verdict set
+ * until the screen closes: the fail-safe direction, since the section's own
+ * Customize button stays correct and reachable.
+ */
+export function notificationsDraftOutOfSync(
+  published: string | null,
+  saved: NotificationSettings | undefined,
+): boolean {
+  if (published === null || saved === undefined) return false;
+  return published !== notificationsSignature(saved);
+}
+
 const EMPTY_OVERRIDE: RepoNotificationOverride = {};
+
+/** Which body the dialog shows. A failed overrides load is its OWN state, never
+ *  a slow one: the query settles with no data, so a loading placeholder would
+ *  spin forever and an editable matrix would edit against nothing. */
+function bodyState({
+  error,
+  loaded,
+  identityPending,
+}: {
+  error: boolean;
+  loaded: boolean;
+  /** The repo's identity keys the lookup, so an editable matrix has to wait for
+   *  it — an identity-keyed override is invisible until it resolves. */
+  identityPending: boolean;
+}): "error" | "loading" | "ready" {
+  if (error) return "error";
+  if (!loaded || identityPending) return "loading";
+  return "ready";
+}
+
+/** The overrides store failed to load. Offers the retry rather than a dead
+ *  dialog: the store's loader doesn't memoize its rejection, so a storage
+ *  hiccup can genuinely clear. */
+function OverridesLoadFailed({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Couldn't load this repository's overrides.
+      </p>
+      <Button variant="outline" size="xs" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
 
 function sortedJson(value: unknown): string {
   return JSON.stringify(value, (_key, val) =>
@@ -398,22 +482,41 @@ function RepoNotificationsBody({
   // select all point at it rather than each repeating the sentence.
   const mutedReasonId = useId();
   // Worktree-stable identity, so a linked worktree edits the same entry as its
-  // main checkout; the raw path stands in while it resolves.
-  const identity = useRepoIdentity(repoPath).data;
+  // main checkout. The raw path is the SETTLED fallback (the resolver returns it
+  // when git can't answer), never a stand-in to edit against while the lookup is
+  // still pending — see the skeleton gate below.
+  const identityQuery = useRepoIdentity(repoPath);
+  const identity = identityQuery.data;
 
+  // undefined until the stored overrides are actually in hand. EMPTY is only
+  // honest once the load SUCCEEDED and found nothing: a failed load standing in
+  // as "no overrides" would let a Save replace the repo's real entry.
   const saved = overrides.data
     ? (overrideEntry(overrides.data, identity ?? repoPath, repoPath) ??
       EMPTY_OVERRIDE)
-    : EMPTY_OVERRIDE;
+    : undefined;
 
   // null = untouched, so the draft follows the saved override (and any refetch
   // of it) until the user's first edit — no seeding effect to race the query.
   const [edited, setEdited] = useState<RepoNotificationOverride | null>(null);
   useSeedOnOpen(open, () => setEdited(null));
 
-  const draft = edited ?? saved;
-  const dirty = edited !== null && sortedJson(edited) !== sortedJson(saved);
   const global = settings.data?.notifications;
+  // Which of the three bodies renders. Every editable path hangs off "ready", so
+  // the baseline behind it is always a real one.
+  const state = bodyState({
+    error: overrides.isError,
+    loaded: global !== undefined && saved !== undefined,
+    identityPending: identityQuery.isPending,
+  });
+
+  // Render-only: the EMPTY tail feeds the derivations below, which are inert
+  // unless `state === "ready"`. The BASELINE `saved` above never falls back.
+  const draft = edited ?? saved ?? EMPTY_OVERRIDE;
+  const dirty =
+    edited !== null &&
+    saved !== undefined &&
+    sortedJson(edited) !== sortedJson(saved);
   const rows = notificationRows(aiEnabled);
   const muted = draft.muted === true;
   const mutedReason = muted
@@ -435,6 +538,9 @@ function RepoNotificationsBody({
   function patch(
     mutate: (current: RepoNotificationOverride) => RepoNotificationOverride,
   ) {
+    // No baseline, no edit: an override minted from a stand-in would be saved
+    // as the repo's whole entry.
+    if (saved === undefined) return;
     setEdited((current) => mutate(current ?? saved));
   }
 
@@ -481,10 +587,19 @@ function RepoNotificationsBody({
   }
 
   async function doSave() {
+    // Captured before the await: this save belongs to ONE opening of the dialog.
+    const savedGeneration = useRepoNotificationsDialog.getState().generation;
     try {
       await save.mutateAsync(draft);
+      // The toast is unconditional — the save landed either way. The close does
+      // not: it drives a SHARED store this continuation can outlive, and closing
+      // a dialog opened AFTER this save started throws away that dialog's edits
+      // (the next open reseeds the draft from disk). Same repo is not the same
+      // dialog, so the generation is what decides.
       toast.success("Repository notifications saved");
-      onClose();
+      const live = useRepoNotificationsDialog.getState();
+      if (live.repoPath === repoPath && live.generation === savedGeneration)
+        onClose();
     } catch (e) {
       toastError(e);
     }
@@ -492,14 +607,28 @@ function RepoNotificationsBody({
 
   const hasOverrides = muted || overrideCount(draft) > 0;
 
+  // Why Save is held, in precedence order. The error arm keeps it unreachable
+  // while there is no baseline to save against.
+  function saveBlockedReason(): string | null {
+    if (save.isPending) return "Saving…";
+    if (state === "error") return "Couldn't load this repository's overrides";
+    if (!dirty) return "No changes to save";
+    return null;
+  }
+  const saveReason = saveBlockedReason();
+
   return (
     <>
       {/* overflow-x-hidden alongside overflow-y-auto so the vertical scrollbar's
           width can't induce a phantom horizontal one. */}
       <div className="min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto pr-1">
-        {!global || overrides.isPending ? (
-          <Skeleton className="h-40 w-full" />
-        ) : (
+        {state === "error" && (
+          <OverridesLoadFailed onRetry={() => overrides.refetch()} />
+        )}
+        {state === "loading" && <Skeleton className="h-40 w-full" />}
+        {/* `global !== undefined` re-narrows the type the discriminant already
+            guarantees; the matrix reads it on every row. */}
+        {state === "ready" && global !== undefined && (
           <>
             <label className="flex cursor-pointer items-center gap-2 text-xs">
               <Checkbox
@@ -589,8 +718,8 @@ function RepoNotificationsBody({
           // Button fills it to match the stretched Cancel beside it.
           className="w-full"
           onClick={doSave}
-          disabled={!dirty || save.isPending}
-          reason={save.isPending ? "Saving…" : "No changes to save"}
+          disabled={saveReason !== null}
+          reason={saveReason}
         >
           Save changes
         </DisabledReasonButton>

--- a/src/features/notifications/RepoNotificationsDialog.tsx
+++ b/src/features/notifications/RepoNotificationsDialog.tsx
@@ -29,6 +29,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { clipTitleFromText } from "@/lib/clip-title";
 import { useRepoIdentity } from "@/lib/git/queries";
+import { useModalGateRegistration } from "@/lib/hotkeys/modal-gate";
 import {
   CHANNEL_LABELS,
   CHANNELS,
@@ -236,9 +237,10 @@ export function WatchRow(props: ComponentProps<typeof WatchSelect>) {
 
 const EMPTY_OVERRIDE: RepoNotificationOverride = {};
 
-/** Which body the dialog shows. A failed overrides load is its OWN state, never
- *  a slow one: the query settles with no data, so a loading placeholder would
- *  spin forever and an editable matrix would edit against nothing. */
+/** Which body the dialog shows. A failed load of EITHER half of the baseline —
+ *  the stored overrides or the global settings they sit on — is its own state,
+ *  never a slow one: the query settles with no data, so a loading placeholder
+ *  would spin forever and an editable matrix would edit against nothing. */
 function bodyState({
   error,
   loaded,
@@ -255,9 +257,9 @@ function bodyState({
   return "ready";
 }
 
-/** The overrides store failed to load. Offers the retry rather than a dead
- *  dialog: the store's loader doesn't memoize its rejection, so a storage
- *  hiccup can genuinely clear. */
+/** Either side of the baseline failed to load. Offers the retry rather than a
+ *  dead dialog: neither loader memoizes its rejection, so a storage hiccup can
+ *  genuinely clear. */
 function OverridesLoadFailed({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="space-y-2">
@@ -282,6 +284,11 @@ export function RepoNotificationsDialogHost() {
   // Retained so the body keeps its repo through the close fade instead of
   // blanking the dialog as it animates out.
   const shownRepo = useRetained(repoPath);
+  // App's repo/settings actions stay reachable from the macOS menu bar, which
+  // sits outside this dialog's modal overlay — register so they refuse while it
+  // owns the screen. Keyed on the live flag, not the retained one, so the close
+  // fade releases the gate.
+  useModalGateRegistration(repoPath !== null);
 
   return (
     <Dialog
@@ -356,7 +363,10 @@ function RepoNotificationsBody({
   // Which of the three bodies renders. Every editable path hangs off "ready", so
   // the baseline behind it is always a real one.
   const state = bodyState({
-    error: overrides.isError,
+    // Settings counts too: `global` is half the baseline, and a failed
+    // loadSettings would otherwise leave it undefined behind a skeleton that
+    // never resolves.
+    error: overrides.isError || settings.isError,
     loaded: global !== undefined && saved !== undefined,
     identityPending: identityQuery.isPending,
   });
@@ -473,8 +483,15 @@ function RepoNotificationsBody({
       {/* overflow-x-hidden alongside overflow-y-auto so the vertical scrollbar's
           width can't induce a phantom horizontal one. */}
       <div className="min-h-0 flex-1 space-y-3 overflow-x-hidden overflow-y-auto pr-1">
+        {/* Retries BOTH halves: the arm fires for either failure, and refetching
+            only one leaves the other's error in place. */}
         {state === "error" && (
-          <OverridesLoadFailed onRetry={() => overrides.refetch()} />
+          <OverridesLoadFailed
+            onRetry={() => {
+              overrides.refetch();
+              settings.refetch();
+            }}
+          />
         )}
         {state === "loading" && <Skeleton className="h-40 w-full" />}
         {/* `global !== undefined` re-narrows the type the discriminant already

--- a/src/features/plan/store.ts
+++ b/src/features/plan/store.ts
@@ -18,10 +18,10 @@ import {
 } from "@/lib/ai/prompt";
 import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { gitListTracked, readRepoInstructions } from "@/lib/git/api";
-import { notify } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
 import { norm } from "@/lib/repo-data-migration";
 import { loadSettings } from "@/lib/settings/api";
-import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
+import { repoNameFromPath } from "@/lib/stores/notifications";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { loadPersistedPlans, savePersistedPlans } from "./persistence";
 
@@ -235,23 +235,21 @@ export const usePlanStore = create<PlanState>((set, get) => {
         : hasQuestions
           ? "Plan ready — answer its questions"
           : "Plan ready";
-      // Hiding AI features mutes the OS ping — a hidden feature must not tap you
-      // on the shoulder. The inbox row below still lands (the dock filters it at
-      // render time), and a settings read that fails falls through to notifying.
-      void loadSettings()
-        .catch(() => null)
-        .then((s) => {
-          if (!s?.hideAi) void notify(headline, label);
-        });
-      pushNotification({
-        kind: "plan-done",
-        tone: failed ? "danger" : hasQuestions ? "warning" : "success",
-        title: headline,
-        subtitle: label,
-        repoPath: run.repoPath,
-        repoName: repoNameFromPath(run.repoPath),
-        target: { type: "agent" },
-        dedupeKey: `plan:${id}:${failed}:${hasQuestions}`,
+      emitNotification({
+        source: "agents",
+        row: {
+          kind: "plan-done",
+          tone: failed ? "danger" : hasQuestions ? "warning" : "success",
+          title: headline,
+          subtitle: label,
+          repoPath: run.repoPath,
+          repoName: repoNameFromPath(run.repoPath),
+          target: { type: "agent" },
+          dedupeKey: `plan:${id}:${failed}:${hasQuestions}`,
+        },
+        // Pings even while focused — the watching check above already excused the
+        // one surface that would make it redundant, questions excepted.
+        os: { title: headline, body: label, focus: "always" },
       });
     };
     try {

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -10,12 +10,17 @@ import {
   useRepoIdentity,
 } from "@/lib/git/queries";
 import type { PrPollInfo } from "@/lib/git/types";
-import { notifyIfUnfocused } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
+import {
+  anyChannelOn,
+  effectiveChecksScope,
+} from "@/lib/notifications/overrides";
+import { useRepoNotificationOverride } from "@/lib/notifications/queries";
+import type { NotificationSource } from "@/lib/settings/api";
 import { useAiEnabled, useSettings } from "@/lib/settings/queries";
 import {
   type NotificationKind,
   type NotificationTone,
-  pushNotification,
   repoNameFromPath,
 } from "@/lib/stores/notifications";
 
@@ -35,9 +40,17 @@ export function usePrNotifications(repoPath: string) {
   // but the poll itself keeps running for the non-AI notifications it also drives.
   const aiEnabled = useAiEnabled();
   const prefs = settings.data?.notifications;
-  const anyNotif = Boolean(
-    prefs && (prefs.prChecks !== "off" || prefs.prActivity || prefs.prReviews),
-  );
+  const override = useRepoNotificationOverride(repoPath);
+  // Same resolution the emit gate applies, so a repo whose PR sources all deliver
+  // on no channel makes no background call — and one whose override ENABLES a
+  // globally-muted source still polls.
+  const anyNotif =
+    settings.data !== undefined &&
+    anyChannelOn(settings.data.notifications, override, [
+      "prChecks",
+      "prActivity",
+      "prReviews",
+    ]);
   // The poll only earns its keep when a notification, pr-sync, or pr-open rule wants
   // it — the default (none of those) makes no background call.
   // Rules are keyed by repo IDENTITY so a worktree checkout sees the same rules as
@@ -151,11 +164,11 @@ export function usePrNotifications(repoPath: string) {
     // `useForgeGhHost`: null off GitHub (GitLab/Bitbucket logins aren't avatar-derivable).
     const ghHost =
       gh.data?.provider === "github" ? gh.data.host || "github.com" : null;
-    // Both channels: the persistent inbox always (notifyIfUnfocused no-ops while
-    // focused, so a focused user still gets a durable record) and an OS notification
-    // when unfocused. One pref gates both, so turning a category off also hides it
-    // from the inbox.
+    // Delivery is entirely emit's: it resolves the source's channels (global prefs
+    // merged with this repo's override) and owns the dedupe for both. What stays
+    // here is the classification — which transition happened, and whose PR it is.
     const record = (
+      source: NotificationSource,
       kind: NotificationKind,
       tone: NotificationTone,
       title: string,
@@ -172,36 +185,42 @@ export function usePrNotifications(repoPath: string) {
       },
     ) => {
       const authorLogin = opts?.authorLogin;
-      pushNotification({
-        kind,
-        tone,
-        title,
-        subtitle: pr.title,
-        repoPath,
-        repoName,
-        authorLogin,
-        authorGhHost: authorLogin ? (ghHost ?? undefined) : undefined,
-        target: {
-          type: "pr",
-          kind: "remote",
-          ref: String(pr.number),
-          // The poll pins the ORIGIN slug (see `gh_pr_poll`), so every event it
-          // reports happened on the fork's own pull requests.
-          lens: "origin",
-          reviewId: opts?.reviewId || undefined,
+      emitNotification({
+        source,
+        row: {
+          kind,
+          tone,
+          title,
+          subtitle: pr.title,
+          repoPath,
+          repoName,
+          authorLogin,
+          authorGhHost: authorLogin ? (ghHost ?? undefined) : undefined,
+          target: {
+            type: "pr",
+            kind: "remote",
+            ref: String(pr.number),
+            // The poll pins the ORIGIN slug (see `gh_pr_poll`), so every event it
+            // reports happened on the fork's own pull requests.
+            lens: "origin",
+            reviewId: opts?.reviewId || undefined,
+          },
+          dedupeKey,
         },
-        dedupeKey,
+        os: { title, body: pr.title, focus: "unfocused" },
       });
-      void notifyIfUnfocused(title, pr.title);
     };
+
+    // Scope is orthogonal to the prChecks channels — which PRs are watched, not
+    // whether the result is delivered (emit owns that).
+    const scope = effectiveChecksScope(prefs, override);
 
     for (const pr of snapshot.values()) {
       const old = before.get(pr.number);
       const mine = login !== null && pr.author === login;
 
       if (
-        prefs.prChecks !== "off" &&
-        (prefs.prChecks === "all" || mine) &&
+        (scope === "all" || mine) &&
         old &&
         pr.state === "OPEN" &&
         old.checksState !== pr.checksState &&
@@ -209,6 +228,7 @@ export function usePrNotifications(repoPath: string) {
       ) {
         const passed = pr.checksState === "SUCCESS";
         record(
+          "prChecks",
           passed ? "checks-passed" : "checks-failed",
           passed ? "success" : "danger",
           passed
@@ -219,30 +239,30 @@ export function usePrNotifications(repoPath: string) {
         );
       }
 
-      if (prefs.prActivity) {
-        if (!old && pr.state === "OPEN" && !mine && !pr.isDraft) {
-          record(
-            "pr-opened",
-            "info",
-            `New pull request #${pr.number}`,
-            pr,
-            `opened:${pr.number}`,
-            { authorLogin: pr.author },
-          );
-        }
-        if (old && old.state === "OPEN" && pr.state !== "OPEN") {
-          const merged = pr.state === "MERGED";
-          record(
-            merged ? "pr-merged" : "pr-closed",
-            merged ? "merged" : "neutral",
-            `#${pr.number} was ${merged ? "merged" : "closed"}`,
-            pr,
-            `state:${pr.number}:${pr.state}`,
-          );
-        }
+      if (!old && pr.state === "OPEN" && !mine && !pr.isDraft) {
+        record(
+          "prActivity",
+          "pr-opened",
+          "info",
+          `New pull request #${pr.number}`,
+          pr,
+          `opened:${pr.number}`,
+          { authorLogin: pr.author },
+        );
+      }
+      if (old && old.state === "OPEN" && pr.state !== "OPEN") {
+        const merged = pr.state === "MERGED";
+        record(
+          "prActivity",
+          merged ? "pr-merged" : "pr-closed",
+          merged ? "merged" : "neutral",
+          `#${pr.number} was ${merged ? "merged" : "closed"}`,
+          pr,
+          `state:${pr.number}:${pr.state}`,
+        );
       }
 
-      if (prefs.prReviews && mine && old) {
+      if (mine && old) {
         if (
           old.reviewDecision !== pr.reviewDecision &&
           (pr.reviewDecision === "APPROVED" ||
@@ -250,6 +270,7 @@ export function usePrNotifications(repoPath: string) {
         ) {
           const approved = pr.reviewDecision === "APPROVED";
           record(
+            "prReviews",
             approved ? "pr-approved" : "pr-changes-requested",
             approved ? "success" : "warning",
             approved
@@ -268,6 +289,7 @@ export function usePrNotifications(repoPath: string) {
           pr.lastReviewAuthor !== login
         ) {
           record(
+            "prReviews",
             "pr-review",
             "info",
             `New review on #${pr.number}`,
@@ -287,6 +309,7 @@ export function usePrNotifications(repoPath: string) {
           pr.lastCommentAuthor !== login
         ) {
           record(
+            "prReviews",
             "pr-comment",
             "info",
             `New comment on #${pr.number}`,
@@ -299,13 +322,13 @@ export function usePrNotifications(repoPath: string) {
       // Review requested FROM you — no author guard needed; a forge won't request
       // review from the PR's own author.
       if (
-        prefs.prReviews &&
         login !== null &&
         old &&
         pr.reviewRequests.includes(login) &&
         !old.reviewRequests.includes(login)
       ) {
         record(
+          "prReviews",
           "review-requested",
           "info",
           `Review requested on #${pr.number}`,

--- a/src/features/repository/usePrNotifications.ts
+++ b/src/features/repository/usePrNotifications.ts
@@ -41,9 +41,9 @@ export function usePrNotifications(repoPath: string) {
   const aiEnabled = useAiEnabled();
   const prefs = settings.data?.notifications;
   const override = useRepoNotificationOverride(repoPath);
-  // Same resolution the emit gate applies, so a repo whose PR sources all deliver
-  // on no channel makes no background call — and one whose override ENABLES a
-  // globally-muted source still polls.
+  // The emit gate's own resolution, applied once the override is in hand: it reads
+  // undefined until the overrides query resolves, so a muted repo can still fire its
+  // first poll. Delivery stays correct regardless — emit re-reads the override itself.
   const anyNotif =
     settings.data !== undefined &&
     anyChannelOn(settings.data.notifications, override, [

--- a/src/features/research/store.ts
+++ b/src/features/research/store.ts
@@ -20,10 +20,10 @@ import {
 } from "@/lib/ai/prompt";
 import { terminalErrorMessage } from "@/lib/ai/terminal-error";
 import { readRepoInstructions } from "@/lib/git/api";
-import { notify } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
 import { norm } from "@/lib/repo-data-migration";
 import { loadSettings } from "@/lib/settings/api";
-import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
+import { repoNameFromPath } from "@/lib/stores/notifications";
 import { errorMessage, invoke } from "@/lib/tauri/invoke";
 import { loadPersistedResearch, savePersistedResearch } from "./persistence";
 
@@ -314,23 +314,21 @@ export const useResearchStore = create<ResearchState>((set, get) => {
         return;
       const label = run.origin?.topic?.trim() || "Research";
       const headline = failed ? "Research failed" : "Research ready";
-      // Hiding AI features mutes the OS ping — a hidden feature must not tap you
-      // on the shoulder. The inbox row below still lands (the dock filters it at
-      // render time), and a settings read that fails falls through to notifying.
-      void loadSettings()
-        .catch(() => null)
-        .then((s) => {
-          if (!s?.hideAi) void notify(headline, label);
-        });
-      pushNotification({
-        kind: "research-done",
-        tone: failed ? "danger" : "success",
-        title: headline,
-        subtitle: label,
-        repoPath: run.repoPath,
-        repoName: repoNameFromPath(run.repoPath),
-        target: { type: "agent" },
-        dedupeKey: `research:${id}:${failed}`,
+      emitNotification({
+        source: "agents",
+        row: {
+          kind: "research-done",
+          tone: failed ? "danger" : "success",
+          title: headline,
+          subtitle: label,
+          repoPath: run.repoPath,
+          repoName: repoNameFromPath(run.repoPath),
+          target: { type: "agent" },
+          dedupeKey: `research:${id}:${failed}`,
+        },
+        // Pings even while focused — the watching check above already excused the
+        // one surface that would make it redundant.
+        os: { title: headline, body: label, focus: "always" },
       });
     };
     try {

--- a/src/features/sessions/store.ts
+++ b/src/features/sessions/store.ts
@@ -20,14 +20,14 @@ import {
   resumeWorktree,
   squashWorktree,
 } from "@/lib/git/worktree";
-import { notify } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
 import { asMcpServerArray, loadSettings } from "@/lib/settings/api";
 import {
   isServerAvailable,
   mcpServerUsableBy,
   mcpSupportedFor,
 } from "@/lib/settings/mcp";
-import { pushNotification, repoNameFromPath } from "@/lib/stores/notifications";
+import { repoNameFromPath } from "@/lib/stores/notifications";
 import { errorMessage } from "@/lib/tauri/invoke";
 import { toastError } from "@/lib/toast";
 import { bumpNavVersion } from "./navVersion";
@@ -371,23 +371,21 @@ async function runTurn(
       "Agent session";
     const failed = t.status === "error";
     const headline = failed ? "Agent failed" : "Agent finished";
-    // Hiding AI features mutes the OS ping — a hidden feature must not tap you
-    // on the shoulder. The inbox row below still lands (the dock filters it at
-    // render time), and a settings read that fails falls through to notifying.
-    void loadSettings()
-      .catch(() => null)
-      .then((s) => {
-        if (!s?.hideAi) void notify(headline, label);
-      });
-    pushNotification({
-      kind: "agent-done",
-      tone: failed ? "danger" : "success",
-      title: headline,
-      subtitle: label,
-      repoPath: s.repoPath,
-      repoName: repoNameFromPath(s.repoPath),
-      target: { type: "agent" },
-      dedupeKey: `agent:${id}:${turnIndex}`,
+    emitNotification({
+      source: "agents",
+      row: {
+        kind: "agent-done",
+        tone: failed ? "danger" : "success",
+        title: headline,
+        subtitle: label,
+        repoPath: s.repoPath,
+        repoName: repoNameFromPath(s.repoPath),
+        target: { type: "agent" },
+        dedupeKey: `agent:${id}:${turnIndex}`,
+      },
+      // Pings even while focused — the watching check above already excused the
+      // one surface that would make it redundant.
+      os: { title: headline, body: label, focus: "always" },
     });
   };
 

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
-import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { Button } from "@/components/ui/button";
@@ -13,11 +13,13 @@ import {
   MatrixCell,
   MatrixTable,
   notificationRows,
+  notificationsDraftOutOfSync,
   notificationsSignature,
   overrideCount,
   RowLabelCell,
   SOURCE_DESCRIPTIONS,
   SOURCE_LABELS,
+  useNotificationsDraft,
   useRepoNotificationsDialog,
   WatchRow,
 } from "@/features/notifications/RepoNotificationsDialog";
@@ -62,22 +64,25 @@ export const NotificationsSection = withForm({
     );
     const checksOff = !sources.prChecks.inApp && !sources.prChecks.os;
 
-    // Per-repo overrides are minted against the SAVED matrix, so an unsaved
-    // draft would let a cell "change" to a value the dialog already reads as
-    // global and store nothing. Only the notifications slice matters — the
-    // dialog reads no other field — and the selector returns the BOOLEAN so a
-    // keystroke elsewhere in the form can't re-render this panel.
+    // Only the notifications slice matters — the dialog reads no other field —
+    // so the selector narrows to it and a keystroke elsewhere in the form can't
+    // re-render this panel.
     const savedNotifications = useSettings().data?.notifications;
-    const savedSignature = savedNotifications
-      ? notificationsSignature(savedNotifications)
-      : null;
-    const draftOutOfSync = useSelector(
-      form.store,
-      (s) =>
-        savedSignature !== null &&
-        notificationsSignature(s.values.notifications) !== savedSignature,
+    const draftSignature = useSelector(form.store, (s) =>
+      notificationsSignature(s.values.notifications),
     );
-    const overrideReason = draftOutOfSync
+    // Published for the routes into the dialog that render outside this form
+    // (the command palette). Never cleared on unmount: a panel switch leaves
+    // the draft live in the form, so App retires it when Settings closes.
+    const publishDraft = useNotificationsDraft((s) => s.publish);
+    useEffect(() => {
+      publishDraft(draftSignature);
+    }, [draftSignature, publishDraft]);
+
+    const overrideReason = notificationsDraftOutOfSync(
+      draftSignature,
+      savedNotifications,
+    )
       ? "Save or discard your changes first — repository overrides start from the saved defaults."
       : null;
 
@@ -269,30 +274,37 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
     : [];
 
   // Identities resolve over IPC, so the mapping is a query rather than render
-  // work; `repoIdentity` memoizes per path, so a repeat costs nothing. Gated on
-  // the list actually rendering.
-  const resolvedPaths = useQuery({
-    queryKey: ["notification-override-repo-paths", otherKeys, recentPaths],
-    queryFn: async () => {
-      const ids = await Promise.all(recentPaths.map((p) => repoIdentity(p)));
-      const byIdentity = new Map(ids.map((id, i) => [id, recentPaths[i]]));
-      // Windows paths are case-insensitive; a legacy raw-path key is compared
-      // that way, exactly as the recent-repo writers dedupe them.
-      const byPath = new Map(recentPaths.map((p) => [p.toLowerCase(), p]));
-      return Object.fromEntries(
-        otherKeys.map((key) => [
-          key,
-          byIdentity.get(key) ?? byPath.get(key.toLowerCase()) ?? null,
-        ]),
-      );
-    },
+  // work; `repoIdentity` memoizes per path, so a repeat costs nothing. Keyed on
+  // the RECENT REPOS alone — what it resolves doesn't depend on which overrides
+  // exist, and carrying the key set would mint a fresh query on every Clear,
+  // flashing the list back to skeletons and unmounting the row focus was headed
+  // for. Returns a plain array aligned with `recentPaths`; the lookups are built
+  // at render, since structural sharing only recurses plain objects and arrays.
+  const recentIdentities = useQuery({
+    queryKey: ["notification-override-repo-identities", recentPaths],
+    queryFn: () => Promise.all(recentPaths.map((p) => repoIdentity(p))),
     enabled: otherKeys.length > 0,
     staleTime: Number.POSITIVE_INFINITY,
+    // Local git reads: the default online mode PARKS the query while the OS
+    // reports no connection, leaving this list on skeletons forever.
+    networkMode: "always",
   });
+
+  const identities = recentIdentities.data;
+  const byIdentity = new Map(
+    (identities ?? []).map((id, i) => [id, recentPaths[i]]),
+  );
+  // Windows paths are case-insensitive; a legacy raw-path key is compared that
+  // way, exactly as the recent-repo writers dedupe them. Maps, not objects: an
+  // override key is hand-editable, and "__proto__"/"toString" would resolve up
+  // an object's prototype chain to something that is not a path.
+  const byPath = new Map(recentPaths.map((p) => [p.toLowerCase(), p]));
 
   const rows: OverrideRow[] = otherKeys
     .map((key) => {
-      const path = resolvedPaths.data?.[key] ?? null;
+      const path = identities
+        ? (byIdentity.get(key) ?? byPath.get(key.toLowerCase()) ?? null)
+        : null;
       return {
         key,
         path,
@@ -310,19 +322,28 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
   });
 
   const rowSignature = otherKeys.join("|");
-  // biome-ignore lint/correctness/useExhaustiveDependencies: rowSignature is the commit trigger — the rows must already be gone before focus moves
+  // Whether a destination can exist in this commit: either the list is gone
+  // (footer fallback) or its rows are actually rendered.
+  const focusTargetReachable =
+    otherKeys.length === 0 || !recentIdentities.isPending;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rowSignature is the commit trigger, not a value the body reads
   useLayoutEffect(() => {
     const target = pendingFocus.current;
-    if (target === null) return;
+    // RETAINED, never consumed, while the list is between renders: focusing a
+    // DOM that isn't there drops focus to body, and this effect gets no second
+    // chance once the aim is spent.
+    if (target === null || !focusTargetReachable) return;
     pendingFocus.current = null;
-    if (target === "") {
-      footerRef.current?.querySelector("button")?.focus();
-      return;
-    }
-    listRef.current
-      ?.querySelector<HTMLElement>(`[data-row="${CSS.escape(target)}"]`)
-      ?.focus();
-  }, [rowSignature]);
+    const row =
+      target === ""
+        ? null
+        : (listRef.current?.querySelector<HTMLElement>(
+            `[data-row="${CSS.escape(target)}"]`,
+          ) ?? null);
+    // The aimed row can be gone for reasons this component didn't cause (another
+    // window's write); the footer control bounds the retention.
+    (row ?? footerRef.current?.querySelector("button"))?.focus();
+  }, [rowSignature, focusTargetReachable]);
 
   async function clearRow(row: OverrideRow) {
     const ok = await useConfirm.getState().ask({
@@ -387,7 +408,7 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
           <h3 className="text-xs font-medium">
             Overrides in other repositories
           </h3>
-          {resolvedPaths.isPending ? (
+          {recentIdentities.isPending ? (
             <ListRowSkeletons
               rows={Math.min(otherKeys.length, 4)}
               lines={1}

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -6,21 +6,9 @@ import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  CHANNELS,
-  CHECKS_OFF_WATCH_REASON,
-  type Channel,
-  channelAriaLabel,
   MatrixCell,
   MatrixTable,
-  notificationRows,
-  notificationsDraftOutOfSync,
-  notificationsSignature,
-  overrideCount,
   RowLabelCell,
-  SOURCE_DESCRIPTIONS,
-  SOURCE_LABELS,
-  useNotificationsDraft,
-  useRepoNotificationsDialog,
   WatchRow,
 } from "@/features/notifications/RepoNotificationsDialog";
 import { clipTitleFromText } from "@/lib/clip-title";
@@ -28,6 +16,20 @@ import { withForm } from "@/lib/form";
 import { useRepoIdentity } from "@/lib/git/queries";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import {
+  CHANNELS,
+  CHECKS_OFF_WATCH_REASON,
+  type Channel,
+  channelAriaLabel,
+  notificationRows,
+  notificationsDraftOutOfSync,
+  notificationsSignature,
+  overrideCount,
+  SOURCE_DESCRIPTIONS,
+  SOURCE_LABELS,
+  useNotificationsDraft,
+  useRepoNotificationsDialog,
+} from "@/lib/notifications/matrix";
 import type { RepoNotificationOverride } from "@/lib/notifications/overrides";
 import {
   useClearNotificationOverride,
@@ -119,7 +121,7 @@ export const NotificationsSection = withForm({
           </p>
         </div>
 
-        <MatrixTable>
+        <MatrixTable caption="Global notification channels">
           <tr>
             <RowLabelCell label="All notifications" className="font-medium" />
             {CHANNELS.map((channel) => {
@@ -263,13 +265,18 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
     overrides.data !== undefined &&
     (repoPath === null || identity !== undefined);
   // Every key the open repo could be stored under — its identity and, until the
-  // next save folds it, its raw checkout path.
+  // next save folds it, its raw checkout path. Compared case-insensitively, in
+  // step with `overrideEntry`, which matches both arms through `samePath`: an
+  // exact-case test here would count a differently-cased path entry as the open
+  // repo's AND list it as another repository's.
   const ownKeys = new Set(
-    [repoPath, identity].filter((k): k is string => typeof k === "string"),
+    [repoPath, identity]
+      .filter((k): k is string => typeof k === "string")
+      .map((k) => k.toLowerCase()),
   );
   const otherKeys = resolved
     ? Object.keys(overrides.data ?? {})
-        .filter((key) => !ownKeys.has(key))
+        .filter((key) => !ownKeys.has(key.toLowerCase()))
         .sort()
     : [];
 
@@ -290,20 +297,25 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
     networkMode: "always",
   });
 
+  // Both maps key on the LOWERCASED form, and every lookup lowercases too, so
+  // the whole file associates keys under one rule — the one `overrideEntry`
+  // resolves the open repo by. An exact-case identity map would miss a stored
+  // key that differs only in case and mislabel its row "(not in recent
+  // repositories)". Values stay original-cased: they are real paths. Maps, not
+  // objects, because an override key is hand-editable and
+  // "__proto__"/"toString" would resolve up an object's prototype chain to
+  // something that is not a path.
   const identities = recentIdentities.data;
   const byIdentity = new Map(
-    (identities ?? []).map((id, i) => [id, recentPaths[i]]),
+    (identities ?? []).map((id, i) => [id.toLowerCase(), recentPaths[i]]),
   );
-  // Windows paths are case-insensitive; a legacy raw-path key is compared that
-  // way, exactly as the recent-repo writers dedupe them. Maps, not objects: an
-  // override key is hand-editable, and "__proto__"/"toString" would resolve up
-  // an object's prototype chain to something that is not a path.
   const byPath = new Map(recentPaths.map((p) => [p.toLowerCase(), p]));
 
   const rows: OverrideRow[] = otherKeys
     .map((key) => {
+      const lowerKey = key.toLowerCase();
       const path = identities
-        ? (byIdentity.get(key) ?? byPath.get(key.toLowerCase()) ?? null)
+        ? (byIdentity.get(lowerKey) ?? byPath.get(lowerKey) ?? null)
         : null;
       return {
         key,

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSelector } from "@tanstack/react-store";
-import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { ListRowSkeletons } from "@/components/list-row-skeleton";
 import { Button } from "@/components/ui/button";
@@ -27,7 +27,6 @@ import {
   overrideCount,
   SOURCE_DESCRIPTIONS,
   SOURCE_LABELS,
-  useNotificationsDraft,
   useRepoNotificationsDialog,
 } from "@/lib/notifications/matrix";
 import type { RepoNotificationOverride } from "@/lib/notifications/overrides";
@@ -68,18 +67,12 @@ export const NotificationsSection = withForm({
 
     // Only the notifications slice matters — the dialog reads no other field —
     // so the selector narrows to it and a keystroke elsewhere in the form can't
-    // re-render this panel.
+    // re-render this panel. SettingsScreen publishes the same value for the
+    // routes that reach the dialog from outside this form.
     const savedNotifications = useSettings().data?.notifications;
     const draftSignature = useSelector(form.store, (s) =>
       notificationsSignature(s.values.notifications),
     );
-    // Published for the routes into the dialog that render outside this form
-    // (the command palette). Never cleared on unmount: a panel switch leaves
-    // the draft live in the form, so App retires it when Settings closes.
-    const publishDraft = useNotificationsDraft((s) => s.publish);
-    useEffect(() => {
-      publishDraft(draftSignature);
-    }, [draftSignature, publishDraft]);
 
     const overrideReason = notificationsDraftOutOfSync(
       draftSignature,
@@ -111,12 +104,16 @@ export const NotificationsSection = withForm({
       <section className="space-y-4">
         <div>
           <h2 className="text-sm font-medium">Notifications</h2>
+          {/* The agent-tasks clause names a row that Hide AI removes, so it is
+              gated exactly like the same sentence in the user guide. */}
           <p className="text-xs text-muted-foreground">
             Choose where each event lands: a row in the activity inbox (In-app),
             an OS notification, or both. A source with both channels off records
-            nothing. OS notifications fire only while GitDesktop is unfocused —
-            agent tasks also ping while you work elsewhere in the app. Pull
-            request events are polled about once a minute while a hosted
+            nothing. OS notifications fire only while GitDesktop is unfocused
+            {aiEnabled
+              ? " — agent tasks also ping while you work elsewhere in the app."
+              : "."}{" "}
+            Pull request events are polled about once a minute while a hosted
             repository (GitHub, GitLab, or Bitbucket) is open.
           </p>
         </div>
@@ -297,14 +294,9 @@ function RepoOverridesBlock({ reason }: { reason: string | null }) {
     networkMode: "always",
   });
 
-  // Both maps key on the LOWERCASED form, and every lookup lowercases too, so
-  // the whole file associates keys under one rule — the one `overrideEntry`
-  // resolves the open repo by. An exact-case identity map would miss a stored
-  // key that differs only in case and mislabel its row "(not in recent
-  // repositories)". Values stay original-cased: they are real paths. Maps, not
-  // objects, because an override key is hand-editable and
-  // "__proto__"/"toString" would resolve up an object's prototype chain to
-  // something that is not a path.
+  // Keys lowercased on both sides, matching `overrideEntry`. Maps, not objects:
+  // an override key is hand-editable, and "__proto__" would resolve up an
+  // object's prototype chain to something that is not a path.
   const identities = recentIdentities.data;
   const byIdentity = new Map(
     (identities ?? []).map((id, i) => [id.toLowerCase(), recentPaths[i]]),

--- a/src/features/settings/NotificationsSection.tsx
+++ b/src/features/settings/NotificationsSection.tsx
@@ -1,84 +1,460 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSelector } from "@tanstack/react-store";
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { ListRowSkeletons } from "@/components/list-row-skeleton";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  CHANNELS,
+  CHECKS_OFF_WATCH_REASON,
+  type Channel,
+  channelAriaLabel,
+  MatrixCell,
+  MatrixTable,
+  notificationRows,
+  notificationsSignature,
+  overrideCount,
+  RowLabelCell,
+  SOURCE_DESCRIPTIONS,
+  SOURCE_LABELS,
+  useRepoNotificationsDialog,
+  WatchRow,
+} from "@/features/notifications/RepoNotificationsDialog";
+import { clipTitleFromText } from "@/lib/clip-title";
 import { withForm } from "@/lib/form";
-import type { PR_CHECK_SCOPES } from "@/lib/settings/api";
-import { useAiEnabled } from "@/lib/settings/queries";
+import { useRepoIdentity } from "@/lib/git/queries";
+import { repoIdentity } from "@/lib/git/repo-identity";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import type { RepoNotificationOverride } from "@/lib/notifications/overrides";
+import {
+  useClearNotificationOverride,
+  useNotificationOverrides,
+  useRepoNotificationOverride,
+} from "@/lib/notifications/queries";
+import { type RecentRepo, repoDisplayName } from "@/lib/settings/api";
+import { useAiEnabled, useSettings } from "@/lib/settings/queries";
+import { useConfirm } from "@/lib/stores/confirm";
+import { repoNameFromPath } from "@/lib/stores/notifications";
+import { useUiStore } from "@/lib/stores/ui";
+import { toastError } from "@/lib/toast";
 import { settingsFormOpts } from "./settings-form";
 
-/** Record-typed against PR_CHECK_SCOPES, which `loadSettings` also heals against,
- *  so an added scope can't reach one without the other. */
-const CHECK_OPTIONS: Record<(typeof PR_CHECK_SCOPES)[number], string> = {
-  off: "Off",
-  mine: "My pull requests only",
-  all: "All open pull requests",
-};
+/** Master-cell state for one column: every visible row on, every one off, or a
+ *  mix — which the checkbox renders as its indeterminate state. */
+type MasterState = boolean | "mixed";
+
+/** Indeterminate styling for the master cells: Base UI renders its indicator for
+ *  the mixed state too, so the call site hides the tick, draws a dash, and keeps
+ *  the filled box — the state reads from the glyph and `aria-checked="mixed"`,
+ *  never from color. */
+const MIXED_CLASS =
+  "data-indeterminate:border-primary data-indeterminate:bg-primary! data-indeterminate:text-primary-foreground data-indeterminate:*:hidden data-indeterminate:before:h-0.5 data-indeterminate:before:w-2 data-indeterminate:before:bg-current";
 
 export const NotificationsSection = withForm({
   ...settingsFormOpts,
   render: function NotificationsSectionRender({ form }) {
     const aiEnabled = useAiEnabled();
+    const rows = notificationRows(aiEnabled);
+    const sources = useSelector(
+      form.store,
+      (s) => s.values.notifications.sources,
+    );
+    const checksOff = !sources.prChecks.inApp && !sources.prChecks.os;
+
+    // Per-repo overrides are minted against the SAVED matrix, so an unsaved
+    // draft would let a cell "change" to a value the dialog already reads as
+    // global and store nothing. Only the notifications slice matters — the
+    // dialog reads no other field — and the selector returns the BOOLEAN so a
+    // keystroke elsewhere in the form can't re-render this panel.
+    const savedNotifications = useSettings().data?.notifications;
+    const savedSignature = savedNotifications
+      ? notificationsSignature(savedNotifications)
+      : null;
+    const draftOutOfSync = useSelector(
+      form.store,
+      (s) =>
+        savedSignature !== null &&
+        notificationsSignature(s.values.notifications) !== savedSignature,
+    );
+    const overrideReason = draftOutOfSync
+      ? "Save or discard your changes first — repository overrides start from the saved defaults."
+      : null;
+
+    function masterState(channel: Channel): MasterState {
+      const on = rows.filter((source) => sources[source][channel]).length;
+      if (on === 0) return false;
+      return on === rows.length ? true : "mixed";
+    }
+
+    // UI sugar with no stored field of its own: it writes the VISIBLE rows'
+    // cells, so a hidden AI row keeps whatever the draft holds, and Discard
+    // reverts it like any other draft edit.
+    function setColumn(channel: Channel, checked: boolean) {
+      form.setFieldValue("notifications.sources", (prev) => {
+        const next = { ...prev };
+        for (const source of rows) {
+          next[source] = { ...next[source], [channel]: checked };
+        }
+        return next;
+      });
+    }
+
     return (
       <section className="space-y-4">
         <div>
           <h2 className="text-sm font-medium">Notifications</h2>
           <p className="text-xs text-muted-foreground">
-            OS notifications fire only while GitDesktop is unfocused — in-app
-            toasts cover the rest. Pull request events are polled about once a
-            minute while a hosted repository (GitHub, GitLab, or Bitbucket) is
-            open.
+            Choose where each event lands: a row in the activity inbox (In-app),
+            an OS notification, or both. A source with both channels off records
+            nothing. OS notifications fire only while GitDesktop is unfocused —
+            agent tasks also ping while you work elsewhere in the app. Pull
+            request events are polled about once a minute while a hosted
+            repository (GitHub, GitLab, or Bitbucket) is open.
           </p>
         </div>
-        <form.AppField name="notifications.prChecks">
-          {(field) => (
-            <field.SelectField
-              label="CI checks finish (pass or fail)"
-              items={CHECK_OPTIONS}
-            />
-          )}
-        </form.AppField>
-        <form.AppField name="notifications.prActivity">
-          {(field) => (
-            <field.CheckboxField
-              label="Pull requests opened, merged, or closed"
-              className="flex cursor-pointer items-center gap-2 text-xs"
-            />
-          )}
-        </form.AppField>
-        <form.AppField name="notifications.prReviews">
-          {(field) => (
-            <field.CheckboxField
-              label="Reviews on my pull requests"
-              className="flex cursor-pointer items-center gap-2 text-xs"
-            />
-          )}
-        </form.AppField>
-        <form.AppField name="notifications.actionRuns">
-          {(field) => (
-            <field.CheckboxField
-              label="Workflow runs finish on the current branch"
-              className="flex cursor-pointer items-center gap-2 text-xs"
-            />
-          )}
-        </form.AppField>
-        {aiEnabled && (
-          <>
-            <form.AppField name="notifications.reviews">
-              {(field) => (
-                <field.CheckboxField
-                  label="An AI review you started finishes in the background"
-                  className="flex cursor-pointer items-center gap-2 text-xs"
-                />
-              )}
-            </form.AppField>
-            <form.AppField name="notifications.automations">
-              {(field) => (
-                <field.CheckboxField
-                  label="Automation results (AI reviews ready, posted, or failed)"
-                  className="flex cursor-pointer items-center gap-2 text-xs"
-                />
-              )}
-            </form.AppField>
-          </>
-        )}
+
+        <MatrixTable>
+          <tr>
+            <RowLabelCell label="All notifications" className="font-medium" />
+            {CHANNELS.map((channel) => {
+              const state = masterState(channel);
+              return (
+                <MatrixCell key={channel}>
+                  <Checkbox
+                    checked={state === true}
+                    indeterminate={state === "mixed"}
+                    aria-label={channelAriaLabel("All notifications", channel)}
+                    className={MIXED_CLASS}
+                    onCheckedChange={(checked) =>
+                      setColumn(channel, checked === true)
+                    }
+                  />
+                </MatrixCell>
+              );
+            })}
+          </tr>
+          {rows.map((source) => {
+            const label = SOURCE_LABELS[source];
+            return (
+              <Fragment key={source}>
+                <tr>
+                  <RowLabelCell
+                    label={label}
+                    description={SOURCE_DESCRIPTIONS[source]}
+                  />
+                  {CHANNELS.map((channel) => (
+                    <MatrixCell key={channel}>
+                      <form.AppField
+                        name={`notifications.sources.${source}.${channel}`}
+                      >
+                        {(field) => (
+                          <Checkbox
+                            checked={field.state.value}
+                            aria-label={channelAriaLabel(label, channel)}
+                            onCheckedChange={(checked) =>
+                              field.handleChange(checked === true)
+                            }
+                            onBlur={field.handleBlur}
+                          />
+                        )}
+                      </form.AppField>
+                    </MatrixCell>
+                  ))}
+                </tr>
+                {/* The scope qualifies the CI-checks row alone, so it sits
+                    under it rather than below the whole matrix. */}
+                {source === "prChecks" && (
+                  <form.AppField name="notifications.prChecksScope">
+                    {(field) => (
+                      <WatchRow
+                        value={field.state.value}
+                        onValueChange={field.handleChange}
+                        disabledReason={
+                          checksOff ? CHECKS_OFF_WATCH_REASON : null
+                        }
+                      />
+                    )}
+                  </form.AppField>
+                )}
+              </Fragment>
+            );
+          })}
+        </MatrixTable>
+
+        <RepoOverridesBlock reason={overrideReason} />
       </section>
     );
   },
 });
+
+/** What to call a repo whose path is known: its recent-list display name when it
+ *  has a row there, else the folder basename. */
+function displayNameFor(path: string, recents: RecentRepo[]): string {
+  const row = recents.find((r) => r.path.toLowerCase() === path.toLowerCase());
+  return row ? repoDisplayName(row) : repoNameFromPath(path);
+}
+
+/** Display fallback for an override key naming no recent repo. The key is a git
+ *  common dir (`…/repo/.git`) or a legacy checkout path, so a bare ".git"
+ *  basename means the repo folder is one level up. */
+function keyBasename(key: string): string {
+  const trimmed = key.replace(/[/\\]+$/, "");
+  const base = repoNameFromPath(trimmed);
+  return base === ".git"
+    ? repoNameFromPath(trimmed.slice(0, -".git".length))
+    : base;
+}
+
+function statusLine(
+  name: string,
+  override: RepoNotificationOverride | undefined,
+): string {
+  if (override?.muted) return `${name} is muted.`;
+  const count = overrideCount(override);
+  if (count === 0) return `${name} follows these defaults.`;
+  return `${name} overrides ${count} ${count === 1 ? "setting" : "settings"}.`;
+}
+
+interface OverrideRow {
+  key: string;
+  /** Resolved checkout path, or null when no recent repo matches the key. */
+  path: string | null;
+  name: string;
+  muted: boolean;
+}
+
+/**
+ * The per-repo layer of the same settings: what the open repository does with
+ * these defaults, plus every other repository that has been customized. Both
+ * lead to the same {@link useRepoNotificationsDialog} surface.
+ */
+function RepoOverridesBlock({ reason }: { reason: string | null }) {
+  const repoPath = useUiStore((s) => s.repoPath);
+  const openDialog = useRepoNotificationsDialog((s) => s.open);
+  const settings = useSettings();
+  const overrides = useNotificationOverrides();
+  const clear = useClearNotificationOverride();
+  // An empty path reads as "no repo open" all the way down: the identity query
+  // is disabled and the override lookup misses, so no branch needs a guard.
+  const identity = useRepoIdentity(repoPath ?? "").data;
+  const current = useRepoNotificationOverride(repoPath ?? "");
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLDivElement>(null);
+  // Where focus goes once the cleared row is gone: a row key, or "" for the
+  // Customize control when the list emptied. Consumed by the layout effect
+  // below — the rows only exist after the invalidation re-render, which a
+  // handler-side rAF can land ahead of.
+  const pendingFocus = useRef<string | null>(null);
+
+  const recents = settings.data?.recentRepos ?? [];
+  const recentPaths = recents.map((r) => r.path);
+  // Nothing is claimed about a repo until BOTH the stored overrides and the open
+  // repo's identity are in hand: an identity-keyed entry is invisible while that
+  // resolves, so an early read would name the open repo as "another repository"
+  // and call it unmodified in the same frame.
+  const resolved =
+    overrides.data !== undefined &&
+    (repoPath === null || identity !== undefined);
+  // Every key the open repo could be stored under — its identity and, until the
+  // next save folds it, its raw checkout path.
+  const ownKeys = new Set(
+    [repoPath, identity].filter((k): k is string => typeof k === "string"),
+  );
+  const otherKeys = resolved
+    ? Object.keys(overrides.data ?? {})
+        .filter((key) => !ownKeys.has(key))
+        .sort()
+    : [];
+
+  // Identities resolve over IPC, so the mapping is a query rather than render
+  // work; `repoIdentity` memoizes per path, so a repeat costs nothing. Gated on
+  // the list actually rendering.
+  const resolvedPaths = useQuery({
+    queryKey: ["notification-override-repo-paths", otherKeys, recentPaths],
+    queryFn: async () => {
+      const ids = await Promise.all(recentPaths.map((p) => repoIdentity(p)));
+      const byIdentity = new Map(ids.map((id, i) => [id, recentPaths[i]]));
+      // Windows paths are case-insensitive; a legacy raw-path key is compared
+      // that way, exactly as the recent-repo writers dedupe them.
+      const byPath = new Map(recentPaths.map((p) => [p.toLowerCase(), p]));
+      return Object.fromEntries(
+        otherKeys.map((key) => [
+          key,
+          byIdentity.get(key) ?? byPath.get(key.toLowerCase()) ?? null,
+        ]),
+      );
+    },
+    enabled: otherKeys.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const rows: OverrideRow[] = otherKeys
+    .map((key) => {
+      const path = resolvedPaths.data?.[key] ?? null;
+      return {
+        key,
+        path,
+        name: path ? displayNameFor(path, recents) : keyBasename(key),
+        muted: overrides.data?.[key]?.muted === true,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const onListKeyDown = listKeyboardNav({
+    items: rows,
+    activeIndex: activeKey ? rows.findIndex((r) => r.key === activeKey) : -1,
+    onActivate: (row) => setActiveKey(row.key),
+    rowKey: (row) => row.key,
+  });
+
+  const rowSignature = otherKeys.join("|");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rowSignature is the commit trigger — the rows must already be gone before focus moves
+  useLayoutEffect(() => {
+    const target = pendingFocus.current;
+    if (target === null) return;
+    pendingFocus.current = null;
+    if (target === "") {
+      footerRef.current?.querySelector("button")?.focus();
+      return;
+    }
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-row="${CSS.escape(target)}"]`)
+      ?.focus();
+  }, [rowSignature]);
+
+  async function clearRow(row: OverrideRow) {
+    const ok = await useConfirm.getState().ask({
+      title: `Clear notification overrides for ${row.name}?`,
+      body: "Its notifications return to the defaults above.",
+      confirmLabel: "Clear overrides",
+      confirmVariant: "destructive",
+    });
+    if (!ok) return;
+    // Aim focus before the row disappears: neighbour by position, else the
+    // Customize control, so clearing the last row never drops focus to body.
+    const index = rows.findIndex((r) => r.key === row.key);
+    const next = rows[index + 1] ?? rows[index - 1];
+    pendingFocus.current = next?.key ?? "";
+    setActiveKey(next?.key ?? null);
+    try {
+      await clear.mutateAsync(row.key);
+    } catch (e) {
+      // The row survives a failed clear, so the aimed focus would land on a
+      // neighbour the user never asked for.
+      pendingFocus.current = null;
+      setActiveKey(row.key);
+      toastError(e);
+    }
+  }
+
+  const repoName = repoPath ? displayNameFor(repoPath, recents) : "";
+
+  return (
+    <div className="space-y-4 border-t pt-4">
+      <div ref={footerRef} className="space-y-2">
+        <h3 className="text-xs font-medium">This repository</h3>
+        {repoPath === null ? (
+          <DisabledReasonButton
+            variant="outline"
+            size="xs"
+            disabled
+            reason="Open a repository to customize its notifications"
+          >
+            Customize…
+          </DisabledReasonButton>
+        ) : (
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="min-w-0 flex-1 text-xs text-muted-foreground">
+              {resolved ? statusLine(repoName, current) : ""}
+            </p>
+            <DisabledReasonButton
+              variant="outline"
+              size="xs"
+              disabled={reason !== null}
+              reason={reason}
+              onClick={() => openDialog(repoPath)}
+            >
+              Customize…
+            </DisabledReasonButton>
+          </div>
+        )}
+      </div>
+
+      {otherKeys.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-xs font-medium">
+            Overrides in other repositories
+          </h3>
+          {resolvedPaths.isPending ? (
+            <ListRowSkeletons
+              rows={Math.min(otherKeys.length, 4)}
+              lines={1}
+              name="repositories with overrides"
+              indent={false}
+            />
+          ) : (
+            // The container is one tab stop and the arrows move the focused
+            // row; each row's own buttons stay natively tabbable, so Tab walks
+            // out of the list through them rather than skipping them.
+            <div
+              ref={listRef}
+              role="group"
+              tabIndex={0}
+              aria-label="Repositories with notification overrides"
+              className="border-t outline-none"
+              onKeyDown={onListKeyDown}
+            >
+              {rows.map((row) => {
+                const path = row.path;
+                return (
+                  <div
+                    key={row.key}
+                    data-row={row.key}
+                    tabIndex={-1}
+                    className="flex items-center gap-2 border-b px-1 py-1.5 outline-none focus-visible:bg-muted"
+                  >
+                    <span
+                      className="min-w-0 flex-1 truncate text-xs"
+                      onMouseEnter={clipTitleFromText}
+                    >
+                      {row.name}
+                      {path === null && (
+                        <span className="text-muted-foreground">
+                          {" "}
+                          (not in recent repositories)
+                        </span>
+                      )}
+                    </span>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {row.muted ? "Muted" : "Customized"}
+                    </span>
+                    {path !== null && (
+                      <DisabledReasonButton
+                        variant="outline"
+                        size="xs"
+                        disabled={reason !== null}
+                        reason={reason}
+                        onClick={() => openDialog(path)}
+                      >
+                        Edit…
+                      </DisabledReasonButton>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => clearRow(row)}
+                    >
+                      Clear
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -18,6 +18,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { AutomationsSection } from "@/features/automations/AutomationsSection";
 import { useAppForm } from "@/lib/form";
+import {
+  notificationsSignature,
+  useNotificationsDraft,
+} from "@/lib/notifications/matrix";
 import { useSaveSettings, useSettings } from "@/lib/settings/queries";
 import { useUiStore } from "@/lib/stores/ui";
 import { useLatestRef } from "@/lib/use-latest-ref";
@@ -185,6 +189,23 @@ export function SettingsScreen() {
       savedStr !== null &&
       stableStringify(s.values) !== savedStr,
   );
+
+  // Publish the notifications slice for the surfaces that reach the per-repo
+  // dialog from OUTSIDE this form (the command palette): overrides are minted
+  // against the SAVED matrix, so those routes have to refuse while a draft
+  // disagrees. It lives here, not in the panel — the screen outlives every panel
+  // switch, so Save and Discard from ANY panel move it, while a panel-level
+  // publisher would freeze the moment its section unmounted. Same derived-string
+  // shape as `dirty`, so a keystroke in another panel can't churn it, and
+  // pre-seed publishes nothing: there is no draft to disagree with yet.
+  const notificationsDraft = useSelector(form.store, (s) =>
+    seeded.current ? notificationsSignature(s.values.notifications) : null,
+  );
+  const publishNotificationsDraft = useNotificationsDraft((s) => s.publish);
+  useEffect(() => {
+    if (notificationsDraft !== null)
+      publishNotificationsDraft(notificationsDraft);
+  }, [notificationsDraft, publishNotificationsDraft]);
 
   // Either the settings form or the Automations panel having unsaved edits
   // should guard closing the screen.

--- a/src/lib/automations/runner.ts
+++ b/src/lib/automations/runner.ts
@@ -36,7 +36,7 @@ import {
 import { sectionFilePath } from "@/lib/git/diff-split";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import type { DiffStatEntry } from "@/lib/git/types";
-import { notifyIfUnfocused } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
 import { listLocalPrs, reloadLocalPrs, updateLocalPr } from "@/lib/pulls/local";
 import {
   listReviews,
@@ -48,10 +48,7 @@ import {
 import { queryClient } from "@/lib/query-client";
 import { effectiveReviewAi, loadSettings } from "@/lib/settings/api";
 import { useConfirm } from "@/lib/stores/confirm";
-import {
-  type NotificationTarget,
-  pushNotification,
-} from "@/lib/stores/notifications";
+import type { NotificationTarget } from "@/lib/stores/notifications";
 import {
   hasLiveAutomationRun,
   type ReviewTarget,
@@ -439,7 +436,6 @@ async function run(
   const head = event.kind === "commit" ? undefined : event.head;
   const base = event.kind === "commit" ? undefined : event.base;
 
-  const notify = settings.notifications.automations;
   // The gate stores, read once and shared by an event's per-action gate checks: `fresh`
   // reloads from disk and queues behind any writer, and pr-reviews.json carries every
   // review's full markdown, so sharing is what keeps a two-mode event from paying twice.
@@ -799,7 +795,7 @@ async function run(
         neutralizeRefs: true,
         text,
       });
-      await deliver(event, action, body, text, notify);
+      await deliver(event, action, body, text);
       // Seed the review-history store so the next run (manual or auto) builds on these
       // findings and this headSha joins the heads pr-sync treats as covered. Best-effort.
       if (event.kind === "pr-open" || event.kind === "pr-sync") {
@@ -887,48 +883,49 @@ async function run(
       }
       toast.error(`AI ${label} failed: ${message}`);
       // Inbox parity with manual runs (reviews.ts's notifyReviewDone): a genuine failure
-      // records an inbox row too, gated on the same automations pref.
-      if (notify) {
-        // Carry the failure reason into the durable subtitle so the inbox row
-        // (and the OS ping) say WHY — subject-only when the reason is empty.
-        const subject =
-          event.kind === "commit"
-            ? `"${event.hash.slice(0, 7)}"`
-            : `"${event.title}"`;
-        const reason = message.trim() ? `${subject} — ${message}` : subject;
-        // Where the kept output waits differs by event: a PR partial is restored into
-        // the review panel, a commit partial only through this row.
-        const partialNote =
-          event.kind === "commit"
-            ? "Partial output is kept — open it from this notification."
-            : "Partial output is kept under Previous reviews.";
-        // The inbox row is where a kept partial gets discovered — a durable failure that
-        // doesn't mention it reads as a run with nothing to show for it.
-        const subtitle = keptPartial
-          ? `${reason}${reason.endsWith(".") ? "" : "."} ${partialNote}`
-          : reason;
-        // Local alias for the loop's `action: ReviewMode` — the Re-run closure's
-        // `run` body sees the outer `action` fine, but aliasing keeps the object
-        // literal (which also has a field named `action`) unambiguous to read.
-        const mode = action;
-        // A commit row navigates only when a partial actually landed — that record
-        // is the whole click-through. PR rows always land on their PR: automations
-        // run against the fork's own PRs (the poll that feeds them pins the origin
-        // slug deliberately), so the lens rides along.
-        let target: NotificationTarget | undefined;
-        if (event.kind === "commit") {
-          if (keptPartial) {
-            target = { type: "automation-result", id: partialResultId };
-          }
-        } else {
-          target = {
-            type: "pr",
-            kind: event.target.type,
-            ref: targetRef(event),
-            lens: "origin",
-          };
+      // records a notification too, on whichever channels the automations source has.
+      // Carry the failure reason into the durable subtitle so the inbox row
+      // (and the OS ping) say WHY — subject-only when the reason is empty.
+      const subject =
+        event.kind === "commit"
+          ? `"${event.hash.slice(0, 7)}"`
+          : `"${event.title}"`;
+      const reason = message.trim() ? `${subject} — ${message}` : subject;
+      // Where the kept output waits differs by event: a PR partial is restored into
+      // the review panel, a commit partial only through this row.
+      const partialNote =
+        event.kind === "commit"
+          ? "Partial output is kept — open it from this notification."
+          : "Partial output is kept under Previous reviews.";
+      // The inbox row is where a kept partial gets discovered — a durable failure that
+      // doesn't mention it reads as a run with nothing to show for it.
+      const subtitle = keptPartial
+        ? `${reason}${reason.endsWith(".") ? "" : "."} ${partialNote}`
+        : reason;
+      // Local alias for the loop's `action: ReviewMode` — the Re-run closure's
+      // `run` body sees the outer `action` fine, but aliasing keeps the object
+      // literal (which also has a field named `action`) unambiguous to read.
+      const mode = action;
+      // A commit row navigates only when a partial actually landed — that record
+      // is the whole click-through. PR rows always land on their PR: automations
+      // run against the fork's own PRs (the poll that feeds them pins the origin
+      // slug deliberately), so the lens rides along.
+      let target: NotificationTarget | undefined;
+      if (event.kind === "commit") {
+        if (keptPartial) {
+          target = { type: "automation-result", id: partialResultId };
         }
-        pushNotification({
+      } else {
+        target = {
+          type: "pr",
+          kind: event.target.type,
+          ref: targetRef(event),
+          lens: "origin",
+        };
+      }
+      emitNotification({
+        source: "automations",
+        row: {
           kind: "review-failed",
           tone: "danger",
           title: `AI ${label} failed`,
@@ -946,14 +943,9 @@ async function run(
           dedupeKey: `automation-failed:${event.repoPath}:${event.kind}:${
             event.kind === "commit" ? event.hash : targetRef(event)
           }:${action}`,
-        });
-        // Re-read rather than trust the run-start snapshot: hiding AI mid-run
-        // mutes the OS ping, while the inbox row above still records the failure
-        // (the dock filters that at render time, so no history is lost).
-        if (!(await loadSettings().catch(() => null))?.hideAi) {
-          void notifyIfUnfocused(`AI ${label} failed`, subtitle);
-        }
-      }
+        },
+        os: { title: `AI ${label} failed`, body: subtitle, focus: "unfocused" },
+      });
       // Persist a "Failed" stopped row (keeping its Re-run) instead of removing it.
       handle.fail(message);
       // A deadline kill and an outright failure look the same from the dock but not
@@ -1647,14 +1639,8 @@ async function deliver(
   mode: ReviewMode,
   body: string,
   rawText: string,
-  notify: boolean,
 ): Promise<void> {
   const label = modeLabel(mode);
-  // Whether this delivery may ping the OS. Read fresh, not from the run-start
-  // snapshot: hiding AI while a run is in flight mutes its ping, and the in-app
-  // toast + inbox row below still land (the dock filters those at render time).
-  // A settings-read failure counts as shown — delivery must never fail on it.
-  const osPing = notify && !(await loadSettings().catch(() => null))?.hideAi;
 
   if (event.kind === "commit") {
     // Commits have no comment surface — the results store is this review's only
@@ -1683,11 +1669,9 @@ async function deliver(
         onClick: () => useAutomationResults.getState().setOpen(result.id),
       },
     });
-    // Inbox parity with the failure path (and with manual runs): the row is gated on
-    // the automations pref ALONE, never on hideAi — the dock filters AI rows at
-    // render time, so hiding AI mutes the ping without losing the history.
-    if (notify) {
-      pushNotification({
+    emitNotification({
+      source: "automations",
+      row: {
         kind: "review-ready",
         tone: "success",
         title: `AI ${label} of ${event.hash.slice(0, 7)} ready`,
@@ -1696,14 +1680,13 @@ async function deliver(
         repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
         target: { type: "automation-result", id: result.id },
         dedupeKey: `automation-review:${event.repoPath}:commit:${event.hash}:${mode}`,
-      });
-    }
-    if (osPing) {
-      void notifyIfUnfocused(
-        `AI ${label} ready`,
-        `${event.hash.slice(0, 7)} — ${event.title}`,
-      );
-    }
+      },
+      os: {
+        title: `AI ${label} ready`,
+        body: `${event.hash.slice(0, 7)} — ${event.title}`,
+        focus: "unfocused",
+      },
+    });
     return;
   }
 
@@ -1724,10 +1707,10 @@ async function deliver(
       queryKey: ["repo", event.repoPath, "pr", "origin", event.target.number],
     });
     toast.success(`AI ${label} posted on #${event.target.number}`);
-    // Gated on the automations pref alone — see the commit arm.
-    if (notify) {
-      const prNumber = event.target.number;
-      pushNotification({
+    const prNumber = event.target.number;
+    emitNotification({
+      source: "automations",
+      row: {
         kind: "review-posted",
         tone: "success",
         title: `AI ${label} posted on #${prNumber}`,
@@ -1743,14 +1726,13 @@ async function deliver(
           lens: "origin",
         },
         dedupeKey: `automation-review:${event.repoPath}:remote:origin:${prNumber}:${mode}`,
-      });
-    }
-    if (osPing) {
-      void notifyIfUnfocused(
-        `AI ${label} posted on #${event.target.number}`,
-        event.title,
-      );
-    }
+      },
+      os: {
+        title: `AI ${label} posted on #${prNumber}`,
+        body: event.title,
+        focus: "unfocused",
+      },
+    });
     return;
   }
 
@@ -1778,9 +1760,9 @@ async function deliver(
     queryKey: ["local-prs", event.repoPath],
   });
   toast.success(`AI ${label} added to "${pr.title}"`);
-  // Gated on the automations pref alone — see the commit arm.
-  if (notify) {
-    pushNotification({
+  emitNotification({
+    source: "automations",
+    row: {
       kind: "review-posted",
       tone: "success",
       title: `AI ${label} added to "${pr.title}"`,
@@ -1788,11 +1770,13 @@ async function deliver(
       repoName: event.repoPath.split(/[/\\]/).pop() ?? event.repoPath,
       target: { type: "pr", kind: "local", ref: targetId, lens: "origin" },
       dedupeKey: `automation-review:${event.repoPath}:local:origin:${targetId}:${mode}`,
-    });
-  }
-  if (osPing) {
-    void notifyIfUnfocused(`AI ${label} finished`, `Local PR "${pr.title}"`);
-  }
+    },
+    os: {
+      title: `AI ${label} finished`,
+      body: `Local PR "${pr.title}"`,
+      focus: "unfocused",
+    },
+  });
 }
 
 /**

--- a/src/lib/hotkeys/registry.ts
+++ b/src/lib/hotkeys/registry.ts
@@ -86,6 +86,18 @@ export const ACTIONS = [
     defaultBinding: null,
   },
   {
+    id: "open-notifications-settings",
+    label: "Notification settings",
+    category: "Application",
+    defaultBinding: null,
+  },
+  {
+    id: "open-repo-notification-settings",
+    label: "Repository notification settings",
+    category: "Application",
+    defaultBinding: null,
+  },
+  {
     id: "cycle-theme",
     label: "Cycle theme",
     category: "Application",

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -1,0 +1,108 @@
+import { notify, notifyIfUnfocused } from "@/lib/notify";
+import {
+  DEFAULT_SETTINGS,
+  loadSettings,
+  type NotificationSource,
+} from "@/lib/settings/api";
+import {
+  AI_NOTIFICATION_KINDS,
+  DEDUPE_WINDOW_MS,
+  pushNotification,
+} from "@/lib/stores/notifications";
+import { effectiveChannels, overrideForRepo } from "./overrides";
+
+export interface EmitOsPing {
+  title: string;
+  body?: string;
+  /** "unfocused" → notifyIfUnfocused; "always" → notify (agent surfaces ping
+   *  even focused — you may be watching a different session). */
+  focus: "unfocused" | "always";
+}
+
+/** When each dedupe key last claimed the window. Held here rather than left to the
+ *  inbox's own dedupe because that one can only suppress the row, never the OS ping.
+ *  A key is claimed synchronously and RELEASED again if the gates end up delivering
+ *  nothing, so a suppressed no-op can't shadow the next real event. */
+const lastEmit = new Map<string, number>();
+/** Bound on a long session's key churn; the oldest delivered key is evicted first
+ *  (insertion order tracks delivery time, since every write re-inserts). */
+const MAX_DEDUPE_KEYS = 500;
+
+/** Check-and-set, synchronous by contract: two same-tick fires must not both pass
+ *  the window. True = this key already holds the window and is suppressed. */
+function seenRecently(key: string, now: number): boolean {
+  const last = lastEmit.get(key);
+  if (last !== undefined && now - last < DEDUPE_WINDOW_MS) return true;
+  for (const [k, ts] of lastEmit) {
+    if (now - ts >= DEDUPE_WINDOW_MS) lastEmit.delete(k);
+  }
+  lastEmit.delete(key);
+  lastEmit.set(key, now);
+  while (lastEmit.size > MAX_DEDUPE_KEYS) {
+    const oldest = lastEmit.keys().next().value;
+    if (oldest === undefined) break;
+    lastEmit.delete(oldest);
+  }
+  return false;
+}
+
+/** Hands a claimed window back when the gates delivered nothing, but only if this
+ *  call still owns it — a later fire's claim must never be cancelled by an earlier
+ *  one settling. */
+function releaseDedupeKey(key: string, claimedAt: number): void {
+  if (lastEmit.get(key) === claimedAt) lastEmit.delete(key);
+}
+
+/**
+ * The single gate every notification producer calls: it resolves the source's
+ * channels (global settings merged with the repo's override) and delivers the
+ * inbox row, the OS ping, or neither. Fire-and-forget: internally async, never
+ * throws or rejects — a missed notification must never break the work that fired
+ * it.
+ *
+ * Each read degrades to its own default independently: a failed settings read
+ * falls back to DEFAULT_SETTINGS (every channel on, AI unhidden) while a surviving
+ * repo override still applies, and a failed override read leaves the user's real
+ * global prefs governing. Silence is never the failure mode.
+ */
+export function emitNotification(input: {
+  source: NotificationSource;
+  row: Parameters<typeof pushNotification>[0];
+  os?: EmitOsPing;
+}): void {
+  const { source, row, os } = input;
+  const { dedupeKey } = row;
+  // Claimed before the first await, so two same-tick fires of one transition can't
+  // both get through and double-deliver on BOTH channels.
+  const claimedAt = Date.now();
+  if (dedupeKey && seenRecently(dedupeKey, claimedAt)) return;
+  void (async () => {
+    const [settings, override] = await Promise.all([
+      loadSettings().catch(() => DEFAULT_SETTINGS),
+      overrideForRepo(row.repoPath).catch(() => undefined),
+    ]);
+    const channels = effectiveChannels(
+      settings.notifications,
+      override,
+      source,
+    );
+    if (channels.inApp) pushNotification(row);
+    // Hiding AI features mutes the OS ping for AI-minted kinds — a hidden feature
+    // must not tap you on the shoulder — but never the inbox row above, which the
+    // dock filters at render time.
+    const aiMuted = settings.hideAi && AI_NOTIFICATION_KINDS.has(row.kind);
+    const pinged = Boolean(os) && channels.os && !aiMuted;
+    if (os && pinged) {
+      void (os.focus === "always"
+        ? notify(os.title, os.body)
+        : notifyIfUnfocused(os.title, os.body));
+    }
+    // Nothing left the gate, so the window was never really used — hand it back,
+    // or a source switched on mid-window would lose its first real event.
+    if (dedupeKey && !channels.inApp && !pinged) {
+      releaseDedupeKey(dedupeKey, claimedAt);
+    }
+  })().catch(() => {
+    // best-effort — a missed notification must never break the work that fired it
+  });
+}

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -71,9 +71,9 @@ export function emitNotification(input: {
   os?: EmitOsPing;
 }): void {
   const { source, row, os } = input;
-  // Producer keys are repo-unqualified (`opened:42`), so two repos raising the same
-  // event would collapse into one. Qualify ONCE here and pass the same key down, so
-  // the inbox backstop dedupes on exactly what this register claimed.
+  // Producer keys vary: most are repo-unqualified (`opened:42`), a few already
+  // embed the path (harmlessly duplicated here), so isolation rests on THIS
+  // uniform prefix, not the producer — and the inbox gets the key we claimed.
   const dedupeKey = row.dedupeKey
     ? `${source}:${row.repoPath}:${row.dedupeKey}`
     : undefined;

--- a/src/lib/notifications/emit.ts
+++ b/src/lib/notifications/emit.ts
@@ -19,10 +19,10 @@ export interface EmitOsPing {
   focus: "unfocused" | "always";
 }
 
-/** When each dedupe key last claimed the window. Held here rather than left to the
- *  inbox's own dedupe because that one can only suppress the row, never the OS ping.
- *  A key is claimed synchronously and RELEASED again if the gates end up delivering
- *  nothing, so a suppressed no-op can't shadow the next real event. */
+/** When each `source:repoPath:producerKey` last claimed the window. Held here rather
+ *  than left to the inbox's own dedupe because that one can only suppress the row,
+ *  never the OS ping. A key is claimed synchronously and RELEASED again if the gates
+ *  end up delivering nothing, so a suppressed no-op can't shadow the next event. */
 const lastEmit = new Map<string, number>();
 /** Bound on a long session's key churn; the oldest delivered key is evicted first
  *  (insertion order tracks delivery time, since every write re-inserts). */
@@ -71,7 +71,12 @@ export function emitNotification(input: {
   os?: EmitOsPing;
 }): void {
   const { source, row, os } = input;
-  const { dedupeKey } = row;
+  // Producer keys are repo-unqualified (`opened:42`), so two repos raising the same
+  // event would collapse into one. Qualify ONCE here and pass the same key down, so
+  // the inbox backstop dedupes on exactly what this register claimed.
+  const dedupeKey = row.dedupeKey
+    ? `${source}:${row.repoPath}:${row.dedupeKey}`
+    : undefined;
   // Claimed before the first await, so two same-tick fires of one transition can't
   // both get through and double-deliver on BOTH channels.
   const claimedAt = Date.now();
@@ -86,7 +91,9 @@ export function emitNotification(input: {
       override,
       source,
     );
-    if (channels.inApp) pushNotification(row);
+    if (channels.inApp) {
+      pushNotification(dedupeKey ? { ...row, dedupeKey } : row);
+    }
     // Hiding AI features mutes the OS ping for AI-minted kinds — a hidden feature
     // must not tap you on the shoulder — but never the inbox row above, which the
     // dock filters at render time.

--- a/src/lib/notifications/matrix.ts
+++ b/src/lib/notifications/matrix.ts
@@ -1,0 +1,183 @@
+import { create } from "zustand";
+import {
+  NOTIFICATION_SOURCES,
+  type NotificationSettings,
+  type NotificationSource,
+  type PrCheckScopeFilter,
+} from "@/lib/settings/api";
+import type { RepoNotificationOverride } from "./overrides";
+
+// The notification matrix's shared vocabulary and its two open-state stores.
+// Component-free on purpose: the table primitives and the dialog live in
+// features/notifications, and a module mixing them with these values can't
+// Fast-Refresh (vite-plugin-react full-invalidates it, which reads as ghost
+// state at runtime).
+
+/** Delivery channels in column order; the matrix's DOM order is row-major over
+ *  this list, so the tab order matches what a reader hears. */
+export const CHANNELS = ["inApp", "os"] as const;
+export type Channel = (typeof CHANNELS)[number];
+
+export const CHANNEL_LABELS: Record<Channel, string> = {
+  inApp: "In-app",
+  os: "OS",
+};
+
+/** Spoken channel word inside a cell's aria-label — the column header is a
+ *  `<th scope="col">`, but a checkbox still needs a name of its own. */
+const CHANNEL_ARIA: Record<Channel, string> = {
+  inApp: "in-app",
+  os: "OS",
+};
+
+/** Record-typed against the manifest, so a new source can't ship label-less. */
+export const SOURCE_LABELS: Record<NotificationSource, string> = {
+  prChecks: "CI checks finish (pass or fail)",
+  prActivity: "Pull requests opened, merged, or closed",
+  prReviews: "Reviews on my pull requests",
+  actionRuns: "Workflow runs finish on the current branch",
+  reviews: "AI reviews I start",
+  automations: "Automation results",
+  agents: "Agent tasks finish",
+};
+
+/** Second line under a row's label; a source with nothing to add carries none. */
+export const SOURCE_DESCRIPTIONS: Partial<Record<NotificationSource, string>> =
+  {
+    prReviews:
+      "Approvals, change requests, comments, and requests for your review",
+    reviews: "A review or security audit finishing in the background",
+    automations: "Automated reviews ready, posted, or failed",
+    agents: "Sessions, plans, and research",
+  };
+
+/** Sources hidden with the AI surfaces. */
+const AI_SOURCES: ReadonlySet<NotificationSource> = new Set<NotificationSource>(
+  ["reviews", "automations", "agents"],
+);
+
+export const CHECK_SCOPE_LABELS: Record<PrCheckScopeFilter, string> = {
+  mine: "My pull requests only",
+  all: "All open pull requests",
+};
+
+/** Why the scope picker is held while the CI-checks source delivers nowhere.
+ *  Shared so the global matrix and the per-repo dialog say the same sentence. */
+export const CHECKS_OFF_WATCH_REASON =
+  "Turn on a CI checks channel to choose which pull requests to watch";
+
+/** The rows the matrix renders, in manifest order. Hidden AI rows keep whatever
+ *  the draft holds — they are omitted from the view, never rewritten. */
+export function notificationRows(
+  aiEnabled: boolean,
+): readonly NotificationSource[] {
+  return aiEnabled
+    ? NOTIFICATION_SOURCES
+    : NOTIFICATION_SOURCES.filter((source) => !AI_SOURCES.has(source));
+}
+
+export function channelAriaLabel(rowLabel: string, channel: Channel): string {
+  return `${rowLabel} — ${CHANNEL_ARIA[channel]}`;
+}
+
+/** JSON with object keys sorted, so a comparison is insensitive to key order. */
+export function sortedJson(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === "object" && !Array.isArray(val)
+      ? Object.fromEntries(
+          Object.keys(val as Record<string, unknown>)
+            .sort()
+            .map((k) => [k, (val as Record<string, unknown>)[k]]),
+        )
+      : val,
+  );
+}
+
+/** Key-order-insensitive fingerprint of the global notification settings. The
+ *  dialog's mint/drop-on-match baseline is the SAVED value, so the settings
+ *  screen compares its draft against this to know when the two disagree. */
+export function notificationsSignature(value: NotificationSettings): string {
+  return sortedJson(value);
+}
+
+/** How many individual settings an override pins — each channel field plus the
+ *  scope. The Reset gate and the settings footer's status line both count it. */
+export function overrideCount(
+  override: RepoNotificationOverride | undefined,
+): number {
+  if (!override) return 0;
+  let count = override.prChecksScope === undefined ? 0 : 1;
+  for (const source of NOTIFICATION_SOURCES) {
+    const cell = override.sources?.[source];
+    if (!cell) continue;
+    if (cell.inApp !== undefined) count += 1;
+    if (cell.os !== undefined) count += 1;
+  }
+  return count;
+}
+
+interface RepoNotificationsDialogState {
+  /** Repo path whose notifications are open, or null when closed. */
+  repoPath: string | null;
+  /** Bumped by every `open()`. An awaited save that outlived its own dialog
+   *  compares this to tell "still my dialog" from "a later one for the same
+   *  repo" — the repo path alone can't, and the two hold different edits. */
+  generation: number;
+  open: (repoPath: string) => void;
+  close: () => void;
+}
+
+/** Open-state for the one mounted `RepoNotificationsDialogHost`, so the settings
+ *  footer, the overrides audit list, and the command palette all reach the same
+ *  dialog without threading props or mounting a second copy. */
+export const useRepoNotificationsDialog =
+  create<RepoNotificationsDialogState>()((set) => ({
+    repoPath: null,
+    generation: 0,
+    open: (repoPath) =>
+      set((s) => ({ repoPath, generation: s.generation + 1 })),
+    close: () => set({ repoPath: null }),
+  }));
+
+interface NotificationsDraftState {
+  /** Fingerprint of the notifications slice a MOUNTED settings form holds, or
+   *  null when no settings screen is on. */
+  signature: string | null;
+  publish: (signature: string) => void;
+  clear: () => void;
+}
+
+/** What a live settings form is holding for notifications, so routes into the
+ *  per-repo dialog that render OUTSIDE the form (the command palette) can see
+ *  it. Screen-scoped, not panel-scoped: the draft survives a panel switch, so
+ *  the section never clears on unmount and App retires it on leaving Settings —
+ *  a flag that outlived its screen would hold the palette action shut forever. */
+export const useNotificationsDraft = create<NotificationsDraftState>()(
+  (set) => ({
+    signature: null,
+    publish: (signature) => set({ signature }),
+    clear: () => set({ signature: null }),
+  }),
+);
+
+/**
+ * Whether a live settings form holds notification edits the store hasn't taken
+ * yet. Per-repo overrides are minted against the SAVED matrix, so opening the
+ * dialog over an unsaved draft lets a user "change" a cell the dialog already
+ * reads as global — it stores nothing, and the pending Save then moves the
+ * global underneath it.
+ *
+ * The published signature carries the draft it was produced under and is
+ * compared against the live saved value rather than cleared by every writer, so
+ * a Save from another panel resolves it on its own. A Discard from another
+ * panel can't be seen — the section is unmounted — and leaves the verdict set
+ * until the screen closes: the fail-safe direction, since the section's own
+ * Customize button stays correct and reachable.
+ */
+export function notificationsDraftOutOfSync(
+  published: string | null,
+  saved: NotificationSettings | undefined,
+): boolean {
+  if (published === null || saved === undefined) return false;
+  return published !== notificationsSignature(saved);
+}

--- a/src/lib/notifications/matrix.ts
+++ b/src/lib/notifications/matrix.ts
@@ -149,9 +149,9 @@ interface NotificationsDraftState {
 
 /** What a live settings form is holding for notifications, so routes into the
  *  per-repo dialog that render OUTSIDE the form (the command palette) can see
- *  it. Screen-scoped, not panel-scoped: the draft survives a panel switch, so
- *  the section never clears on unmount and App retires it on leaving Settings —
- *  a flag that outlived its screen would hold the palette action shut forever. */
+ *  it. SettingsScreen publishes it from the form store and App retires it on
+ *  leaving Settings: the screen outlives every panel switch, and a value that
+ *  outlived its screen would hold the palette action shut forever. */
 export const useNotificationsDraft = create<NotificationsDraftState>()(
   (set) => ({
     signature: null,
@@ -168,11 +168,9 @@ export const useNotificationsDraft = create<NotificationsDraftState>()(
  * global underneath it.
  *
  * The published signature carries the draft it was produced under and is
- * compared against the live saved value rather than cleared by every writer, so
- * a Save from another panel resolves it on its own. A Discard from another
- * panel can't be seen — the section is unmounted — and leaves the verdict set
- * until the screen closes: the fail-safe direction, since the section's own
- * Customize button stays correct and reachable.
+ * compared against the live saved value rather than cleared per writer, so a
+ * Save OR a Discard from any panel resolves it: SettingsScreen publishes from
+ * the form store, which outlives panel switches, and App clears on screen close.
  */
 export function notificationsDraftOutOfSync(
   published: string | null,

--- a/src/lib/notifications/overrides.ts
+++ b/src/lib/notifications/overrides.ts
@@ -165,20 +165,22 @@ export function anyChannelOn(
   });
 }
 
-/** Windows paths are case-insensitive, so a legacy checkout-path key can differ in
- *  case from the live `repoPath` (see `addRecentRepo`). Identity keys stay exact —
- *  git reports one spelling of the common dir. */
+/** Both repo-key forms here are PATHS — the identity is the git common dir, whose
+ *  casing follows however the repo was opened — and Windows paths are
+ *  case-insensitive, so every key comparison goes through this (see `addRecentRepo`).
+ *  Deliberately unconditional on every platform, matching the recents store's
+ *  trade-off: case-twin paths naming genuinely distinct repos on a case-sensitive
+ *  filesystem would share one entry — accepted; a platform-aware compare belongs in
+ *  a shared helper adopted by all stores at once, never a per-store fork. */
 const samePath = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 
-/** Every stored key that is the legacy raw-path form of `repoPath`. Used on read
- *  (the fallback) and on write (the fold), so both see the same set. */
-function legacyPathKeys(
+/** Every stored key naming `path`, whatever its casing. Used on read (lookup) and on
+ *  write (the fold), so neither arm can see a key the other misses. */
+function keysMatching(
   map: Record<string, RepoNotificationOverride>,
-  identity: string,
-  repoPath: string,
+  path: string,
 ): string[] {
-  if (identity === repoPath) return [];
-  return Object.keys(map).filter((key) => samePath(key, repoPath));
+  return Object.keys(map).filter((key) => samePath(key, path));
 }
 
 /** A repo's override, looked up by its worktree-stable identity with a legacy
@@ -190,9 +192,10 @@ export function overrideEntry(
   identity: string,
   repoPath: string,
 ): RepoNotificationOverride | undefined {
-  const exact = map[identity];
-  if (exact) return exact;
-  const legacy = legacyPathKeys(map, identity, repoPath)[0];
+  const own = keysMatching(map, identity)[0];
+  if (own !== undefined) return map[own];
+  if (samePath(identity, repoPath)) return undefined;
+  const legacy = keysMatching(map, repoPath)[0];
   return legacy === undefined ? undefined : map[legacy];
 }
 
@@ -245,11 +248,14 @@ export async function saveRepoNotificationOverride(
   const normalized = normalizeOverride(override);
   return mutateOverrides((current) => {
     const next = { ...current };
-    // Every case-variant of the raw path goes, not just the live spelling — a
-    // survivor would sit beside the identity key as a ghost nothing ever reads.
-    for (const key of legacyPathKeys(next, id, repoPath)) delete next[key];
+    // Drop every case-variant of BOTH key forms before writing back under the
+    // freshly resolved casing — a survivor would be a ghost entry that
+    // `overrideEntry` might return instead, and that no save could reach again.
+    for (const key of keysMatching(next, id)) delete next[key];
+    if (!samePath(id, repoPath)) {
+      for (const key of keysMatching(next, repoPath)) delete next[key];
+    }
     if (normalized) next[id] = normalized;
-    else delete next[id];
     return next;
   });
 }

--- a/src/lib/notifications/overrides.ts
+++ b/src/lib/notifications/overrides.ts
@@ -1,0 +1,267 @@
+import { load, type Store } from "@tauri-apps/plugin-store";
+import { repoIdentity } from "@/lib/git/repo-identity";
+import {
+  type ChannelPrefs,
+  NOTIFICATION_SOURCES,
+  type NotificationSettings,
+  type NotificationSource,
+  PR_CHECK_SCOPE_FILTERS,
+  type PrCheckScopeFilter,
+} from "@/lib/settings/api";
+import { storeName } from "@/lib/test-mode";
+
+/** A repo's adjustments; every absent field inherits the global. */
+export interface RepoNotificationOverride {
+  /** true = nothing from this repo notifies on any channel; wins over cells. */
+  muted?: boolean;
+  sources?: Partial<Record<NotificationSource, Partial<ChannelPrefs>>>;
+  prChecksScope?: PrCheckScopeFilter;
+}
+
+/** The single store key holding `Record<repoKey, RepoNotificationOverride>`. */
+const STORE_KEY = "overrides";
+
+// Personal app-data — notification preferences are the user's, never the repo's.
+let storePromise: Promise<Store> | null = null;
+function getStore(): Promise<Store> {
+  storePromise ??= load(storeName("notification-overrides.json"), {
+    autoSave: true,
+    defaults: {},
+  }).catch((e: unknown) => {
+    // A rejected load must not be memoized: the emit gate reads this store on every
+    // notification, and a pinned failure would silently ignore every pref for the
+    // rest of the session. Drop the memo so the next call retries.
+    storePromise = null;
+    throw e;
+  });
+  return storePromise;
+}
+
+// Serialize every read-modify-write on this store through one in-process queue:
+// autoSave persists on a ~100ms debounce, so two overlapping saves would both read
+// the same pre-flush disk snapshot and the later would drop the earlier's change.
+// Mirrors automations/store.ts. In-process only; cross-window races remain out of
+// scope.
+let opChain: Promise<unknown> = Promise.resolve();
+function serialize<T>(op: () => Promise<T>): Promise<T> {
+  const run = opChain.then(op, op);
+  // Keep the queue alive whether `op` fulfilled or rejected; callers still get `run`.
+  opChain = run.catch(() => undefined);
+  return run;
+}
+
+/** Re-read the file into the in-memory store, tolerating a missing one: `load()`
+ *  tolerates it but `reload()` rejects with a raw io error until the first `save()`
+ *  creates it, so ANY reload failure proceeds with in-memory state.
+ *  `ignoreDefaults: true` matches the store to disk so externally-deleted keys drop.
+ *  Call inside the serialized queue so it can't land between a set and its flush. */
+async function reloadRaw(store: Store): Promise<void> {
+  try {
+    await store.reload({ ignoreDefaults: true });
+  } catch {
+    // Missing file — the next save() creates it.
+  }
+}
+
+// ── Normalization (every load) ──────────────────────────────────────────────
+
+/** Type-checks one untrusted channel cell, keeping only boolean fields. Returns
+ *  undefined for a cell that ends up empty — an inherit-everything cell is no
+ *  override. */
+function normalizeCell(v: unknown): Partial<ChannelPrefs> | undefined {
+  if (!v || typeof v !== "object") return undefined;
+  const pair = v as { inApp?: unknown; os?: unknown };
+  const cell: Partial<ChannelPrefs> = {};
+  if (typeof pair.inApp === "boolean") cell.inApp = pair.inApp;
+  if (typeof pair.os === "boolean") cell.os = pair.os;
+  return cell.inApp === undefined && cell.os === undefined ? undefined : cell;
+}
+
+/** The manifest is the only enumeration, so a key naming no known source drops. */
+function normalizeSources(
+  v: unknown,
+): RepoNotificationOverride["sources"] | undefined {
+  if (!v || typeof v !== "object") return undefined;
+  const obj = v as Record<string, unknown>;
+  const out: Partial<Record<NotificationSource, Partial<ChannelPrefs>>> = {};
+  let any = false;
+  for (const source of NOTIFICATION_SOURCES) {
+    const cell = normalizeCell(obj[source]);
+    if (cell) {
+      out[source] = cell;
+      any = true;
+    }
+  }
+  return any ? out : undefined;
+}
+
+/** Type-checks one untrusted override, dropping malformed fields. Returns undefined
+ *  when nothing usable survives: an empty override is no override, and storing one
+ *  would mark the repo as overridden while it inherits everything. */
+function normalizeOverride(v: unknown): RepoNotificationOverride | undefined {
+  if (!v || typeof v !== "object") return undefined;
+  const obj = v as {
+    muted?: unknown;
+    sources?: unknown;
+    prChecksScope?: unknown;
+  };
+  const out: RepoNotificationOverride = {};
+  if (obj.muted === true) out.muted = true;
+  const sources = normalizeSources(obj.sources);
+  if (sources) out.sources = sources;
+  if (
+    PR_CHECK_SCOPE_FILTERS.includes(obj.prChecksScope as PrCheckScopeFilter)
+  ) {
+    out.prChecksScope = obj.prChecksScope as PrCheckScopeFilter;
+  }
+  if (!out.muted && !out.sources && !out.prChecksScope) return undefined;
+  return out;
+}
+
+function normalizeOverrides(
+  saved: unknown,
+): Record<string, RepoNotificationOverride> {
+  const out: Record<string, RepoNotificationOverride> = {};
+  if (!saved || typeof saved !== "object" || Array.isArray(saved)) return out;
+  for (const [key, value] of Object.entries(saved)) {
+    const override = normalizeOverride(value);
+    if (override) out[key] = override;
+  }
+  return out;
+}
+
+// ── Pure resolution ─────────────────────────────────────────────────────────
+
+/** The channels a source actually delivers on for one repo. `muted` is repo-wide
+ *  and beats every cell; otherwise each channel falls back to the global. */
+export function effectiveChannels(
+  global: NotificationSettings,
+  override: RepoNotificationOverride | undefined,
+  source: NotificationSource,
+): ChannelPrefs {
+  if (override?.muted) return { inApp: false, os: false };
+  return { ...global.sources[source], ...override?.sources?.[source] };
+}
+
+/** Which PRs a repo watches for CI checks — orthogonal to the prChecks channels,
+ *  so it stays meaningful even while that source is muted. */
+export function effectiveChecksScope(
+  global: NotificationSettings,
+  override: RepoNotificationOverride | undefined,
+): PrCheckScopeFilter {
+  return override?.prChecksScope ?? global.prChecksScope;
+}
+
+/** Whether any of `sources` delivers on any channel — the shape a poll-enable
+ *  predicate needs, so a poll can't run for sources that would deliver nothing. */
+export function anyChannelOn(
+  global: NotificationSettings,
+  override: RepoNotificationOverride | undefined,
+  sources: readonly NotificationSource[],
+): boolean {
+  return sources.some((source) => {
+    const channels = effectiveChannels(global, override, source);
+    return channels.inApp || channels.os;
+  });
+}
+
+/** Windows paths are case-insensitive, so a legacy checkout-path key can differ in
+ *  case from the live `repoPath` (see `addRecentRepo`). Identity keys stay exact —
+ *  git reports one spelling of the common dir. */
+const samePath = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+/** Every stored key that is the legacy raw-path form of `repoPath`. Used on read
+ *  (the fallback) and on write (the fold), so both see the same set. */
+function legacyPathKeys(
+  map: Record<string, RepoNotificationOverride>,
+  identity: string,
+  repoPath: string,
+): string[] {
+  if (identity === repoPath) return [];
+  return Object.keys(map).filter((key) => samePath(key, repoPath));
+}
+
+/** A repo's override, looked up by its worktree-stable identity with a legacy
+ *  checkout-path fallback (until the next save folds the old key onto the
+ *  identity). Pure, so the sync React consumers and the async helper below share
+ *  it — the caller resolves `identity` via `repoIdentity`/`useRepoIdentity`. */
+export function overrideEntry(
+  map: Record<string, RepoNotificationOverride>,
+  identity: string,
+  repoPath: string,
+): RepoNotificationOverride | undefined {
+  const exact = map[identity];
+  if (exact) return exact;
+  const legacy = legacyPathKeys(map, identity, repoPath)[0];
+  return legacy === undefined ? undefined : map[legacy];
+}
+
+// ── Public store API ────────────────────────────────────────────────────────
+
+/** Every repo's overrides, normalized on each load so partial/hand-edited data
+ *  never reaches a consumer. */
+export async function loadNotificationOverrides(): Promise<
+  Record<string, RepoNotificationOverride>
+> {
+  const store = await getStore();
+  return normalizeOverrides(await store.get<unknown>(STORE_KEY));
+}
+
+/** One repo's override. Reads the memoized store instance, so a same-process write
+ *  is visible immediately; another window's is not (matching automations). */
+export async function overrideForRepo(
+  repoPath: string,
+): Promise<RepoNotificationOverride | undefined> {
+  const map = await loadNotificationOverrides();
+  return overrideEntry(map, await repoIdentity(repoPath), repoPath);
+}
+
+/** Serialized read-modify-write against fresh disk state. The force-save flushes
+ *  past the autoSave debounce so the next queued op's reload sees it. */
+function mutateOverrides(
+  mutate: (
+    current: Record<string, RepoNotificationOverride>,
+  ) => Record<string, RepoNotificationOverride>,
+): Promise<void> {
+  return serialize(async () => {
+    const store = await getStore();
+    await reloadRaw(store);
+    const current = normalizeOverrides(await store.get<unknown>(STORE_KEY));
+    await store.set(STORE_KEY, mutate(current));
+    await store.save();
+  });
+}
+
+/** Replaces one repo's override, dropping the entry when it holds nothing usable.
+ *  Keys by worktree-stable identity and deletes any legacy checkout-path entry
+ *  (folding it), so a repo's overrides apply from every worktree. */
+export async function saveRepoNotificationOverride(
+  repoPath: string,
+  override: RepoNotificationOverride,
+): Promise<void> {
+  // Resolve the identity before entering the serialized mutator (it's async; the
+  // mutator runs synchronously over fresh state).
+  const id = await repoIdentity(repoPath);
+  const normalized = normalizeOverride(override);
+  return mutateOverrides((current) => {
+    const next = { ...current };
+    // Every case-variant of the raw path goes, not just the live spelling — a
+    // survivor would sit beside the identity key as a ghost nothing ever reads.
+    for (const key of legacyPathKeys(next, id, repoPath)) delete next[key];
+    if (normalized) next[id] = normalized;
+    else delete next[id];
+    return next;
+  });
+}
+
+/** Drops one stored key verbatim — the repo-key form the caller read back from
+ *  {@link loadNotificationOverrides}, which may still be a legacy checkout path. */
+export async function clearNotificationOverride(
+  repoKey: string,
+): Promise<void> {
+  return mutateOverrides((current) => {
+    const next = { ...current };
+    delete next[repoKey];
+    return next;
+  });
+}

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRepoIdentity } from "@/lib/git/queries";
+import {
+  clearNotificationOverride,
+  loadNotificationOverrides,
+  overrideEntry,
+  type RepoNotificationOverride,
+  saveRepoNotificationOverride,
+} from "./overrides";
+
+export const notificationOverridesKey = ["notification-overrides"] as const;
+
+export function useNotificationOverrides() {
+  return useQuery({
+    queryKey: notificationOverridesKey,
+    queryFn: loadNotificationOverrides,
+  });
+}
+
+/** The open repo's override (undefined while loading or when none). Keyed by the
+ *  repo's worktree-stable identity, falling back to the raw path while that
+ *  resolves and for entries still stored under it. */
+export function useRepoNotificationOverride(
+  repoPath: string,
+): RepoNotificationOverride | undefined {
+  const overrides = useNotificationOverrides();
+  const identity = useRepoIdentity(repoPath).data;
+  if (!overrides.data) return undefined;
+  return overrideEntry(overrides.data, identity ?? repoPath, repoPath);
+}
+
+export function useSaveRepoNotificationOverride(repoPath: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (override: RepoNotificationOverride) =>
+      saveRepoNotificationOverride(repoPath, override),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: notificationOverridesKey }),
+  });
+}
+
+export function useClearNotificationOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (repoKey: string) => clearNotificationOverride(repoKey),
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: notificationOverridesKey }),
+  });
+}

--- a/src/lib/notifications/queries.ts
+++ b/src/lib/notifications/queries.ts
@@ -14,6 +14,9 @@ export function useNotificationOverrides() {
   return useQuery({
     queryKey: notificationOverridesKey,
     queryFn: loadNotificationOverrides,
+    // Local plugin-store read: the default online mode PARKS it while the OS
+    // reports no connection, and every override-gated surface wedges.
+    networkMode: "always",
   });
 }
 
@@ -34,6 +37,8 @@ export function useSaveRepoNotificationOverride(repoPath: string) {
   return useMutation({
     mutationFn: (override: RepoNotificationOverride) =>
       saveRepoNotificationOverride(repoPath, override),
+    // Local plugin-store write — never park it offline (see the query above).
+    networkMode: "always",
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: notificationOverridesKey }),
   });
@@ -43,6 +48,8 @@ export function useClearNotificationOverride() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (repoKey: string) => clearNotificationOverride(repoKey),
+    // Local plugin-store write — never park it offline (see the query above).
+    networkMode: "always",
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: notificationOverridesKey }),
   });

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -90,6 +90,7 @@ const IDENTITY_STORES: IdentityStore[] = [
   { file: "repo-lens.json", merge: "keep-new" },
   { file: "conversation-filters.json", merge: "keep-new" },
   { file: "branch-rules.json", merge: "keep-new" },
+  { file: "notification-overrides.json", merge: "keep-new" },
   {
     file: "automations.json",
     merge: "keep-new",

--- a/src/lib/repo-data-migration.ts
+++ b/src/lib/repo-data-migration.ts
@@ -90,7 +90,14 @@ const IDENTITY_STORES: IdentityStore[] = [
   { file: "repo-lens.json", merge: "keep-new" },
   { file: "conversation-filters.json", merge: "keep-new" },
   { file: "branch-rules.json", merge: "keep-new" },
-  { file: "notification-overrides.json", merge: "keep-new" },
+  {
+    // The whole repo map lives under one store key, so the nested walk addresses
+    // it with an identity getMap: `config` IS the map. No shape check here — the
+    // walker narrows `config` before the call and re-checks the result after.
+    file: "notification-overrides.json",
+    merge: "keep-new",
+    nested: { configKey: "overrides", getMap: (config) => config },
+  },
   {
     file: "automations.json",
     merge: "keep-new",

--- a/src/lib/settings/api.ts
+++ b/src/lib/settings/api.ts
@@ -167,22 +167,38 @@ export const AUTO_FETCH_INTERVALS = ["5", "10", "15", "30", "60"] as const;
  *  settings Select directly). */
 export type AutoFetchInterval = (typeof AUTO_FETCH_INTERVALS)[number];
 
-/** The CI-check notification scopes offered in Settings, in render order. */
-export const PR_CHECK_SCOPES = ["off", "mine", "all"] as const;
+/** Delivery channels for one notification source. */
+export interface ChannelPrefs {
+  /** Record a row in the activity-dock inbox. */
+  inApp: boolean;
+  /** OS notification (each producer's focus policy governs when). */
+  os: boolean;
+}
+
+/** Every notification source, in render order. The single manifest: the settings
+ *  matrix, the heal, and the emit gate all iterate THIS list, so a new source
+ *  cannot ship half-wired. */
+export const NOTIFICATION_SOURCES = [
+  "prChecks",
+  "prActivity",
+  "prReviews",
+  "actionRuns",
+  "reviews",
+  "automations",
+  "agents",
+] as const;
+export type NotificationSource = (typeof NOTIFICATION_SOURCES)[number];
+
+/** CI-check scopes offered in Settings. The legacy tri-state's "off" is retired —
+ *  both prChecks channels off expresses it, and {@link healNotifications} maps it. */
+export const PR_CHECK_SCOPE_FILTERS = ["mine", "all"] as const;
+export type PrCheckScopeFilter = (typeof PR_CHECK_SCOPE_FILTERS)[number];
 
 export interface NotificationSettings {
-  /** Automation results (review posted / ready / failed). */
-  automations: boolean;
-  /** An AI code review or security audit you started finishing in the background. */
-  reviews: boolean;
-  /** CI check completion on open PRs. */
-  prChecks: (typeof PR_CHECK_SCOPES)[number];
-  /** PRs opened / merged / closed in the current repo. */
-  prActivity: boolean;
-  /** Review decisions on PRs you authored. */
-  prReviews: boolean;
-  /** Workflow runs finishing (success/failure) on the current branch. */
-  actionRuns: boolean;
+  /** Per-source delivery channels, Record-typed against the manifest. */
+  sources: Record<NotificationSource, ChannelPrefs>;
+  /** Which PRs the prChecks source watches — orthogonal to its channels. */
+  prChecksScope: PrCheckScopeFilter;
 }
 
 /** The agent CLIs offerable as the Default agent, in render order. Spelled out here
@@ -244,7 +260,7 @@ export interface AppSettings {
    *  automations: no new automated run starts while set (an in-flight run finishes).
    *  Provider config, API keys, and rules are kept. */
   hideAi: boolean;
-  /** OS notifications (sent only while the window is unfocused). */
+  /** Which sources notify, and on which channels. */
   notifications: NotificationSettings;
   /** Hide the app to the system tray on window close (so background work keeps
    *  running) instead of quitting. */
@@ -390,12 +406,16 @@ export const DEFAULT_SETTINGS: AppSettings = {
   reviewEffort: "auto",
   hideAi: false,
   notifications: {
-    automations: true,
-    reviews: true,
-    prChecks: "all",
-    prActivity: true,
-    prReviews: true,
-    actionRuns: true,
+    sources: {
+      prChecks: { inApp: true, os: true },
+      prActivity: { inApp: true, os: true },
+      prReviews: { inApp: true, os: true },
+      actionRuns: { inApp: true, os: true },
+      reviews: { inApp: true, os: true },
+      automations: { inApp: true, os: true },
+      agents: { inApp: true, os: true },
+    },
+    prChecksScope: "all",
   },
   closeToTray: true,
   agentIsolation: "worktree",
@@ -529,6 +549,79 @@ export const asMcpServerArray = (value: unknown): McpServer[] =>
       )
     : [];
 
+/** A plain object, or `{}` for anything else (null, an array, a primitive) — the
+ *  stored settings file is hand-editable, so every branch below reads through this. */
+const asObject = (v: unknown): Record<string, unknown> =>
+  v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : {};
+
+/** Builds a full source map from the manifest, which is the only enumeration of
+ *  source keys — a new source therefore cannot be missed by a heal branch. */
+const mapSources = (
+  cell: (source: NotificationSource) => ChannelPrefs,
+): Record<NotificationSource, ChannelPrefs> =>
+  Object.fromEntries(
+    NOTIFICATION_SOURCES.map((source) => [source, cell(source)]),
+  ) as Record<NotificationSource, ChannelPrefs>;
+
+/**
+ * Coerces a stored `notifications` value — new-shape, legacy (six accreted prefs),
+ * or junk — into a full {@link NotificationSettings}. The legacy branch stays
+ * forever: an install that skips several releases must still find its path here.
+ * A stored `sources` object marks the new shape and wins outright, so a file
+ * carrying both shapes never reads a stale legacy key.
+ *
+ * Pure; exported for the heal's reviewability.
+ */
+export function healNotifications(saved: unknown): NotificationSettings {
+  const defaults = DEFAULT_SETTINGS.notifications;
+  const obj = asObject(saved);
+
+  if (
+    obj.sources &&
+    typeof obj.sources === "object" &&
+    !Array.isArray(obj.sources)
+  ) {
+    const stored = obj.sources as Record<string, unknown>;
+    return {
+      sources: mapSources((source) => {
+        const pair = asObject(stored[source]);
+        return {
+          inApp:
+            typeof pair.inApp === "boolean"
+              ? pair.inApp
+              : defaults.sources[source].inApp,
+          os:
+            typeof pair.os === "boolean"
+              ? pair.os
+              : defaults.sources[source].os,
+        };
+      }),
+      prChecksScope: pick(obj.prChecksScope, PR_CHECK_SCOPE_FILTERS, "all"),
+    };
+  }
+
+  // Legacy: five boolean prefs named exactly like their sources, plus a tri-state
+  // prChecks whose "off" becomes both channels off and whose scope moves out. The
+  // `agents` producers were ungated before this shape, so they default on.
+  const legacyChecks = obj.prChecks;
+  return {
+    sources: mapSources((source) => {
+      if (source === "prChecks") {
+        return legacyChecks === "off"
+          ? { inApp: false, os: false }
+          : { ...defaults.sources.prChecks };
+      }
+      const stored = obj[source];
+      return typeof stored === "boolean"
+        ? { inApp: stored, os: stored }
+        : { ...defaults.sources[source] };
+    }),
+    prChecksScope: pick(legacyChecks, PR_CHECK_SCOPE_FILTERS, "all"),
+  };
+}
+
 /**
  * Coerces every statically-enumerable field to its default when the stored value is
  * off-list. settings.json is hand-editable and no writer validates membership, so an
@@ -569,14 +662,6 @@ function healEnumerated(settings: AppSettings): AppSettings {
     ),
     reviewTimeout: pick(settings.reviewTimeout, REVIEW_TIMEOUTS, "auto"),
     reviewEffort: pick(settings.reviewEffort, REVIEW_EFFORTS, "auto"),
-    notifications: {
-      ...settings.notifications,
-      prChecks: pick(
-        settings.notifications.prChecks,
-        PR_CHECK_SCOPES,
-        DEFAULT_SETTINGS.notifications.prChecks,
-      ),
-    },
     agentIsolation: pick(
       settings.agentIsolation,
       AGENT_ISOLATIONS,
@@ -618,8 +703,10 @@ function healEnumerated(settings: AppSettings): AppSettings {
 
 /** Loads settings, healing an older or partial saved object against DEFAULT_SETTINGS:
  *  any field absent (stored before that field shipped) reads as its default. Nested
- *  ai/reviewAi/notifications objects are merged, not replaced. Enumerated fields are
- *  then membership-checked by {@link healEnumerated}, so every caller — the settings
+ *  ai/reviewAi objects are merged, not replaced; `notifications` is rebuilt by
+ *  {@link healNotifications}, which is total (a nested spread there would splash
+ *  legacy primitives over the new channel objects). Enumerated fields are then
+ *  membership-checked by {@link healEnumerated}, so every caller — the settings
  *  form, the pre-React theme apply, and the RMW writers below — sees a valid object. */
 export async function loadSettings(): Promise<AppSettings> {
   const store = await getStore();
@@ -640,10 +727,7 @@ export async function loadSettings(): Promise<AppSettings> {
           },
         }
       : {}),
-    notifications: {
-      ...DEFAULT_SETTINGS.notifications,
-      ...saved?.notifications,
-    },
+    notifications: healNotifications(saved?.notifications),
   });
 }
 

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -40,7 +40,10 @@ export type NotificationKind =
  *  OS-ping gates both read this set, so a new AI producer can't drift out of the
  *  Hide-AI story. `review-requested` is deliberately absent — it is a forge event
  *  (a human asked you to review), not AI output. Widened to `string` on read
- *  because {@link AppNotification.kind} is untrusted: an unlisted kind shows. */
+ *  because {@link AppNotification.kind} is untrusted: an unlisted kind shows.
+ *  Kind never implies source: `review-ready`/`review-failed` are minted by BOTH the
+ *  manual-review store and the automation runner under different sources, so every
+ *  emit site declares its source explicitly. */
 export const AI_NOTIFICATION_KINDS: ReadonlySet<string> =
   new Set<NotificationKind>([
     "review-ready",
@@ -121,7 +124,7 @@ export interface AppNotification {
 const CAP = 50;
 const STORE_KEY = "items";
 /** A repeated identical event inside this window is treated as a double-fire. */
-const DEDUPE_WINDOW_MS = 8_000;
+export const DEDUPE_WINDOW_MS = 8_000;
 
 /** The valid tones — used to coerce a corrupt/older on-disk `tone` to a safe
  *  default so the glyph never renders uncolored. */

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -34,7 +34,7 @@ import { track } from "@/lib/analytics";
 import { readRepoInstructions } from "@/lib/git/api";
 import { repoIdentity } from "@/lib/git/repo-identity";
 import type { DiffStatEntry, RemoteLens } from "@/lib/git/types";
-import { notifyIfUnfocused } from "@/lib/notify";
+import { emitNotification } from "@/lib/notifications/emit";
 import {
   reviewHistoryKey,
   reviewPartialKey,
@@ -42,7 +42,6 @@ import {
 } from "@/lib/pulls/reviews-history";
 import { queryClient } from "@/lib/query-client";
 import { loadSettings } from "@/lib/settings/api";
-import { pushNotification } from "@/lib/stores/notifications";
 import { errorMessage } from "@/lib/tauri/invoke";
 
 export interface ReviewContext {
@@ -349,9 +348,10 @@ function releaseSlot(lane: Limiter): void {
   lane.active--;
 }
 
-/** OS notification when a review settles while the window is hidden (close to
- *  tray) or unfocused, gated on the user's setting. Best-effort. */
-async function notifyReviewDone(
+/** Announces a settled review — inbox row plus an OS ping when the window is
+ *  hidden (close to tray) or unfocused, on whichever channels the `reviews`
+ *  source has for this repo. Best-effort. */
+function notifyReviewDone(
   title: string,
   mode: ReviewMode,
   ok: boolean,
@@ -361,39 +361,35 @@ async function notifyReviewDone(
    *  automation): a manual re-fire closure would capture a stale AiSettings snapshot,
    *  whereas the panel's Run button re-resolves fresh config. */
   error?: string,
-): Promise<void> {
+): void {
   try {
-    const { notifications, hideAi } = await loadSettings();
-    if (!notifications.reviews) return;
     const label = mode === "security" ? "security audit" : "review";
     const headline = ok ? `AI ${label} ready` : `AI ${label} failed`;
     // A failed review carries its reason in the subtitle; success stays subject-only.
     const subtitle =
       !ok && error?.trim() ? `"${title}" — ${error}` : `"${title}"`;
-    // Durable record in the inbox (regardless of focus), plus the OS ping when
-    // the window is hidden. Both ride the same `reviews` pref.
-    pushNotification({
-      kind: ok ? "review-ready" : "review-failed",
-      tone: ok ? "success" : "danger",
-      title: headline,
-      subtitle,
-      repoPath: target.repoPath,
-      repoName: target.repoName,
-      target: {
-        type: "pr",
-        kind: target.kind,
-        ref: target.ref,
-        lens: target.lens,
+    emitNotification({
+      source: "reviews",
+      row: {
+        kind: ok ? "review-ready" : "review-failed",
+        tone: ok ? "success" : "danger",
+        title: headline,
+        subtitle,
+        repoPath: target.repoPath,
+        repoName: target.repoName,
+        target: {
+          type: "pr",
+          kind: target.kind,
+          ref: target.ref,
+          lens: target.lens,
+        },
+        // The lens is in the dedupe key because a fork's origin and upstream PRs share
+        // a number: without it, two reviews settling in the same window collapse into
+        // one notification.
+        dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
       },
-      // The lens is in the dedupe key because a fork's origin and upstream PRs share
-      // a number: without it, two reviews settling in the same window collapse into
-      // one notification.
-      dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
+      os: { title: headline, body: subtitle, focus: "unfocused" },
     });
-    // Hiding AI features mutes the OS ping (a hidden feature must not tap you on
-    // the shoulder) but never the inbox record above — the dock filters that at
-    // render time, so the history is whole again when AI is shown.
-    if (!hideAi) void notifyIfUnfocused(headline, subtitle);
   } catch {
     // best-effort — a missed notification must never affect the review
   }
@@ -776,7 +772,7 @@ export async function startReview(
       truncatedCoverage: coverage.diffTruncated && !agenticRun,
       endedAt: Date.now(),
     });
-    void notifyReviewDone(title, mode, true, target);
+    notifyReviewDone(title, mode, true, target);
     // Persist the finished review so the NEXT run can use it as soft context.
     // Best-effort.
     // The agentic run's narration, peeled off at settle — persisted as display-only
@@ -827,7 +823,7 @@ export async function startReview(
         error: message,
         endedAt: Date.now(),
       });
-      void notifyReviewDone(title, mode, false, target, message);
+      notifyReviewDone(title, mode, false, target, message);
       // Whatever the run produced before it failed — this store is memory-only, so
       // without a record a timed-out 20-minute run is gone at the next restart. Saved
       // as a PARTIAL record (`phase`), which the history reads exclude: it's kept

--- a/src/lib/stores/reviews.ts
+++ b/src/lib/stores/reviews.ts
@@ -383,10 +383,10 @@ function notifyReviewDone(
           ref: target.ref,
           lens: target.lens,
         },
-        // The lens is in the dedupe key because a fork's origin and upstream PRs share
-        // a number: without it, two reviews settling in the same window collapse into
-        // one notification.
-        dedupeKey: `review:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
+        // Mode and lens both key it: a security audit queues behind a general run on the
+        // same target, and a fork's origin and upstream PRs share a number. Without
+        // either, two reviews settling in the same window collapse into one notification.
+        dedupeKey: `review:${mode}:${target.kind}:${target.repoPath}:${target.lens}:${target.ref}:${ok}`,
       },
       os: { title: headline, body: subtitle, focus: "unfocused" },
     });


### PR DESCRIPTION
Notification preferences were six accreted booleans that conflated "record it" with "ping me", and three producers (agent sessions, plans, research) bypassed them entirely — nothing the user set could silence an agent-finished ping. This replaces that with a source × channel matrix (in-app inbox, OS, both, or neither), per-repository overrides, and a single `emitNotification` gate every producer now routes through, enforced by a banned-patterns check so a future producer cannot ship ungated.

### Settings model

- Reshapes `NotificationSettings` in `src/lib/settings/api.ts` around `NOTIFICATION_SOURCES` — a single manifest (`prChecks`, `prActivity`, `prReviews`, `actionRuns`, `reviews`, `automations`, `agents`) that the matrix, the heal, and the gate all iterate — with per-source `ChannelPrefs { inApp, os }`.
- Retires the tri-state `PR_CHECK_SCOPES` in favor of `PR_CHECK_SCOPE_FILTERS` (`mine` | `all`) plus a top-level `prChecksScope`: "off" is now expressed as both `prChecks` channels being clear.
- Adds an exported, pure `healNotifications` that coerces new-shape, legacy six-pref, or junk stored values into a full settings object; a stored `sources` object marks the new shape and wins outright, and the legacy branch maps `prChecks: "off"` onto cleared channels with the scope moved out.

### Delivery gate

- Adds `src/lib/notifications/emit.ts` — `emitNotification({ source, row, os })` resolves the source's channels (global prefs merged with the repo override), delivers the inbox row and/or the OS ping, mutes the OS ping for `AI_NOTIFICATION_KINDS` while AI is hidden, and owns a synchronous check-and-set dedupe across both channels (bounded at `MAX_DEDUPE_KEYS`, with `releaseDedupeKey` handing the window back when nothing was delivered).
- Degrades each read independently: a failed `loadSettings` falls back to `DEFAULT_SETTINGS` while a surviving override still applies, and a failed override read leaves the real global prefs governing — silence is never the failure mode.
- Exports `DEDUPE_WINDOW_MS` from `src/lib/stores/notifications.ts` and documents that kind never implies source (`review-ready`/`review-failed` are minted under two different sources).

### Per-repo overrides

- Adds `src/lib/notifications/overrides.ts`: a `notification-overrides.json` plugin store keyed by worktree-stable repo identity, with normalization of every untrusted field, a serialized read-modify-write queue (autoSave's ~100ms debounce would otherwise drop a change), a non-memoized failed `load()`, and the pure resolvers `effectiveChannels`, `effectiveChecksScope`, `anyChannelOn`, and `overrideEntry`.
- Adds `src/lib/notifications/queries.ts` with `useNotificationOverrides`, `useRepoNotificationOverride`, `useSaveRepoNotificationOverride`, and `useClearNotificationOverride`.
- Registers `notification-overrides.json` in `IDENTITY_STORES` in `src/lib/repo-data-migration.ts` so overrides follow a relocated repo.

### UI

- Adds `src/features/notifications/RepoNotificationsDialog.tsx`: the per-repo dialog plus the vocabulary Settings shares (`CHANNELS`, `SOURCE_LABELS`, `SOURCE_DESCRIPTIONS`, `CHECK_SCOPE_LABELS`, `MatrixTable`, `RowLabelCell`, `MatrixCell`, `WatchRow`, `notificationRows`). "Mute this repository" silences every source; untouched cells follow the global settings; the matrix is a real table with `scope="row"`/`scope="col"` headers carrying the a11y wiring.
- Rewrites `src/features/settings/NotificationsSection.tsx` as the global matrix with per-column master checkboxes (tri-state, rendered as a dash glyph rather than by color alone), a **Customize…** entry point gated on the draft matching saved settings via `notificationsSignature`, and a list of repos that already carry an override.
- Registers `open-notifications-settings` and `open-repo-notification-settings` in `src/lib/hotkeys/registry.ts`, wires them in `src/App.tsx` (re-reading `repoPath` at fire time so a switch is honored), and mounts `RepoNotificationsDialogHost`.

### Producers routed through the gate

- `src/features/repository/usePrNotifications.ts` — `record()` now takes a `source`, `anyChannelOn` gates the poll (so an override that *enables* a globally-muted source still polls), and `effectiveChecksScope` decides which PRs are watched.
- `src/features/actions/useRunNotifications.ts` — same gating for `actionRuns`; the poll no longer runs while settings are unloaded.
- `src/features/sessions/store.ts`, `src/features/plan/store.ts`, `src/features/research/store.ts` — previously ungated `notify` + `pushNotification` pairs now emit under the `agents` source with `focus: "always"`.
- `src/lib/automations/runner.ts` and `src/lib/stores/reviews.ts` — drop their local `notifications.automations` / `notifications.reviews` boolean checks and emit under their source, letting the gate decide both channels.

### Enforcement

- Adds the `ungated-notification-producer` check to `scripts/check-banned-patterns.mjs`, flagging direct imports of `pushNotification` (specifier and namespace forms) and of the `notify` module, anchored on the trailing path segment so relative spellings can't dodge it; `emit.ts` is excluded by `appliesTo` and the allowlist is empty by construction.
- Adds coverage in `scripts/checks.test.mjs` for both routes, renamed and wrapped specifiers, relative and namespace imports, and the legal sibling imports (`emitNotification`, `repoNameFromPath`, type-only exports) the check must leave alone.

### Docs

- `README.md`: rewrites the integrations and activity bullets around per-source channels and per-repo overrides.
- `src/features/help/content.ts`: rewrites the Settings → Notifications entry to describe the channel pairs, the per-source list, the **Watch** choice, **Customize…**, and the two palette commands; the automation-failure row's gating wording follows.
- `site/src/data/capabilities.ts`: adds the "Per-source notification controls" capability under *Repository & workspace*.
- `changelog.d/added-notification-controls.md`: new fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-source controls for Activity inbox and desktop notifications, including agent tasks.
  * Added repository-specific notification customization, muting, reset, and CI check watch scope.
  * Added notification settings and repository notification settings to the command palette.
* **Documentation**
  * Updated in-app guidance, capability descriptions, and changelog information.
* **Bug Fixes**
  * Improved notification delivery consistency across activity, reviews, automation, plans, sessions, and research.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->