### PR TITLE
feat(github,issues,pulls): edit GitHub Projects field values in-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,10 @@ in one click.
   the browser. Labels and assignees on GitHub & GitLab (set them when you
   open a PR/MR or any time after), request reviewers across GitHub, GitLab &
   Bitbucket, see, link, and unlink an open PR's **GitHub Projects** in its
-  header alongside each board's **Status**, **Priority**, and **Iteration**
-  values, flip a PR between **draft and ready for review** either way on all
-  three, and **create new PRs as drafts by default** (Settings → General).
+  header and set each board's **Status**, **Priority**, **Iteration** and
+  custom fields right there, flip a PR between **draft and ready for review**
+  either way on all three, and **create new PRs as drafts by default**
+  (Settings → General).
 - **Linked issues**: link related issues when you open *or* edit a PR, as
   chips **auto-detected** from your branch name and commits (a `fix/123-…`
   branch seeds `#123`) or picked by hand. Each chip toggles between
@@ -516,8 +517,9 @@ remote needed; publishable to GitHub, GitLab, or linked Jira in one click).
 Browse, create, and edit (drafting with AI from your repo's issue
 templates), react with emoji, and manage the shared metadata: labels,
 assignees, and milestones. On GitHub, add **projects** (GitHub Projects,
-repo and owner level) and read each board's **Status**, **Priority**,
-**Iteration**, dates and custom fields, a line per board under the chips.
+repo and owner level) and set each board's **Status**, **Priority**,
+**Iteration**, dates and custom fields from the rail — a line per board
+below the chips, and one popup that edits every field on every board.
 Also on GitHub: issue type, sub-issues, dependencies (blocked-by /
 blocking), and development links (linked and closing PRs and branches, plus
 create-a-branch); on GitLab, related issues. Close or reopen with a comment

--- a/changelog.d/added-project-field-editor.md
+++ b/changelog.d/added-project-field-editor.md
@@ -1,0 +1,7 @@
+- **Set an issue or pull request's GitHub Projects fields without leaving it.** The
+  **Project fields** row is now a trigger: it opens one popup holding every field you can
+  set on every board the item is on — **Status**, **Priority**, **Iteration**, plus date,
+  text, number, and multi-select fields — filled in or not, and any that already holds a
+  value carries a **Clear** to empty it again. Like the Projects and Labels pickers, it
+  drafts your edits and writes them when it closes, one write per board. GitHub only, and
+  it uses the same `project` sign-in scope the Projects picker already needs.

--- a/changelog.d/added-project-field-editor.md
+++ b/changelog.d/added-project-field-editor.md
@@ -1,7 +1,7 @@
 - **Set an issue or pull request's GitHub Projects fields without leaving it.** The
   **Project fields** row is now a trigger: it opens one popup holding every field you can
-  set on every board the item is on — **Status**, **Priority**, **Iteration**, plus date,
-  text, number, and multi-select fields — filled in or not, and any that already holds a
+  set on every board the item is on (**Status**, **Priority**, **Iteration**, plus date,
+  text, number, and multi-select fields), filled in or not, and any that already holds a
   value carries a **Clear** to empty it again. Like the Projects and Labels pickers, it
   drafts your edits and writes them when it closes, one write per board. GitHub only, and
   it uses the same `project` sign-in scope the Projects picker already needs.

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -325,7 +325,7 @@ export const capabilities: Capability[] = [
   {
     group: "Issues & discussions",
     label:
-      "Project field values — Status, Priority, Iteration & dates on issues and PRs",
+      "Project field values — read & set Status, Priority, Iteration & dates on issues and PRs",
   },
   {
     group: "Issues & discussions",

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -1,11 +1,12 @@
-//! Projects v2 field values for issue and PR sidebars.
+//! Projects v2 field values and definitions for issue and PR sidebars.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::{AppError, AppResult};
 use crate::github::gh_unreadable;
 use crate::github::issue::repo_owner_name;
+use crate::github::pr::validate_graphql_embed;
 use crate::github::project::{project_ref, ProjectV2Ref, PROJECT_FIELDS};
 use crate::github::runner::{run_gh, GH_NETWORK_TIMEOUT};
 
@@ -59,6 +60,7 @@ pub enum ProjectFieldValue {
     Iteration {
         field_id: String,
         field_name: String,
+        iteration_id: String,
         title: String,
         start_date: String,
         duration: u32,
@@ -75,6 +77,278 @@ pub struct SelectOptionRef {
     pub id: String,
     pub name: String,
     pub color: String,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum ProjectFieldDef {
+    SingleSelect {
+        id: String,
+        name: String,
+        options: Vec<FieldOptionDef>,
+        is_issue_field: bool,
+    },
+    MultiSelect {
+        id: String,
+        name: String,
+        options: Vec<FieldOptionDef>,
+        is_issue_field: bool,
+    },
+    Iteration {
+        id: String,
+        name: String,
+        iterations: Vec<IterationDef>,
+        completed_iterations: Vec<IterationDef>,
+    },
+    Text {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    Number {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    Date {
+        id: String,
+        name: String,
+        is_issue_field: bool,
+    },
+    System {
+        id: String,
+        name: String,
+        data_type: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldOptionDef {
+    pub id: String,
+    pub name: String,
+    pub color: String,
+    pub description: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IterationDef {
+    pub id: String,
+    pub title: String,
+    pub start_date: String,
+    pub duration: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum FieldValueUpdate {
+    Text {
+        field_id: String,
+        text: String,
+    },
+    Number {
+        field_id: String,
+        number: f64,
+    },
+    Date {
+        field_id: String,
+        date: String,
+    },
+    SingleSelect {
+        field_id: String,
+        option_id: String,
+    },
+    MultiSelect {
+        field_id: String,
+        option_ids: Vec<String>,
+    },
+    Iteration {
+        field_id: String,
+        iteration_id: String,
+    },
+}
+
+fn build_set_item_field_values_args(
+    project_id: &str,
+    item_id: &str,
+    updates: &[FieldValueUpdate],
+    clears: &[String],
+) -> AppResult<Vec<String>> {
+    validate_graphql_embed(project_id, "project id")?;
+    validate_graphql_embed(item_id, "project item id")?;
+    let mut variables = vec!["$p:ID!".to_string(), "$i:ID!".to_string()];
+    let mut parts = Vec::with_capacity(updates.len() + clears.len());
+    let mut args = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("p={project_id}"),
+        "-f".to_string(),
+        format!("i={item_id}"),
+    ];
+    for (n, update) in updates.iter().enumerate() {
+        let (field_id, key, value_type, values) = match update {
+            FieldValueUpdate::Text { field_id, text } => {
+                (field_id, "text", Some("String!"), vec![text.clone()])
+            }
+            FieldValueUpdate::Number { field_id, number } => {
+                if !number.is_finite() {
+                    return Err(AppError::InvalidArgument(
+                        "field number must be finite".into(),
+                    ));
+                }
+                (field_id, "number", None, vec![number.to_string()])
+            }
+            FieldValueUpdate::Date { field_id, date } => {
+                (field_id, "date", Some("Date!"), vec![date.clone()])
+            }
+            FieldValueUpdate::SingleSelect {
+                field_id,
+                option_id,
+            } => {
+                validate_graphql_embed(option_id, "option id")?;
+                (
+                    field_id,
+                    "singleSelectOptionId",
+                    Some("String!"),
+                    vec![option_id.clone()],
+                )
+            }
+            FieldValueUpdate::MultiSelect {
+                field_id,
+                option_ids,
+            } => {
+                for option_id in option_ids {
+                    validate_graphql_embed(option_id, "option id")?;
+                }
+                (
+                    field_id,
+                    "multiSelectOptionIds",
+                    Some("[String!]!"),
+                    option_ids.clone(),
+                )
+            }
+            FieldValueUpdate::Iteration {
+                field_id,
+                iteration_id,
+            } => {
+                validate_graphql_embed(iteration_id, "iteration id")?;
+                (
+                    field_id,
+                    "iterationId",
+                    Some("String!"),
+                    vec![iteration_id.clone()],
+                )
+            }
+        };
+        validate_graphql_embed(field_id, "field id")?;
+        variables.push(format!("$f{n}:ID!"));
+        args.extend(["-f".to_string(), format!("f{n}={field_id}")]);
+        let value = if let Some(value_type) = value_type {
+            variables.push(format!("$v{n}:{value_type}"));
+            let value_name = if matches!(update, FieldValueUpdate::MultiSelect { .. }) {
+                format!("v{n}[]")
+            } else {
+                format!("v{n}")
+            };
+            if values.is_empty() {
+                // gh's bracket key without '=' represents an empty array.
+                args.extend(["-f".to_string(), value_name]);
+            } else {
+                for value in values {
+                    args.extend(["-f".to_string(), format!("{value_name}={value}")]);
+                }
+            }
+            format!("$v{n}")
+        } else {
+            // The is_finite gate above is required: finite f64 Display produces only
+            // a valid GraphQL numeric literal, so this splice cannot inject structure.
+            values[0].clone()
+        };
+        parts.push(format!(
+            "s{n}: updateProjectV2ItemFieldValue(input:{{projectId:$p,itemId:$i,fieldId:$f{n},value:{{{key}:{value}}}}}){{projectV2Item{{id}}}}"
+        ));
+    }
+    for (n, field_id) in clears.iter().enumerate() {
+        validate_graphql_embed(field_id, "field id")?;
+        variables.push(format!("$g{n}:ID!"));
+        args.extend(["-f".to_string(), format!("g{n}={field_id}")]);
+        parts.push(format!(
+            "c{n}: clearProjectV2ItemFieldValue(input:{{projectId:$p,itemId:$i,fieldId:$g{n}}}){{projectV2Item{{id}}}}"
+        ));
+    }
+    args.extend([
+        "-f".to_string(),
+        format!(
+            "query=mutation({}){{ {} }}",
+            variables.join(","),
+            parts.join(" ")
+        ),
+    ]);
+    Ok(args)
+}
+
+fn map_field_write_error(error: AppError) -> AppError {
+    // run_gh exposes nonzero GraphQL responses as stderr, where gh lists errors in order.
+    let error = match error {
+        AppError::Gh(message) if message.starts_with("gh: ") => AppError::Gh(
+            message
+                .strip_prefix("gh: ")
+                .unwrap_or(&message)
+                .lines()
+                .next()
+                .unwrap_or(&message)
+                .to_string(),
+        ),
+        other => other,
+    };
+    map_scope_error(error)
+}
+
+fn parse_field_write_response(stdout: &str) -> AppResult<()> {
+    let value: Value = serde_json::from_str(stdout).map_err(|e| {
+        gh_unreadable(
+            "the project field update",
+            format!("could not parse the field update: {e}"),
+        )
+    })?;
+    if let Some(error) = array(&value["errors"]).next() {
+        let message = error["message"]
+            .as_str()
+            .unwrap_or("GitHub could not update the project fields.");
+        return Err(map_scope_error(AppError::Gh(message.to_string())));
+    }
+    Ok(())
+}
+
+/// A batch can partially apply; the first error is returned and callers must refetch even on failure.
+#[tauri::command]
+pub async fn gh_set_item_field_values(
+    repo_path: String,
+    project_id: String,
+    item_id: String,
+    updates: Vec<FieldValueUpdate>,
+    clears: Vec<String>,
+) -> Result<(), String> {
+    if updates.is_empty() && clears.is_empty() {
+        return Ok(());
+    }
+    let args = build_set_item_field_values_args(&project_id, &item_id, &updates, &clears)
+        .map_err(|e| e.to_string())?;
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT)
+        .await
+        .map_err(|e| map_field_write_error(e).to_string())?;
+    parse_field_write_response(&out.stdout_lossy()).map_err(|e| e.to_string())
 }
 
 const FIELDS_SCOPE_HINT: &str =
@@ -106,7 +380,7 @@ fn item_field_values_query(field: &str) -> String {
          ... on ProjectV2ItemFieldTextValue{{ field{{ {FIELD_COMMON} }} text }} \
          ... on ProjectV2ItemFieldNumberValue{{ field{{ {FIELD_COMMON} }} number }} \
          ... on ProjectV2ItemFieldDateValue{{ field{{ {FIELD_COMMON} }} date }} \
-         ... on ProjectV2ItemFieldIterationValue{{ field{{ {FIELD_COMMON} }} title startDate duration }} \
+         ... on ProjectV2ItemFieldIterationValue{{ field{{ {FIELD_COMMON} }} iterationId title startDate duration }} \
          ... on ProjectV2ItemIssueFieldValue{{ field{{ {FIELD_COMMON} }} issueFieldValue{{ __typename \
            ... on IssueFieldSingleSelectValue{{ name optionId color }} \
            ... on IssueFieldMultiSelectValue{{ options{{ id name color }} }} \
@@ -115,6 +389,20 @@ fn item_field_values_query(field: &str) -> String {
            ... on IssueFieldDateValue{{ date: value }} \
          }} }} \
          }} }} }} }} }} }} }}"
+    )
+}
+
+fn project_fields_query() -> String {
+    format!(
+        "query($id:ID!){{ node(id:$id){{ ... on ProjectV2{{ fields(first:50){{ nodes{{ \
+         __typename {FIELD_COMMON} \
+         ... on ProjectV2SingleSelectField{{ options{{ id name color description }} }} \
+         ... on ProjectV2MultiSelectField{{ multiSelectOptions{{ id name color description }} }} \
+         ... on ProjectV2IterationField{{ configuration{{ \
+           iterations{{ id title startDate duration }} \
+           completedIterations{{ id title startDate duration }} \
+         }} }} \
+         }} }} }} }} }}"
     )
 }
 
@@ -203,14 +491,20 @@ fn parse_field_value(node: &Value) -> ProjectFieldValue {
                 is_issue_field,
             }
         }
-        ("ProjectV2ItemFieldIterationValue", "ITERATION") => ProjectFieldValue::Iteration {
-            field_id,
-            field_name,
-            title: text(value, "title"),
-            start_date: text(value, "startDate"),
-            duration: duration(value),
-            is_issue_field,
-        },
+        ("ProjectV2ItemFieldIterationValue", "ITERATION") => {
+            let Some(iteration_id) = value["iterationId"].as_str() else {
+                return ProjectFieldValue::Unknown { field_name };
+            };
+            ProjectFieldValue::Iteration {
+                field_id,
+                field_name,
+                iteration_id: iteration_id.to_string(),
+                title: text(value, "title"),
+                start_date: text(value, "startDate"),
+                duration: duration(value),
+                is_issue_field,
+            }
+        }
         _ => ProjectFieldValue::Unknown { field_name },
     }
 }
@@ -228,6 +522,83 @@ fn parse_item_field_values(value: &Value, field: &str) -> Vec<ItemProjectFieldVa
                 values: array(&node["fieldValues"]["nodes"])
                     .map(parse_field_value)
                     .collect(),
+            })
+        })
+        .collect()
+}
+
+fn field_options(value: &Value) -> Vec<FieldOptionDef> {
+    array(value)
+        .map(|node| FieldOptionDef {
+            id: text(node, "id"),
+            name: text(node, "name"),
+            color: text(node, "color"),
+            description: text(node, "description"),
+        })
+        .collect()
+}
+
+fn iterations(value: &Value) -> Vec<IterationDef> {
+    array(value)
+        .map(|node| IterationDef {
+            id: text(node, "id"),
+            title: text(node, "title"),
+            start_date: text(node, "startDate"),
+            duration: duration(node),
+        })
+        .collect()
+}
+
+const PROJECT_FIELDS_POINTER: &str = "/data/node/fields/nodes";
+
+fn parse_project_fields(value: &Value) -> Vec<ProjectFieldDef> {
+    value
+        .pointer(PROJECT_FIELDS_POINTER)
+        .into_iter()
+        .flat_map(array)
+        .filter_map(|node| {
+            let id = node.get("id")?.as_str()?.to_string();
+            let name = text(node, "name");
+            let is_issue_field = node["isIssueField"].as_bool().unwrap_or(false);
+            Some(match node["dataType"].as_str().unwrap_or_default() {
+                "SINGLE_SELECT" => ProjectFieldDef::SingleSelect {
+                    id,
+                    name,
+                    options: field_options(&node["options"]),
+                    is_issue_field,
+                },
+                "MULTI_SELECT" => ProjectFieldDef::MultiSelect {
+                    id,
+                    name,
+                    options: field_options(&node["multiSelectOptions"]),
+                    is_issue_field,
+                },
+                "ITERATION" => ProjectFieldDef::Iteration {
+                    id,
+                    name,
+                    iterations: iterations(&node["configuration"]["iterations"]),
+                    completed_iterations: iterations(&node["configuration"]["completedIterations"]),
+                },
+                "TEXT" => ProjectFieldDef::Text {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                "NUMBER" => ProjectFieldDef::Number {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                "DATE" => ProjectFieldDef::Date {
+                    id,
+                    name,
+                    is_issue_field,
+                },
+                _ => ProjectFieldDef::System {
+                    id,
+                    name,
+                    data_type: text(node, "dataType"),
+                },
             })
         })
         .collect()
@@ -274,6 +645,35 @@ pub async fn gh_item_field_values(
     Ok(parse_item_field_values(&value, field))
 }
 
+#[tauri::command]
+pub async fn gh_project_fields(
+    repo_path: String,
+    project_id: String,
+) -> AppResult<Vec<ProjectFieldDef>> {
+    let query = project_fields_query();
+    let out = run_gh(
+        Some(&repo_path),
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &format!("id={project_id}"),
+            "-f",
+            &format!("query={query}"),
+        ],
+        GH_NETWORK_TIMEOUT,
+    )
+    .await
+    .map_err(map_scope_error)?;
+    let value: Value = serde_json::from_str(&out.stdout_lossy()).map_err(|e| {
+        gh_unreadable(
+            "the project fields",
+            format!("could not parse the project's fields: {e}"),
+        )
+    })?;
+    Ok(parse_project_fields(&value))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -286,8 +686,20 @@ mod tests {
             {"__typename":"ProjectV2ItemFieldTextValue", "field":{"id":"notes","name":"Notes","dataType":"TEXT","isIssueField":false}, "text":"Ship it"},
             {"__typename":"ProjectV2ItemFieldNumberValue", "field":{"id":"points","name":"Points","dataType":"NUMBER","isIssueField":false}, "number":2.5},
             {"__typename":"ProjectV2ItemFieldDateValue", "field":{"id":"due","name":"Due","dataType":"DATE","isIssueField":false}, "date":"2026-09-12"},
-            {"__typename":"ProjectV2ItemFieldIterationValue", "field":{"id":"sprint","name":"Sprint","dataType":"ITERATION","isIssueField":false}, "title":"Sprint 1","startDate":"2026-09-01","duration":14}
+            {"__typename":"ProjectV2ItemFieldIterationValue", "field":{"id":"sprint","name":"Sprint","dataType":"ITERATION","isIssueField":false}, "iterationId":"sprint-1","title":"Sprint 1","startDate":"2026-09-01","duration":14}
         ])
+    }
+
+    fn field_defs() -> Value {
+        json!({"data":{"node":{"fields":{"nodes":[
+            {"__typename":"ProjectV2SingleSelectField","id":"status","name":"Status","dataType":"SINGLE_SELECT","isIssueField":true,"options":[{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}]},
+            {"__typename":"ProjectV2MultiSelectField","id":"teams","name":"Teams","dataType":"MULTI_SELECT","isIssueField":false,"multiSelectOptions":[{"id":"web","name":"Web","color":"BLUE","description":"Browser"}]},
+            {"__typename":"ProjectV2IterationField","id":"sprint","name":"Sprint","dataType":"ITERATION","configuration":{"iterations":[{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}],"completedIterations":[{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}]}},
+            {"__typename":"ProjectV2Field","id":"notes","name":"Notes","dataType":"TEXT","isIssueField":false},
+            {"__typename":"ProjectV2Field","id":"points","name":"Points","dataType":"NUMBER","isIssueField":false},
+            {"__typename":"ProjectV2Field","id":"due","name":"Due","dataType":"DATE","isIssueField":true},
+            {"__typename":"ProjectV2Field","id":"labels","name":"Labels","dataType":"LABELS"}
+        ]}}}})
     }
 
     fn assert_keys(value: &Value, expected: &[&str]) {
@@ -295,6 +707,370 @@ mod tests {
         let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
         keys.sort_unstable();
         assert_eq!(keys, expected);
+    }
+
+    fn field_updates() -> Vec<FieldValueUpdate> {
+        vec![
+            FieldValueUpdate::Text {
+                field_id: "notes".into(),
+                text: "@secret\n\"quoted\" {repo}".into(),
+            },
+            FieldValueUpdate::Number {
+                field_id: "points".into(),
+                number: 0.0001,
+            },
+            FieldValueUpdate::Date {
+                field_id: "due".into(),
+                date: "2027-01-01".into(),
+            },
+            FieldValueUpdate::SingleSelect {
+                field_id: "status".into(),
+                option_id: "done".into(),
+            },
+            FieldValueUpdate::MultiSelect {
+                field_id: "teams".into(),
+                option_ids: vec!["web".into(), "api".into()],
+            },
+            FieldValueUpdate::Iteration {
+                field_id: "sprint".into(),
+                iteration_id: "past".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn field_update_serialization_pins_every_camel_case_key() {
+        let expected: [(&str, &[&str]); 6] = [
+            ("text", &["fieldId", "kind", "text"]),
+            ("number", &["fieldId", "kind", "number"]),
+            ("date", &["date", "fieldId", "kind"]),
+            ("singleSelect", &["fieldId", "kind", "optionId"]),
+            ("multiSelect", &["fieldId", "kind", "optionIds"]),
+            ("iteration", &["fieldId", "iterationId", "kind"]),
+        ];
+        for (update, (kind, keys)) in field_updates().iter().zip(expected) {
+            let wire = serde_json::to_value(update).expect("update serializes");
+            assert_keys(&wire, keys);
+            assert_eq!(wire["kind"], kind);
+        }
+    }
+
+    #[test]
+    fn field_updates_deserialize_from_the_typescript_contract() {
+        let updates: Vec<FieldValueUpdate> = serde_json::from_value(json!([
+            {"kind":"text","fieldId":"notes","text":"@secret\n\"quoted\" {repo}"},
+            {"kind":"number","fieldId":"points","number":0.0001},
+            {"kind":"date","fieldId":"due","date":"2027-01-01"},
+            {"kind":"singleSelect","fieldId":"status","optionId":"done"},
+            {"kind":"multiSelect","fieldId":"teams","optionIds":["web","api"]},
+            {"kind":"iteration","fieldId":"sprint","iterationId":"past"}
+        ]))
+        .expect("TS-shaped updates deserialize");
+        assert_eq!(updates.len(), 6);
+        for (actual, expected) in updates.iter().zip(field_updates()) {
+            assert_eq!(
+                serde_json::to_value(actual).unwrap(),
+                serde_json::to_value(expected).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn two_updates_and_a_clear_share_one_graphql_request() {
+        let args = build_set_item_field_values_args(
+            "PVT_project",
+            "PVTI_item",
+            &field_updates()[..2],
+            &["due".into()],
+        )
+        .expect("valid batch");
+        assert_eq!(&args[..2], &["api", "graphql"]);
+        let query = args.last().unwrap();
+        assert_eq!(query.matches("updateProjectV2ItemFieldValue(").count(), 2);
+        assert_eq!(query.matches("clearProjectV2ItemFieldValue(").count(), 1);
+        for alias in ["s0:", "s1:", "c0:"] {
+            assert_eq!(query.matches(alias).count(), 1);
+        }
+        assert!(!query.contains("s2:"));
+        assert!(!query.contains("c1:"));
+        assert!(query.contains("$f0:ID!,$v0:String!,$f1:ID!,$g0:ID!"));
+        assert!(query.contains("value:{number:0.0001}"));
+        assert!(!query.contains("$v1"));
+        for scalar in [
+            "PVT_project",
+            "PVTI_item",
+            "notes",
+            "points",
+            "due",
+            "@secret",
+        ] {
+            assert!(
+                !query.contains(scalar),
+                "data must stay outside the document: {scalar}"
+            );
+        }
+        let fields: Vec<_> = args[2..args.len() - 2]
+            .chunks_exact(2)
+            .map(|pair| (pair[0].as_str(), pair[1].as_str()))
+            .collect();
+        assert_eq!(
+            fields,
+            [
+                ("-f", "p=PVT_project"),
+                ("-f", "i=PVTI_item"),
+                ("-f", "f0=notes"),
+                ("-f", "v0=@secret\n\"quoted\" {repo}"),
+                ("-f", "f1=points"),
+                ("-f", "g0=due"),
+            ]
+        );
+    }
+
+    #[test]
+    fn every_update_kind_uses_its_value_key_and_scalar_transport() {
+        let args =
+            build_set_item_field_values_args("PVT_project", "PVTI_item", &field_updates(), &[])
+                .expect("valid full-spread batch");
+        let query = args.last().unwrap();
+        for (n, key) in [
+            "text",
+            "number",
+            "date",
+            "singleSelectOptionId",
+            "multiSelectOptionIds",
+            "iterationId",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let value = if *key == "number" {
+                "0.0001".to_string()
+            } else {
+                format!("$v{n}")
+            };
+            assert!(query.contains(&format!("value:{{{key}:{value}}}")));
+        }
+        assert!(query.contains("$v2:Date!"));
+        assert!(query.contains("$v4:[String!]!"));
+        let fields: Vec<_> = args[2..].chunks_exact(2).collect();
+        for pair in &fields {
+            assert_eq!(pair[0], "-f");
+        }
+        for scalar in [
+            "v2=2027-01-01",
+            "v3=done",
+            "v4[]=web",
+            "v4[]=api",
+            "v5=past",
+        ] {
+            assert!(args.iter().any(|arg| arg == scalar));
+        }
+    }
+
+    #[test]
+    fn finite_numbers_are_document_literals_without_value_variables() {
+        for (number, literal) in [
+            (0.0001, "0.0001"),
+            (1e-7, "0.0000001"),
+            (-1e-7, "-0.0000001"),
+            (3.0, "3"),
+            (-0.0, "-0"),
+        ] {
+            let args = build_set_item_field_values_args(
+                "project",
+                "item",
+                &[FieldValueUpdate::Number {
+                    field_id: "points".into(),
+                    number,
+                }],
+                &[],
+            )
+            .unwrap();
+            let query = args.last().unwrap();
+            assert!(query.contains(&format!("value:{{number:{literal}}}")));
+            assert!(!query.contains("$v0"));
+            assert!(!query.contains("Float!"));
+            assert_eq!(
+                &args[..args.len() - 2],
+                &[
+                    "api",
+                    "graphql",
+                    "-f",
+                    "p=project",
+                    "-f",
+                    "i=item",
+                    "-f",
+                    "f0=points"
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn empty_multi_select_and_clear_only_batches_are_supported() {
+        let args = build_set_item_field_values_args(
+            "PVT_project",
+            "PVTI_item",
+            &[FieldValueUpdate::MultiSelect {
+                field_id: "teams".into(),
+                option_ids: vec![],
+            }],
+            &[],
+        )
+        .unwrap();
+        assert!(args.windows(2).any(|pair| pair == ["-f", "v0[]"]));
+        let args =
+            build_set_item_field_values_args("PVT_project", "PVTI_item", &[], &["teams".into()])
+                .unwrap();
+        let query = args.last().unwrap();
+        assert!(query.contains("c0: clearProjectV2ItemFieldValue"));
+        assert!(!query.contains("updateProjectV2ItemFieldValue"));
+    }
+
+    #[tokio::test]
+    async fn empty_field_writes_need_neither_a_repo_nor_ids() {
+        assert!(gh_set_item_field_values(
+            String::new(),
+            String::new(),
+            String::new(),
+            vec![],
+            vec![]
+        )
+        .await
+        .is_ok());
+    }
+
+    #[test]
+    fn every_variable_id_passes_the_embed_gate() {
+        for bad in ["", "@secret", "bad\"}", "bad\n", "bad&value"] {
+            let mut cases = vec![
+                build_set_item_field_values_args(bad, "item", &[], &["field".into()]),
+                build_set_item_field_values_args("project", bad, &[], &["field".into()]),
+                build_set_item_field_values_args("project", "item", &[], &[bad.into()]),
+            ];
+            for mut update in field_updates() {
+                let field_id = match &mut update {
+                    FieldValueUpdate::Text { field_id, .. }
+                    | FieldValueUpdate::Number { field_id, .. }
+                    | FieldValueUpdate::Date { field_id, .. }
+                    | FieldValueUpdate::SingleSelect { field_id, .. }
+                    | FieldValueUpdate::MultiSelect { field_id, .. }
+                    | FieldValueUpdate::Iteration { field_id, .. } => field_id,
+                };
+                *field_id = bad.into();
+                cases.push(build_set_item_field_values_args(
+                    "project",
+                    "item",
+                    &[update],
+                    &[],
+                ));
+            }
+            for update in [
+                FieldValueUpdate::SingleSelect {
+                    field_id: "field".into(),
+                    option_id: bad.into(),
+                },
+                FieldValueUpdate::MultiSelect {
+                    field_id: "field".into(),
+                    option_ids: vec!["valid".into(), bad.into()],
+                },
+                FieldValueUpdate::Iteration {
+                    field_id: "field".into(),
+                    iteration_id: bad.into(),
+                },
+            ] {
+                cases.push(build_set_item_field_values_args(
+                    "project",
+                    "item",
+                    &[update],
+                    &[],
+                ));
+            }
+            for case in cases {
+                assert!(matches!(case, Err(AppError::InvalidArgument(_))));
+            }
+        }
+        for number in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(build_set_item_field_values_args(
+                "project",
+                "item",
+                &[FieldValueUpdate::Number {
+                    field_id: "points".into(),
+                    number
+                },],
+                &[]
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn partial_field_write_failures_return_the_first_error_and_map_scopes() {
+        let response = json!({"data":{"s0":{"projectV2Item":{"id":"item"}},"s1":null},
+            "errors":[{"message":"first failure","path":["s1"]},{"message":"second failure"}]})
+        .to_string();
+        assert_eq!(
+            parse_field_write_response(&response)
+                .unwrap_err()
+                .to_string(),
+            "first failure"
+        );
+        assert_eq!(
+            map_field_write_error(AppError::Gh("gh: first failure\nsecond failure".into()))
+                .to_string(),
+            "first failure"
+        );
+        assert_eq!(
+            map_field_write_error(AppError::Gh("connection reset".into())).to_string(),
+            "connection reset"
+        );
+        for message in [
+            "Your token has not been granted the required scopes to execute this query.",
+            "missing scope read:project",
+        ] {
+            let response = json!({"errors":[{"message":message}]}).to_string();
+            assert_eq!(
+                parse_field_write_response(&response)
+                    .unwrap_err()
+                    .to_string(),
+                FIELDS_SCOPE_HINT
+            );
+            assert_eq!(
+                map_field_write_error(AppError::Gh(format!("gh: {message}\nsecond failure")))
+                    .to_string(),
+                FIELDS_SCOPE_HINT
+            );
+        }
+        assert!(
+            parse_field_write_response(r#"{"data":{"s0":{"projectV2Item":{"id":"item"}}}}"#)
+                .is_ok()
+        );
+        assert!(parse_field_write_response("not JSON").is_err());
+    }
+
+    #[test]
+    fn definitions_cover_builtins_empty_options_and_completed_only_iterations() {
+        let builtins = json!({"data":{"node":{"fields":{"nodes":[
+            {"id":"title","name":"Title","dataType":"TITLE"},
+            {"id":"labels","name":"Labels","dataType":"LABELS"}
+        ]}}}});
+        let defs = parse_project_fields(&builtins);
+        assert_eq!(defs.len(), 2);
+        assert!(defs
+            .iter()
+            .all(|def| matches!(def, ProjectFieldDef::System { .. })));
+        let response = json!({"data":{"node":{"fields":{"nodes":[
+            {"id":"status","dataType":"SINGLE_SELECT","options":[]},
+            {"id":"sprint","dataType":"ITERATION","configuration":{"iterations":[],"completedIterations":[{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}]}},
+            {"id":"teams","dataType":"MULTI_SELECT","isIssueField":true,"multiSelectOptions":[{"id":"web","name":"Web","color":"BLUE"}]}
+        ]}}}});
+        let defs = serde_json::to_value(parse_project_fields(&response)).unwrap();
+        assert_eq!(defs[0]["options"], json!([]));
+        assert_eq!(defs[1]["iterations"], json!([]));
+        assert_eq!(defs[1]["completedIterations"][0]["id"], "past");
+        assert_eq!(defs[2]["kind"], "multiSelect");
+        assert_eq!(defs[2]["isIssueField"], true);
+        assert_eq!(defs[2]["options"][0]["id"], "web");
     }
 
     #[test]
@@ -341,6 +1117,7 @@ mod tests {
                     "fieldId",
                     "fieldName",
                     "isIssueField",
+                    "iterationId",
                     "kind",
                     "startDate",
                     "title",
@@ -350,6 +1127,35 @@ mod tests {
         ];
         for (value, (kind, keys)) in values.iter().zip(expected) {
             let wire = serde_json::to_value(value).expect("field value serializes");
+            assert_keys(&wire, keys);
+            assert_eq!(wire["kind"], kind);
+        }
+    }
+
+    #[test]
+    fn field_definition_wire_shapes_are_camel_case() {
+        let defs = parse_project_fields(&field_defs());
+        assert_eq!(defs.len(), 7);
+        let expected: [(&str, &[&str]); 7] = [
+            (
+                "singleSelect",
+                &["id", "isIssueField", "kind", "name", "options"],
+            ),
+            (
+                "multiSelect",
+                &["id", "isIssueField", "kind", "name", "options"],
+            ),
+            (
+                "iteration",
+                &["completedIterations", "id", "iterations", "kind", "name"],
+            ),
+            ("text", &["id", "isIssueField", "kind", "name"]),
+            ("number", &["id", "isIssueField", "kind", "name"]),
+            ("date", &["id", "isIssueField", "kind", "name"]),
+            ("system", &["dataType", "id", "kind", "name"]),
+        ];
+        for (def, (kind, keys)) in defs.iter().zip(expected) {
+            let wire = serde_json::to_value(def).expect("field definition serializes");
             assert_keys(&wire, keys);
             assert_eq!(wire["kind"], kind);
         }
@@ -368,9 +1174,24 @@ mod tests {
                 {"kind":"text","fieldId":"notes","fieldName":"Notes","text":"Ship it","isIssueField":false},
                 {"kind":"number","fieldId":"points","fieldName":"Points","number":2.5,"isIssueField":false},
                 {"kind":"date","fieldId":"due","fieldName":"Due","date":"2026-09-12","isIssueField":false},
-                {"kind":"iteration","fieldId":"sprint","fieldName":"Sprint","title":"Sprint 1","startDate":"2026-09-01","duration":14,"isIssueField":false}
+                {"kind":"iteration","fieldId":"sprint","fieldName":"Sprint","iterationId":"sprint-1","title":"Sprint 1","startDate":"2026-09-01","duration":14,"isIssueField":false}
             ])
         );
+    }
+
+    #[test]
+    fn iteration_values_without_a_string_id_are_unknown() {
+        for iteration_id in [None, Some(Value::Null), Some(json!(7))] {
+            let mut node = custom_values()[5].clone();
+            node.as_object_mut().unwrap().remove("iterationId");
+            if let Some(iteration_id) = iteration_id {
+                node["iterationId"] = iteration_id;
+            }
+            assert_eq!(
+                serde_json::to_value(parse_field_value(&node)).unwrap(),
+                json!({"kind":"unknown","fieldName":"Sprint"})
+            );
+        }
     }
 
     #[test]
@@ -492,6 +1313,14 @@ mod tests {
         ] {
             assert!(parse_item_field_values(&response, "issue").is_empty());
         }
+        for response in [
+            json!({"data":{"node":{"fields":{"nodes":[]}}}}),
+            json!({"data":{"node":{"fields":null}}}),
+            json!({"data":{"node":null}}),
+            Value::Null,
+        ] {
+            assert!(parse_project_fields(&response).is_empty());
+        }
     }
 
     #[test]
@@ -561,6 +1390,81 @@ mod tests {
             ),
             ProjectFieldValue::Unknown { .. }
         ));
+        let response = json!({"data":{"node":{"fields":{"nodes":[
+            {"id":"select","dataType":"SINGLE_SELECT","options":[{"id":"option","description":null}]},
+            {"id":"multi","dataType":"MULTI_SELECT","multiSelectOptions":null},
+            {"id":"iteration","dataType":"ITERATION","configuration":null},
+            {"id":"unknown"}, {"id":null}, null
+        ]}}}});
+        let defs = serde_json::to_value(parse_project_fields(&response))
+            .expect("partial definitions serialize");
+        assert_eq!(defs.as_array().expect("definitions array").len(), 4);
+        assert_eq!(defs[0]["options"][0]["description"], "");
+        assert_eq!(defs[1]["options"], json!([]));
+        assert_eq!(defs[2]["iterations"], json!([]));
+        assert_eq!(defs[2]["completedIterations"], json!([]));
+        assert_eq!(defs[3]["dataType"], "");
+    }
+
+    #[test]
+    fn definitions_keep_options_and_both_iteration_lists() {
+        let defs = serde_json::to_value(parse_project_fields(&field_defs()))
+            .expect("definitions serialize");
+        assert_eq!(
+            defs[0]["options"],
+            json!([{"id":"done","name":"Done","color":"GREEN","description":"Delivered"}])
+        );
+        assert_eq!(defs[0]["isIssueField"], true);
+        assert_eq!(
+            defs[1]["options"],
+            json!([{"id":"web","name":"Web","color":"BLUE","description":"Browser"}])
+        );
+        assert_eq!(
+            defs[2]["iterations"],
+            json!([{"id":"next","title":"Next","startDate":"2026-09-15","duration":14}])
+        );
+        assert_eq!(
+            defs[2]["completedIterations"],
+            json!([{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}])
+        );
+        assert_keys(
+            &defs[0]["options"][0],
+            &["color", "description", "id", "name"],
+        );
+        assert_keys(
+            &defs[2]["iterations"][0],
+            &["duration", "id", "startDate", "title"],
+        );
+    }
+
+    #[test]
+    fn system_and_future_data_types_stay_readable() {
+        for data_type in [
+            "ASSIGNEES",
+            "LABELS",
+            "MILESTONE",
+            "REPOSITORY",
+            "TITLE",
+            "TRACKS",
+            "TRACKED_BY",
+            "ISSUE_TYPE",
+            "PARENT_ISSUE",
+            "SUB_ISSUES_PROGRESS",
+            "CREATED",
+            "UPDATED",
+            "CLOSED",
+            "LINKED_PULL_REQUESTS",
+            "REVIEWERS",
+            "FUTURE_TYPE",
+        ] {
+            let response = json!({"data":{"node":{"fields":{"nodes":[{"__typename":"ProjectV2Field","id":"field","name":"System","dataType":data_type}]}}}});
+            let defs = serde_json::to_value(parse_project_fields(&response))
+                .expect("system field serializes");
+            assert_eq!(
+                defs,
+                json!([{"kind":"system","id":"field","name":"System","dataType":data_type}])
+            );
+        }
     }
 
     fn assert_query_fields(query: &str, paths: &[&str]) {
@@ -612,6 +1516,7 @@ mod tests {
                     "/text",
                     "/number",
                     "/date",
+                    "/iterationId",
                     "/title",
                     "/startDate",
                     "/duration",
@@ -629,6 +1534,40 @@ mod tests {
                 assert!(query.contains(fragment));
             }
         }
+    }
+
+    #[test]
+    fn every_definition_pointer_names_a_field_the_query_actually_asks_for() {
+        let query = project_fields_query();
+        assert_query_fields(
+            &query,
+            &[
+                PROJECT_FIELDS_POINTER,
+                "/id",
+                "/name",
+                "/dataType",
+                "/isIssueField",
+                "/options/id",
+                "/options/name",
+                "/options/color",
+                "/options/description",
+                "/multiSelectOptions/id",
+                "/multiSelectOptions/name",
+                "/multiSelectOptions/color",
+                "/multiSelectOptions/description",
+                "/configuration/iterations/id",
+                "/configuration/iterations/title",
+                "/configuration/iterations/startDate",
+                "/configuration/iterations/duration",
+                "/configuration/completedIterations/id",
+                "/configuration/completedIterations/title",
+                "/configuration/completedIterations/startDate",
+                "/configuration/completedIterations/duration",
+            ],
+        );
+        assert!(query.starts_with("query($id:ID!)"));
+        assert!(query.contains("node(id:$id)"));
+        assert!(query.contains("fields(first:50)"));
     }
 
     #[test]

--- a/src-tauri/src/github/project_fields.rs
+++ b/src-tauri/src/github/project_fields.rs
@@ -128,6 +128,13 @@ pub enum ProjectFieldDef {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ProjectFieldDefs {
+    pub fields: Vec<ProjectFieldDef>,
+    pub truncated: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FieldOptionDef {
     pub id: String,
     pub name: String,
@@ -260,7 +267,7 @@ fn build_set_item_field_values_args(
             } else {
                 format!("v{n}")
             };
-            if values.is_empty() {
+            if matches!(update, FieldValueUpdate::MultiSelect { .. }) && values.is_empty() {
                 // gh's bracket key without '=' represents an empty array.
                 args.extend(["-f".to_string(), value_name]);
             } else {
@@ -338,17 +345,16 @@ pub async fn gh_set_item_field_values(
     item_id: String,
     updates: Vec<FieldValueUpdate>,
     clears: Vec<String>,
-) -> Result<(), String> {
+) -> AppResult<()> {
     if updates.is_empty() && clears.is_empty() {
         return Ok(());
     }
-    let args = build_set_item_field_values_args(&project_id, &item_id, &updates, &clears)
-        .map_err(|e| e.to_string())?;
+    let args = build_set_item_field_values_args(&project_id, &item_id, &updates, &clears)?;
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
     let out = run_gh(Some(&repo_path), &args, GH_NETWORK_TIMEOUT)
         .await
-        .map_err(|e| map_field_write_error(e).to_string())?;
-    parse_field_write_response(&out.stdout_lossy()).map_err(|e| e.to_string())
+        .map_err(map_field_write_error)?;
+    parse_field_write_response(&out.stdout_lossy())
 }
 
 const FIELDS_SCOPE_HINT: &str =
@@ -394,7 +400,7 @@ fn item_field_values_query(field: &str) -> String {
 
 fn project_fields_query() -> String {
     format!(
-        "query($id:ID!){{ node(id:$id){{ ... on ProjectV2{{ fields(first:50){{ nodes{{ \
+        "query($id:ID!){{ node(id:$id){{ ... on ProjectV2{{ fields(first:50){{ pageInfo{{ hasNextPage }} nodes{{ \
          __typename {FIELD_COMMON} \
          ... on ProjectV2SingleSelectField{{ options{{ id name color description }} }} \
          ... on ProjectV2MultiSelectField{{ multiSelectOptions{{ id name color description }} }} \
@@ -550,9 +556,10 @@ fn iterations(value: &Value) -> Vec<IterationDef> {
 }
 
 const PROJECT_FIELDS_POINTER: &str = "/data/node/fields/nodes";
+const PROJECT_FIELDS_TRUNCATED_POINTER: &str = "/data/node/fields/pageInfo/hasNextPage";
 
-fn parse_project_fields(value: &Value) -> Vec<ProjectFieldDef> {
-    value
+fn parse_project_fields(value: &Value) -> ProjectFieldDefs {
+    let fields = value
         .pointer(PROJECT_FIELDS_POINTER)
         .into_iter()
         .flat_map(array)
@@ -601,7 +608,14 @@ fn parse_project_fields(value: &Value) -> Vec<ProjectFieldDef> {
                 },
             })
         })
-        .collect()
+        .collect();
+    ProjectFieldDefs {
+        fields,
+        truncated: value
+            .pointer(PROJECT_FIELDS_TRUNCATED_POINTER)
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    }
 }
 
 #[tauri::command]
@@ -649,7 +663,7 @@ pub async fn gh_item_field_values(
 pub async fn gh_project_fields(
     repo_path: String,
     project_id: String,
-) -> AppResult<Vec<ProjectFieldDef>> {
+) -> AppResult<ProjectFieldDefs> {
     let query = project_fields_query();
     let out = run_gh(
         Some(&repo_path),
@@ -868,6 +882,81 @@ mod tests {
     }
 
     #[test]
+    fn double_digit_update_aliases_and_variables_are_distinct() {
+        let updates: Vec<_> = (0..11)
+            .map(|n| FieldValueUpdate::Text {
+                field_id: format!("field-{n}"),
+                text: format!("text-{n}"),
+            })
+            .collect();
+        let args = build_set_item_field_values_args("project", "item", &updates, &[]).unwrap();
+        let query = args.last().unwrap();
+        let declarations: Vec<_> = query
+            .strip_prefix("query=mutation(")
+            .unwrap()
+            .split_once(')')
+            .unwrap()
+            .0
+            .split(',')
+            .collect();
+        for declaration in ["$f1:ID!", "$f10:ID!", "$v1:String!", "$v10:String!"] {
+            assert_eq!(
+                declarations.iter().filter(|d| **d == declaration).count(),
+                1
+            );
+        }
+        assert_eq!(query.matches("updateProjectV2ItemFieldValue(").count(), 11);
+        for n in 0..11 {
+            assert_eq!(query.matches(&format!("s{n}: ")).count(), 1);
+        }
+        assert!(query.contains("s10: updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f10,value:{text:$v10}})"));
+        let pairs: Vec<_> = args[2..]
+            .chunks_exact(2)
+            .map(|pair| (pair[0].as_str(), pair[1].as_str()))
+            .collect();
+        for pair in [
+            ("-f", "f1=field-1"),
+            ("-f", "f10=field-10"),
+            ("-f", "v10=text-10"),
+        ] {
+            assert!(pairs.contains(&pair));
+        }
+    }
+
+    #[test]
+    fn empty_text_uses_an_empty_value_argument() {
+        let args = build_set_item_field_values_args(
+            "project",
+            "item",
+            &[FieldValueUpdate::Text {
+                field_id: "notes".into(),
+                text: String::new(),
+            }],
+            &[],
+        )
+        .unwrap();
+        assert!(args[2..].chunks_exact(2).any(|pair| pair == ["-f", "v0="]));
+        assert!(!args.iter().any(|arg| arg == "v0" || arg == "v0[]"));
+        assert!(args.last().unwrap().contains("value:{text:$v0}"));
+    }
+
+    #[tokio::test]
+    async fn field_write_errors_keep_their_serialized_kind() {
+        let result: AppResult<()> = gh_set_item_field_values(
+            String::new(),
+            String::new(),
+            "item".into(),
+            vec![],
+            vec!["field".into()],
+        )
+        .await;
+        let wire = serde_json::to_value(result.unwrap_err()).unwrap();
+        assert_eq!(wire["kind"], "invalidArgument");
+        let wire = serde_json::to_value(map_field_write_error(AppError::GhNotFound)).unwrap();
+        assert_eq!(wire["kind"], "ghNotFound");
+    }
+
+    #[test]
     fn finite_numbers_are_document_literals_without_value_variables() {
         for (number, literal) in [
             (0.0001, "0.0001"),
@@ -1054,7 +1143,7 @@ mod tests {
             {"id":"title","name":"Title","dataType":"TITLE"},
             {"id":"labels","name":"Labels","dataType":"LABELS"}
         ]}}}});
-        let defs = parse_project_fields(&builtins);
+        let defs = parse_project_fields(&builtins).fields;
         assert_eq!(defs.len(), 2);
         assert!(defs
             .iter()
@@ -1064,7 +1153,7 @@ mod tests {
             {"id":"sprint","dataType":"ITERATION","configuration":{"iterations":[],"completedIterations":[{"id":"past","title":"Past","startDate":"2026-09-01","duration":14}]}},
             {"id":"teams","dataType":"MULTI_SELECT","isIssueField":true,"multiSelectOptions":[{"id":"web","name":"Web","color":"BLUE"}]}
         ]}}}});
-        let defs = serde_json::to_value(parse_project_fields(&response)).unwrap();
+        let defs = serde_json::to_value(parse_project_fields(&response).fields).unwrap();
         assert_eq!(defs[0]["options"], json!([]));
         assert_eq!(defs[1]["iterations"], json!([]));
         assert_eq!(defs[1]["completedIterations"][0]["id"], "past");
@@ -1133,8 +1222,36 @@ mod tests {
     }
 
     #[test]
+    fn field_definition_wrapper_reports_truncation_tolerantly() {
+        for (page_info, truncated) in [
+            (None, false),
+            (Some(Value::Null), false),
+            (Some(json!({})), false),
+            (Some(json!({"hasNextPage": null})), false),
+            (Some(json!({"hasNextPage": "true"})), false),
+            (Some(json!({"hasNextPage": false})), false),
+            (Some(json!({"hasNextPage": true})), true),
+        ] {
+            let mut response = field_defs();
+            if let Some(page_info) = page_info {
+                response["data"]["node"]["fields"]["pageInfo"] = page_info;
+            }
+            let defs = parse_project_fields(&response);
+            assert_eq!(defs.truncated, truncated);
+            assert_eq!(defs.fields.len(), 7);
+            let wire = serde_json::to_value(defs).unwrap();
+            assert_keys(&wire, &["fields", "truncated"]);
+            assert_eq!(wire["truncated"], truncated);
+            assert_eq!(wire["fields"][0]["id"], "status");
+        }
+        let defs = parse_project_fields(&Value::Null);
+        assert!(defs.fields.is_empty());
+        assert!(!defs.truncated);
+    }
+
+    #[test]
     fn field_definition_wire_shapes_are_camel_case() {
-        let defs = parse_project_fields(&field_defs());
+        let defs = parse_project_fields(&field_defs()).fields;
         assert_eq!(defs.len(), 7);
         let expected: [(&str, &[&str]); 7] = [
             (
@@ -1319,7 +1436,7 @@ mod tests {
             json!({"data":{"node":null}}),
             Value::Null,
         ] {
-            assert!(parse_project_fields(&response).is_empty());
+            assert!(parse_project_fields(&response).fields.is_empty());
         }
     }
 
@@ -1396,7 +1513,7 @@ mod tests {
             {"id":"iteration","dataType":"ITERATION","configuration":null},
             {"id":"unknown"}, {"id":null}, null
         ]}}}});
-        let defs = serde_json::to_value(parse_project_fields(&response))
+        let defs = serde_json::to_value(parse_project_fields(&response).fields)
             .expect("partial definitions serialize");
         assert_eq!(defs.as_array().expect("definitions array").len(), 4);
         assert_eq!(defs[0]["options"][0]["description"], "");
@@ -1408,7 +1525,7 @@ mod tests {
 
     #[test]
     fn definitions_keep_options_and_both_iteration_lists() {
-        let defs = serde_json::to_value(parse_project_fields(&field_defs()))
+        let defs = serde_json::to_value(parse_project_fields(&field_defs()).fields)
             .expect("definitions serialize");
         assert_eq!(
             defs[0]["options"],
@@ -1458,7 +1575,7 @@ mod tests {
             "FUTURE_TYPE",
         ] {
             let response = json!({"data":{"node":{"fields":{"nodes":[{"__typename":"ProjectV2Field","id":"field","name":"System","dataType":data_type}]}}}});
-            let defs = serde_json::to_value(parse_project_fields(&response))
+            let defs = serde_json::to_value(parse_project_fields(&response).fields)
                 .expect("system field serializes");
             assert_eq!(
                 defs,
@@ -1543,6 +1660,7 @@ mod tests {
             &query,
             &[
                 PROJECT_FIELDS_POINTER,
+                PROJECT_FIELDS_TRUNCATED_POINTER,
                 "/id",
                 "/name",
                 "/dataType",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -572,6 +572,8 @@ pub fn run() {
             github::project::gh_item_projects,
             github::project::gh_edit_item_projects,
             github::project_fields::gh_item_field_values,
+            github::project_fields::gh_project_fields,
+            github::project_fields::gh_set_item_field_values,
             github::discussion::gh_discussion_categories,
             github::discussion::gh_discussion_list,
             github::discussion::gh_discussion_view,

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -36,7 +36,8 @@ const OPTION_COLORS: Record<string, string> = {
 };
 
 /** GitHub's Date scalar, which carries no zone — and the only form a native date
- *  input accepts, so the editor seeds anything else empty rather than blank. */
+ *  input accepts: the control's own sanitization silently discards any other
+ *  shape, so the editor seeds those empty on purpose instead. */
 export const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 function optionColor(color: string): string {

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -15,6 +15,7 @@ import type {
   RemoteLens,
 } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
+import { ProjectFieldsEditor } from "./ProjectFieldsEditor";
 import { projectScopeMissing } from "./ProjectsPopover";
 
 const FIELD_LABEL = "Project fields";
@@ -85,9 +86,26 @@ function iterationRange(startDate: string, duration: number): string {
   return `${shortDay(start, spansYears)} – ${shortDay(end, spansYears)}`;
 }
 
+/** An iteration's span in muted parentheses, or nothing when it can't be read. The
+ *  parenthetical is one unbreakable run: wrapped mid-span it reads as two values on
+ *  two lines. Shared with the field editor's iteration rows. */
+export function IterationRange({
+  startDate,
+  duration,
+}: {
+  startDate: string;
+  duration: number;
+}) {
+  const range = iterationRange(startDate, duration);
+  if (range === "") return null;
+  return (
+    <span className="whitespace-nowrap text-muted-foreground"> ({range})</span>
+  );
+}
+
 /** One select option. The dot is decorative and the name carries the value, so
- *  nothing here rests on the colour. */
-function OptionValue({ name, color }: { name: string; color: string }) {
+ *  nothing here rests on the colour. Shared with the field editor's option rows. */
+export function OptionValue({ name, color }: { name: string; color: string }) {
   return (
     <span className="inline-flex min-w-0 max-w-full items-center gap-1">
       <span
@@ -148,14 +166,18 @@ function fieldValueNode(value: ProjectFieldValue): ReactNode {
     case "date":
       return value.date === "" ? null : formatFieldDate(value.date);
     case "iteration": {
-      const range = iterationRange(value.startDate, value.duration);
-      if (value.title === "" && range === "") return null;
+      if (
+        value.title === "" &&
+        iterationRange(value.startDate, value.duration) === ""
+      )
+        return null;
       return (
         <>
           {value.title}
-          {range === "" ? null : (
-            <span className="text-muted-foreground"> ({range})</span>
-          )}
+          <IterationRange
+            startDate={value.startDate}
+            duration={value.duration}
+          />
         </>
       );
     }
@@ -224,12 +246,12 @@ function ProjectFieldLine({
 }
 
 /**
- * The read-only view of an item's GitHub Projects field values — one line per
- * board, under the Projects picker on both the issue rail and the PR header grid.
- * Nothing renders until there is something to say: no memberships, no set fields,
- * or no GitHub, and the block is absent entirely rather than showing empty chrome.
- * Reads only — the picker above owns the memberships, and the fields themselves
- * aren't editable here.
+ * An item's GitHub Projects field values — one line per board, under the Projects
+ * picker on both the issue rail and the PR header grid, with the editor's trigger
+ * taking the place of the heading that names them. Nothing renders until there is
+ * something to say: no memberships, or no GitHub, and the block is absent entirely
+ * rather than leaving a heading standing over nothing. The picker above owns the
+ * memberships; this owns the values.
  */
 export function ProjectFieldValues({
   repoPath,
@@ -237,6 +259,7 @@ export function ProjectFieldValues({
   kind,
   number,
   lens,
+  disabledReason,
   cells = false,
 }: {
   repoPath: string;
@@ -247,6 +270,11 @@ export function ProjectFieldValues({
   number: number;
   /** The origin|upstream lens the parent PR/issue surface resolved. */
   lens: RemoteLens;
+  /** Set when the editor can't be opened right now — the viewer lacks the access
+   *  its writes need, or the surface is still loading the entity. Write access
+   *  itself is the MOUNT's gate: both call sites render this only where they render
+   *  the Projects picker, which is the same permission. */
+  disabledReason?: string;
   /** Emit a label cell and a value cell as two SIBLING elements for a caller's
    *  label/value grid. Default renders the rail form, which labels itself above
    *  the lines. */
@@ -339,23 +367,68 @@ export function ProjectFieldValues({
     }
   })();
 
-  if (content === null) return null;
+  // The editor rides the same gate the VALUES do: a boardless item has nothing to
+  // edit, so it gets no trigger and — the null contract below — no heading either.
+  const showEditor = canRead && boardsKnown;
+  // Memberships order, not the values read's: the boards are named in the same
+  // sequence the chips above are. A board whose values haven't arrived has no
+  // baseline to draft from, so it stays out and the trigger says why.
+  // PARITY REQUIREMENT: both reads page `projectItems(first: 20)`, and a board the
+  // memberships read returns but the values read doesn't leaves the editor without
+  // a word — this intersection is only safe while their caps and filters agree.
+  const entryByProject = new Map(
+    entries.map((entry) => [entry.project.id, entry]),
+  );
+  const boards = (memberships.data ?? [])
+    .map((item) => entryByProject.get(item.project.id))
+    .filter((entry): entry is ItemProjectFieldValues => entry !== undefined);
+  const unsettledReason = (() => {
+    switch (true) {
+      case boards.length > 0:
+        return undefined;
+      case loading:
+        return "Loading project fields…";
+      // Reachable with no error and nothing to retry — a values read that settled
+      // empty against live memberships lands here, so this names no control.
+      default:
+        return "Project fields haven't loaded for this item's boards yet.";
+    }
+  })();
+  const heading = showEditor ? (
+    <ProjectFieldsEditor
+      repoPath={repoPath}
+      kind={kind}
+      number={number}
+      lens={lens}
+      boards={boards}
+      disabledReason={disabledReason}
+      unsettledReason={unsettledReason}
+    />
+  ) : null;
+
+  if (content === null && heading === null) return null;
   // The rail form carries its OWN heading rather than taking the row list's: this
   // block renders nothing on a boardless item, and a host-supplied heading would
   // be left standing over it.
   if (!cells)
     return (
       <div className="space-y-1.5">
-        <p className="text-xs font-medium text-muted-foreground">
-          {FIELD_LABEL}
-        </p>
+        {heading ?? (
+          <p className="text-xs font-medium text-muted-foreground">
+            {FIELD_LABEL}
+          </p>
+        )}
         {content}
       </div>
     );
   return (
     <>
-      <MetaFieldLabel>{FIELD_LABEL}</MetaFieldLabel>
-      <MetaValueCell label={FIELD_LABEL} busy={lines.length === 0 && loading}>
+      {heading ?? <MetaFieldLabel>{FIELD_LABEL}</MetaFieldLabel>}
+      <MetaValueCell
+        label={FIELD_LABEL}
+        empty={content === null}
+        busy={lines.length === 0 && loading}
+      >
         {content}
       </MetaValueCell>
     </>

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -15,7 +15,7 @@ import type {
   RemoteLens,
 } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
-import { type EditableBoard, ProjectFieldsEditor } from "./ProjectFieldsEditor";
+import { ProjectFieldsEditor } from "./ProjectFieldsEditor";
 import { projectScopeMissing } from "./ProjectsPopover";
 
 const FIELD_LABEL = "Project fields";
@@ -35,8 +35,9 @@ const OPTION_COLORS: Record<string, string> = {
   PURPLE: "#8d80ba",
 };
 
-/** GitHub's Date scalar, which carries no zone. */
-const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+/** GitHub's Date scalar, which carries no zone — and the only form a native date
+ *  input accepts, so the editor seeds anything else empty rather than blank. */
+export const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 function optionColor(color: string): string {
   return OPTION_COLORS[color.toUpperCase()] ?? OPTION_COLORS.GRAY;
@@ -379,17 +380,9 @@ export function ProjectFieldValues({
   const entryByProject = new Map(
     entries.map((entry) => [entry.project.id, entry]),
   );
-  // `viewerCanUpdate` is read off the MEMBERSHIP row, which is the read that
-  // populates it — the same board inside a values entry doesn't carry the viewer's
-  // access, and the editor holds a board's rows on this flag.
   const boards = (memberships.data ?? [])
-    .map((item) => {
-      const entry = entryByProject.get(item.project.id);
-      return entry === undefined
-        ? undefined
-        : { ...entry, viewerCanUpdate: item.project.viewerCanUpdate };
-    })
-    .filter((board): board is EditableBoard => board !== undefined);
+    .map((item) => entryByProject.get(item.project.id))
+    .filter((entry): entry is ItemProjectFieldValues => entry !== undefined);
   const unsettledReason = (() => {
     switch (true) {
       case boards.length > 0:

--- a/src/features/conversations/ProjectFieldValues.tsx
+++ b/src/features/conversations/ProjectFieldValues.tsx
@@ -15,7 +15,7 @@ import type {
   RemoteLens,
 } from "@/lib/git/types";
 import { parseableDate } from "@/lib/time";
-import { ProjectFieldsEditor } from "./ProjectFieldsEditor";
+import { type EditableBoard, ProjectFieldsEditor } from "./ProjectFieldsEditor";
 import { projectScopeMissing } from "./ProjectsPopover";
 
 const FIELD_LABEL = "Project fields";
@@ -379,9 +379,17 @@ export function ProjectFieldValues({
   const entryByProject = new Map(
     entries.map((entry) => [entry.project.id, entry]),
   );
+  // `viewerCanUpdate` is read off the MEMBERSHIP row, which is the read that
+  // populates it — the same board inside a values entry doesn't carry the viewer's
+  // access, and the editor holds a board's rows on this flag.
   const boards = (memberships.data ?? [])
-    .map((item) => entryByProject.get(item.project.id))
-    .filter((entry): entry is ItemProjectFieldValues => entry !== undefined);
+    .map((item) => {
+      const entry = entryByProject.get(item.project.id);
+      return entry === undefined
+        ? undefined
+        : { ...entry, viewerCanUpdate: item.project.viewerCanUpdate };
+    })
+    .filter((board): board is EditableBoard => board !== undefined);
   const unsettledReason = (() => {
     switch (true) {
       case boards.length > 0:

--- a/src/features/conversations/ProjectFieldsEditor.tsx
+++ b/src/features/conversations/ProjectFieldsEditor.tsx
@@ -42,12 +42,12 @@ const NO_ITERATIONS_REASON =
 const ISSUE_FIELD_REASON =
   "Issue fields are edited on GitHub — board editing arrives later";
 const MULTILINE_TEXT_REASON = "Multi-line text is edited on GitHub";
-
-/** A board text value the API wrote with line breaks in it. */
-const MULTILINE = /[\r\n]/;
 const SAVING_REASON = "Saving your last change…";
 const STRANDED_NOTICE =
   "Field changes weren't applied — this item is no longer on the board they were drafted for";
+
+/** A board text value the API wrote with line breaks in it. */
+const MULTILINE = /[\r\n]/;
 
 /** The field kinds this editor can write. The built-in fields GitHub owns on the
  *  issue/PR itself (title, assignees, labels, milestone, repository, reviewers,

--- a/src/features/conversations/ProjectFieldsEditor.tsx
+++ b/src/features/conversations/ProjectFieldsEditor.tsx
@@ -1,6 +1,6 @@
 import { Popover } from "@base-ui/react/popover";
 import { SlidersHorizontalIcon } from "@phosphor-icons/react";
-import { useId, useState } from "react";
+import { useEffect, useEffectEvent, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DisabledReasonButton } from "@/components/disabled-reason-button";
 import { LabeledGroup } from "@/components/form/labeled-group";
@@ -34,6 +34,9 @@ import { ScopeGapBlock } from "./ProjectsPopover";
 
 const READ_ONLY_SCOPE_REASON =
   "Your GitHub sign-in can read project fields but not change them (needs the project scope)";
+/** Mirrors the Projects picker's own row wording verbatim — the two surfaces gate on
+ *  the same `viewerCanUpdate` flag and must not say it differently. */
+const NO_ACCESS_REASON = "You don't have write access to this project";
 const NO_ITERATIONS_REASON =
   "This board's iteration field has no iterations to pick from yet";
 const ISSUE_FIELD_REASON =
@@ -56,6 +59,21 @@ function isWritable(def: ProjectFieldDef): def is WritableFieldDef {
   return def.kind !== "system";
 }
 
+/** Why a whole board's rows are held, or `undefined` when they're editable. */
+function boardLockedReason(
+  readOnlyScope: boolean,
+  board: EditableBoard,
+): string | undefined {
+  switch (true) {
+    case readOnlyScope:
+      return READ_ONLY_SCOPE_REASON;
+    case !board.viewerCanUpdate:
+      return NO_ACCESS_REASON;
+    default:
+      return undefined;
+  }
+}
+
 /** An org issue-field bridged onto a board. `updateProjectV2ItemFieldValue` is not
  *  its write path, so its row is held rather than hidden — the rail shows the value,
  *  and a missing row there would read as a broken render. */
@@ -63,16 +81,34 @@ function isIssueFieldDef(def: WritableFieldDef): boolean {
   return def.kind !== "iteration" && def.isIssueField;
 }
 
-/** One field's drafted state: what it will READ as once written, plus the write that
+/** One field's drafted VALUE: what it will read as once written, plus the write that
  *  puts it there. Both halves are built where the definitions are — the ids a write
- *  needs and the names a value renders live only there. `null` is a drafted UNSET. */
-type FieldDraft = {
+ *  needs and the names a value renders live only there. */
+type CommittedDraft = {
   value: ProjectFieldValue;
   update: ProjectFieldValueUpdate;
-} | null;
+};
+
+/** A control holding an entry the browser can't parse. Measured in Chromium: a
+ *  half-typed exponent ("1e", "-") and an unfinished date segment all report
+ *  `value === ""` with `validity.badInput`, which is indistinguishable from the
+ *  emptied control that MEANS clear — hence a third state rather than `null`. */
+const INVALID_DRAFT = "invalid";
+
+/** One field's drafted state. `null` is a drafted UNSET (the clear gesture);
+ *  {@link INVALID_DRAFT} commits nothing at all, overriding any earlier draft. */
+type FieldDraft = CommittedDraft | typeof INVALID_DRAFT | null;
 
 /** Every touched field of one board, by field id. An absent key is untouched. */
 type BoardDraft = Record<string, FieldDraft>;
+
+/** One board this item sits on: its cached field values, plus whether the viewer may
+ *  change them. The flag rides the MEMBERSHIP row — the project object inside a values
+ *  entry carries a `viewerCanUpdate` of its own that this deliberately shadows, the
+ *  memberships read being the one that populates it. */
+export type EditableBoard = ItemProjectFieldValues & {
+  viewerCanUpdate: boolean;
+};
 
 /** A value's identity for the close-time diff. Kinds compare on what a write
  *  changes, so a multi-select reordered by the server still reads as unchanged, and
@@ -116,8 +152,9 @@ type FieldDiff = {
   updates: ProjectFieldValueUpdate[];
   clears: string[];
   /** The drafts that survived the diff, by field id — what the optimistic patch
-   *  applies, so a skipped draft can't reach the cache either. */
-  applied: Map<string, FieldDraft>;
+   *  applies, so a skipped draft can't reach the cache either. Typed without the
+   *  invalid arm: a skipped entry is never recorded here. */
+  applied: Map<string, CommittedDraft | null>;
 };
 
 /** Diffs one board's touched fields against its seeded snapshot. Untouched fields
@@ -130,10 +167,13 @@ function fieldDiff(
 ): FieldDiff {
   const updates: ProjectFieldValueUpdate[] = [];
   const clears: string[] = [];
-  const applied = new Map<string, FieldDraft>();
+  const applied = new Map<string, CommittedDraft | null>();
   for (const [fieldId, entry] of Object.entries(touched)) {
-    // A half-typed number stays on screen but never reaches the wire: the backend
-    // would have to read the NaN as something, and every reading is wrong.
+    // Neither an update nor a clear: the field keeps what the server holds while
+    // its control shows an entry still being typed.
+    if (entry === INVALID_DRAFT) continue;
+    // Defensive twin for a raw string that reached a parse from somewhere other
+    // than a number input, whose own sanitizing never yields an unparseable one.
     if (
       entry !== null &&
       entry.value.kind === "number" &&
@@ -208,7 +248,7 @@ export function ProjectFieldsEditor({
   lens: RemoteLens;
   /** The boards this item is on, in memberships order, each with the cached values
    *  the draft seeds from. Empty while those values are still unread. */
-  boards: ItemProjectFieldValues[];
+  boards: EditableBoard[];
   /** Set when the surface can't be edited right now — the viewer lacks the access
    *  its action needs, or the entity is still loading. Outranks every other hold. */
   disabledReason?: string;
@@ -262,10 +302,13 @@ export function ProjectFieldsEditor({
   }
 
   async function commit() {
-    const pending: { board: ItemProjectFieldValues; write: BoardWrite }[] = [];
+    const pending: { board: EditableBoard; write: BoardWrite }[] = [];
     for (const board of boards) {
       const touched = drafts[board.project.id];
       if (touched === undefined) continue;
+      // Belt for the rows' own hold: a board the viewer can't write would 403 at the
+      // end of a chain that stops on the first failure, stranding the boards after it.
+      if (!board.viewerCanUpdate) continue;
       // A board that appeared mid-open has no snapshot, so its LIVE values stand
       // in — a baseline that can move under a background refetch while a mounted
       // input's text stays frozen. Diffing only touched fields bounds that.
@@ -379,9 +422,10 @@ export function ProjectFieldsEditor({
                   open={open}
                   // A board GitHub reports with no title has no header to render.
                   showTitle={showTitles && board.project.title !== ""}
-                  lockedReason={
-                    readOnlyScope ? READ_ONLY_SCOPE_REASON : undefined
-                  }
+                  // Ranked as the Projects picker ranks its rows: the popover-wide
+                  // scope gap outranks the per-board access one, and BoardSection
+                  // puts the per-field issue-field reason below both.
+                  lockedReason={boardLockedReason(readOnlyScope, board)}
                   seed={seeds[board.project.id]}
                   draft={drafts[board.project.id]}
                   onChange={(fieldId, entry) =>
@@ -464,11 +508,7 @@ function BoardSection({
         <FieldRow
           key={def.id}
           def={def}
-          current={
-            def.id in (draft ?? {})
-              ? (draft?.[def.id]?.value ?? null)
-              : (baseline[def.id] ?? null)
-          }
+          current={currentValue(def, draft, baseline)}
           // The board-wide hold outranks the per-field one, as the Projects
           // picker's rows rank theirs: a scope gap has a remedy on this popup.
           lockedReason={
@@ -480,6 +520,20 @@ function BoardSection({
       ))}
     </div>
   );
+}
+
+/** What a row reads as now: its draft where the field was touched, else the seed. An
+ *  INVALID entry reads as the SEED — nothing will be written for it, so the field
+ *  still holds what it held, and its Clear stays offered. */
+function currentValue(
+  def: WritableFieldDef,
+  draft: BoardDraft | undefined,
+  baseline: Record<string, ProjectFieldValue>,
+): ProjectFieldValue | null {
+  const entry = draft?.[def.id];
+  if (entry === undefined || entry === INVALID_DRAFT)
+    return baseline[def.id] ?? null;
+  return entry?.value ?? null;
 }
 
 /** One field's control, plus the header that names it and clears it. A set field
@@ -498,6 +552,10 @@ function FieldRow({
   onChange: (entry: FieldDraft) => void;
 }) {
   const inputId = useId();
+  // Remounts the scalar input, which is uncontrolled so that a partly-typed entry
+  // the browser reports as empty stays legible while it can't be parsed. Bumped
+  // only by Clear, so a keystroke never costs the caret its place.
+  const [clearSeq, setClearSeq] = useState(0);
   const action =
     current === null ? (
       <span className="text-[11px] text-muted-foreground">Not set</span>
@@ -510,7 +568,10 @@ function FieldRow({
         aria-label={`Clear ${def.name}`}
         disabled={!!lockedReason}
         reason={lockedReason}
-        onClick={() => onChange(null)}
+        onClick={() => {
+          setClearSeq((n) => n + 1);
+          onChange(null);
+        }}
       >
         Clear
       </DisabledReasonButton>
@@ -531,6 +592,7 @@ function FieldRow({
           {action}
         </div>
         <ScalarInput
+          key={clearSeq}
           id={inputId}
           def={def}
           current={current}
@@ -602,8 +664,18 @@ function scalarText(def: ScalarDef, current: ProjectFieldValue | null): string {
 }
 
 /** Turns a scalar input's raw text into a draft. Empty is an UNSET rather than an
- *  empty value — an empty text field and a missing one read the same on a board. */
-function scalarDraft(def: ScalarDef, raw: string): FieldDraft {
+ *  empty value — an empty text field and a missing one read the same on a board.
+ *
+ *  `badInput` is what separates the two ways a control reads empty: the user cleared
+ *  it (clear), or the browser can't parse what's in it and reports `""` on their
+ *  behalf (commit nothing). Without it, typing the "e" of "1e5" into a set field
+ *  wipes the value on close. */
+function scalarDraft(
+  def: ScalarDef,
+  raw: string,
+  badInput: boolean,
+): FieldDraft {
+  if (badInput) return INVALID_DRAFT;
   const base = {
     fieldId: def.id,
     fieldName: def.name,
@@ -628,15 +700,21 @@ function scalarDraft(def: ScalarDef, raw: string): FieldDraft {
       value: { kind: "text", ...base, text: raw },
       update: { kind: "text", fieldId: def.id, text: raw },
     };
+  // Every intermediate of a typed 4-digit year is a valid date with a 1-3 digit one
+  // ("2026-12-15" arrives as 0002-, 0020-, 0202- first), and no project dates year
+  // <1000 — so the floor puts an unfinished year in the same commit-nothing state as
+  // an unparseable entry, where a valid-looking wrong date would otherwise be written.
+  if (Number(raw.split("-")[0]) < 1000) return INVALID_DRAFT;
   return {
     value: { kind: "date", ...base, date: raw },
     update: { kind: "date", fieldId: def.id, date: raw },
   };
 }
 
-/** Text / number / date. Controlled from its own state so the row's Clear can empty
- *  it: the draft above mirrors what's typed, and an unparseable number stays here
- *  exactly as entered rather than snapping back to the last good value. */
+/** Text / number / date. UNCONTROLLED: a number or date input mid-entry reports its
+ *  value as `""` while still showing what was typed, so re-driving it from that value
+ *  would blank the field under the user's cursor. The DOM keeps the text, the draft
+ *  above keeps the meaning, and the row's Clear remounts this via its `key`. */
 function ScalarInput({
   id,
   def,
@@ -650,28 +728,43 @@ function ScalarInput({
   lockedReason?: string;
   onChange: (entry: FieldDraft) => void;
 }) {
-  const [text, setText] = useState(() => scalarText(def, current));
-  // Clear empties the draft, which this mirrors — the row's own button is outside
-  // this component, so the emptied state has to arrive as a prop change.
-  const shown = current === null && text !== "" ? "" : text;
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const onEdit = useEffectEvent((el: HTMLInputElement) => {
+    onChange(scalarDraft(def, el.value, el.validity.badInput));
+  });
+  // A NATIVE listener, not React's `onChange`: React gates its synthetic change on
+  // the input's exposed value STRING (`updateValueIfChanged`, react-dom-client
+  // :1592), so an edit that leaves that string `""` is never delivered. Both such
+  // edits flip badInput and so decide whether this field clears — typing the "-" of
+  // "-5" into a just-emptied field, and deleting it again to recover. Measured in
+  // Chromium: the native `input` event fires for both and bubbles to this host.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (host === null) return;
+    const handle = (e: Event) => {
+      if (e.target instanceof HTMLInputElement) onEdit(e.target);
+    };
+    host.addEventListener("input", handle);
+    return () => host.removeEventListener("input", handle);
+  }, []);
   return (
-    <Input
-      id={id}
-      type={def.kind === "text" ? "text" : def.kind}
-      // `any` rather than the default step of 1: a board's number field takes
-      // fractions, and a stepped input reports those as invalid.
-      step={def.kind === "number" ? "any" : undefined}
-      // A native date input renders its own segment mask and ignores this, so only
-      // the two free-text kinds get the invitation; the header says "Not set".
-      placeholder={def.kind === "date" ? undefined : `Set ${def.name}…`}
-      className="h-7"
-      disabled={!!lockedReason}
-      value={shown}
-      onChange={(e) => {
-        setText(e.target.value);
-        onChange(scalarDraft(def, e.target.value));
-      }}
-    />
+    // Owns the listener so the input's own ref-forwarding is never load-bearing;
+    // `block` keeps the input's full width in the row's column.
+    <span ref={hostRef} className="block">
+      <Input
+        id={id}
+        type={def.kind === "text" ? "text" : def.kind}
+        // `any` rather than the default step of 1: a board's number field takes
+        // fractions, and a stepped input reports those as invalid.
+        step={def.kind === "number" ? "any" : undefined}
+        // A native date input renders its own segment mask and ignores this, so only
+        // the two free-text kinds get the invitation; the header says "Not set".
+        placeholder={def.kind === "date" ? undefined : `Set ${def.name}…`}
+        className="h-7"
+        disabled={!!lockedReason}
+        defaultValue={scalarText(def, current)}
+      />
+    </span>
   );
 }
 

--- a/src/features/conversations/ProjectFieldsEditor.tsx
+++ b/src/features/conversations/ProjectFieldsEditor.tsx
@@ -1,0 +1,933 @@
+import { Popover } from "@base-ui/react/popover";
+import { SlidersHorizontalIcon } from "@phosphor-icons/react";
+import { useId, useState } from "react";
+import { toast } from "sonner";
+import { DisabledReasonButton } from "@/components/disabled-reason-button";
+import { LabeledGroup } from "@/components/form/labeled-group";
+import { usePanelPortalContainer } from "@/components/panel-portal";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Radio, RadioGroup } from "@/components/ui/radio-group";
+import { Spinner } from "@/components/ui/spinner";
+import { presentError } from "@/lib/error-summary";
+import { useActiveGhHost } from "@/lib/git/host";
+import {
+  useGhScopes,
+  useProjectFields,
+  useSetItemFieldValues,
+} from "@/lib/git/queries";
+import type {
+  ItemProjectFieldValues,
+  ProjectFieldDef,
+  ProjectFieldValue,
+  ProjectFieldValueUpdate,
+  ProjectIterationDef,
+  RemoteLens,
+} from "@/lib/git/types";
+import { listKeyboardNav } from "@/lib/list-keyboard-nav";
+import { useUiStore } from "@/lib/stores/ui";
+import { cn } from "@/lib/utils";
+import { IterationRange, OptionValue } from "./ProjectFieldValues";
+import { ScopeGapBlock } from "./ProjectsPopover";
+
+const READ_ONLY_SCOPE_REASON =
+  "Your GitHub sign-in can read project fields but not change them (needs the project scope)";
+const NO_ITERATIONS_REASON =
+  "This board's iteration field has no iterations to pick from yet";
+const ISSUE_FIELD_REASON =
+  "Issue fields are edited on GitHub — board editing arrives later.";
+const SAVING_REASON = "Saving your last change…";
+const STRANDED_NOTICE =
+  "Field changes weren't applied — this item is no longer on the board they were drafted for";
+
+/** GitHub's Date scalar, which carries no zone — and the only form a native date
+ *  input accepts, so anything else seeds it empty rather than silently blank. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The field kinds this editor can write. The built-in fields GitHub owns on the
+ *  issue/PR itself (title, assignees, labels, milestone, repository, reviewers,
+ *  tracking) arrive as `system`, so the exclusion is by KIND: a name-based one
+ *  would miss a renamed built-in and catch a custom field that borrowed its name. */
+type WritableFieldDef = Exclude<ProjectFieldDef, { kind: "system" }>;
+
+function isWritable(def: ProjectFieldDef): def is WritableFieldDef {
+  return def.kind !== "system";
+}
+
+/** An org issue-field bridged onto a board. `updateProjectV2ItemFieldValue` is not
+ *  its write path, so its row is held rather than hidden — the rail shows the value,
+ *  and a missing row there would read as a broken render. */
+function isIssueFieldDef(def: WritableFieldDef): boolean {
+  return def.kind !== "iteration" && def.isIssueField;
+}
+
+/** One field's drafted state: what it will READ as once written, plus the write that
+ *  puts it there. Both halves are built where the definitions are — the ids a write
+ *  needs and the names a value renders live only there. `null` is a drafted UNSET. */
+type FieldDraft = {
+  value: ProjectFieldValue;
+  update: ProjectFieldValueUpdate;
+} | null;
+
+/** Every touched field of one board, by field id. An absent key is untouched. */
+type BoardDraft = Record<string, FieldDraft>;
+
+/** A value's identity for the close-time diff. Kinds compare on what a write
+ *  changes, so a multi-select reordered by the server still reads as unchanged, and
+ *  an iteration renamed or rescheduled on the board is still the same iteration. */
+function valueKey(value: ProjectFieldValue | null): string {
+  if (value === null) return "";
+  switch (value.kind) {
+    case "text":
+      return `text:${value.text}`;
+    case "number":
+      return `number:${value.number}`;
+    case "date":
+      return `date:${value.date}`;
+    case "singleSelect":
+      return `singleSelect:${value.optionId}`;
+    case "multiSelect":
+      return `multiSelect:${value.options
+        .map((option) => option.id)
+        .toSorted()
+        .join(",")}`;
+    case "iteration":
+      return `iteration:${value.iterationId}`;
+    // `unknown` never reaches a draft and never seeds one — it carries no field id.
+    default:
+      return "";
+  }
+}
+
+/** One board's values by field id, the baseline a close diffs against. */
+function seedBoard(
+  board: ItemProjectFieldValues,
+): Record<string, ProjectFieldValue> {
+  const seed: Record<string, ProjectFieldValue> = {};
+  for (const value of board.values) {
+    if ("fieldId" in value) seed[value.fieldId] = value;
+  }
+  return seed;
+}
+
+type FieldDiff = {
+  updates: ProjectFieldValueUpdate[];
+  clears: string[];
+  /** The drafts that survived the diff, by field id — what the optimistic patch
+   *  applies, so a skipped draft can't reach the cache either. */
+  applied: Map<string, FieldDraft>;
+};
+
+/** Diffs one board's touched fields against its seeded snapshot. Untouched fields
+ *  can't differ, so the loop is over the drafts alone. Split out from the write
+ *  because a board that left the item mid-open still has to answer "did this draft
+ *  hold changes?" with no board object left to patch. */
+function fieldDiff(
+  seed: Record<string, ProjectFieldValue>,
+  touched: BoardDraft,
+): FieldDiff {
+  const updates: ProjectFieldValueUpdate[] = [];
+  const clears: string[] = [];
+  const applied = new Map<string, FieldDraft>();
+  for (const [fieldId, entry] of Object.entries(touched)) {
+    // A half-typed number stays on screen but never reaches the wire: the backend
+    // would have to read the NaN as something, and every reading is wrong.
+    if (
+      entry !== null &&
+      entry.value.kind === "number" &&
+      !Number.isFinite(entry.value.number)
+    )
+      continue;
+    if (valueKey(seed[fieldId] ?? null) === valueKey(entry?.value ?? null))
+      continue;
+    if (entry === null) clears.push(fieldId);
+    else updates.push(entry.update);
+    applied.set(fieldId, entry);
+  }
+  return { updates, clears, applied };
+}
+
+type BoardWrite = FieldDiff & {
+  /** That board's values as they'll read once the write lands — the optimistic patch. */
+  values: ProjectFieldValue[];
+};
+
+/** One board's diff plus the patched value list it implies, which keeps the
+ *  server's order and appends whatever the item had no value for before. */
+function boardWrite(
+  board: ItemProjectFieldValues,
+  seed: Record<string, ProjectFieldValue>,
+  touched: BoardDraft,
+): BoardWrite {
+  const diff = fieldDiff(seed, touched);
+  const { applied } = diff;
+  const values: ProjectFieldValue[] = [];
+  const had = new Set<string>();
+  for (const value of board.values) {
+    if (!("fieldId" in value)) {
+      values.push(value);
+      continue;
+    }
+    had.add(value.fieldId);
+    if (!applied.has(value.fieldId)) {
+      values.push(value);
+      continue;
+    }
+    const entry = applied.get(value.fieldId);
+    if (entry) values.push(entry.value);
+  }
+  for (const [fieldId, entry] of applied) {
+    if (entry !== null && !had.has(fieldId)) values.push(entry.value);
+  }
+  return { ...diff, values };
+}
+
+/**
+ * The editable half of an item's GitHub Projects fields: one trigger that opens a
+ * popover listing every writable field of every board the item sits on, set and
+ * unset alike. Edits are drafted while it's open and committed as one batched write
+ * per board on close — the same model as the Projects and Labels pickers, and the
+ * reason the popup says so above its rows.
+ */
+export function ProjectFieldsEditor({
+  repoPath,
+  kind,
+  number,
+  lens,
+  boards,
+  disabledReason,
+  unsettledReason,
+}: {
+  repoPath: string;
+  /** Which surface this item is — the backend addresses issues and PRs apart. */
+  kind: "issue" | "pr";
+  number: number;
+  /** The origin|upstream lens the parent PR/issue surface resolved. */
+  lens: RemoteLens;
+  /** The boards this item is on, in memberships order, each with the cached values
+   *  the draft seeds from. Empty while those values are still unread. */
+  boards: ItemProjectFieldValues[];
+  /** Set when the surface can't be edited right now — the viewer lacks the access
+   *  its action needs, or the entity is still loading. Outranks every other hold. */
+  disabledReason?: string;
+  /** Set when `boards` can't be trusted yet, with the words that say so. */
+  unsettledReason?: string;
+}) {
+  const host = useActiveGhHost();
+  const scopes = useGhScopes(host);
+  const openReconnect = useUiStore((s) => s.openReconnect);
+  // Read-only classic token: the reads work, every write 403s. Hold the controls
+  // rather than letting each edit round-trip to a rollback + toast.
+  const readOnlyScope =
+    scopes.data?.classic === true &&
+    scopes.data.scopes.includes("read:project") &&
+    !scopes.data.scopes.includes("project");
+
+  const [open, setOpen] = useState(false);
+  const [drafts, setDrafts] = useState<Record<string, BoardDraft>>({});
+  // Each board's values AS SEEN at open. The close diffs draft-vs-SEEDED, never
+  // draft-vs-live, so a value landing mid-open is in neither set and left alone.
+  const [seeds, setSeeds] = useState<
+    Record<string, Record<string, ProjectFieldValue>>
+  >({});
+  const portalContainer = usePanelPortalContainer();
+  const setFields = useSetItemFieldValues(repoPath, kind, number, lens);
+
+  // Ranked: the caller's reason outranks a write the viewer started, which outranks
+  // values this surface hasn't read yet.
+  const heldReason = (() => {
+    switch (true) {
+      case disabledReason !== undefined:
+        return disabledReason;
+      // No second edit may be drafted while one is in flight: the cache holds an
+      // optimistic patch whose real values only the settle refetch supplies, and
+      // that refetch is what a fresh draft would have to seed from. The mutation's
+      // `onSettled` returns its invalidate promise, so this hold spans it.
+      case setFields.isPending:
+        return SAVING_REASON;
+      case unsettledReason !== undefined:
+        return unsettledReason;
+      default:
+        return undefined;
+    }
+  })();
+
+  function setDraft(projectId: string, fieldId: string, entry: FieldDraft) {
+    setDrafts((prev) => ({
+      ...prev,
+      [projectId]: { ...(prev[projectId] ?? {}), [fieldId]: entry },
+    }));
+  }
+
+  async function commit() {
+    const pending: { board: ItemProjectFieldValues; write: BoardWrite }[] = [];
+    for (const board of boards) {
+      const touched = drafts[board.project.id];
+      if (touched === undefined) continue;
+      // A board that appeared mid-open has no snapshot, so its LIVE values stand
+      // in — a baseline that can move under a background refetch while a mounted
+      // input's text stays frozen. Diffing only touched fields bounds that.
+      const seed = seeds[board.project.id] ?? seedBoard(board);
+      const write = boardWrite(board, seed, touched);
+      if (write.updates.length === 0 && write.clears.length === 0) continue;
+      pending.push({ board, write });
+    }
+    // Drafts for a board the item left mid-open have nowhere to go — the
+    // membership their itemId addressed is gone, and its section left the popup
+    // as it went. Said once, however many boards it was.
+    const live = new Set(boards.map((board) => board.project.id));
+    const stranded = Object.entries(drafts).some(([projectId, touched]) => {
+      if (live.has(projectId)) return false;
+      const { updates, clears } = fieldDiff(seeds[projectId] ?? {}, touched);
+      return updates.length > 0 || clears.length > 0;
+    });
+    if (stranded) toast.info(STRANDED_NOTICE);
+
+    for (const [i, { board, write }] of pending.entries()) {
+      try {
+        await setFields.mutateAsync({
+          projectId: board.project.id,
+          itemId: board.itemId,
+          updates: write.updates,
+          clears: write.clears,
+          values: write.values,
+          unwritten: pending.length - i - 1,
+        });
+      } catch {
+        // The mutation owns the report, including what this stop left undone.
+        return;
+      }
+    }
+  }
+
+  function handleOpenChange(o: boolean) {
+    if (o) {
+      const next: Record<string, Record<string, ProjectFieldValue>> = {};
+      for (const board of boards) next[board.project.id] = seedBoard(board);
+      setSeeds(next);
+      setDrafts({});
+      setOpen(true);
+      return;
+    }
+    setOpen(false);
+    void commit();
+  }
+
+  const showTitles = boards.length > 1;
+  return (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      <Popover.Trigger
+        render={
+          <DisabledReasonButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit project fields"
+            disabled={!!heldReason}
+            reason={heldReason}
+          />
+        }
+      >
+        {/* size-3 explicitly: the Button's own icon rule skips a sized element,
+            and a 16px swap would widen the label column mid-write. */}
+        {setFields.isPending ? (
+          <Spinner className="size-3" data-icon="inline-start" />
+        ) : (
+          <SlidersHorizontalIcon data-icon="inline-start" />
+        )}
+        Project fields
+      </Popover.Trigger>
+      <Popover.Portal container={portalContainer}>
+        <Popover.Positioner
+          align="start"
+          sideOffset={4}
+          className="isolate z-50"
+        >
+          <Popover.Popup className="w-80 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <p className="px-1 pb-1.5 text-xs font-medium">Project fields</p>
+            {readOnlyScope && (
+              <div className="mb-1 border-b pb-1">
+                <ScopeGapBlock
+                  host={host}
+                  onReconnect={() =>
+                    openReconnect({
+                      provider: "github",
+                      host,
+                      mode: "refresh",
+                      scopes: ["project"],
+                    })
+                  }
+                >
+                  Changing project fields needs the{" "}
+                  <span className="font-mono">project</span> scope, which your
+                  GitHub sign-in is missing.
+                </ScopeGapBlock>
+              </div>
+            )}
+            {/* The popup's ONE scroll region, as the Projects picker has one: every
+                row below renders at natural height, so nothing nests a second
+                scrollbar inside this one. Capped against the WINDOW rather than at a
+                fixed height — a full field spread is taller than any cap that also
+                fits a short window, and `max-h` only bites once content exceeds it. */}
+            <div className="max-h-[70vh] space-y-3 overflow-y-auto px-1">
+              {boards.map((board) => (
+                <BoardSection
+                  key={board.itemId}
+                  repoPath={repoPath}
+                  board={board}
+                  open={open}
+                  // A board GitHub reports with no title has no header to render.
+                  showTitle={showTitles && board.project.title !== ""}
+                  lockedReason={
+                    readOnlyScope ? READ_ONLY_SCOPE_REASON : undefined
+                  }
+                  seed={seeds[board.project.id]}
+                  draft={drafts[board.project.id]}
+                  onChange={(fieldId, entry) =>
+                    setDraft(board.project.id, fieldId, entry)
+                  }
+                />
+              ))}
+            </div>
+            {boards.length > 0 && !readOnlyScope && (
+              <p className="mt-1 border-t px-1 pt-1.5 text-[11px] text-muted-foreground">
+                Changes apply when this closes.
+              </p>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+/** One board's rows. The definitions are read here rather than in the parent: a
+ *  hook can't be called per board from a list, and this is also what keeps a board
+ *  whose popover never opens from ever fetching them. */
+function BoardSection({
+  repoPath,
+  board,
+  open,
+  showTitle,
+  lockedReason,
+  seed,
+  draft,
+  onChange,
+}: {
+  repoPath: string;
+  board: ItemProjectFieldValues;
+  open: boolean;
+  showTitle: boolean;
+  lockedReason?: string;
+  seed?: Record<string, ProjectFieldValue>;
+  draft?: BoardDraft;
+  onChange: (fieldId: string, entry: FieldDraft) => void;
+}) {
+  const defs = useProjectFields(repoPath, board.project.id, open);
+  const writable = (defs.data ?? []).filter(isWritable);
+  const baseline = seed ?? seedBoard(board);
+  return (
+    <div className="space-y-2">
+      {showTitle && (
+        <p
+          className="truncate text-[11px] font-medium"
+          title={board.project.title}
+        >
+          {board.project.title}
+        </p>
+      )}
+      {defs.isPending && (
+        <p className="py-1 text-xs text-muted-foreground">Loading fields…</p>
+      )}
+      {defs.error !== null && (
+        <div className="py-1 text-xs">
+          <p className="text-muted-foreground">
+            {presentError(defs.error).summary}
+          </p>
+          <Button
+            variant="outline"
+            size="xs"
+            className="mt-1.5"
+            onClick={() => defs.refetch()}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+      {defs.isSuccess && writable.length === 0 && (
+        <p className="py-1 text-xs text-muted-foreground">
+          This board defines no fields you can change here.
+        </p>
+      )}
+      {writable.map((def) => (
+        <FieldRow
+          key={def.id}
+          def={def}
+          current={
+            def.id in (draft ?? {})
+              ? (draft?.[def.id]?.value ?? null)
+              : (baseline[def.id] ?? null)
+          }
+          // The board-wide hold outranks the per-field one, as the Projects
+          // picker's rows rank theirs: a scope gap has a remedy on this popup.
+          lockedReason={
+            lockedReason ??
+            (isIssueFieldDef(def) ? ISSUE_FIELD_REASON : undefined)
+          }
+          onChange={(entry) => onChange(def.id, entry)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** One field's control, plus the header that names it and clears it. A set field
+ *  offers Clear; an unset one says so where Clear would be, so no row is ever a
+ *  bare control with nothing to read. */
+function FieldRow({
+  def,
+  current,
+  lockedReason,
+  onChange,
+}: {
+  def: WritableFieldDef;
+  /** What the field reads as right now — the draft if touched, else the seed. */
+  current: ProjectFieldValue | null;
+  lockedReason?: string;
+  onChange: (entry: FieldDraft) => void;
+}) {
+  const inputId = useId();
+  const action =
+    current === null ? (
+      <span className="text-[11px] text-muted-foreground">Not set</span>
+    ) : (
+      <DisabledReasonButton
+        type="button"
+        variant="ghost"
+        size="xs"
+        className="text-muted-foreground"
+        aria-label={`Clear ${def.name}`}
+        disabled={!!lockedReason}
+        reason={lockedReason}
+        onClick={() => onChange(null)}
+      >
+        Clear
+      </DisabledReasonButton>
+    );
+
+  // Text, number and date share one shell: a labelled input whose own emptiness is
+  // the unset state, so clearing needs no separate control path.
+  if (def.kind === "text" || def.kind === "number" || def.kind === "date") {
+    return (
+      <div className="space-y-1" title={lockedReason}>
+        <div className="flex items-center justify-between gap-2">
+          <Label
+            htmlFor={inputId}
+            className="min-w-0 truncate text-xs text-muted-foreground"
+          >
+            {def.name}
+          </Label>
+          {action}
+        </div>
+        <ScalarInput
+          id={inputId}
+          def={def}
+          current={current}
+          lockedReason={lockedReason}
+          onChange={onChange}
+        />
+        {lockedReason && <span className="sr-only">{lockedReason}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <LabeledGroup
+      className="space-y-1"
+      label={
+        <span className="min-w-0 truncate text-muted-foreground">
+          {def.name}
+        </span>
+      }
+      actions={action}
+    >
+      <div title={lockedReason}>
+        {def.kind === "singleSelect" && (
+          <SingleSelectRows
+            def={def}
+            current={current}
+            lockedReason={lockedReason}
+            onChange={onChange}
+          />
+        )}
+        {def.kind === "multiSelect" && (
+          <MultiSelectRows
+            def={def}
+            current={current}
+            lockedReason={lockedReason}
+            onChange={onChange}
+          />
+        )}
+        {def.kind === "iteration" && (
+          <IterationRows
+            def={def}
+            current={current}
+            lockedReason={lockedReason}
+            onChange={onChange}
+          />
+        )}
+        {lockedReason && <span className="sr-only">{lockedReason}</span>}
+      </div>
+    </LabeledGroup>
+  );
+}
+
+type ScalarDef = Extract<
+  WritableFieldDef,
+  { kind: "text" | "number" | "date" }
+>;
+
+/** The initial text for a scalar field's input — what the value reads as in the
+ *  control's own grammar, never a formatted one: a locale-grouped number or date
+ *  would not survive the round trip back through this input. */
+function scalarText(def: ScalarDef, current: ProjectFieldValue | null): string {
+  if (current === null) return "";
+  if (def.kind === "text" && current.kind === "text") return current.text;
+  if (def.kind === "number" && current.kind === "number")
+    return Number.isFinite(current.number) ? String(current.number) : "";
+  if (def.kind === "date" && current.kind === "date")
+    return DATE_ONLY.test(current.date) ? current.date : "";
+  return "";
+}
+
+/** Turns a scalar input's raw text into a draft. Empty is an UNSET rather than an
+ *  empty value — an empty text field and a missing one read the same on a board. */
+function scalarDraft(def: ScalarDef, raw: string): FieldDraft {
+  const base = {
+    fieldId: def.id,
+    fieldName: def.name,
+    isIssueField: def.isIssueField,
+  };
+  if (def.kind === "number") {
+    // Trimmed only here: `Number("  ")` is 0, so whitespace would write a value the
+    // user meant to clear. Text is NOT trimmed for emptiness — the space that starts
+    // a word would blank the field on the keystroke that typed it.
+    if (raw.trim() === "") return null;
+    // Number(), not parseFloat(): a trailing "1.2.3" must read as unparseable, and
+    // the whole point of keeping the raw text is that nothing here re-rounds it.
+    const parsed = Number(raw);
+    return {
+      value: { kind: "number", ...base, number: parsed },
+      update: { kind: "number", fieldId: def.id, number: parsed },
+    };
+  }
+  if (raw === "") return null;
+  if (def.kind === "text")
+    return {
+      value: { kind: "text", ...base, text: raw },
+      update: { kind: "text", fieldId: def.id, text: raw },
+    };
+  return {
+    value: { kind: "date", ...base, date: raw },
+    update: { kind: "date", fieldId: def.id, date: raw },
+  };
+}
+
+/** Text / number / date. Controlled from its own state so the row's Clear can empty
+ *  it: the draft above mirrors what's typed, and an unparseable number stays here
+ *  exactly as entered rather than snapping back to the last good value. */
+function ScalarInput({
+  id,
+  def,
+  current,
+  lockedReason,
+  onChange,
+}: {
+  id: string;
+  def: ScalarDef;
+  current: ProjectFieldValue | null;
+  lockedReason?: string;
+  onChange: (entry: FieldDraft) => void;
+}) {
+  const [text, setText] = useState(() => scalarText(def, current));
+  // Clear empties the draft, which this mirrors — the row's own button is outside
+  // this component, so the emptied state has to arrive as a prop change.
+  const shown = current === null && text !== "" ? "" : text;
+  return (
+    <Input
+      id={id}
+      type={def.kind === "text" ? "text" : def.kind}
+      // `any` rather than the default step of 1: a board's number field takes
+      // fractions, and a stepped input reports those as invalid.
+      step={def.kind === "number" ? "any" : undefined}
+      // A native date input renders its own segment mask and ignores this, so only
+      // the two free-text kinds get the invitation; the header says "Not set".
+      placeholder={def.kind === "date" ? undefined : `Set ${def.name}…`}
+      className="h-7"
+      disabled={!!lockedReason}
+      value={shown}
+      onChange={(e) => {
+        setText(e.target.value);
+        onChange(scalarDraft(def, e.target.value));
+      }}
+    />
+  );
+}
+
+const ROW_CLASS =
+  "flex cursor-pointer items-center gap-2 px-1 py-1 text-xs hover:bg-muted/60";
+
+/** A single-select field's options as a radio group — one choice, and the group's
+ *  own arrow-key navigation, which is what a radio group already is. */
+function SingleSelectRows({
+  def,
+  current,
+  lockedReason,
+  onChange,
+}: {
+  def: Extract<WritableFieldDef, { kind: "singleSelect" }>;
+  current: ProjectFieldValue | null;
+  lockedReason?: string;
+  onChange: (entry: FieldDraft) => void;
+}) {
+  const selected =
+    current !== null && current.kind === "singleSelect" ? current.optionId : "";
+  return (
+    // `gap-0` only: the rows carry their own padding, and the popup body owns the
+    // scrolling — a cap here would nest a scrollbar inside that one.
+    <RadioGroup
+      className="gap-0"
+      value={selected}
+      onValueChange={(next) => {
+        const option = def.options.find((o) => o.id === next);
+        if (option === undefined) return;
+        onChange({
+          value: {
+            kind: "singleSelect",
+            fieldId: def.id,
+            fieldName: def.name,
+            optionId: option.id,
+            name: option.name,
+            color: option.color,
+            isIssueField: def.isIssueField,
+          },
+          update: {
+            kind: "singleSelect",
+            fieldId: def.id,
+            optionId: option.id,
+          },
+        });
+      }}
+    >
+      {def.options.map((option) => (
+        <label
+          key={option.id}
+          className={cn(ROW_CLASS, lockedReason && "cursor-not-allowed")}
+        >
+          <Radio value={option.id} disabled={!!lockedReason} />
+          <OptionValue name={option.name} color={option.color} />
+        </label>
+      ))}
+      {def.options.length === 0 && (
+        <p className="px-1 py-1 text-xs text-muted-foreground">
+          This field has no options.
+        </p>
+      )}
+    </RadioGroup>
+  );
+}
+
+/** A multi-select field's options as checkbox rows, the labels picker's shape. */
+function MultiSelectRows({
+  def,
+  current,
+  lockedReason,
+  onChange,
+}: {
+  def: Extract<WritableFieldDef, { kind: "multiSelect" }>;
+  current: ProjectFieldValue | null;
+  lockedReason?: string;
+  onChange: (entry: FieldDraft) => void;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const chosen =
+    current !== null && current.kind === "multiSelect" ? current.options : [];
+  const chosenIds = new Set(chosen.map((option) => option.id));
+  // Locked rows are skipped by the arrows rather than made focus black holes: a
+  // natively-disabled checkbox can't take focus.
+  const navRows = lockedReason ? [] : def.options;
+  const navIndexById = new Map(navRows.map((option, i) => [option.id, i]));
+  const activeIndex =
+    activeId === null ? -1 : (navIndexById.get(activeId) ?? -1);
+  // Nothing active yet parks the single tab stop on the first row.
+  const focusIndex = activeIndex === -1 ? 0 : activeIndex;
+  const onKeyDown = listKeyboardNav({
+    items: navRows,
+    activeIndex,
+    onActivate: (option) => setActiveId(option.id),
+    rowKey: (option) => option.id,
+  });
+
+  function toggle(optionId: string, on: boolean) {
+    const next = def.options.filter(
+      (option) =>
+        (chosenIds.has(option.id) || option.id === optionId) &&
+        (option.id !== optionId || on),
+    );
+    if (next.length === 0) {
+      onChange(null);
+      return;
+    }
+    onChange({
+      value: {
+        kind: "multiSelect",
+        fieldId: def.id,
+        fieldName: def.name,
+        options: next,
+        isIssueField: def.isIssueField,
+      },
+      update: {
+        kind: "multiSelect",
+        fieldId: def.id,
+        optionIds: next.map((option) => option.id),
+      },
+    });
+  }
+
+  return (
+    // Unstyled but NOT removable: it hosts the key handler, and `listKeyboardNav`
+    // finds the row to focus by querying within this element. The popup body owns
+    // the scrolling, so this list renders at natural height.
+    <div onKeyDown={onKeyDown}>
+      {def.options.map((option) => (
+        <label
+          key={option.id}
+          className={cn(
+            ROW_CLASS,
+            lockedReason && "cursor-not-allowed",
+            activeId === option.id && "bg-muted/60",
+          )}
+        >
+          <Checkbox
+            data-row={option.id}
+            tabIndex={navIndexById.get(option.id) === focusIndex ? 0 : -1}
+            checked={chosenIds.has(option.id)}
+            disabled={!!lockedReason}
+            onCheckedChange={(v) => toggle(option.id, v === true)}
+            onFocus={() => setActiveId(option.id)}
+          />
+          <OptionValue name={option.name} color={option.color} />
+        </label>
+      ))}
+      {def.options.length === 0 && (
+        <p className="px-1 py-1 text-xs text-muted-foreground">
+          This field has no options.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** An iteration field's iterations, current ones first and the completed ones under
+ *  their own caption — assignable, but not what a board means by "the current one".
+ *  A field with none is held with the reason rather than shown as an empty list. */
+function IterationRows({
+  def,
+  current,
+  lockedReason,
+  onChange,
+}: {
+  def: Extract<WritableFieldDef, { kind: "iteration" }>;
+  current: ProjectFieldValue | null;
+  lockedReason?: string;
+  onChange: (entry: FieldDraft) => void;
+}) {
+  const { iterations, completedIterations } = def;
+  const all = [...iterations, ...completedIterations];
+  // The reason is the row's own text: nothing here is focusable, so a tooltip or an
+  // aria-disabled flag would reach no one, and a second dimming layer over
+  // muted-foreground drops the one thing that IS readable below AA.
+  if (all.length === 0) {
+    return (
+      <p className="px-1 py-1 text-xs text-muted-foreground">
+        {NO_ITERATIONS_REASON}
+      </p>
+    );
+  }
+  // An iteration the field no longer offers matches no row, so nothing is checked
+  // — the header still reports the field as set, and its Clear still empties it.
+  const selected =
+    current !== null && current.kind === "iteration" ? current.iterationId : "";
+  return (
+    // `gap-0` only — see the single-select group: the popup body owns the scrolling.
+    <RadioGroup
+      className="gap-0"
+      value={selected}
+      onValueChange={(next) => {
+        const iteration = all.find((it) => it.id === next);
+        if (iteration === undefined) return;
+        onChange({
+          value: {
+            kind: "iteration",
+            fieldId: def.id,
+            fieldName: def.name,
+            iterationId: iteration.id,
+            title: iteration.title,
+            startDate: iteration.startDate,
+            duration: iteration.duration,
+            // Constant where the other kinds thread the def's flag: an iteration
+            // field is board-defined, so its def carries no `isIssueField`.
+            isIssueField: false,
+          },
+          update: {
+            kind: "iteration",
+            fieldId: def.id,
+            iterationId: iteration.id,
+          },
+        });
+      }}
+    >
+      {iterations.map((iteration) => (
+        <IterationRow
+          key={iteration.id}
+          iteration={iteration}
+          lockedReason={lockedReason}
+        />
+      ))}
+      {completedIterations.length > 0 && (
+        <p className="px-1 pt-1.5 pb-0.5 text-[11px] text-muted-foreground">
+          Completed
+        </p>
+      )}
+      {completedIterations.map((iteration) => (
+        <IterationRow
+          key={iteration.id}
+          iteration={iteration}
+          lockedReason={lockedReason}
+        />
+      ))}
+    </RadioGroup>
+  );
+}
+
+function IterationRow({
+  iteration,
+  lockedReason,
+}: {
+  iteration: ProjectIterationDef;
+  lockedReason?: string;
+}) {
+  return (
+    <label className={cn(ROW_CLASS, lockedReason && "cursor-not-allowed")}>
+      <Radio value={iteration.id} disabled={!!lockedReason} />
+      <span className="min-w-0 truncate">
+        {iteration.title}
+        <IterationRange
+          startDate={iteration.startDate}
+          duration={iteration.duration}
+        />
+      </span>
+    </label>
+  );
+}

--- a/src/features/conversations/ProjectFieldsEditor.tsx
+++ b/src/features/conversations/ProjectFieldsEditor.tsx
@@ -29,8 +29,8 @@ import type {
 import { listKeyboardNav } from "@/lib/list-keyboard-nav";
 import { useUiStore } from "@/lib/stores/ui";
 import { cn } from "@/lib/utils";
-import { IterationRange, OptionValue } from "./ProjectFieldValues";
-import { ScopeGapBlock } from "./ProjectsPopover";
+import { DATE_ONLY, IterationRange, OptionValue } from "./ProjectFieldValues";
+import { projectScopeReadOnly, ScopeGapBlock } from "./ProjectsPopover";
 
 const READ_ONLY_SCOPE_REASON =
   "Your GitHub sign-in can read project fields but not change them (needs the project scope)";
@@ -40,14 +40,14 @@ const NO_ACCESS_REASON = "You don't have write access to this project";
 const NO_ITERATIONS_REASON =
   "This board's iteration field has no iterations to pick from yet";
 const ISSUE_FIELD_REASON =
-  "Issue fields are edited on GitHub — board editing arrives later.";
+  "Issue fields are edited on GitHub — board editing arrives later";
+const MULTILINE_TEXT_REASON = "Multi-line text is edited on GitHub";
+
+/** A board text value the API wrote with line breaks in it. */
+const MULTILINE = /[\r\n]/;
 const SAVING_REASON = "Saving your last change…";
 const STRANDED_NOTICE =
   "Field changes weren't applied — this item is no longer on the board they were drafted for";
-
-/** GitHub's Date scalar, which carries no zone — and the only form a native date
- *  input accepts, so anything else seeds it empty rather than silently blank. */
-const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 /** The field kinds this editor can write. The built-in fields GitHub owns on the
  *  issue/PR itself (title, assignees, labels, milestone, repository, reviewers,
@@ -62,12 +62,12 @@ function isWritable(def: ProjectFieldDef): def is WritableFieldDef {
 /** Why a whole board's rows are held, or `undefined` when they're editable. */
 function boardLockedReason(
   readOnlyScope: boolean,
-  board: EditableBoard,
+  board: ItemProjectFieldValues,
 ): string | undefined {
   switch (true) {
     case readOnlyScope:
       return READ_ONLY_SCOPE_REASON;
-    case !board.viewerCanUpdate:
+    case !board.project.viewerCanUpdate:
       return NO_ACCESS_REASON;
     default:
       return undefined;
@@ -79,6 +79,26 @@ function boardLockedReason(
  *  and a missing row there would read as a broken render. */
 function isIssueFieldDef(def: WritableFieldDef): boolean {
   return def.kind !== "iteration" && def.isIssueField;
+}
+
+/** Why ONE field's row is held, or `undefined` when it's editable. Both arms are
+ *  per-field and rank below any board-wide hold; `seeded` is the value the board
+ *  holds now, which is what the multi-line arm protects. */
+function rowLockedReason(
+  def: WritableFieldDef,
+  seeded: ProjectFieldValue | undefined,
+): string | undefined {
+  switch (true) {
+    case isIssueFieldDef(def):
+      return ISSUE_FIELD_REASON;
+    // A single-line input strips CR/LF as the value is assigned to it, so the first
+    // keystroke would draft the flattened string and the close would commit it — a
+    // multi-line control belongs to a board surface if ever.
+    case seeded?.kind === "text" && MULTILINE.test(seeded.text):
+      return MULTILINE_TEXT_REASON;
+    default:
+      return undefined;
+  }
 }
 
 /** One field's drafted VALUE: what it will read as once written, plus the write that
@@ -101,14 +121,6 @@ type FieldDraft = CommittedDraft | typeof INVALID_DRAFT | null;
 
 /** Every touched field of one board, by field id. An absent key is untouched. */
 type BoardDraft = Record<string, FieldDraft>;
-
-/** One board this item sits on: its cached field values, plus whether the viewer may
- *  change them. The flag rides the MEMBERSHIP row — the project object inside a values
- *  entry carries a `viewerCanUpdate` of its own that this deliberately shadows, the
- *  memberships read being the one that populates it. */
-export type EditableBoard = ItemProjectFieldValues & {
-  viewerCanUpdate: boolean;
-};
 
 /** A value's identity for the close-time diff. Kinds compare on what a write
  *  changes, so a multi-select reordered by the server still reads as unchanged, and
@@ -248,7 +260,7 @@ export function ProjectFieldsEditor({
   lens: RemoteLens;
   /** The boards this item is on, in memberships order, each with the cached values
    *  the draft seeds from. Empty while those values are still unread. */
-  boards: EditableBoard[];
+  boards: ItemProjectFieldValues[];
   /** Set when the surface can't be edited right now — the viewer lacks the access
    *  its action needs, or the entity is still loading. Outranks every other hold. */
   disabledReason?: string;
@@ -258,12 +270,7 @@ export function ProjectFieldsEditor({
   const host = useActiveGhHost();
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
-  // Read-only classic token: the reads work, every write 403s. Hold the controls
-  // rather than letting each edit round-trip to a rollback + toast.
-  const readOnlyScope =
-    scopes.data?.classic === true &&
-    scopes.data.scopes.includes("read:project") &&
-    !scopes.data.scopes.includes("project");
+  const readOnlyScope = projectScopeReadOnly(scopes.data);
 
   const [open, setOpen] = useState(false);
   const [drafts, setDrafts] = useState<Record<string, BoardDraft>>({});
@@ -302,13 +309,13 @@ export function ProjectFieldsEditor({
   }
 
   async function commit() {
-    const pending: { board: EditableBoard; write: BoardWrite }[] = [];
+    const pending: { board: ItemProjectFieldValues; write: BoardWrite }[] = [];
     for (const board of boards) {
       const touched = drafts[board.project.id];
       if (touched === undefined) continue;
       // Belt for the rows' own hold: a board the viewer can't write would 403 at the
       // end of a chain that stops on the first failure, stranding the boards after it.
-      if (!board.viewerCanUpdate) continue;
+      if (!board.project.viewerCanUpdate) continue;
       // A board that appeared mid-open has no snapshot, so its LIVE values stand
       // in — a baseline that can move under a background refetch while a mounted
       // input's text stays frozen. Diffing only touched fields bounds that.
@@ -388,7 +395,16 @@ export function ProjectFieldsEditor({
           className="isolate z-50"
         >
           <Popover.Popup className="w-80 rounded-none bg-popover p-2 text-popover-foreground shadow-md ring-1 ring-foreground/10">
-            <p className="px-1 pb-1.5 text-xs font-medium">Project fields</p>
+            {/* The caption IS the popup's accessible name: Popover.Popup takes its
+                `aria-labelledby` from whatever Title registers, and a bare element
+                leaves the dialog unnamed. `render` keeps the <p> it has always been
+                — Title's own default element is an <h2>. */}
+            <Popover.Title
+              render={<p />}
+              className="px-1 pb-1.5 text-xs font-medium"
+            >
+              Project fields
+            </Popover.Title>
             {readOnlyScope && (
               <div className="mb-1 border-b pb-1">
                 <ScopeGapBlock
@@ -469,7 +485,7 @@ function BoardSection({
   onChange: (fieldId: string, entry: FieldDraft) => void;
 }) {
   const defs = useProjectFields(repoPath, board.project.id, open);
-  const writable = (defs.data ?? []).filter(isWritable);
+  const writable = (defs.data?.fields ?? []).filter(isWritable);
   const baseline = seed ?? seedBoard(board);
   return (
     <div className="space-y-2">
@@ -509,15 +525,20 @@ function BoardSection({
           key={def.id}
           def={def}
           current={currentValue(def, draft, baseline)}
-          // The board-wide hold outranks the per-field one, as the Projects
+          // The board-wide hold outranks the per-field ones, as the Projects
           // picker's rows rank theirs: a scope gap has a remedy on this popup.
-          lockedReason={
-            lockedReason ??
-            (isIssueFieldDef(def) ? ISSUE_FIELD_REASON : undefined)
-          }
+          lockedReason={lockedReason ?? rowLockedReason(def, baseline[def.id])}
           onChange={(entry) => onChange(def.id, entry)}
         />
       ))}
+      {/* Stands alone, as the picker's own truncation note does: a capped list of
+          fields this build can't write renders zero rows, where the empty-state
+          line above would be a lie. */}
+      {defs.data?.truncated === true && (
+        <p className="text-[11px] text-muted-foreground">
+          Some fields aren't shown.
+        </p>
+      )}
     </div>
   );
 }
@@ -817,6 +838,9 @@ function SingleSelectRows({
         <label
           key={option.id}
           className={cn(ROW_CLASS, lockedReason && "cursor-not-allowed")}
+          // The board's own note on what the option means, where GitHub shows it —
+          // supplementary, so it stays off the row's visible chrome.
+          title={option.description || undefined}
         >
           <Radio value={option.id} disabled={!!lockedReason} />
           <OptionValue name={option.name} color={option.color} />
@@ -901,6 +925,8 @@ function MultiSelectRows({
             lockedReason && "cursor-not-allowed",
             activeId === option.id && "bg-muted/60",
           )}
+          // See the single-select rows: the board's note on the option, hover-only.
+          title={option.description || undefined}
         >
           <Checkbox
             data-row={option.id}

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -58,6 +58,17 @@ export function projectScopeMissing(scopes: GhScopes | undefined): boolean {
   );
 }
 
+/** Read-only classic token: the reads work, every write 403s. Hold the controls
+ *  rather than letting each edit round-trip to a rollback + toast. Shared so no
+ *  Projects surface can offer a write another one holds. */
+export function projectScopeReadOnly(scopes: GhScopes | undefined): boolean {
+  return (
+    scopes?.classic === true &&
+    scopes.scopes.includes("read:project") &&
+    !scopes.scopes.includes("project")
+  );
+}
+
 /** A closed board still holds items, so its rows and chips stay — the state rides
  *  the label as words, never as a colour. */
 function projectLabel(project: ProjectV2Ref): string {
@@ -106,12 +117,7 @@ export function ProjectsPopover({
   const scopes = useGhScopes(host);
   const openReconnect = useUiStore((s) => s.openReconnect);
   const classicMissing = projectScopeMissing(scopes.data);
-  // Read-only classic token: the reads work, every write 403s. Hold the rows
-  // rather than letting each toggle round-trip to a rollback + toast.
-  const readOnlyScope =
-    scopes.data?.classic === true &&
-    scopes.data.scopes.includes("read:project") &&
-    !scopes.data.scopes.includes("project");
+  const readOnlyScope = projectScopeReadOnly(scopes.data);
   const canRead = enabled && !classicMissing;
 
   const [open, setOpen] = useState(false);

--- a/src/features/conversations/ProjectsPopover.tsx
+++ b/src/features/conversations/ProjectsPopover.tsx
@@ -525,7 +525,7 @@ function ProjectRow({
  *  be attempted at all) and one with only `read:project` (reads work, writes 403).
  *  Both need the same `project` scope, so both get the same remedy; `children` is
  *  the one sentence that differs. */
-function ScopeGapBlock({
+export function ScopeGapBlock({
   host,
   onReconnect,
   children,

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1752,10 +1752,9 @@ duplicates, and same-project mentions.
   the trigger: it opens one popup holding every field you can set on every board the issue is
   on, filled in or not, and any field that already holds a value carries a **Clear** to empty
   it again. Like the pickers above it, the popup drafts your edits and writes them when it
-  closes — one write per board.
-  GitHub only, and changing anything needs the \`project\` scope: with just \`read:project\`
-  the boards still show but every row is locked, and with neither the picker says so and
-  helps you get it — when your sign-in's scopes are readable,
+  closes — one write per board. GitHub only, and changing anything needs the \`project\`
+  scope: with just \`read:project\` the boards still show but every row is locked, and with
+  neither the picker says so and helps you get it — when your sign-in's scopes are readable,
   that's a one-click **Reconnect GitHub…** plus a copyable \`gh auth refresh\` command
   already pointed at your host.
 

--- a/src/features/help/content.ts
+++ b/src/features/help/content.ts
@@ -1070,8 +1070,9 @@ leaving the app — see *Conflicts with the base branch* below.
 
 An open pull request gets a **Projects** picker alongside its **labels**, **assignees**, and
 **reviewers**: chips for the **GitHub Projects** it belongs to, and a popup to link or
-unlink it. Under the chips, a **Project fields** row reads out where the pull request
-stands on each of those boards (see *Issues*).
+unlink it. Alongside the chips, a **Project fields** row reads out where the pull
+request stands on each of those boards, and its trigger opens the editor that sets
+them (see *Issues*).
 
 The list toolbar's **All | Mine | Needs review** switch scopes the list in one click:
 **Mine** is everything assigned to you or awaiting your review, and **Needs review** is
@@ -1747,10 +1748,14 @@ duplicates, and same-project mentions.
   changes apply when the picker closes. Below the chips, one line per board reads out where
   the issue stands: **Status**, **Priority**, **Iteration** (with the dates it covers), plus
   date, text, number, and multi-select fields, each named beside its value. A board is named
-  on its own line once the issue sits on more than one. Those values are read-only here;
-  change them on the board itself. GitHub only, and changing anything needs the \`project\`
-  scope: with just \`read:project\` the boards still show but every row is locked, and with
-  neither the picker says so and helps you get it — when your sign-in's scopes are readable,
+  on its own line once the issue sits on more than one. The **Project fields** row itself is
+  the trigger: it opens one popup holding every field you can set on every board the issue is
+  on, filled in or not, and any field that already holds a value carries a **Clear** to empty
+  it again. Like the pickers above it, the popup drafts your edits and writes them when it
+  closes — one write per board.
+  GitHub only, and changing anything needs the \`project\` scope: with just \`read:project\`
+  the boards still show but every row is locked, and with neither the picker says so and
+  helps you get it — when your sign-in's scopes are readable,
   that's a one-click **Reconnect GitHub…** plus a copyable \`gh auth refresh\` command
   already pointed at your host.
 

--- a/src/features/issues/RemoteIssueViewParts.tsx
+++ b/src/features/issues/RemoteIssueViewParts.tsx
@@ -289,6 +289,7 @@ export function IssueSidebar({
           kind="issue"
           number={number}
           lens={lens}
+          disabledReason={pickerDisabledReason}
         />
       ),
     },

--- a/src/features/pulls/RemotePrView.tsx
+++ b/src/features/pulls/RemotePrView.tsx
@@ -2471,8 +2471,9 @@ export function RemotePrView({
         disabledReason={pickerReason}
       />,
     );
-    // Read-only field values under the picker, on the same gate: they come from
-    // the same boards, so wherever the chips are, the fields belong.
+    // Field values under the picker, on the same gate: they come from the same
+    // boards, so wherever the chips are, the fields belong — and so does the
+    // editor's trigger, which this row carries in place of its label.
     metaCells.push(
       <ProjectFieldValues
         key={`project-fields-${entityKey}`}
@@ -2482,6 +2483,7 @@ export function RemotePrView({
         kind="pr"
         number={number}
         lens={lens}
+        disabledReason={pickerReason}
       />,
     );
   }

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -109,6 +109,8 @@ import type {
   PrInfo,
   PrMergeability,
   PrMergeabilityState,
+  ProjectFieldDef,
+  ProjectFieldValueUpdate,
   ProjectItemRef,
   ProjectItemRemove,
   PrPollInfo,
@@ -2530,6 +2532,30 @@ export const ghEditItemProjects = (
     contentId,
     addProjectIds,
     removes,
+  });
+
+/** One board's field definitions — every field it defines, writable or not. Board
+ *  state, not item state, so it takes no lens: a board is the same object whichever
+ *  remote the item was read through. */
+export const ghProjectFields = (repoPath: string, projectId: string) =>
+  invoke<ProjectFieldDef[]>("gh_project_fields", { repoPath, projectId });
+
+/** Writes one board's field values for one item in a single call. `updates` sets or
+ *  replaces; `clears` carries the field ids to UNSET, which no update shape can
+ *  express. Both address the item by its membership `itemId` on `projectId`. */
+export const ghSetItemFieldValues = (
+  repoPath: string,
+  projectId: string,
+  itemId: string,
+  updates: ProjectFieldValueUpdate[],
+  clears: string[],
+) =>
+  invoke<void>("gh_set_item_field_values", {
+    repoPath,
+    projectId,
+    itemId,
+    updates,
+    clears,
   });
 
 /** Third-party AI-reviewer findings on a PR/MR (Copilot/CodeRabbit/…), behind the

--- a/src/lib/git/api.ts
+++ b/src/lib/git/api.ts
@@ -109,7 +109,7 @@ import type {
   PrInfo,
   PrMergeability,
   PrMergeabilityState,
-  ProjectFieldDef,
+  ProjectFieldDefs,
   ProjectFieldValueUpdate,
   ProjectItemRef,
   ProjectItemRemove,
@@ -2538,7 +2538,7 @@ export const ghEditItemProjects = (
  *  state, not item state, so it takes no lens: a board is the same object whichever
  *  remote the item was read through. */
 export const ghProjectFields = (repoPath: string, projectId: string) =>
-  invoke<ProjectFieldDef[]>("gh_project_fields", { repoPath, projectId });
+  invoke<ProjectFieldDefs>("gh_project_fields", { repoPath, projectId });
 
 /** Writes one board's field values for one item in a single call. `updates` sets or
  *  replaces; `clears` carries the field ids to UNSET, which no update shape can

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -2676,10 +2676,20 @@ export function useSetItemFieldValues(
     },
     // Cancel-before-invalidate, and RETURNED so `isPending` spans the refetch —
     // both for the reasons {@link useEditItemProjects}'s `onSettled` states.
-    onSettled: () =>
+    // Only the chain's LAST settle refetches: every board writes the same query and
+    // the caller awaits each, so invalidating per board would pay a full read
+    // between writes for a result the next write supersedes. An ERROR is also a
+    // last settle — the caller stops there, so this is the only chance to reconcile
+    // the boards already written. The cancel stays unconditional (an in-flight read
+    // still holds pre-write values), and `isPending` spans the chain either way.
+    onSettled: (_d, e, args) =>
       queryClient
         .cancelQueries({ queryKey: fieldsKey })
-        .then(() => queryClient.invalidateQueries({ queryKey: fieldsKey })),
+        .then(() =>
+          args.unwritten === 0 || e !== null
+            ? queryClient.invalidateQueries({ queryKey: fieldsKey })
+            : undefined,
+        ),
   });
 }
 

--- a/src/lib/git/queries.ts
+++ b/src/lib/git/queries.ts
@@ -14,7 +14,7 @@ import { reloadReviewNotes } from "@/lib/review-notes/store";
 import { useUiStore } from "@/lib/stores/ui";
 import { isAppError } from "@/lib/tauri/invoke";
 import { COLD_START_NO_GH, COLD_START_NO_GIT } from "@/lib/test-mode";
-import { toastError } from "@/lib/toast";
+import { toastError, toastErrorWithNote } from "@/lib/toast";
 import * as api from "./api";
 import { primeCommitAuthorIndex } from "./commit-avatar";
 import {
@@ -48,10 +48,13 @@ import type {
   IssueReactions,
   IssueRelation,
   IssueType,
+  ItemProjectFieldValues,
   MyWorkSources,
   PrDetails,
   PrInfo,
   PrMergeabilityState,
+  ProjectFieldValue,
+  ProjectFieldValueUpdate,
   ProjectItemRef,
   ProjectItemRemove,
   ProjectV2Ref,
@@ -2585,6 +2588,101 @@ export function useEditItemProjects(
   });
 }
 
+/** One board's field DEFINITIONS. Keyed on the board alone — no lens, no item: the
+ *  same board serves every item on it. Options mirror {@link useAvailableProjects},
+ *  `enabled` being the caller's own UI state, never another query's cache. */
+export function useProjectFields(
+  repo: string,
+  projectId: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["repo", repo, "project-fields", projectId] as const,
+    queryFn: () => api.ghProjectFields(repo, projectId),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
+/**
+ * The field editor's batched per-board write, with an optimistic patch of that
+ * board's entry in the item-field-values cache. `values` is the patch itself: the
+ * wire `updates` carry ids alone, so only the editor — which holds the board's
+ * definitions — can say what those ids render as.
+ */
+export function useSetItemFieldValues(
+  repo: string,
+  kind: "issue" | "pr",
+  number: number,
+  lens: RemoteLens,
+) {
+  const queryClient = useQueryClient();
+  const fieldsKey = itemFieldValuesKey(repo, lens, kind, number);
+  return useMutation({
+    mutationFn: (args: {
+      projectId: string;
+      /** The membership's item id on `projectId` — what the write addresses. */
+      itemId: string;
+      updates: ProjectFieldValueUpdate[];
+      /** Field ids to UNSET; no update shape expresses a clear. */
+      clears: string[];
+      /** That board's values as they'll read once this lands. */
+      values: ProjectFieldValue[];
+      /** Boards queued behind this one. The editor writes board by board and stops
+       *  at the first failure, so a failure here names what that stop left undone. */
+      unwritten: number;
+    }) =>
+      api.ghSetItemFieldValues(
+        repo,
+        args.projectId,
+        args.itemId,
+        args.updates,
+        args.clears,
+      ),
+    onMutate: async (args) => {
+      await queryClient.cancelQueries({ queryKey: fieldsKey });
+      const prev =
+        queryClient.getQueryData<ItemProjectFieldValues[]>(fieldsKey);
+      if (prev) {
+        queryClient.setQueryData<ItemProjectFieldValues[]>(
+          fieldsKey,
+          prev.map((entry) =>
+            entry.project.id === args.projectId
+              ? { ...entry, values: args.values }
+              : entry,
+          ),
+        );
+      }
+      return { prev };
+    },
+    // Reporting lives here, not in the caller's `mutate` options: the popover that
+    // fires this closes as it does, and react-query drops mutate-scoped callbacks
+    // once the observer loses its listeners. The caller still sees the rejection
+    // through `mutateAsync`, which is what stops its per-board chain.
+    onError: (e, args, ctx) => {
+      if (ctx?.prev)
+        queryClient.setQueryData<ItemProjectFieldValues[]>(fieldsKey, ctx.prev);
+      if (args.unwritten === 0) {
+        toastError(e);
+        return;
+      }
+      toastErrorWithNote(
+        e,
+        args.unwritten === 1
+          ? "One more board's changes were left unwritten."
+          : `${args.unwritten} more boards' changes were left unwritten.`,
+      );
+    },
+    // Cancel-before-invalidate, and RETURNED so `isPending` spans the refetch —
+    // both for the reasons {@link useEditItemProjects}'s `onSettled` states.
+    onSettled: () =>
+      queryClient
+        .cancelQueries({ queryKey: fieldsKey })
+        .then(() => queryClient.invalidateQueries({ queryKey: fieldsKey })),
+  });
+}
+
 /**
  * An issue-lifecycle write (close/reopen/edit/pin/lock/transfer/delete) that reconciles
  * NARROWLY instead of whole-repo: the one issue's detail subtree (prefix-matched, so its
@@ -3202,9 +3300,10 @@ export function useAccountsHealth() {
  *  token scopes (a reconnect can grant new ones), and the repo-settings lists a
  *  scope hint sends users here from — secrets, variables and webhooks all fail
  *  closed on a missing scope, so their error cards must retry the call themselves,
- *  as do the three GitHub Projects reads (catalog, memberships and field values): a
- *  granted `project` scope has to light the picker and the rail's field lines up
- *  without a restart, and the work inbox's sources probe plus its pages
+ *  as do the four GitHub Projects reads (catalog, memberships, field values and a
+ *  board's field definitions): a granted `project` scope has to light the picker,
+ *  the rail's field lines and the field editor up without a restart, and the work
+ *  inbox's sources probe plus its pages
  *  (a `login` mode reconnect is how a forge becomes a source in the first place).
  *  Call from a reconnect's `finished: ok` handler. */
 export function useInvalidateAfterReconnect() {
@@ -3216,6 +3315,10 @@ export function useInvalidateAfterReconnect() {
     queryClient.invalidateQueries({ queryKey: ["gh", "token-scopes"] });
     queryClient.invalidateQueries({
       // Partial keys with a repo path in slot 1, so match on the axis instead.
+      // Its charter is SCOPE-GRANT RECOVERY only: every axis listed here is one a
+      // newly granted scope can change the answer to. Cache identity across
+      // ACCOUNTS is a query-key-axis concern — a cache that may hold another
+      // account's answer needs that account in its key, never a wider sweep here.
       predicate: (q) =>
         q.queryKey[0] === "repo" &&
         (q.queryKey[2] === "forge-status" ||
@@ -3225,7 +3328,8 @@ export function useInvalidateAfterReconnect() {
           q.queryKey[2] === "webhooks" ||
           q.queryKey[2] === "projects-available" ||
           q.queryKey[2] === "item-projects" ||
-          q.queryKey[2] === "item-field-values"),
+          q.queryKey[2] === "item-field-values" ||
+          q.queryKey[2] === "project-fields"),
     });
     // A `login` here is a real source change for the work inbox — its probe gates
     // each forge's leg on a 5-minute window, so without this a session signed in

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -2444,6 +2444,14 @@ export type ProjectFieldDef =
   | { kind: "date"; id: string; name: string; isIssueField: boolean }
   | { kind: "system"; id: string; name: string; dataType: string };
 
+/** One board's field definitions. `truncated` reports that the server capped the
+ *  list, which the editor says rather than implying it offers every field — the
+ *  same claim {@link AvailableProjects} makes about the catalog. */
+export interface ProjectFieldDefs {
+  fields: ProjectFieldDef[];
+  truncated: boolean;
+}
+
 /** One field to SET on an item, tagged by the field's kind. These field names are
  *  the wire the backend deserializes by — a renamed one reads as absent there.
  *  Unsetting is not expressed here: a clear rides the write's separate id list. */

--- a/src/lib/git/types.ts
+++ b/src/lib/git/types.ts
@@ -2369,6 +2369,10 @@ export type ProjectFieldValue =
       kind: "iteration";
       fieldId: string;
       fieldName: string;
+      /** Which iteration of the field's configured set this is — the id a write
+       *  addresses it by, and the only stable identity it has: title and dates are
+       *  editable on the board. */
+      iterationId: string;
       title: string;
       startDate: string;
       /** Length in DAYS, so the last day is `startDate + duration - 1`. */
@@ -2384,6 +2388,72 @@ export interface ItemProjectFieldValues {
   project: ProjectV2Ref;
   values: ProjectFieldValue[];
 }
+
+/** One option a board's single/multi-select field offers. */
+export interface ProjectFieldOptionDef {
+  id: string;
+  name: string;
+  /** GitHub color NAME (GRAY/BLUE/GREEN/YELLOW/ORANGE/RED/PINK/PURPLE). */
+  color: string;
+  description: string;
+}
+
+/** One iteration a board's iteration field offers. `duration` is a DAY count, so
+ *  the last day is `startDate + duration - 1` — the same shape the iteration VALUE
+ *  arm carries, plus the `id` a write addresses it by. */
+export interface ProjectIterationDef {
+  id: string;
+  title: string;
+  /** A bare `YYYY-MM-DD` as GitHub's Date scalar sends it — no zone. */
+  startDate: string;
+  duration: number;
+}
+
+/** One project field's DEFINITION, tagged by kind — what the editor offers, where
+ *  {@link ProjectFieldValue} is what an item currently holds. `system` is both the
+ *  built-ins bucket (title, assignees, labels, milestone, repository, reviewers,
+ *  tracking — GitHub owns those on the issue/PR itself) and the tolerant fallback
+ *  for a `dataType` this build doesn't know, which is how the editor excludes them:
+ *  by kind, never by name. */
+export type ProjectFieldDef =
+  | {
+      kind: "singleSelect";
+      id: string;
+      name: string;
+      options: ProjectFieldOptionDef[];
+      isIssueField: boolean;
+    }
+  | {
+      kind: "multiSelect";
+      id: string;
+      name: string;
+      options: ProjectFieldOptionDef[];
+      isIssueField: boolean;
+    }
+  | {
+      kind: "iteration";
+      id: string;
+      name: string;
+      iterations: ProjectIterationDef[];
+      /** Past iterations, offered apart: still assignable, but not what a board
+       *  means by "the current one". */
+      completedIterations: ProjectIterationDef[];
+    }
+  | { kind: "text"; id: string; name: string; isIssueField: boolean }
+  | { kind: "number"; id: string; name: string; isIssueField: boolean }
+  | { kind: "date"; id: string; name: string; isIssueField: boolean }
+  | { kind: "system"; id: string; name: string; dataType: string };
+
+/** One field to SET on an item, tagged by the field's kind. These field names are
+ *  the wire the backend deserializes by — a renamed one reads as absent there.
+ *  Unsetting is not expressed here: a clear rides the write's separate id list. */
+export type ProjectFieldValueUpdate =
+  | { kind: "text"; fieldId: string; text: string }
+  | { kind: "number"; fieldId: string; number: number }
+  | { kind: "date"; fieldId: string; date: string }
+  | { kind: "singleSelect"; fieldId: string; optionId: string }
+  | { kind: "multiSelect"; fieldId: string; optionIds: string[] }
+  | { kind: "iteration"; fieldId: string; iterationId: string };
 
 export interface Reaction {
   /** GitHub ReactionContent enum value (THUMBS_UP, HEART, ROCKET, …). */


### PR DESCRIPTION
Issues and pull requests already read out where they stand on each GitHub Projects board, but changing **Status**, **Priority**, or an iteration meant leaving the app for github.com. This turns the existing **Project fields** row into a trigger that opens one popup covering every writable field on every board the item sits on, drafting the edits and writing them board by board when it closes, the same way the Projects and Labels pickers behave.

### Backend (Tauri/Rust)

- Adds two commands in `src-tauri/src/github/project_fields.rs`: `gh_project_fields` (a board's field definitions) and `gh_set_item_field_values` (one batched write per board), both registered in the handler list in `src-tauri/src/lib.rs`.
- Introduces the `ProjectFieldDef` tagged enum with `singleSelect`, `multiSelect`, `iteration`, `text`, `number`, `date`, and a tolerant `system` arm for built-ins and unknown `dataType`s, plus `FieldOptionDef` and `IterationDef` payloads.
- Adds the inbound `FieldValueUpdate` enum and `build_set_item_field_values_args`, which assembles the `gh api graphql` variables and arguments for the batch, runs every embedded id (project, item, field, option, iteration) through `validate_graphql_embed`, and rejects non-finite numbers with `AppError::InvalidArgument`.
- Extends the existing `ProjectFieldValue::Iteration` arm with `iteration_id`, the stable identity a write addresses (title and dates are editable on the board).

### Field editor UI

- Adds `src/features/conversations/ProjectFieldsEditor.tsx`: a popover that loads each board's definitions, drafts per-field edits in a `BoardDraft` map, diffs them against the seeded values on close (`seedBoard`, `valueKey`, `fieldDiff` splitting `updates` from `clears`), and writes one call per board. Fields already holding a value offer a **Clear**; list navigation uses `listKeyboardNav`.
- Excludes GitHub's built-in fields by kind rather than by name (`isWritable`), and holds org issue fields with an explanatory reason (`ISSUE_FIELD_REASON`) instead of hiding their rows, alongside reasons for read-only scope, an iteration field with no iterations, and an in-flight save.
- Reworks `ProjectFieldValues.tsx`: the heading becomes the editor trigger, `IterationRange` and `OptionValue` are exported for reuse in the editor's rows, a new `disabledReason` prop covers the permission and loading gates, and the board list is intersected in memberships order so the editor never drafts against a board whose values haven't arrived.
- Exports `ScopeGapBlock` from `ProjectsPopover.tsx` so the editor reuses the `project`-scope remedy, and passes the picker's existing disabled reason down from both call sites, `src/features/issues/RemoteIssueViewParts.tsx` and `src/features/pulls/RemotePrView.tsx`.

### Client data layer

- `src/lib/git/api.ts` gains `ghProjectFields` and `ghSetItemFieldValues` wrappers.
- `src/lib/git/queries.ts` adds `useProjectFields` (keyed on the board alone, 5-minute `staleTime`) and `useSetItemFieldValues`, which optimistically patches the board's entry in the item-field-values cache, rolls back on failure, reports through `toastErrorWithNote` naming how many boards were left unwritten, and cancels before invalidating on settle.
- `useInvalidateAfterReconnect` now also refreshes the board's field definitions, so a newly granted `project` scope lights the editor up without a restart.
- `src/lib/git/types.ts` adds `ProjectFieldOptionDef`, `ProjectIterationDef`, the `ProjectFieldDef` union, and the `ProjectFieldValueUpdate` write union mirroring the Rust wire shapes.

### Documentation

- `README.md`: the pull-request and issues bullets now say fields can be set, not just read.
- `site/src/data/capabilities.ts`: the project-field-values capability reads "read & set".
- `src/features/help/content.ts`: the *Pull requests* and *Issues* guide sections describe the trigger, the one-popup-per-item editor, the **Clear** affordance, and the draft-then-write-on-close behaviour, keeping the existing `project` vs `read:project` scope guidance.
- Adds `changelog.d/added-project-field-editor.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-place GitHub Projects field editor for issues and pull requests, available from the header or sidebar.
  - Edit Status, Priority, Iteration, dates, text, numbers, single-select, and multi-select fields across boards.
  - Clear existing values; changes save when the editor closes.
  - Added permission, sign-in-scope, unavailable-field, and truncated-field messaging.
  - Added option descriptions and accessible editor labeling.

- **Documentation**
  - Updated help content, capabilities, README, and changelog documentation to describe editable project fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->